### PR TITLE
Don't publish types... yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
-  "types": "index.d.ts",
   "scripts": {
     "commit": "git add . && git-cz",
     "test": "is-ci 'test:ci' 'test:dev'",


### PR DESCRIPTION
I'm going to be out for a few days on vacation and haven't gotten the types reworked to the latest alpha yet. I don't want to hold you back from publishing additional alphas. 

This will keep the existing functionality of before my previous PR but keep the type definition file. I will keep working on it and when we get it back to in sync with the codebase, we can re-add this and it will be ready.