### PR TITLE
docs: fix jsx tag in column definitions docs

### DIFF
--- a/docs/guide/04-column-defs.md
+++ b/docs/guide/04-column-defs.md
@@ -50,7 +50,7 @@ const table = createTable().setRowType<Person>()
 const defaultColumns = [
   table.createDisplayColumn({
     id: 'actions',
-    cell: props => <RowActions row={props.row}>
+    cell: props => <RowActions row={props.row} />
   }),
   table.createGroup({
     header: 'Name',


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/46059092/170895643-6781f545-ba5e-4399-9be0-e5d1ce734d6f.png)

After:
![image](https://user-images.githubusercontent.com/46059092/170895657-166a9616-a22f-403b-a744-1769beec40b3.png)
