### PR TITLE
update code snippet to reflect `size` is used for these fields

### DIFF
--- a/docs/guide/column-sizing.md
+++ b/docs/guide/column-sizing.md
@@ -20,9 +20,9 @@ Columns by default are given the following measurement options:
 
 ```tsx
 export const defaultColumnSizing = {
-  width: 150,
-  minWidth: 20,
-  maxWidth: Number.MAX_SAFE_INTEGER,
+  size: 150,
+  minSize: 20,
+  maxSize: Number.MAX_SAFE_INTEGER,
 }
 ```
 


### PR DESCRIPTION
Based on the current source

https://github.com/TanStack/table/blob/33169d3c2459215c5601b3ea062103c5ffda1548/packages/table-core/src/features/ColumnSizing.ts#L80-L84

This snippet is stale and mentions `width`s, which are not part of the v8 API