### PR TITLE
Fix sum aggregate function

### DIFF
--- a/packages/table-core/src/aggregationFns.ts
+++ b/packages/table-core/src/aggregationFns.ts
@@ -4,7 +4,10 @@ const sum: AggregationFn<any> = (columnId, _leafRows, childRows) => {
   // It's faster to just add the aggregations together instead of
   // process leaf nodes individually
   return childRows.reduce(
-    (sum: number, next: unknown) => sum + (typeof next === 'number' ? next : 0),
+    (sum, next) => {
+      const nextValue = next.getValue(columnId)
+      return sum + (typeof nextValue === 'number' ? nextValue : 0)
+    },
     0
   )
 }


### PR DESCRIPTION
The sum aggregate function always returned zero for me. It seems like a `.getValue()` is missing there. 