### PR TITLE
Add ability to define return type for getValue

### DIFF
--- a/packages/table-core/src/core/cell.ts
+++ b/packages/table-core/src/core/cell.ts
@@ -1,8 +1,8 @@
-import { RowData, Cell, Column, Row, Table } from '../types'
+import { RowData, Cell, Column, GetValue, Row, Table } from '../types'
 
 export type CoreCell<TData extends RowData> = {
   id: string
-  getValue: () => any
+  getValue: GetValue
   renderValue: () => unknown
   row: Row<TData>
   column: Column<TData>
@@ -11,7 +11,7 @@ export type CoreCell<TData extends RowData> = {
     column: Column<TData>
     row: Row<TData>
     cell: Cell<TData>
-    getValue: () => any
+    getValue: GetValue
     renderValue: () => any
   }
 }

--- a/packages/table-core/src/core/row.ts
+++ b/packages/table-core/src/core/row.ts
@@ -8,7 +8,7 @@ export type CoreRow<TData extends RowData> = {
   original?: TData
   depth: number
   _valuesCache: Record<string, any>
-  getValue: (columnId: string) => any
+  getValue: <T = unknown>(columnId: string) => T
   renderValue: (columnId: string) => unknown
   subRows: Row<TData>[]
   getLeafRows: () => Row<TData>[]

--- a/packages/table-core/src/types.ts
+++ b/packages/table-core/src/types.ts
@@ -198,3 +198,5 @@ export type Header<TData extends RowData> = CoreHeader<TData> &
 export type HeaderGroup<TData extends RowData> = CoreHeaderGroup<TData>
 
 export type NoInfer<A extends any> = [A][A extends any ? 0 : never]
+
+export type GetValue<T = unknown> = () => T


### PR DESCRIPTION
It is a simple idea, I might be completely wrong here, but think it would be nice if we could define the return type of `getValue`.
It would be even better if `getValue` could find out the return type based on the `accessorKey` or `accessorFn` but I am not sure if that is possible. :/