### PR TITLE
fix: getRowCanExpand override other conditions for getCanExpand

### DIFF
--- a/packages/table-core/src/features/Expanding.ts
+++ b/packages/table-core/src/features/Expanding.ts
@@ -218,8 +218,11 @@ export const Expanding: TableFeature = {
       },
       getCanExpand: () => {
         return (
-          (table.options.getRowCanExpand?.(row) ?? true) ||
-          ((table.options.enableExpanding ?? true) && !!row.subRows?.length)
+          !!row.subRows?.length && (
+            table.options.getRowCanExpand?.(row) ??
+            table.options.enableExpanding ??
+            true
+          )
         )
       },
       getToggleExpandedHandler: () => {

--- a/packages/table-core/src/features/Expanding.ts
+++ b/packages/table-core/src/features/Expanding.ts
@@ -218,9 +218,8 @@ export const Expanding: TableFeature = {
       },
       getCanExpand: () => {
         return (
-          (table.options.getRowCanExpand?.(row) ?? true) &&
-          (table.options.enableExpanding ?? true) &&
-          !!row.subRows?.length
+          (table.options.getRowCanExpand?.(row) ?? true) ||
+          ((table.options.enableExpanding ?? true) && !!row.subRows?.length)
         )
       },
       getToggleExpandedHandler: () => {

--- a/packages/table-core/src/features/Expanding.ts
+++ b/packages/table-core/src/features/Expanding.ts
@@ -219,8 +219,10 @@ export const Expanding: TableFeature = {
       getCanExpand: () => {
         return (
           table.options.getRowCanExpand?.(row) ??
-          table.options.enableExpanding ??
-          !!row.subRows?.length
+          (
+            (table.options.enableExpanding ?? true) &&
+            !!row.subRows?.length
+          )
         )
       },
       getToggleExpandedHandler: () => {

--- a/packages/table-core/src/features/Expanding.ts
+++ b/packages/table-core/src/features/Expanding.ts
@@ -218,11 +218,9 @@ export const Expanding: TableFeature = {
       },
       getCanExpand: () => {
         return (
-          !!row.subRows?.length && (
-            table.options.getRowCanExpand?.(row) ??
-            table.options.enableExpanding ??
-            true
-          )
+          table.options.getRowCanExpand?.(row) ??
+          table.options.enableExpanding ??
+          !!row.subRows?.length
         )
       },
       getToggleExpandedHandler: () => {


### PR DESCRIPTION
Discussion here -
https://github.com/TanStack/table/discussions/4137

Details:
GetRowCanExpand should override other condition checks when getCanExpand is called.