### PR TITLE
Fix bug in `getToggleAllRowsSelectedHandler` when there are non-selectable rows.

### DIFF
--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -108,6 +108,9 @@ export const RowSelection: TableFeature = {
           // All of the rows are flat already, so it wouldn't be worth it
           if (value) {
             preGroupedFlatRows.forEach(row => {
+              if (!row.getCanSelect()) {
+                return
+              }
               rowSelection[row.id] = true
             })
           } else {
@@ -430,7 +433,9 @@ const mutateRowIsSelected = <TData extends RowData>(
     if (!row.getCanMultiSelect()) {
       Object.keys(selectedRowIds).forEach(key => delete selectedRowIds[key])
     }
-    selectedRowIds[id] = true
+    if (row.getCanSelect()) {
+      selectedRowIds[id] = true
+    }
   } else {
     delete selectedRowIds[id]
   }

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -283,7 +283,7 @@ export const RowSelection: TableFeature = {
         )
 
         if (isAllRowsSelected) {
-          if (preFilteredFlatRows.some(row => !rowSelection[row.id])) {
+          if (preFilteredFlatRows.some(row => row.getCanSelect() && !rowSelection[row.id])) {
             isAllRowsSelected = false
           }
         }
@@ -308,10 +308,8 @@ export const RowSelection: TableFeature = {
       },
 
       getIsSomeRowsSelected: () => {
-        return (
-          !table.getIsAllRowsSelected() &&
-          !!Object.keys(table.getState().rowSelection ?? {}).length
-        )
+        const totalSelected = Object.keys(table.getState().rowSelection ?? {}).length
+        return totalSelected < table.getCoreRowModel().flatRows.length
       },
 
       getIsSomePageRowsSelected: () => {
@@ -319,8 +317,8 @@ export const RowSelection: TableFeature = {
         return table.getIsAllPageRowsSelected()
           ? false
           : paginationFlatRows.some(
-              d => d.getIsSelected() || d.getIsSomeSelected()
-            )
+            d => d.getIsSelected() || d.getIsSomeSelected()
+          )
       },
 
       getToggleAllRowsSelectedHandler: () => {


### PR DESCRIPTION
This is another fix for an issue which arose in #4128. As discussed in the issue, https://github.com/TanStack/table/issues/4121#issuecomment-1180721652, the `getIsAllRowsSelected` method doesn't use a filter to only match the rows which are allowed to be selected. This PR adds this behavior into it.