### PR TITLE
Fix a bug in `isSomeRowsSelected`

### DIFF
--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -309,7 +309,7 @@ export const RowSelection: TableFeature = {
 
       getIsSomeRowsSelected: () => {
         const totalSelected = Object.keys(table.getState().rowSelection ?? {}).length
-        return totalSelected < table.getCoreRowModel().flatRows.length
+        return totalSelected > 0 && totalSelected < table.getCoreRowModel().flatRows.length
       },
 
       getIsSomePageRowsSelected: () => {


### PR DESCRIPTION
This is a small fix for a recently introduced bug described in this issue https://github.com/TanStack/table/issues/4212 where `getIsSomeRowsSelected` returned `true` even when no rows were selected.