### PR TITLE
fix: columns with accessor key should have optional id and header

### DIFF
--- a/packages/table-core/src/types.ts
+++ b/packages/table-core/src/types.ts
@@ -240,7 +240,7 @@ export type AccessorFnColumnDef<
 
 export type AccessorKeyColumnDef<TData extends RowData, TValue = unknown> = {
   id?: string
-} & ColumnIdentifiers<TData, TValue> &
+} & Partial<ColumnIdentifiers<TData, TValue>> &
   ColumnDefBase<TData, TValue> & {
     accessorKey: DeepKeys<TData>
   }


### PR DESCRIPTION
Some examples show that when you have an `accessorKey` you don't need a `header` or `id`. This should make `header` and `id` optional when an `accessorKey` is present. 

Other option is to just update the examples column defs that are wrong.