### PR TITLE
Update repo links to TanStack/table

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Requests & Questions
-    url: https://github.com/tannerlinsley/react-table/discussions
+    url: https://github.com/TanStack/table/discussions
     about: Please ask and answer questions here.
   - name: Community Chat
     url: https://discord.gg/mQd7egN

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Headless UI for building **powerful tables & datagrids** for **React, Solid, Vue
 
 ## Enjoy this library?
 
-Try some other [TanStack](https://tanstack.com) like [React Query](https://github.com/tannerlinsley/react-query), [React Form](https://github.com/tannerlinsley/react-form), [React Charts](https://github.com/tannerlinsley/react-charts)
+Try some other [TanStack](https://tanstack.com) like [React Query](https://github.com/TanStack/query), [React Form](https://github.com/tannerlinsley/react-form), [React Charts](https://github.com/TanStack/react-charts)
 
 ## Visit [tanstack.com/table](https://tanstack.com/table) for docs, guides, API and more!
 

--- a/old-examples/expanding/README.md
+++ b/old-examples/expanding/README.md
@@ -2,5 +2,5 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 You can:
 
-- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/v7/examples/expanding)
+- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/TanStack/table/tree/v7/examples/expanding)
 - `yarn` and `yarn start` to run and edit the example

--- a/old-examples/grouping-column/README.md
+++ b/old-examples/grouping-column/README.md
@@ -2,5 +2,5 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 You can:
 
-- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/v7/examples/grouping-column)
+- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/TanStack/table/tree/v7/examples/grouping-column)
 - `yarn` and `yarn start` to run and edit the example

--- a/old-examples/pagination/README.md
+++ b/old-examples/pagination/README.md
@@ -1,6 +1,6 @@
 # Pagination
 
-- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/v7/examples/pagination)
+- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/TanStack/table/tree/v7/examples/pagination)
 - `yarn` and `yarn start` to run and edit the example
 
 ## Guide

--- a/old-examples/pivoting/README.md
+++ b/old-examples/pivoting/README.md
@@ -2,5 +2,5 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 You can:
 
-- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/v7/examples/pivoting)
+- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/TanStack/table/tree/v7/examples/pivoting)
 - `yarn` and `yarn start` to run and edit the example

--- a/old-examples/rmwc-components/README.md
+++ b/old-examples/rmwc-components/README.md
@@ -2,5 +2,5 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 You can:
 
-- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/v7/examples/material-ui-components)
+- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/TanStack/table/tree/v7/examples/material-ui-components)
 - `yarn` and `yarn start` to run and edit the example

--- a/old-examples/sub-components-lazy/README.md
+++ b/old-examples/sub-components-lazy/README.md
@@ -2,5 +2,5 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 You can:
 
-- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/tannerlinsley/react-table/tree/v7/examples/sub-components-lazy)
+- [Open this example in a new CodeSandbox](https://codesandbox.io/s/github/TanStack/table/tree/v7/examples/sub-components-lazy)
 - `yarn` and `yarn start` to run and edit the example


### PR DESCRIPTION
## Description
Updates links to point to `TanStack/table` instead of `tannerlinsley/react-table`.