### PR TITLE
docs(column): add explanation on how to access meta

### DIFF
--- a/docs/api/core/column-def.md
+++ b/docs/api/core/column-def.md
@@ -92,7 +92,7 @@ The cell to display each row for the column. If a function is passed, it will be
 meta?: ColumnMeta // This interface is extensible via declaration merging. See below!
 ```
 
-The meta data to associated with the column. This type is global to all tables and can be extended like so:
+The meta data to associated with the column. We can access it anywhere when the column is available via `column.columnDef.meta`. This type is global to all tables and can be extended like so:
 
 ```tsx
 declare module '@tanstack/table-core' {


### PR DESCRIPTION
## Description

I didn't find any documentations on how we access column meta data. Luckily found this solution in this issue: https://github.com/TanStack/table/issues/3983#issuecomment-1142334750. I think it's better to add it to current documentations.