### PR TITLE
filter out invalid sort id

### DIFF
--- a/packages/table-core/src/utils/getSortedRowModel.ts
+++ b/packages/table-core/src/utils/getSortedRowModel.ts
@@ -18,8 +18,9 @@ export function getSortedRowModel<TData extends RowData>(): (
         const sortedFlatRows: Row<TData>[] = []
 
         // Filter out sortings that correspond to non existing columns
+        const columns = table._getAllFlatColumnsById();
         const availableSorting = sortingState.filter(sort =>
-          table.getColumn(sort.id).getCanSort()
+          columns[sort.id] && columns[sort.id]?.getCanSort()
         )
 
         const columnInfoById: Record<


### PR DESCRIPTION
When user provides invalid sort id either from initialState or state the table blows up.

This PR improve default getSortedRowModel to guard against this case.

Behavior change:

- Invalid sort id will be ignored and table can still render.

