### PR TITLE
perf: optimise types

### DIFF
--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -50,7 +50,7 @@ import { DeepKeys, DeepValue } from './utils'
 // })
 
 type Accessor<TData extends RowData> = <
-  TAccessor extends AccessorFn<TData> | DeepKeys<TData>,
+  TAccessor extends AccessorFn<TData> | string,
   TValue extends TAccessor extends AccessorFn<TData, infer TReturn>
     ? TReturn
     : TAccessor extends DeepKeys<TData>

--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -6,7 +6,7 @@ import {
   IdentifiedColumnDef,
   RowData,
 } from './types'
-import { DeepKeys, DeepValue } from './utils'
+import { DeepValue } from './utils'
 
 // type Person = {
 //   firstName: string
@@ -53,9 +53,7 @@ type Accessor<TData extends RowData> = <
   TAccessor extends AccessorFn<TData> | string,
   TValue extends TAccessor extends AccessorFn<TData, infer TReturn>
     ? TReturn
-    : TAccessor extends DeepKeys<TData>
-      ? DeepValue<TData, TAccessor>
-      : never
+    : DeepValue<TData, TAccessor>
   >(
   accessor: TValue extends never ? never : TAccessor,
   column: TAccessor extends AccessorFn<TData>

--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -49,17 +49,24 @@ import { DeepValue } from './utils'
 //   cell: info => info.getValue(),
 // })
 
+type AccessorType<TData, TAccessor> = TAccessor extends AccessorFn<
+  TData,
+  infer TReturn
+>
+  ? TReturn
+  : DeepValue<TData, TAccessor>
+
 type Accessor<TData extends RowData> = <
   TAccessor extends AccessorFn<TData> | string,
-  TValue extends TAccessor extends AccessorFn<TData, infer TReturn>
-    ? TReturn
-    : DeepValue<TData, TAccessor>
-  >(
+  TValue extends AccessorType<TData, TAccessor>
+>(
   accessor: TValue extends never ? never : TAccessor,
   column: TAccessor extends AccessorFn<TData>
     ? DisplayColumnDef<TData, TValue>
     : IdentifiedColumnDef<TData, TValue>
-) => AccessorColumnDef<TData, TValue>
+) => TValue extends never
+  ? never
+  : AccessorColumnDef<TData, AccessorType<TData, TAccessor>>
 
 export interface ColumnHelper<TData extends RowData> {
   accessor: Accessor<TData>

--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -1,12 +1,12 @@
 import {
+  AccessorColumnDef,
   AccessorFn,
-  ColumnDef,
   DisplayColumnDef,
   GroupColumnDef,
   IdentifiedColumnDef,
   RowData,
 } from './types'
-import { DeepKeys, DeepValue, RequiredKeys } from './utils'
+import { DeepKeys, DeepValue } from './utils'
 
 // type Person = {
 //   firstName: string
@@ -49,22 +49,24 @@ import { DeepKeys, DeepValue, RequiredKeys } from './utils'
 //   cell: info => info.getValue(),
 // })
 
-export type ColumnHelper<TData extends RowData> = {
-  accessor: <
-    TAccessor extends AccessorFn<TData> | DeepKeys<TData>,
-    TValue extends TAccessor extends AccessorFn<TData, infer TReturn>
-      ? TReturn
-      : TAccessor extends DeepKeys<TData>
-      ? DeepValue<TData, TAccessor>
-      : never
-  >(
-    accessor: TAccessor,
-    column: TAccessor extends AccessorFn<TData>
-      ? DisplayColumnDef<TData, TValue>
-      : IdentifiedColumnDef<TData, TValue>
-  ) => ColumnDef<TData, TValue>
-  display: (column: DisplayColumnDef<TData>) => ColumnDef<TData, unknown>
-  group: (column: GroupColumnDef<TData>) => ColumnDef<TData, unknown>
+type Accessor<TData extends RowData> = <
+  TAccessor extends AccessorFn<TData> | DeepKeys<TData>,
+  TValue extends TAccessor extends AccessorFn<TData, infer TReturn>
+    ? TReturn
+    : TAccessor extends DeepKeys<TData>
+    ? DeepValue<TData, TAccessor>
+    : never
+>(
+  accessor: TAccessor,
+  column: TAccessor extends AccessorFn<TData>
+    ? DisplayColumnDef<TData, TValue>
+    : IdentifiedColumnDef<TData, TValue>
+) => AccessorColumnDef<TData, TValue>
+
+export interface ColumnHelper<TData extends RowData> {
+  accessor: Accessor<TData>
+  display: (column: DisplayColumnDef<TData>) => DisplayColumnDef<TData>
+  group: (column: GroupColumnDef<TData>) => GroupColumnDef<TData>
 }
 
 export function createColumnHelper<
@@ -82,7 +84,7 @@ export function createColumnHelper<
             accessorKey: accessor,
           }
     },
-    display: column => column as ColumnDef<TData, unknown>,
-    group: column => column as ColumnDef<TData, unknown>,
+    display: column => column as DisplayColumnDef<TData>,
+    group: column => column as GroupColumnDef<TData>,
   }
 }

--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -54,10 +54,10 @@ type Accessor<TData extends RowData> = <
   TValue extends TAccessor extends AccessorFn<TData, infer TReturn>
     ? TReturn
     : TAccessor extends DeepKeys<TData>
-    ? DeepValue<TData, TAccessor>
-    : never
->(
-  accessor: TAccessor,
+      ? DeepValue<TData, TAccessor>
+      : never
+  >(
+  accessor: TValue extends never ? never : TAccessor,
   column: TAccessor extends AccessorFn<TData>
     ? DisplayColumnDef<TData, TValue>
     : IdentifiedColumnDef<TData, TValue>

--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -6,7 +6,7 @@ import {
   IdentifiedColumnDef,
   RowData,
 } from './types'
-import { DeepValue } from './utils'
+import { DeepKeys, DeepValue } from './utils'
 
 // type Person = {
 //   firstName: string
@@ -56,11 +56,11 @@ type AccessorType<TData, TAccessor> = TAccessor extends AccessorFn<
   ? TReturn
   : DeepValue<TData, TAccessor>
 
-type Accessor<TData extends RowData> = <
-  TAccessor extends AccessorFn<TData> | string,
+type Accessor<TData extends RowData, TAllowedKeys> = <
+  TAccessor extends AccessorFn<TData> | TAllowedKeys,
   TValue extends AccessorType<TData, TAccessor>
 >(
-  accessor: TValue extends never ? never : TAccessor,
+  accessor: TAccessor,
   column: TAccessor extends AccessorFn<TData>
     ? DisplayColumnDef<TData, TValue>
     : IdentifiedColumnDef<TData, TValue>
@@ -68,15 +68,16 @@ type Accessor<TData extends RowData> = <
   ? never
   : AccessorColumnDef<TData, AccessorType<TData, TAccessor>>
 
-export interface ColumnHelper<TData extends RowData> {
-  accessor: Accessor<TData>
+export interface ColumnHelper<TData extends RowData, TAllowedKeys> {
+  accessor: Accessor<TData, TAllowedKeys>
   display: (column: DisplayColumnDef<TData>) => DisplayColumnDef<TData>
   group: (column: GroupColumnDef<TData>) => GroupColumnDef<TData>
 }
 
 export function createColumnHelper<
-  TData extends RowData
->(): ColumnHelper<TData> {
+  TData extends RowData,
+  TAllowedKeys = DeepKeys<TData>
+>(): ColumnHelper<TData, TAllowedKeys> {
   return {
     accessor: (accessor, column) => {
       return typeof accessor === 'function'

--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -6,7 +6,7 @@ import {
   IdentifiedColumnDef,
   RowData,
 } from './types'
-import { DeepKeys, DeepValue } from './utils'
+import { DeepValue } from './utils'
 
 // type Person = {
 //   firstName: string
@@ -56,8 +56,8 @@ type AccessorType<TData, TAccessor> = TAccessor extends AccessorFn<
   ? TReturn
   : DeepValue<TData, TAccessor>
 
-type Accessor<TData extends RowData, TAllowedKeys> = <
-  TAccessor extends AccessorFn<TData> | TAllowedKeys,
+type Accessor<TData extends RowData> = <
+  TAccessor extends AccessorFn<TData> | string,
   TValue extends AccessorType<TData, TAccessor>
 >(
   accessor: TAccessor,
@@ -68,16 +68,15 @@ type Accessor<TData extends RowData, TAllowedKeys> = <
   ? never
   : AccessorColumnDef<TData, AccessorType<TData, TAccessor>>
 
-export interface ColumnHelper<TData extends RowData, TAllowedKeys> {
-  accessor: Accessor<TData, TAllowedKeys>
+export interface ColumnHelper<TData extends RowData> {
+  accessor: Accessor<TData>
   display: (column: DisplayColumnDef<TData>) => DisplayColumnDef<TData>
   group: (column: GroupColumnDef<TData>) => GroupColumnDef<TData>
 }
 
 export function createColumnHelper<
-  TData extends RowData,
-  TAllowedKeys = DeepKeys<TData>
->(): ColumnHelper<TData, TAllowedKeys> {
+  TData extends RowData
+>(): ColumnHelper<TData> {
   return {
     accessor: (accessor, column) => {
       return typeof accessor === 'function'

--- a/packages/table-core/src/core/cell.ts
+++ b/packages/table-core/src/core/cell.ts
@@ -1,7 +1,7 @@
 import { RowData, Cell, Column, Row, Table } from '../types'
 import { Getter, memo } from '../utils'
 
-export type CellContext<TData extends RowData, TValue> = {
+export interface CellContext<TData extends RowData, TValue> {
   table: Table<TData>
   column: Column<TData, TValue>
   row: Row<TData>
@@ -10,7 +10,7 @@ export type CellContext<TData extends RowData, TValue> = {
   renderValue: Getter<TValue | null>
 }
 
-export type CoreCell<TData extends RowData, TValue> = {
+export interface CoreCell<TData extends RowData, TValue> {
   id: string
   getValue: CellContext<TData, TValue>['getValue']
   renderValue: CellContext<TData, TValue>['renderValue']
@@ -24,7 +24,7 @@ export function createCell<TData extends RowData, TValue>(
   row: Row<TData>,
   column: Column<TData, TValue>,
   columnId: string
-) {
+): Cell<TData, TValue> {
   const getRenderValue = () =>
     cell.getValue() ?? table.options.renderFallbackValue
 

--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -1,17 +1,14 @@
-import { TaggedTemplateExpression } from '@babel/types'
 import {
   Column,
   Table,
   AccessorFn,
   ColumnDef,
-  ColumnDefTemplate,
   RowData,
-  ColumnMeta,
   ColumnDefResolved,
 } from '../types'
 import { memo } from '../utils'
 
-export type CoreColumn<TData extends RowData, TValue> = {
+export interface CoreColumn<TData extends RowData, TValue> {
   id: string
   depth: number
   accessorFn?: AccessorFn<TData, TValue>
@@ -27,7 +24,7 @@ export function createColumn<TData extends RowData, TValue>(
   columnDef: ColumnDef<TData, TValue>,
   depth: number,
   parent?: Column<TData, TValue>
-) {
+): Column<TData, TValue> {
   const defaultColumn = table._getDefaultColumnDef()
 
   const resolvedColumnDef = {

--- a/packages/table-core/src/core/headers.ts
+++ b/packages/table-core/src/core/headers.ts
@@ -2,19 +2,19 @@ import { RowData, Column, Header, HeaderGroup, Table } from '../types'
 import { memo } from '../utils'
 import { TableFeature } from './table'
 
-export type CoreHeaderGroup<TData extends RowData> = {
+export interface CoreHeaderGroup<TData extends RowData> {
   id: string
   depth: number
   headers: Header<TData, unknown>[]
 }
 
-export type HeaderContext<TData, TValue> = {
+export interface HeaderContext<TData, TValue> {
   table: Table<TData>
   header: Header<TData, TValue>
   column: Column<TData, TValue>
 }
 
-export type CoreHeader<TData extends RowData, TValue> = {
+export interface CoreHeader<TData extends RowData, TValue> {
   id: string
   index: number
   depth: number
@@ -29,7 +29,7 @@ export type CoreHeader<TData extends RowData, TValue> = {
   getContext: () => HeaderContext<TData, TValue>
 }
 
-export type HeadersInstance<TData extends RowData> = {
+export interface HeadersInstance<TData extends RowData> {
   getHeaderGroups: () => HeaderGroup<TData>[]
   getLeftHeaderGroups: () => HeaderGroup<TData>[]
   getCenterHeaderGroups: () => HeaderGroup<TData>[]
@@ -63,7 +63,7 @@ function createHeader<TData extends RowData, TValue>(
     index: number
     depth: number
   }
-) {
+): Header<TData, TValue> {
   const id = options.id ?? column.id
 
   let header: CoreHeader<TData, TValue> = {

--- a/packages/table-core/src/core/row.ts
+++ b/packages/table-core/src/core/row.ts
@@ -2,7 +2,7 @@ import { RowData, Cell, Row, Table } from '../types'
 import { flattenBy, memo } from '../utils'
 import { createCell } from './cell'
 
-export type CoreRow<TData extends RowData> = {
+export interface CoreRow<TData extends RowData> {
   id: string
   index: number
   original: TData

--- a/packages/table-core/src/core/table.ts
+++ b/packages/table-core/src/core/table.ts
@@ -1,11 +1,10 @@
-import { flattenBy, functionalUpdate, memo, RequiredKeys } from '../utils'
+import { functionalUpdate, memo, RequiredKeys } from '../utils'
 
 import {
   Updater,
   TableOptionsResolved,
   TableState,
   Table,
-  ColumnDefTemplate,
   InitialTableState,
   Row,
   Column,
@@ -26,7 +25,7 @@ import { Headers } from './headers'
 import { ColumnSizing } from '../features/ColumnSizing'
 import { Expanding } from '../features/Expanding'
 import { Filters } from '../features/Filters'
-import { Grouping, GroupingColumnDef } from '../features/Grouping'
+import { Grouping } from '../features/Grouping'
 import { Ordering } from '../features/Ordering'
 import { Pagination } from '../features/Pagination'
 import { Pinning } from '../features/Pinning'
@@ -34,7 +33,7 @@ import { RowSelection } from '../features/RowSelection'
 import { Sorting } from '../features/Sorting'
 import { Visibility } from '../features/Visibility'
 
-export type TableFeature = {
+export interface TableFeature {
   getDefaultOptions?: (table: any) => any
   getInitialState?: (initialState?: InitialTableState) => any
   createTable?: (table: any) => any
@@ -61,9 +60,9 @@ const features = [
 
 //
 
-export type CoreTableState = {}
+export interface CoreTableState {}
 
-export type CoreOptions<TData extends RowData> = {
+export interface CoreOptions<TData extends RowData> {
   data: TData[]
   state: Partial<TableState>
   onStateChange: (updater: Updater<TableState>) => void
@@ -87,7 +86,7 @@ export type CoreOptions<TData extends RowData> = {
   renderFallbackValue: any
 }
 
-export type CoreInstance<TData extends RowData> = {
+export interface CoreInstance<TData extends RowData> {
   initialState: TableState
   reset: () => void
   options: RequiredKeys<TableOptionsResolved<TData>, 'state'>

--- a/packages/table-core/src/features/ColumnSizing.ts
+++ b/packages/table-core/src/features/ColumnSizing.ts
@@ -5,14 +5,14 @@ import { ColumnPinningPosition } from './Pinning'
 
 //
 
-export type ColumnSizingTableState = {
+export interface ColumnSizingTableState {
   columnSizing: ColumnSizingState
   columnSizingInfo: ColumnSizingInfoState
 }
 
 export type ColumnSizingState = Record<string, number>
 
-export type ColumnSizingInfoState = {
+export interface ColumnSizingInfoState {
   startOffset: null | number
   startSize: null | number
   deltaOffset: null | number
@@ -23,20 +23,20 @@ export type ColumnSizingInfoState = {
 
 export type ColumnResizeMode = 'onChange' | 'onEnd'
 
-export type ColumnSizingOptions = {
+export interface ColumnSizingOptions {
   enableColumnResizing?: boolean
   columnResizeMode?: ColumnResizeMode
   onColumnSizingChange?: OnChangeFn<ColumnSizingState>
   onColumnSizingInfoChange?: OnChangeFn<ColumnSizingInfoState>
 }
 
-export type ColumnSizingDefaultOptions = {
+export interface ColumnSizingDefaultOptions {
   columnResizeMode: ColumnResizeMode
   onColumnSizingChange: OnChangeFn<ColumnSizingState>
   onColumnSizingInfoChange: OnChangeFn<ColumnSizingInfoState>
 }
 
-export type ColumnSizingInstance = {
+export interface ColumnSizingInstance {
   setColumnSizing: (updater: Updater<ColumnSizingState>) => void
   setColumnSizingInfo: (updater: Updater<ColumnSizingInfoState>) => void
   resetColumnSizing: (defaultState?: boolean) => void
@@ -47,14 +47,14 @@ export type ColumnSizingInstance = {
   getRightTotalSize: () => number
 }
 
-export type ColumnSizingColumnDef = {
+export interface ColumnSizingColumnDef {
   enableResizing?: boolean
   size?: number
   minSize?: number
   maxSize?: number
 }
 
-export type ColumnSizingColumn = {
+export interface ColumnSizingColumn {
   getSize: () => number
   getStart: (position?: ColumnPinningPosition) => number
   getCanResize: () => boolean
@@ -62,7 +62,7 @@ export type ColumnSizingColumn = {
   resetSize: () => void
 }
 
-export type ColumnSizingHeader = {
+export interface ColumnSizingHeader {
   getSize: () => number
   getStart: (position?: ColumnPinningPosition) => number
   getResizeHandler: () => (event: unknown) => void

--- a/packages/table-core/src/features/Expanding.ts
+++ b/packages/table-core/src/features/Expanding.ts
@@ -5,18 +5,18 @@ import { makeStateUpdater } from '../utils'
 
 export type ExpandedStateList = Record<string, boolean>
 export type ExpandedState = true | Record<string, boolean>
-export type ExpandedTableState = {
+export interface ExpandedTableState {
   expanded: ExpandedState
 }
 
-export type ExpandedRow = {
+export interface ExpandedRow {
   toggleExpanded: (expanded?: boolean) => void
   getIsExpanded: () => boolean
   getCanExpand: () => boolean
   getToggleExpandedHandler: () => () => void
 }
 
-export type ExpandedOptions<TData extends RowData> = {
+export interface ExpandedOptions<TData extends RowData> {
   manualExpanding?: boolean
   onExpandedChange?: OnChangeFn<ExpandedState>
   autoResetExpanded?: boolean
@@ -27,7 +27,7 @@ export type ExpandedOptions<TData extends RowData> = {
   paginateExpandedRows?: boolean
 }
 
-export type ExpandedInstance<TData extends RowData> = {
+export interface ExpandedInstance<TData extends RowData> {
   _autoResetExpanded: () => void
   setExpanded: (updater: Updater<ExpandedState>) => void
   toggleAllRowsExpanded: (expanded?: boolean) => void

--- a/packages/table-core/src/features/Filters.ts
+++ b/packages/table-core/src/features/Filters.ts
@@ -13,25 +13,25 @@ import {
 } from '../types'
 import { functionalUpdate, isFunction, makeStateUpdater } from '../utils'
 
-export type FiltersTableState = {
+export interface FiltersTableState {
   columnFilters: ColumnFiltersState
   globalFilter: any
 }
 
 export type ColumnFiltersState = ColumnFilter[]
 
-export type ColumnFilter = {
+export interface ColumnFilter {
   id: string
   value: unknown
 }
 
-export type ResolvedColumnFilter<TData extends RowData> = {
+export interface ResolvedColumnFilter<TData extends RowData> {
   id: string
   resolvedValue: unknown
   filterFn: FilterFn<TData>
 }
 
-export type FilterFn<TData extends RowData> = {
+export interface FilterFn<TData extends RowData> {
   (
     row: Row<TData>,
     columnId: string,
@@ -64,13 +64,13 @@ export type FilterFnOption<TData extends RowData> =
   | keyof FilterFns
   | FilterFn<TData>
 
-export type FiltersColumnDef<TData extends RowData> = {
+export interface FiltersColumnDef<TData extends RowData> {
   filterFn?: FilterFnOption<TData>
   enableColumnFilter?: boolean
   enableGlobalFilter?: boolean
 }
 
-export type FiltersColumn<TData extends RowData> = {
+export interface FiltersColumn<TData extends RowData> {
   getAutoFilterFn: () => FilterFn<TData> | undefined
   getFilterFn: () => FilterFn<TData> | undefined
   setFilterValue: (updater: Updater<any>) => void
@@ -87,12 +87,12 @@ export type FiltersColumn<TData extends RowData> = {
   _getFacetedMinMaxValues?: () => undefined | [number, number]
 }
 
-export type FiltersRow<TData extends RowData> = {
+export interface FiltersRow<TData extends RowData> {
   columnFilters: Record<string, boolean>
   columnFiltersMeta: Record<string, FilterMeta>
 }
 
-export type FiltersOptions<TData extends RowData> = {
+interface FiltersOptionsBase<TData extends RowData> {
   enableFilters?: boolean
   manualFiltering?: boolean
   filterFromLeafRows?: boolean
@@ -121,15 +121,21 @@ export type FiltersOptions<TData extends RowData> = {
     table: Table<TData>,
     columnId: string
   ) => () => undefined | [number, number]
-} & (keyof FilterFns extends never
+}
+
+type ResolvedFilterFns = keyof FilterFns extends never
   ? {
       filterFns?: Record<string, FilterFn<any>>
     }
   : {
       filterFns: Record<keyof FilterFns, FilterFn<any>>
-    })
+    }
 
-export type FiltersInstance<TData extends RowData> = {
+export interface FiltersOptions<TData extends RowData>
+  extends FiltersOptionsBase<TData>,
+    ResolvedFilterFns {}
+
+export interface FiltersInstance<TData extends RowData> {
   setColumnFilters: (updater: Updater<ColumnFiltersState>) => void
 
   resetColumnFilters: (defaultState?: boolean) => void

--- a/packages/table-core/src/features/Grouping.ts
+++ b/packages/table-core/src/features/Grouping.ts
@@ -16,7 +16,7 @@ import { isFunction, makeStateUpdater } from '../utils'
 
 export type GroupingState = string[]
 
-export type GroupingTableState = {
+export interface GroupingTableState {
   grouping: GroupingState
 }
 
@@ -34,7 +34,7 @@ export type AggregationFnOption<TData extends RowData> =
   | BuiltInAggregationFn
   | AggregationFn<TData>
 
-export type GroupingColumnDef<TData extends RowData, TValue> = {
+export interface GroupingColumnDef<TData extends RowData, TValue> {
   aggregationFn?: AggregationFnOption<TData>
   aggregatedCell?: ColumnDefTemplate<
     ReturnType<Cell<TData, TValue>['getContext']>
@@ -42,7 +42,7 @@ export type GroupingColumnDef<TData extends RowData, TValue> = {
   enableGrouping?: boolean
 }
 
-export type GroupingColumn<TData extends RowData> = {
+export interface GroupingColumn<TData extends RowData> {
   getCanGroup: () => boolean
   getIsGrouped: () => boolean
   getGroupedIndex: () => number
@@ -52,42 +52,48 @@ export type GroupingColumn<TData extends RowData> = {
   getAggregationFn: () => AggregationFn<TData> | undefined
 }
 
-export type GroupingRow = {
+export interface GroupingRow {
   groupingColumnId?: string
   groupingValue?: unknown
   getIsGrouped: () => boolean
   _groupingValuesCache: Record<string, any>
 }
 
-export type GroupingCell = {
+export interface GroupingCell {
   getIsGrouped: () => boolean
   getIsPlaceholder: () => boolean
   getIsAggregated: () => boolean
 }
 
-export type ColumnDefaultOptions = {
+export interface ColumnDefaultOptions {
   // Column
   onGroupingChange: OnChangeFn<GroupingState>
   enableGrouping: boolean
 }
 
-export type GroupingOptions = {
+interface GroupingOptionsBase {
   manualGrouping?: boolean
   onGroupingChange?: OnChangeFn<GroupingState>
   enableGrouping?: boolean
   getGroupedRowModel?: (table: Table<any>) => () => RowModel<any>
   groupedColumnMode?: false | 'reorder' | 'remove'
-} & (keyof AggregationFns extends never
+}
+
+type ResolvedAggregationFns = keyof AggregationFns extends never
   ? {
       aggregationFns?: Record<string, AggregationFn<any>>
     }
   : {
       aggregationFns: Record<keyof AggregationFns, AggregationFn<any>>
-    })
+    }
+
+export interface GroupingOptions
+  extends GroupingOptionsBase,
+    ResolvedAggregationFns {}
 
 export type GroupingColumnMode = false | 'reorder' | 'remove'
 
-export type GroupingInstance<TData extends RowData> = {
+export interface GroupingInstance<TData extends RowData> {
   setGrouping: (updater: Updater<GroupingState>) => void
   resetGrouping: (defaultState?: boolean) => void
   getPreGroupedRowModel: () => RowModel<TData>

--- a/packages/table-core/src/features/Ordering.ts
+++ b/packages/table-core/src/features/Ordering.ts
@@ -2,24 +2,24 @@ import { makeStateUpdater, memo } from '../utils'
 
 import { Table, OnChangeFn, Updater, Column, RowData } from '../types'
 
-import { Grouping, orderColumns } from './Grouping'
+import { orderColumns } from './Grouping'
 import { TableFeature } from '../core/table'
 
-export type ColumnOrderTableState = {
+export interface ColumnOrderTableState {
   columnOrder: ColumnOrderState
 }
 
 export type ColumnOrderState = string[]
 
-export type ColumnOrderOptions = {
+export interface ColumnOrderOptions {
   onColumnOrderChange?: OnChangeFn<ColumnOrderState>
 }
 
-export type ColumnOrderDefaultOptions = {
+export interface ColumnOrderDefaultOptions {
   onColumnOrderChange: OnChangeFn<ColumnOrderState>
 }
 
-export type ColumnOrderInstance<TData extends RowData> = {
+export interface ColumnOrderInstance<TData extends RowData> {
   setColumnOrder: (updater: Updater<ColumnOrderState>) => void
   resetColumnOrder: (defaultState?: boolean) => void
   _getOrderColumnsFn: () => (

--- a/packages/table-core/src/features/Pagination.ts
+++ b/packages/table-core/src/features/Pagination.ts
@@ -2,20 +2,20 @@ import { TableFeature } from '../core/table'
 import { OnChangeFn, Table, RowModel, Updater, RowData } from '../types'
 import { functionalUpdate, makeStateUpdater, memo } from '../utils'
 
-export type PaginationState = {
+export interface PaginationState {
   pageIndex: number
   pageSize: number
 }
 
-export type PaginationTableState = {
+export interface PaginationTableState {
   pagination: PaginationState
 }
 
-export type PaginationInitialTableState = {
+export interface PaginationInitialTableState {
   pagination?: Partial<PaginationState>
 }
 
-export type PaginationOptions = {
+export interface PaginationOptions {
   pageCount?: number
   manualPagination?: boolean
   onPaginationChange?: OnChangeFn<PaginationState>
@@ -23,11 +23,11 @@ export type PaginationOptions = {
   getPaginationRowModel?: (table: Table<any>) => () => RowModel<any>
 }
 
-export type PaginationDefaultOptions = {
+export interface PaginationDefaultOptions {
   onPaginationChange: OnChangeFn<PaginationState>
 }
 
-export type PaginationInstance<TData extends RowData> = {
+export interface PaginationInstance<TData extends RowData> {
   _autoResetPageIndex: () => void
   setPagination: (updater: Updater<PaginationState>) => void
   resetPagination: (defaultState?: boolean) => void

--- a/packages/table-core/src/features/Pinning.ts
+++ b/packages/table-core/src/features/Pinning.ts
@@ -12,42 +12,42 @@ import { makeStateUpdater, memo } from '../utils'
 
 export type ColumnPinningPosition = false | 'left' | 'right'
 
-export type ColumnPinningState = {
+export interface ColumnPinningState {
   left?: string[]
   right?: string[]
 }
 
-export type ColumnPinningTableState = {
+export interface ColumnPinningTableState {
   columnPinning: ColumnPinningState
 }
 
-export type ColumnPinningOptions = {
+export interface ColumnPinningOptions {
   onColumnPinningChange?: OnChangeFn<ColumnPinningState>
   enablePinning?: boolean
 }
 
-export type ColumnPinningDefaultOptions = {
+export interface ColumnPinningDefaultOptions {
   onColumnPinningChange: OnChangeFn<ColumnPinningState>
 }
 
-export type ColumnPinningColumnDef = {
+export interface ColumnPinningColumnDef {
   enablePinning?: boolean
 }
 
-export type ColumnPinningColumn = {
+export interface ColumnPinningColumn {
   getCanPin: () => boolean
   getPinnedIndex: () => number
   getIsPinned: () => ColumnPinningPosition
   pin: (position: ColumnPinningPosition) => void
 }
 
-export type ColumnPinningRow<TData extends RowData> = {
+export interface ColumnPinningRow<TData extends RowData> {
   getLeftVisibleCells: () => Cell<TData, unknown>[]
   getCenterVisibleCells: () => Cell<TData, unknown>[]
   getRightVisibleCells: () => Cell<TData, unknown>[]
 }
 
-export type ColumnPinningInstance<TData extends RowData> = {
+export interface ColumnPinningInstance<TData extends RowData> {
   setColumnPinning: (updater: Updater<ColumnPinningState>) => void
   resetColumnPinning: (defaultState?: boolean) => void
   getIsSomeColumnsPinned: (position?: ColumnPinningPosition) => boolean

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -4,11 +4,11 @@ import { makeStateUpdater, memo } from '../utils'
 
 export type RowSelectionState = Record<string, boolean>
 
-export type RowSelectionTableState = {
+export interface RowSelectionTableState {
   rowSelection: RowSelectionState
 }
 
-export type RowSelectionOptions<TData extends RowData> = {
+export interface RowSelectionOptions<TData extends RowData> {
   enableRowSelection?: boolean | ((row: Row<TData>) => boolean)
   enableMultiRowSelection?: boolean | ((row: Row<TData>) => boolean)
   enableSubRowSelection?: boolean | ((row: Row<TData>) => boolean)
@@ -26,7 +26,7 @@ export type RowSelectionOptions<TData extends RowData> = {
   // ) => RowModel<TData>
 }
 
-export type RowSelectionRow = {
+export interface RowSelectionRow {
   getIsSelected: () => boolean
   getIsSomeSelected: () => boolean
   getIsAllSubRowsSelected: () => boolean
@@ -37,7 +37,7 @@ export type RowSelectionRow = {
   getToggleSelectedHandler: () => (event: unknown) => void
 }
 
-export type RowSelectionInstance<TData extends RowData> = {
+export interface RowSelectionInstance<TData extends RowData> {
   getToggleAllRowsSelectedHandler: () => (event: unknown) => void
   getToggleAllPageRowsSelectedHandler: () => (event: unknown) => void
   setRowSelection: (updater: Updater<RowSelectionState>) => void

--- a/packages/table-core/src/features/Sorting.ts
+++ b/packages/table-core/src/features/Sorting.ts
@@ -20,18 +20,18 @@ import { isFunction, makeStateUpdater } from '../utils'
 
 export type SortDirection = 'asc' | 'desc'
 
-export type ColumnSort = {
+export interface ColumnSort {
   id: string
   desc: boolean
 }
 
 export type SortingState = ColumnSort[]
 
-export type SortingTableState = {
+export interface SortingTableState {
   sorting: SortingState
 }
 
-export type SortingFn<TData extends RowData> = {
+export interface SortingFn<TData extends RowData> {
   (rowA: Row<TData>, rowB: Row<TData>, columnId: string): number
 }
 
@@ -46,7 +46,7 @@ export type SortingFnOption<TData extends RowData> =
   | BuiltInSortingFn
   | SortingFn<TData>
 
-export type SortingColumnDef<TData extends RowData> = {
+export interface SortingColumnDef<TData extends RowData> {
   sortingFn?: SortingFnOption<TData>
   sortDescFirst?: boolean
   enableSorting?: boolean
@@ -55,7 +55,7 @@ export type SortingColumnDef<TData extends RowData> = {
   sortUndefined?: false | -1 | 1
 }
 
-export type SortingColumn<TData extends RowData> = {
+export interface SortingColumn<TData extends RowData> {
   getAutoSortingFn: () => SortingFn<TData>
   getAutoSortDir: () => SortDirection
   getSortingFn: () => SortingFn<TData>
@@ -70,7 +70,7 @@ export type SortingColumn<TData extends RowData> = {
   getToggleSortingHandler: () => undefined | ((event: unknown) => void)
 }
 
-export type SortingOptions<TData extends RowData> = {
+interface SortingOptionsBase {
   manualSorting?: boolean
   onSortingChange?: OnChangeFn<SortingState>
   enableSorting?: boolean
@@ -81,15 +81,21 @@ export type SortingOptions<TData extends RowData> = {
   getSortedRowModel?: (table: Table<any>) => () => RowModel<any>
   maxMultiSortColCount?: number
   isMultiSortEvent?: (e: unknown) => boolean
-} & (keyof SortingFns extends never
+}
+
+type ResolvedSortingFns = keyof SortingFns extends never
   ? {
       sortingFns?: Record<string, SortingFn<any>>
     }
   : {
       sortingFns: Record<keyof SortingFns, SortingFn<any>>
-    })
+    }
 
-export type SortingInstance<TData extends RowData> = {
+export interface SortingOptions<TData extends RowData>
+  extends SortingOptionsBase,
+    ResolvedSortingFns {}
+
+export interface SortingInstance<TData extends RowData> {
   setSorting: (updater: Updater<SortingState>) => void
   resetSorting: (defaultState?: boolean) => void
   getPreSortedRowModel: () => RowModel<TData>

--- a/packages/table-core/src/features/Visibility.ts
+++ b/packages/table-core/src/features/Visibility.ts
@@ -12,20 +12,20 @@ import { makeStateUpdater, memo } from '../utils'
 
 export type VisibilityState = Record<string, boolean>
 
-export type VisibilityTableState = {
+export interface VisibilityTableState {
   columnVisibility: VisibilityState
 }
 
-export type VisibilityOptions = {
+export interface VisibilityOptions {
   onColumnVisibilityChange?: OnChangeFn<VisibilityState>
   enableHiding?: boolean
 }
 
-export type VisibilityDefaultOptions = {
+export interface VisibilityDefaultOptions {
   onColumnVisibilityChange: OnChangeFn<VisibilityState>
 }
 
-export type VisibilityInstance<TData extends RowData> = {
+export interface VisibilityInstance<TData extends RowData> {
   getVisibleFlatColumns: () => Column<TData, unknown>[]
   getVisibleLeafColumns: () => Column<TData, unknown>[]
   getLeftVisibleLeafColumns: () => Column<TData, unknown>[]
@@ -39,16 +39,16 @@ export type VisibilityInstance<TData extends RowData> = {
   getToggleAllColumnsVisibilityHandler: () => (event: unknown) => void
 }
 
-export type VisibilityColumnDef = {
+export interface VisibilityColumnDef {
   enableHiding?: boolean
 }
 
-export type VisibilityRow<TData extends RowData> = {
+export interface VisibilityRow<TData extends RowData> {
   _getAllVisibleCells: () => Cell<TData, unknown>[]
   getVisibleCells: () => Cell<TData, unknown>[]
 }
 
-export type VisibilityColumn = {
+export interface VisibilityColumn {
   getCanHide: () => boolean
   getIsVisible: () => boolean
   toggleVisibility: (value?: boolean) => void

--- a/packages/table-core/src/types.ts
+++ b/packages/table-core/src/types.ts
@@ -27,7 +27,6 @@ import {
   HeadersInstance,
 } from './core/headers'
 import {
-  FilterFn,
   FiltersColumn,
   FiltersColumnDef,
   FiltersInstance,
@@ -43,7 +42,6 @@ import {
   SortingTableState,
 } from './features/Sorting'
 import {
-  CustomAggregationFns,
   GroupingCell,
   GroupingColumn,
   GroupingColumnDef,
@@ -79,15 +77,20 @@ import {
   RowSelectionTableState,
 } from './features/RowSelection'
 import { CoreRow } from './core/row'
-import { DeepKeys, PartialKeys, UnionToIntersection } from './utils'
+import { PartialKeys, UnionToIntersection } from './utils'
 import { CellContext, CoreCell } from './core/cell'
 import { CoreColumn } from './core/column'
 
 export interface TableMeta<TData extends RowData> {}
+
 export interface ColumnMeta<TData extends RowData, TValue> {}
+
 export interface FilterMeta {}
+
 export interface FilterFns {}
+
 export interface SortingFns {}
+
 export interface AggregationFns {}
 
 export type Updater<T> = T | ((old: T) => T)
@@ -97,71 +100,79 @@ export type RowData = unknown | object | any[]
 
 export type AnyRender = (Comp: any, props: any) => any
 
-export type Table<TData extends RowData> = CoreInstance<TData> &
-  HeadersInstance<TData> &
-  VisibilityInstance<TData> &
-  ColumnOrderInstance<TData> &
-  ColumnPinningInstance<TData> &
-  FiltersInstance<TData> &
-  SortingInstance<TData> &
-  GroupingInstance<TData> &
-  ColumnSizingInstance &
-  ExpandedInstance<TData> &
-  PaginationInstance<TData> &
-  RowSelectionInstance<TData>
+export interface Table<TData extends RowData>
+  extends CoreInstance<TData>,
+    HeadersInstance<TData>,
+    VisibilityInstance<TData>,
+    ColumnOrderInstance<TData>,
+    ColumnPinningInstance<TData>,
+    FiltersInstance<TData>,
+    SortingInstance<TData>,
+    GroupingInstance<TData>,
+    ColumnSizingInstance,
+    ExpandedInstance<TData>,
+    PaginationInstance<TData>,
+    RowSelectionInstance<TData> {}
+
+interface FeatureOptions<TData extends RowData>
+  extends VisibilityOptions,
+    ColumnOrderOptions,
+    ColumnPinningOptions,
+    FiltersOptions<TData>,
+    SortingOptions<TData>,
+    GroupingOptions,
+    ExpandedOptions<TData>,
+    ColumnSizingOptions,
+    PaginationOptions,
+    RowSelectionOptions<TData> {}
 
 export type TableOptionsResolved<TData extends RowData> = CoreOptions<TData> &
-  VisibilityOptions &
-  ColumnOrderOptions &
-  ColumnPinningOptions &
-  FiltersOptions<TData> &
-  SortingOptions<TData> &
-  GroupingOptions &
-  ExpandedOptions<TData> &
-  ColumnSizingOptions &
-  PaginationOptions &
-  RowSelectionOptions<TData>
+  FeatureOptions<TData>
 
-export type TableOptions<TData extends RowData> = PartialKeys<
-  TableOptionsResolved<TData>,
-  'state' | 'onStateChange' | 'renderFallbackValue'
->
+export interface TableOptions<TData extends RowData>
+  extends PartialKeys<
+    TableOptionsResolved<TData>,
+    'state' | 'onStateChange' | 'renderFallbackValue'
+  > {}
 
-export type TableState = CoreTableState &
-  VisibilityTableState &
-  ColumnOrderTableState &
-  ColumnPinningTableState &
-  FiltersTableState &
-  SortingTableState &
-  ExpandedTableState &
-  GroupingTableState &
-  ColumnSizingTableState &
-  PaginationTableState &
-  RowSelectionTableState
+export interface TableState
+  extends CoreTableState,
+    VisibilityTableState,
+    ColumnOrderTableState,
+    ColumnPinningTableState,
+    FiltersTableState,
+    SortingTableState,
+    ExpandedTableState,
+    GroupingTableState,
+    ColumnSizingTableState,
+    PaginationTableState,
+    RowSelectionTableState {}
 
-export type InitialTableState = Partial<
-  CoreTableState &
-    VisibilityTableState &
-    ColumnOrderTableState &
-    ColumnPinningTableState &
-    FiltersTableState &
-    SortingTableState &
-    ExpandedTableState &
-    GroupingTableState &
-    ColumnSizingTableState &
-    PaginationInitialTableState &
-    RowSelectionTableState
->
+interface CompleteInitialTableState
+  extends CoreTableState,
+    VisibilityTableState,
+    ColumnOrderTableState,
+    ColumnPinningTableState,
+    FiltersTableState,
+    SortingTableState,
+    ExpandedTableState,
+    GroupingTableState,
+    ColumnSizingTableState,
+    PaginationInitialTableState,
+    RowSelectionTableState {}
 
-export type Row<TData extends RowData> = CoreRow<TData> &
-  VisibilityRow<TData> &
-  ColumnPinningRow<TData> &
-  FiltersRow<TData> &
-  GroupingRow &
-  RowSelectionRow &
-  ExpandedRow
+export interface InitialTableState extends Partial<CompleteInitialTableState> {}
 
-export type RowModel<TData extends RowData> = {
+export interface Row<TData extends RowData>
+  extends CoreRow<TData>,
+    VisibilityRow<TData>,
+    ColumnPinningRow<TData>,
+    FiltersRow<TData>,
+    GroupingRow,
+    RowSelectionRow,
+    ExpandedRow {}
+
+export interface RowModel<TData extends RowData> {
   rows: Row<TData>[]
   flatRows: Row<TData>[]
   rowsById: Record<string, Row<TData>>
@@ -180,12 +191,12 @@ export type StringOrTemplateHeader<TData, TValue> =
   | string
   | ColumnDefTemplate<HeaderContext<TData, TValue>>
 
-type StringHeaderIdentifier = {
+interface StringHeaderIdentifier {
   header: string
   id?: string
 }
 
-type IdIdentifier<TData extends RowData, TValue> = {
+interface IdIdentifier<TData extends RowData, TValue> {
   id: string
   header?: StringOrTemplateHeader<TData, TValue>
 }
@@ -196,23 +207,25 @@ type ColumnIdentifiers<TData extends RowData, TValue> =
 
 //
 
-export type ColumnDefBase<TData extends RowData, TValue = unknown> = {
+interface ColumnDefExtensions<TData extends RowData, TValue = unknown>
+  extends VisibilityColumnDef,
+    ColumnPinningColumnDef,
+    FiltersColumnDef<TData>,
+    SortingColumnDef<TData>,
+    GroupingColumnDef<TData, TValue>,
+    ColumnSizingColumnDef {}
+
+export interface ColumnDefBase<TData extends RowData, TValue = unknown>
+  extends ColumnDefExtensions<TData, TValue> {
   footer?: ColumnDefTemplate<HeaderContext<TData, TValue>>
   cell?: ColumnDefTemplate<CellContext<TData, TValue>>
   meta?: ColumnMeta<TData, TValue>
-} & VisibilityColumnDef &
-  ColumnPinningColumnDef &
-  FiltersColumnDef<TData> &
-  SortingColumnDef<TData> &
-  GroupingColumnDef<TData, TValue> &
-  ColumnSizingColumnDef
+}
 
 //
 
-export type IdentifiedColumnDef<
-  TData extends RowData,
-  TValue = unknown
-> = ColumnDefBase<TData, TValue> & {
+export interface IdentifiedColumnDef<TData extends RowData, TValue = unknown>
+  extends ColumnDefBase<TData, TValue> {
   id?: string
   header?: StringOrTemplateHeader<TData, TValue>
 }
@@ -222,28 +235,37 @@ export type DisplayColumnDef<
   TValue = unknown
 > = ColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
 
+interface GroupColumnDefBase<TData extends RowData, TValue = unknown>
+  extends ColumnDefBase<TData, TValue> {
+  columns?: ColumnDef<TData, any>[]
+}
+
 export type GroupColumnDef<
   TData extends RowData,
   TValue = unknown
-> = ColumnDefBase<TData, TValue> &
-  ColumnIdentifiers<TData, TValue> & {
-    columns?: ColumnDef<TData, any>[]
-  }
+> = GroupColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
+
+interface AccessorFnColumnDefBase<TData extends RowData, TValue = unknown>
+  extends ColumnDefBase<TData, TValue> {
+  accessorFn: AccessorFn<TData, TValue>
+}
 
 export type AccessorFnColumnDef<
   TData extends RowData,
   TValue = unknown
-> = ColumnDefBase<TData, TValue> &
-  ColumnIdentifiers<TData, TValue> & {
-    accessorFn: AccessorFn<TData, TValue>
-  }
+> = AccessorFnColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
 
-export type AccessorKeyColumnDef<TData extends RowData, TValue = unknown> = {
+interface AccessorKeyColumnDefBase<TData extends RowData, TValue = unknown>
+  extends ColumnDefBase<TData, TValue> {
   id?: string
-} & Partial<ColumnIdentifiers<TData, TValue>> &
-  ColumnDefBase<TData, TValue> & {
-    accessorKey: string | keyof TData
-  }
+  accessorKey: string | keyof TData
+}
+
+export type AccessorKeyColumnDef<
+  TData extends RowData,
+  TValue = unknown
+> = AccessorKeyColumnDefBase<TData, TValue> &
+  Partial<ColumnIdentifiers<TData, TValue>>
 
 export type AccessorColumnDef<TData extends RowData, TValue = unknown> =
   | AccessorKeyColumnDef<TData, TValue>
@@ -263,21 +285,22 @@ export type ColumnDefResolved<
   accessorKey?: string
 }
 
-export type Column<TData extends RowData, TValue = unknown> = CoreColumn<
-  TData,
-  TValue
-> &
-  ColumnVisibilityColumn &
-  ColumnPinningColumn &
-  FiltersColumn<TData> &
-  SortingColumn<TData> &
-  GroupingColumn<TData> &
-  ColumnSizingColumn
+export interface Column<TData extends RowData, TValue = unknown>
+  extends CoreColumn<TData, TValue>,
+    ColumnVisibilityColumn,
+    ColumnPinningColumn,
+    FiltersColumn<TData>,
+    SortingColumn<TData>,
+    GroupingColumn<TData>,
+    ColumnSizingColumn {}
 
-export type Cell<TData extends RowData, TValue> = CoreCell<TData, TValue> &
-  GroupingCell
+export interface Cell<TData extends RowData, TValue>
+  extends CoreCell<TData, TValue>,
+    GroupingCell {}
 
-export type Header<TData extends RowData, TValue> = CoreHeader<TData, TValue> &
-  ColumnSizingHeader
+export interface Header<TData extends RowData, TValue>
+  extends CoreHeader<TData, TValue>,
+    ColumnSizingHeader {}
 
-export type HeaderGroup<TData extends RowData> = CoreHeaderGroup<TData>
+export interface HeaderGroup<TData extends RowData>
+  extends CoreHeaderGroup<TData> {}

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -23,6 +23,7 @@ export type DeepValue<T, TProp> = T extends IndexableData
     ? DeepValue<T[TBranch], TDeepProp>
     : TProp extends keyof T ? T[TProp] : never
   : never
+export type PropertyPath<T extends IndexableData, TProp> = DeepValue<T, TProp> extends never ? never : TProp;
 
 export type NoInfer<T> = [T][T extends any ? 0 : never]
 

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -17,10 +17,11 @@ export type UnionToIntersection<T> = (
 export type IsAny<T, Y, N> = 1 extends 0 & T ? Y : N
 export type IsKnown<T, Y, N> = unknown extends T ? N : Y
 
-export type DeepValue<T, TProp> = T extends Record<string | number, any>
+type IndexableData = Record<string | number, any>;
+export type DeepValue<T, TProp> = T extends IndexableData
   ? TProp extends `${infer TBranch}.${infer TDeepProp}`
     ? DeepValue<T[TBranch], TDeepProp>
-    : T[TProp & string]
+    : TProp extends keyof T ? T[TProp] : never
   : never
 
 export type NoInfer<T> = [T][T extends any ? 0 : never]

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -23,7 +23,7 @@ export type DeepValue<T, TProp> = T extends IndexableData
     ? DeepValue<T[TBranch], TDeepProp>
     : TProp extends keyof T ? T[TProp] : never
   : never
-export type PropertyPath<T extends IndexableData, TProp> = DeepValue<T, TProp> extends never ? never : TProp;
+export type HasProperty<T extends IndexableData, TProp> = DeepValue<T, TProp> extends never ? never : TProp;
 
 export type NoInfer<T> = [T][T extends any ? 0 : never]
 

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -1,8 +1,7 @@
 import { TableState, Updater } from './types'
 
-export type PartialKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
-export type RequiredKeys<T, K extends keyof T> = Omit<T, K> &
-  Required<Pick<T, K>>
+export type PartialKeys<T, K extends keyof T> = Omit<T, K> & Partial<T>
+export type RequiredKeys<T, K extends keyof T> = T & { [P in K]-?: T[P] }
 export type Overwrite<T, U extends { [TKey in keyof T]?: any }> = Omit<
   T,
   keyof U

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -17,49 +17,6 @@ export type UnionToIntersection<T> = (
 export type IsAny<T, Y, N> = 1 extends 0 & T ? Y : N
 export type IsKnown<T, Y, N> = unknown extends T ? N : Y
 
-type ComputeRange<
-  N extends number,
-  Result extends Array<unknown> = []
-> = Result['length'] extends N
-  ? Result
-  : ComputeRange<N, [...Result, Result['length']]>
-type Index40 = ComputeRange<40>[number]
-
-// Is this type a tuple?
-type IsTuple<T> = T extends readonly any[] & { length: infer Length }
-  ? Length extends Index40
-    ? T
-    : never
-  : never
-
-// If this type is a tuple, what indices are allowed?
-type AllowedIndexes<
-  Tuple extends ReadonlyArray<any>,
-  Keys extends number = never
-> = Tuple extends readonly []
-  ? Keys
-  : Tuple extends readonly [infer _, ...infer Tail]
-  ? AllowedIndexes<Tail, Keys | Tail['length']>
-  : Keys
-
-export type DeepKeys<T> = unknown extends T
-  ? keyof T
-  : object extends T
-  ? string
-  : T extends readonly any[] & IsTuple<T>
-  ? AllowedIndexes<T> | DeepKeysPrefix<T, AllowedIndexes<T>>
-  : T extends any[]
-  ? never & 'Dynamic length array indexing is not supported'
-  : T extends Date
-  ? never
-  : T extends object
-  ? (keyof T & string) | DeepKeysPrefix<T, keyof T>
-  : never
-
-type DeepKeysPrefix<T, TPrefix> = TPrefix extends keyof T & (number | string)
-  ? `${TPrefix}.${DeepKeys<T[TPrefix]> & string}`
-  : never
-
 export type DeepValue<T, TProp> = T extends Record<string | number, any>
   ? TProp extends `${infer TBranch}.${infer TDeepProp}`
     ? DeepValue<T[TBranch], TDeepProp>

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -17,13 +17,68 @@ export type UnionToIntersection<T> = (
 export type IsAny<T, Y, N> = 1 extends 0 & T ? Y : N
 export type IsKnown<T, Y, N> = unknown extends T ? N : Y
 
-type IndexableData = Record<string | number, any>;
+type IndexableData = Record<string | number, any>
 export type DeepValue<T, TProp> = T extends IndexableData
   ? TProp extends `${infer TBranch}.${infer TDeepProp}`
     ? DeepValue<T[TBranch], TDeepProp>
-    : TProp extends keyof T ? T[TProp] : never
+    : TProp extends keyof T
+    ? T[TProp]
+    : never
   : never
-export type HasProperty<T extends IndexableData, TProp> = DeepValue<T, TProp> extends never ? never : TProp;
+
+type Join<K, P> = K extends string | number
+  ? P extends string | number
+    ? `${K}${'' extends P ? '' : '.'}${P}`
+    : never
+  : never
+
+type Prev = [
+  never,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  ...0[]
+]
+
+type ExplicitLeaves =
+  | Date
+  | Number
+  | BigInt
+  | String
+  | Set<unknown>
+  | Map<unknown, unknown>
+  | WeakSet<object>
+  | WeakMap<object, unknown>
+
+export type DeepKeys<T, D extends number = 10> = [D] extends [never]
+  ? never
+  : T extends ExplicitLeaves
+  ? never
+  : T extends object
+  ? {
+      [K in keyof T]-?: K extends string | number
+        ? `${K}` | Join<K, DeepKeys<T[K], Prev[D]>>
+        : never
+    }[keyof T]
+  : ''
 
 export type NoInfer<T> = [T][T extends any ? 0 : never]
 


### PR DESCRIPTION
This PR optimises TypeScript types, following [Microsoft's Writing Easy-to-Compile Code](https://github.com/microsoft/TypeScript/wiki/Performance#writing-easy-to-compile-code) section of the TypeScript wiki.

After migrating to version 8, I encountered severe performance degradation in a file with 100+ column definitions, to the point that TS type checking and autocomplete ceased to function in the editor. I believe IntelliJ uses the standard TypeScript language server, so these issues may also crop up in other editors.

The changes in this PR have resolved the issues I was having. Most of the work in this PR migrates from `type` to `interface` based type definitions, but there are a few smaller optimisations as well. The aforementioned link to the TS wiki details the benefits of using `interface` when possible.

## Results
These trace excerpts were generated with `tsc --generateTrace my_trace && npx analyze-trace my_trace/ --forceMillis 100 --skipMillis 50 --color`.

**Before:**
`Check file <path>/column-definitions.tsx (394ms)`

**After:**
`Check file <path>/column-definitions.tsx (287ms)`