### PR TITLE
docs: Remove extra typing for Column Defs

### DIFF
--- a/docs/guide/column-defs.md
+++ b/docs/guide/column-defs.md
@@ -46,7 +46,7 @@ type Person = {
 const columnHelper = createColumnHelper<Person>()
 
 // Make some columns!
-const defaultColumns: ColumnDef<Person>[] = [
+const defaultColumns = [
   // Display Column
   columnHelper.display({
     id: 'actions',


### PR DESCRIPTION
When using an `accessor` type column helper in a top level column defs array where the array is also typed, you get the type error brought up #4382. It was also mentioned that the solution here is to not type the array, so this PR removes the typing from the example in the docs.