### PR TITLE
Update table.md

### DIFF
--- a/docs/api/core/table.md
+++ b/docs/api/core/table.md
@@ -26,7 +26,7 @@ The data for the table to display. This is array should match the type you provi
 
 When the `data` option changes reference (compared via `Object.is`), the table will reprocess the data. Any other data processing that relies on the core data model (such as grouping, sorting, filtering, etc) will also be reprocessed.
 
-> 🧠 Make sure your `data` option is only changing when you want the table to reprocess. Providing an inline `[]` or construction the data array as a new object every time you want to render the table will result in a _lot_ of unnecessary re-processing. This can easily go unnoticed in smaller tables, but you will likely notice it in larger tables.
+> 🧠 Make sure your `data` option is only changing when you want the table to reprocess. Providing an inline `[]` or constructing the data array as a new object every time you want to render the table will result in a _lot_ of unnecessary re-processing. This can easily go unnoticed in smaller tables, but you will likely notice it in larger tables.
 
 ### `columns`
 


### PR DESCRIPTION
just a  tiny typo but can really help with understanding
> 🧠 Make sure your `data` option is only changing when you want the table to reprocess. Providing an inline `[]` or **constructing** the data array as a new object every time you want to render the table will result in a _lot_ of unnecessary re-processing. This can easily go unnoticed in smaller tables, but you will likely notice it in larger tables.
was construction ==> should  be ..."or constructi*ng* the data array"