### PR TITLE
Update useSortBy.js

### DIFF
--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -38,7 +38,7 @@ const defaultGetSortByToggleProps = (props, { instance, column }) => {
     {
       onClick: column.canSort
         ? function(e) {
-            if (e.nativeEvent?.currentTarget?.attributes?.title?.value === this.title) {
+            if (e.nativeEvent?.target?.attributes?.title?.value === this.title) {
               e.persist()
               column.toggleSortBy(
                 undefined,

--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -37,12 +37,14 @@ const defaultGetSortByToggleProps = (props, { instance, column }) => {
     props,
     {
       onClick: column.canSort
-        ? e => {
-            e.persist()
-            column.toggleSortBy(
-              undefined,
-              !instance.disableMultiSort && isMultiSortEvent(e)
-            )
+        ? function(e) {
+            if (e.nativeEvent?.currentTarget?.attributes?.title?.value === this.title) {
+              e.persist()
+              column.toggleSortBy(
+                undefined,
+                !instance.disableMultiSort && isMultiSortEvent(e)
+              )
+            }
           }
         : undefined,
       style: {


### PR DESCRIPTION
Fixes issue where using `useResizableColumns` in conjunction with `useSortyBy` triggers a sort when resizing columns.