### PR TITLE
fix(types): correctly set type for `AccessorKeyColumnDef#accessorKey`

### DIFF
--- a/packages/table-core/src/types.ts
+++ b/packages/table-core/src/types.ts
@@ -259,7 +259,7 @@ export type AccessorFnColumnDef<
 interface AccessorKeyColumnDefBase<TData extends RowData, TValue = unknown>
   extends ColumnDefBase<TData, TValue> {
   id?: string
-  accessorKey: string | keyof TData
+  accessorKey: (string & {}) | keyof TData
 }
 
 export type AccessorKeyColumnDef<


### PR DESCRIPTION
**This PR includes:**

Sets the correct type for `AccessorKeyColumnDef#accessorKey`. Currently with out this PR it doesn't give the correct auto complete, with this fix it does. 