### PR TITLE
make unit test time limit more lenient

### DIFF
--- a/packages/table-core/__tests__/getGroupedRowModel.test.ts
+++ b/packages/table-core/__tests__/getGroupedRowModel.test.ts
@@ -17,7 +17,7 @@ function generateColumns(people: Person[]): PersonColumn[] {
 }
 
 describe('#getGroupedRowModel', () => {
-  it('groups 50k rows and 3 grouped columns with clustered data in less than 2 seconds', () => {
+  it('groups 50k rows and 3 grouped columns with clustered data in less than 3 seconds', () => {
     const data = makeData(50000);
     const columns = generateColumns(data);
     const grouping = ['firstName', 'lastName', 'age'];
@@ -42,6 +42,6 @@ describe('#getGroupedRowModel', () => {
     expect(groupedById['firstName:Fixed'].leafRows.length).toEqual(50000)
     expect(groupedById['firstName:Fixed>lastName:Name'].leafRows.length).toEqual(50000)
     expect(groupedById['firstName:Fixed>lastName:Name>age:123'].leafRows.length).toEqual(50000)
-    expect(end.valueOf() - start.valueOf()).toBeLessThan(2000);
+    expect(end.valueOf() - start.valueOf()).toBeLessThan(3000);
   });
 })


### PR DESCRIPTION
The previous [github actions pipeline](https://github.com/TanStack/table/actions/runs/3451872738/jobs/5761396109#step:4:319) failed by a margin of 13ms. The unit test should add some margin for when resources are not as strong in the Github pipelines. Increasing margin by 50%.