### PR TITLE
docs(sorting): Clarify enableSortingRemoval effect

### DIFF
--- a/docs/api/features/sorting.md
+++ b/docs/api/features/sorting.md
@@ -284,7 +284,9 @@ Enables/Disables sorting for the table.
 enableSortingRemoval?: boolean
 ```
 
-Enables/Disables the ability to remove sorting for the table.
+Enables/Disables the ability to remove sorting for the table. 
+If `true` then changing sort order will circle like: 'none' -> 'desc' -> 'asc' -> 'none' -> ...
+If `false` then changing sort order will circle like: 'none' -> 'desc' -> 'asc' -> 'desc' -> 'asc' -> ...
 
 ### `enableMultiRemove`
 


### PR DESCRIPTION
I spend quite some time looking for a way to change default behaviour when changing sort order with `getToggleSortingHandler` repeatedly. I've seen this option in docs, but I didn't understand what it does at first, I think this should be clarified a bit more.

Also `true` feels like default behaviour - should that be explicitly said as well?

This is proposed change, but I'm very much open for the wording changes to make it more understandable/clear.