### PR TITLE
Update ColumnDef docs to make extending meta clearer

### DIFF
--- a/docs/api/core/column-def.md
+++ b/docs/api/core/column-def.md
@@ -95,6 +95,8 @@ meta?: ColumnMeta // This interface is extensible via declaration merging. See b
 The meta data to associated with the column. This type is global to all tables and can be extended like so:
 
 ```tsx
+import '@tanstack/react-table';
+
 declare module '@tanstack/table-core' {
   interface ColumnMeta<TData extends RowData, TValue> {
     foo: string


### PR DESCRIPTION
It took me a minute to realise why extending `meta` didn't work. Just thought it might be worth making the example work out of the box.