### PR TITLE
feat: new maxLeafRowFilterDepth filter option

### DIFF
--- a/docs/api/features/filters.md
+++ b/docs/api/features/filters.md
@@ -351,6 +351,16 @@ filterFromLeafRows?: boolean
 
 By default, filtering is done from parent rows down (so if a parent row is filtered out, all of its children will be filtered out as well). Setting this option to `true` will cause filtering to be done from leaf rows up (which means parent rows will be included so long as one of their child or grand-child rows is also included).
 
+### `maxLeafRowFilterDepth`
+
+```tsx
+maxLeafRowFilterDepth?: number
+```
+
+By default, filtering is done for all rows (max depth of 100), no matter if they are root level parent rows or the child leaf rows of a parent row. Setting this option to `0` will cause filtering to only be applied to the root level parent rows, with all sub-rows remaining unfiltered. Similarly, setting this option to `1` will cause filtering to only be applied to child leaf rows 1 level deep, and so on.
+
+This is useful for situations where you want a row's entire child hierarchy to be visible regardless of the applied filter.
+
 ### `enableFilters`
 
 ```tsx

--- a/packages/table-core/src/features/Filters.ts
+++ b/packages/table-core/src/features/Filters.ts
@@ -96,6 +96,7 @@ interface FiltersOptionsBase<TData extends RowData> {
   enableFilters?: boolean
   manualFiltering?: boolean
   filterFromLeafRows?: boolean
+  maxLeafRowFilterDepth?: number
   getFilteredRowModel?: (table: Table<any>) => () => RowModel<any>
 
   // Column
@@ -184,6 +185,7 @@ export const Filters: TableFeature = {
       onColumnFiltersChange: makeStateUpdater('columnFilters', table),
       onGlobalFilterChange: makeStateUpdater('globalFilter', table),
       filterFromLeafRows: false,
+      maxLeafRowFilterDepth: 100,
       globalFilterFn: 'auto',
       getColumnCanGlobalFilter: column => {
         const value = table

--- a/packages/table-core/src/utils/filterRowsUtils.ts
+++ b/packages/table-core/src/utils/filterRowsUtils.ts
@@ -20,6 +20,7 @@ export function filterRowModelFromLeafs<TData extends RowData>(
 ): RowModel<TData> {
   const newFilteredFlatRows: Row<TData>[] = []
   const newFilteredRowsById: Record<string, Row<TData>> = {}
+  const maxDepth = table.options.maxLeafRowFilterDepth ?? 100
 
   const recurseFilterRows = (rowsToFilter: Row<TData>[], depth = 0) => {
     const rows: Row<TData>[] = []
@@ -37,7 +38,7 @@ export function filterRowModelFromLeafs<TData extends RowData>(
       )
       newRow.columnFilters = row.columnFilters
 
-      if (row.subRows?.length) {
+      if (row.subRows?.length && depth < maxDepth) {
         newRow.subRows = recurseFilterRows(row.subRows, depth + 1)
         row = newRow
 
@@ -81,6 +82,7 @@ export function filterRowModelFromRoot<TData extends RowData>(
 ): RowModel<TData> {
   const newFilteredFlatRows: Row<TData>[] = []
   const newFilteredRowsById: Record<string, Row<TData>> = {}
+  const maxDepth = table.options.maxLeafRowFilterDepth ?? 100
 
   // Filters top level and nested rows
   const recurseFilterRows = (rowsToFilter: Row<TData>[], depth = 0) => {
@@ -95,7 +97,7 @@ export function filterRowModelFromRoot<TData extends RowData>(
       const pass = filterRow(row)
 
       if (pass) {
-        if (row.subRows?.length) {
+        if (row.subRows?.length && depth < maxDepth) {
           const newRow = createRow(
             table,
             row.id,


### PR DESCRIPTION
Proposal: new `maxLeafRowFilterDepth` filter option

Problem: Sometimes in grouped or expanded sub-row tables, a user wants to search/filter for a parent row and view all of its child rows. Currently most of those child rows get filtered out, even if using the `filterFromLeafRows` option.

Solution: `maxLeafRowFilterDepth` allows how many levels deep in the row tree that filtering should be applied. A value of `0` here will only apply filters to the root level rows, and so on. Defaults to `100` if not specified to keep current functionality.

maxLeafRowFilterDepth was the 3rd name I settled on for this feature. I originally had it as a boolean called `filterLeafRows`. Could consider a better name.