### PR TITLE
Small documentation fix for defaultColumn type

### DIFF
--- a/docs/api/core/table.md
+++ b/docs/api/core/table.md
@@ -39,7 +39,7 @@ The array of column defs to use for the table.
 ### `defaultColumn`
 
 ```tsx
-defaultColumn?: Partial<ColumnDef<TData>>[]
+defaultColumn?: Partial<ColumnDef<TData>>
 ```
 
 Default column options to use for all column defs supplied to the table. This is useful for providing default cell/header/footer renderers, sorting/filtering/grouping options, etc.


### PR DESCRIPTION
The type for defaultColumn in the documentation is incorrect since it shows an array type.