### PR TITLE
feat: better esm support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,10 +6,13 @@ module.exports = {
   targets: 'defaults, not ie 11, not ie_mob 11',
   presets: [
     [
-      '@babel/env',
+      '@babel/preset-env',
       {
         loose,
         modules: false,
+        include: [
+          "@babel/plugin-proposal-nullish-coalescing-operator",
+        ],
         // exclude: ['@babel/plugin-transform-regenerator'],
       },
     ],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "(is-ci && npm run test:ci) || npm run test:dev",
     "test:ci": "jest",
     "test:dev": "jest --watch",
-    "build": "rollup --config rollup.config.js",
+    "build": "rollup --config rollup.config.js && npm run typecheck",
     "watch": "concurrently --kill-others \"rollup --config rollup.config.js -w\" \"tsc -b --watch\"",
     "linkAll": "lerna exec 'npm link' --parallel",
     "unlinkAll": "lerna exec 'npm unlink' --parallel",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.17.9",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",

--- a/packages/match-sorter-utils/package.json
+++ b/packages/match-sorter-utils/package.json
@@ -28,16 +28,24 @@
     "type": "github",
     "url": "https://github.com/sponsors/kentcdodds"
   },
-  "module": "build/esm/index.js",
-  "main": "build/cjs/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/types/index.d.ts",
+  "module": "build/lib/index.esm.js",
+  "main": "build/lib/index.js",
+  "types": "build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.mjs",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=12"
   },
   "files": [
-    "build/**",
+    "build/lib/*",
+    "build/umd/*",
     "src"
   ],
   "dependencies": {

--- a/packages/match-sorter-utils/tsconfig.json
+++ b/packages/match-sorter-utils/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "composite": true,
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/types"
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./build/lib",
+    "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
-  "files": ["src/index.ts"],
-  "include": [
-    "src"
-    //  "__tests__/**/*.test.*"
-  ]
+  "include": ["src"]
 }

--- a/packages/react-table-devtools/package.json
+++ b/packages/react-table-devtools/package.json
@@ -22,16 +22,24 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
-  "module": "build/esm/index.js",
-  "main": "build/cjs/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/types/index.d.ts",
+  "module": "build/lib/index.esm.js",
+  "main": "build/lib/index.js",
+  "types": "build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.mjs",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=12"
   },
   "files": [
-    "build/**",
+    "build/lib/*",
+    "build/umd/*",
     "src"
   ],
   "peerDependencies": {

--- a/packages/react-table-devtools/tsconfig.json
+++ b/packages/react-table-devtools/tsconfig.json
@@ -1,12 +1,13 @@
 {
-  "composite": true,
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/types"
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./build/lib",
+    "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
-  "files": ["src/index.tsx"],
-  "include": [
-    "src"
-    // "__tests__/**/*.test.*"
+  "include": ["src"],
+  "references": [
+    { "path": "../react-table" }
   ]
 }

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -22,16 +22,24 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
-  "module": "build/esm/index.js",
-  "main": "build/cjs/react-table/src/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/types/index.d.ts",
+  "module": "build/lib/index.esm.js",
+  "main": "build/lib/index.js",
+  "types": "build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.mjs",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=12"
   },
   "files": [
-    "build/**",
+    "build/lib/*",
+    "build/umd/*",
     "src"
   ],
   "dependencies": {

--- a/packages/react-table/tsconfig.json
+++ b/packages/react-table/tsconfig.json
@@ -1,12 +1,13 @@
 {
-  "composite": true,
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/types"
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./build/lib",
+    "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
-  "files": ["src/index.tsx"],
-  "include": [
-    "src"
-    //  "__tests__/**/*.test.*"
+  "include": ["src"],
+  "references": [
+    { "path": "../table-core" }
   ]
 }

--- a/packages/solid-table/package.json
+++ b/packages/solid-table/package.json
@@ -22,16 +22,24 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
-  "module": "build/esm/index.js",
-  "main": "build/cjs/solid-table/src/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/types/index.d.ts",
+  "module": "build/lib/index.esm.js",
+  "main": "build/lib/index.js",
+  "types": "build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.mjs",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=12"
   },
   "files": [
-    "build/**",
+    "build/lib/*",
+    "build/umd/*",
     "src"
   ],
   "dependencies": {

--- a/packages/solid-table/tsconfig.json
+++ b/packages/solid-table/tsconfig.json
@@ -1,12 +1,13 @@
 {
-  "composite": true,
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/types"
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./build/lib",
+    "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
-  "files": ["src/index.tsx"],
-  "include": [
-    "src"
-    //  "__tests__/**/*.test.*"
+  "include": ["src"],
+  "references": [
+    { "path": "../table-core" }
   ]
 }

--- a/packages/svelte-table/package.json
+++ b/packages/svelte-table/package.json
@@ -22,15 +22,23 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
-  "module": "build/esm/index.js",
-  "main": "build/cjs/svelte-table/src/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/types/index.d.ts",
+  "module": "build/lib/index.esm.js",
+  "main": "build/lib/index.js",
+  "types": "build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.mjs",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "engines": {
     "node": ">=12"
   },
   "files": [
-    "build/**",
+    "build/lib/*",
+    "build/umd/*",
     "src"
   ],
   "dependencies": {

--- a/packages/svelte-table/tsconfig.json
+++ b/packages/svelte-table/tsconfig.json
@@ -1,15 +1,13 @@
 {
-  "composite": true,
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/types",
-    "sourceMap": true
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./build/lib",
+    "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
-  "files": [
-    "src/index.ts"
-  ],
-  "include": [
-    "src"
-    //  "__tests__/**/*.test.*"
+  "include": ["src"],
+  "references": [
+    { "path": "../table-core" }
   ]
 }

--- a/packages/table-core/package.json
+++ b/packages/table-core/package.json
@@ -24,16 +24,24 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
-  "module": "build/esm/index.js",
-  "main": "build/cjs/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/types/index.d.ts",
+  "module": "build/lib/index.esm.js",
+  "main": "build/lib/index.js",
+  "types": "build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.mjs",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=12"
   },
   "files": [
-    "build/**",
+    "build/lib/*",
+    "build/umd/*",
     "src"
   ]
 }

--- a/packages/table-core/src/features/Filters.ts
+++ b/packages/table-core/src/features/Filters.ts
@@ -193,7 +193,7 @@ export const Filters: TableFeature = {
 
         return typeof value === 'string' || typeof value === 'number'
       },
-    }
+    } as FiltersOptions<TData>
   },
 
   createColumn: <TData extends RowData>(
@@ -233,6 +233,7 @@ export const Filters: TableFeature = {
           ? column.columnDef.filterFn
           : column.columnDef.filterFn === 'auto'
           ? column.getAutoFilterFn()
+          // @ts-ignore
           : table.options.filterFns?.[column.columnDef.filterFn as string] ??
             filterFns[column.columnDef.filterFn as BuiltInFilterFn]
       },
@@ -365,6 +366,7 @@ export const Filters: TableFeature = {
           ? globalFilterFn
           : globalFilterFn === 'auto'
           ? table.getGlobalAutoFilterFn()
+          // @ts-ignore
           : table.options.filterFns?.[globalFilterFn as string] ??
             filterFns[globalFilterFn as BuiltInFilterFn]
       },

--- a/packages/table-core/tsconfig.json
+++ b/packages/table-core/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "composite": true,
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/types"
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./build/lib",
+    "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
-  "files": ["src/index.ts"],
-  "include": [
-    "src"
-    //  "__tests__/**/*.test.*"
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/vue-table/package.json
+++ b/packages/vue-table/package.json
@@ -22,16 +22,24 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
-  "module": "build/esm/index.js",
-  "main": "build/cjs/vue-table/src/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/types/index.d.ts",
+  "module": "build/lib/index.esm.js",
+  "main": "build/lib/index.js",
+  "types": "build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.mjs",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=12"
   },
   "files": [
-    "build/**",
+    "build/lib/*",
+    "build/umd/*",
     "src"
   ],
   "dependencies": {

--- a/packages/vue-table/tsconfig.json
+++ b/packages/vue-table/tsconfig.json
@@ -1,12 +1,13 @@
 {
-  "composite": true,
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./build/types"
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./build/lib",
+    "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
-  "files": ["src/index.ts"],
-  "include": [
-    "src"
-    //  "__tests__/**/*.test.*"
+  "include": ["src"],
+  "references": [
+    { "path": "../table-core" }
   ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,19 +9,19 @@
     "noUncheckedIndexedAccess": true,
     "strictNullChecks": true,
     "jsx": "react",
-    "declaration": false,
-    "noEmit": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@tanstack/table-core": ["packages/table-core"],
-      "@tanstack/react-table": ["packages/react-table"],
-      "@tanstack/solid-table": ["packages/solid-table"],
-      "@tanstack/vue-table": ["packages/vue-table"],
-      "@tanstack/svelte-table": ["packages/svelte-table"],
-      "@tanstack/react-table-devtools": ["packages/react-table-devtools"],
-      "@tanstack/match-sorter-utils": ["packages/match-sorter-utils"]
+      "@tanstack/table-core": ["packages/table-core/src"],
+      "@tanstack/react-table": ["packages/react-table/src"],
+      "@tanstack/solid-table": ["packages/solid-table/src"],
+      "@tanstack/vue-table": ["packages/vue-table/src"],
+      "@tanstack/svelte-table": ["packages/svelte-table/src"],
+      "@tanstack/react-table-devtools": ["packages/react-table-devtools/src"],
+      "@tanstack/match-sorter-utils": ["packages/match-sorter-utils/src"]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,6 +2547,11 @@
   dependencies:
     "@tanstack/table-core" "8.5.28"
 
+"@tanstack/table-core@8.5.28":
+  version "8.5.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.5.28.tgz#c6f33413cce2688d7578696d8599b1067e61218b"
+  integrity sha512-DTK/OdF6b+tls5/xsa46rbav16oXq7Sb3oKWAVuAkjc0VwQxR+afT8GWmAwemfLGUDIF/4qQOTjVQk0eG2b54g==
+
 "@testing-library/dom@^8.0.0":
   version "8.19.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.19.0.tgz#bd3f83c217ebac16694329e413d9ad5fdcfd785f"


### PR DESCRIPTION
This PR should bring better ESM support for both older and newer bundlers.
I tried to replicate the setup that we have in https://github.com/TanStack/query.

There are few typescript issues in `packages/table-core/src/features/Filters.ts`

It would be ideal if people using different adapters could test this before integrationg to main branch.