### PR TITLE
fix: do not check for `browser` in package.json

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -361,7 +361,7 @@ async function run() {
       )
 
       await Promise.all(
-        (['module', 'main', 'browser', 'types'] as const).map(
+        (['module', 'main', 'types'] as const).map(
           async entryKey => {
             const entry = pkgJson[entryKey] as string
 


### PR DESCRIPTION
@KevinVandy Small fix to stop requiring `browser` field in `package.json` during deploy as it's breaking older webpack versions.