### PR TITLE
Fix hooks error in default column cell renderer

### DIFF
--- a/examples/react/editable-data/src/main.tsx
+++ b/examples/react/editable-data/src/main.tsx
@@ -26,7 +26,7 @@ declare module '@tanstack/react-table' {
 
 // Give our default column cell renderer editing superpowers!
 const defaultColumn: Partial<ColumnDef<Person>> = {
-  cell: ({ getValue, row: { index }, column: { id }, table }) => {
+  Cell: ({ getValue, row: { index }, column: { id }, table }) => {
     const initialValue = getValue()
     // We need to keep and update the state of the cell normally
     const [value, setValue] = React.useState(initialValue)
@@ -194,7 +194,7 @@ function App() {
                   return (
                     <td key={cell.id}>
                       {flexRender(
-                        cell.column.columnDef.cell,
+                        cell.column.columnDef.Cell,
                         cell.getContext()
                       )}
                     </td>


### PR DESCRIPTION
React Hooks "useState" && "useEffect" are called in function "cell" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. So I simply capitalized the C to fix this error.