### PR TITLE
Fix: onColumnSizingChange does not return correct value when react.strictmode is not used

### DIFF
--- a/packages/table-core/src/features/ColumnSizing.ts
+++ b/packages/table-core/src/features/ColumnSizing.ts
@@ -218,7 +218,7 @@ export const ColumnSizing: TableFeature = {
             ? Math.round(e.touches[0]!.clientX)
             : (e as MouseEvent).clientX
 
-          let newColumnSizing: ColumnSizingState = {}
+          const newColumnSizing: ColumnSizingState = {}
 
           const updateOffset = (
             eventType: 'move' | 'end',

--- a/packages/table-core/src/features/ColumnSizing.ts
+++ b/packages/table-core/src/features/ColumnSizing.ts
@@ -218,6 +218,8 @@ export const ColumnSizing: TableFeature = {
             ? Math.round(e.touches[0]!.clientX)
             : (e as MouseEvent).clientX
 
+          let newColumnSizing: ColumnSizingState = {}
+
           const updateOffset = (
             eventType: 'move' | 'end',
             clientXPos?: number
@@ -225,8 +227,6 @@ export const ColumnSizing: TableFeature = {
             if (typeof clientXPos !== 'number') {
               return
             }
-
-            let newColumnSizing: ColumnSizingState = {}
 
             table.setColumnSizingInfo(old => {
               const deltaOffset = clientXPos - (old?.startOffset ?? 0)


### PR DESCRIPTION
When onColumnSizingChange is used without react.strictmode / production the function does not return the correct updated values. This breaks the resize feature as discussed in https://github.com/TanStack/table/issues/4479 