### PR TITLE
Render the actual component for svelte when returned from cell function

### DIFF
--- a/packages/svelte-table/src/index.ts
+++ b/packages/svelte-table/src/index.ts
@@ -55,7 +55,7 @@ export function flexRender(component: any, props: any) {
     const result = component(props)
 
     if (isSvelteComponent(result)) {
-      return result
+      return renderComponent(result, props)
     }
 
     return wrapInPlaceholder(result)


### PR DESCRIPTION
Currently the flexRender function checks if the result of `cell` function is a Svelte component, and if it is, it just returns the actual Component instead of rendering the component with the props. This PR fixes this issue