### PR TITLE
fix: throw with error message for `getColumn`

### DIFF
--- a/packages/table-core/src/core/table.ts
+++ b/packages/table-core/src/core/table.ts
@@ -342,7 +342,7 @@ export function createTable<TData extends RowData>(
         if (process.env.NODE_ENV !== 'production') {
           console.warn(`[Table] Column with id ${columnId} does not exist.`)
         }
-        throw new Error()
+        throw new Error(`[Table] Column with id ${columnId} does not exist.`)
       }
 
       return column


### PR DESCRIPTION
This PR includes:

- Throw with error message in prod/dev when a column is not found. This makes it easier to debug.

