### PR TITLE
fix: return a null value for undefined nested keys

### DIFF
--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -52,7 +52,7 @@ export function createColumn<TData extends RowData, TValue>(
         let result = originalRow as Record<string, any>
 
         for (const key of accessorKey.split('.')) {
-          if (!(key in result)) {
+          if (result == null || !(key in result)) {
             if (process.env.NODE_ENV !== 'production') {
               console.warn(
                 `"${key}" in deeply nested key "${accessorKey}" returned undefined.`

--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -53,6 +53,11 @@ export function createColumn<TData extends RowData, TValue>(
 
         for (const key of accessorKey.split('.')) {
           if (!(key in result)) {
+            if (process.env.NODE_ENV !== 'production') {
+              console.warn(
+                `"${key}" in deeply nested key "${accessorKey}" returned undefined.`
+              )
+            }
             return null
           }
 

--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -52,12 +52,11 @@ export function createColumn<TData extends RowData, TValue>(
         let result = originalRow as Record<string, any>
 
         for (const key of accessorKey.split('.')) {
-          result = result[key]
-          if (process.env.NODE_ENV !== 'production' && result === undefined) {
-            throw new Error(
-              `"${key}" in deeply nested key "${accessorKey}" returned undefined.`
-            )
+          if (!(key in result)) {
+            return null
           }
+
+          result = result[key]
         }
 
         return result


### PR DESCRIPTION
Since PR #4407 undefined nested keys throw an error message.
This might be helpful, but does not solve the issue when you have to work with data which looks like

```json
[
  { "firstName": "John", "address": { "street": "Main street 1" } },
  { "firstName": "Jane", "address": null }
]
```

```accessor``` ```address.street``` in this case will throw the error in dev.
(or will break the application later in production in case the data here is not as complete)

So the suggestion from @dennemark in issue #4499 makes sense to me.
This PR will return a ```null``` value, if the nested value does not exist.
Optionally, there could also be a ```console.warn``` statement with what used to be the error message.


Fixes: #4499 