### PR TITLE
Update column-defs.md

### DIFF
--- a/docs/guide/column-defs.md
+++ b/docs/guide/column-defs.md
@@ -12,7 +12,7 @@ Column defs are the single most important part of building a table. They are res
 
 - Building the underlying data model that will be used for everything including sorting, filtering, grouping, etc.
 - Formatting the data model into what will be displayed in the table
-- Creating [header groups, headers and footers](./headers)
+- Creating [header groups](./api/core/header-group), [headers](./api/core/header) and footers(./api/core/column-def#footer)
 - Creating columns for display-only purposes, eg. action buttons, checkboxes, expanders, sparklines, etc.
 
 ## Column Def Types


### PR DESCRIPTION
Current link routes to 404 page. So I propose `header groups`, `headers` and `footers` are seperated and route to each API docs.