### PR TITLE
#4500 - Force babel to transform optional chaining

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,10 @@ module.exports = {
       {
         loose,
         modules: false,
-        include: ['@babel/plugin-proposal-nullish-coalescing-operator'],
+        include: [
+          '@babel/plugin-proposal-nullish-coalescing-operator',
+          '@babel/plugin-proposal-optional-chaining'
+        ],
         // exclude: ['@babel/plugin-transform-regenerator'],
       },
     ],


### PR DESCRIPTION
I've tested this locally installing dependencies using `npm install` the same way as the CI scripts do.

See https://github.com/TanStack/table/issues/4500#issuecomment-1374953210 for context.