### PR TITLE
fix: do not crash when sorting state has non existing columns

### DIFF
--- a/packages/table-core/src/utils/getSortedRowModel.ts
+++ b/packages/table-core/src/utils/getSortedRowModel.ts
@@ -19,6 +19,7 @@ export function getSortedRowModel<TData extends RowData>(): (
 
         // Filter out sortings that correspond to non existing columns
         const availableSorting = sortingState.filter(sort =>
+          table._getAllFlatColumnsById()[sort.id] &&
           table.getColumn(sort.id).getCanSort()
         )
 

--- a/packages/table-core/src/utils/getSortedRowModel.ts
+++ b/packages/table-core/src/utils/getSortedRowModel.ts
@@ -19,8 +19,7 @@ export function getSortedRowModel<TData extends RowData>(): (
 
         // Filter out sortings that correspond to non existing columns
         const availableSorting = sortingState.filter(sort =>
-          table._getAllFlatColumnsById()[sort.id] &&
-          table.getColumn(sort.id).getCanSort()
+          table._getAllFlatColumnsById()[sort.id]?.getCanSort()
         )
 
         const columnInfoById: Record<


### PR DESCRIPTION
We have very dynamic columns in our project (they can be added, sorted, then removed based on the data manipulated by the user).
It would be unnecessarily complicated and error prone to have to reset the sorting everywhere we make changes that may affect the existing columns.