### PR TITLE
fix(solid-table): add solid to package.json exports table to fix hydration errors

### DIFF
--- a/packages/solid-table/package.json
+++ b/packages/solid-table/package.json
@@ -29,7 +29,8 @@
     ".": {
       "types": "./build/lib/index.d.ts",
       "import": "./build/lib/index.mjs",
-      "default": "./build/lib/index.js"
+      "default": "./build/lib/index.js",
+      "solid": "./src/index.tsx"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
As it stands, one ends up with hydration errors in certain SSR situations.

This PR adds `solid` to the package.json exports map, along the lines of what [@solidjs/router](https://github.com/solidjs/solid-router/blob/main/package.json#L23) and [@tanstack/solid-query](https://github.com/TanStack/query/blob/main/packages/solid-query/package.json#L19) do. In my local testing, this fixes the hydration error.