### PR TITLE
fix: allow for null nested data and do not crash when invalid column id is passed

### DIFF
--- a/docs/api/core/table.md
+++ b/docs/api/core/table.md
@@ -355,7 +355,7 @@ Returns all leaf-node columns in the table flattened to a single level. This doe
 ### `getColumn`
 
 ```tsx
-type getColumn = (id: string) => Column<TData>
+type getColumn = (id: string) => Column<TData> | undefined
 ```
 
 Returns a single column by its ID.

--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -52,9 +52,9 @@ export function createColumn<TData extends RowData, TValue>(
         let result = originalRow as Record<string, any>
 
         for (const key of accessorKey.split('.')) {
-          result = result[key]
+          result = result?.[key]
           if (process.env.NODE_ENV !== 'production' && result === undefined) {
-            throw new Error(
+            console.warn(
               `"${key}" in deeply nested key "${accessorKey}" returned undefined.`
             )
           }

--- a/packages/table-core/src/core/row.ts
+++ b/packages/table-core/src/core/row.ts
@@ -41,7 +41,7 @@ export const createRow = <TData extends RowData>(
 
       const column = table.getColumn(columnId)
 
-      if (!column.accessorFn) {
+      if (!column?.accessorFn) {
         return undefined
       }
 
@@ -59,7 +59,7 @@ export const createRow = <TData extends RowData>(
 
       const column = table.getColumn(columnId)
 
-      if (!column.accessorFn) {
+      if (!column?.accessorFn) {
         return undefined
       }
 

--- a/packages/table-core/src/core/table.ts
+++ b/packages/table-core/src/core/table.ts
@@ -106,7 +106,7 @@ export interface CoreInstance<TData extends RowData> {
   getAllColumns: () => Column<TData, unknown>[]
   getAllFlatColumns: () => Column<TData, unknown>[]
   getAllLeafColumns: () => Column<TData, unknown>[]
-  getColumn: (columnId: string) => Column<TData, unknown>
+  getColumn: (columnId: string) => Column<TData, unknown> | undefined
 }
 
 export function createTable<TData extends RowData>(
@@ -337,11 +337,8 @@ export function createTable<TData extends RowData>(
     getColumn: columnId => {
       const column = table._getAllFlatColumnsById()[columnId]
 
-      if (!column) {
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn(`[Table] Column with id ${columnId} does not exist.`)
-        }
-        throw new Error()
+      if (process.env.NODE_ENV !== 'production' && !column) {
+        console.error(`[Table] Column with id '${columnId}' does not exist.`)
       }
 
       return column

--- a/packages/table-core/src/features/ColumnSizing.ts
+++ b/packages/table-core/src/features/ColumnSizing.ts
@@ -190,10 +190,10 @@ export const ColumnSizing: TableFeature = {
       },
       getResizeHandler: () => {
         const column = table.getColumn(header.column.id)
-        const canResize = column.getCanResize()
+        const canResize = column?.getCanResize()
 
         return (e: unknown) => {
-          if (!canResize) {
+          if (!column || !canResize) {
             return
           }
 

--- a/packages/table-core/src/utils/getFacetedMinMaxValues.ts
+++ b/packages/table-core/src/utils/getFacetedMinMaxValues.ts
@@ -7,8 +7,10 @@ export function getFacetedMinMaxValues<TData extends RowData>(): (
 ) => () => undefined | [number, number] {
   return (table, columnId) =>
     memo(
-      () => [table.getColumn(columnId).getFacetedRowModel()],
+      () => [table.getColumn(columnId)?.getFacetedRowModel()],
       facetedRowModel => {
+        if (!facetedRowModel) return undefined
+        
         const firstValue =
           facetedRowModel.flatRows[0]?.getUniqueValues(columnId)
 

--- a/packages/table-core/src/utils/getFacetedUniqueValues.ts
+++ b/packages/table-core/src/utils/getFacetedUniqueValues.ts
@@ -7,8 +7,10 @@ export function getFacetedUniqueValues<TData extends RowData>(): (
 ) => () => Map<any, number> {
   return (table, columnId) =>
     memo(
-      () => [table.getColumn(columnId).getFacetedRowModel()],
+      () => [table.getColumn(columnId)?.getFacetedRowModel()],
       facetedRowModel => {
+        if (!facetedRowModel) return new Map()
+
         let facetedUniqueValues = new Map<any, number>()
 
         for (let i = 0; i < facetedRowModel.flatRows.length; i++) {

--- a/packages/table-core/src/utils/getFilteredRowModel.ts
+++ b/packages/table-core/src/utils/getFilteredRowModel.ts
@@ -32,11 +32,7 @@ export function getFilteredRowModel<TData extends RowData>(): (
           const column = table.getColumn(d.id)
 
           if (!column) {
-            if (process.env.NODE_ENV !== 'production') {
-              console.warn(
-                `Table: Could not find a column to filter with columnId: ${d.id}`
-              )
-            }
+            return
           }
 
           const filterFn = column.getFilterFn()

--- a/packages/table-core/src/utils/getGroupedRowModel.ts
+++ b/packages/table-core/src/utils/getGroupedRowModel.ts
@@ -48,7 +48,7 @@ export function getGroupedRowModel<TData extends RowData>(): (
             })
           }
 
-          const columnId = existingGrouping[depth]!
+          const columnId: string = existingGrouping[depth]!
 
           // Group the rows together for this level
           const rowGroupsMap = groupBy(rows, columnId)
@@ -101,7 +101,7 @@ export function getGroupedRowModel<TData extends RowData>(): (
 
                   // Aggregate the values
                   const column = table.getColumn(columnId)
-                  const aggregateFn = column.getAggregationFn()
+                  const aggregateFn = column?.getAggregationFn()
 
                   if (aggregateFn) {
                     row._groupingValuesCache[columnId] = aggregateFn(

--- a/packages/table-core/src/utils/getSortedRowModel.ts
+++ b/packages/table-core/src/utils/getSortedRowModel.ts
@@ -19,7 +19,7 @@ export function getSortedRowModel<TData extends RowData>(): (
 
         // Filter out sortings that correspond to non existing columns
         const availableSorting = sortingState.filter(sort =>
-          table.getColumn(sort.id).getCanSort()
+          table.getColumn(sort.id)?.getCanSort()
         )
 
         const columnInfoById: Record<
@@ -33,6 +33,7 @@ export function getSortedRowModel<TData extends RowData>(): (
 
         availableSorting.forEach(sortEntry => {
           const column = table.getColumn(sortEntry.id)
+          if(!column) return
 
           columnInfoById[sortEntry.id] = {
             sortUndefined: column.columnDef.sortUndefined,


### PR DESCRIPTION
add safe check for nested accessor keys with dot notation to make sure data is not undefined, warn if not, but do not crash.

allow table.getColumn to return undefined if no column is found. Console error still, but do not crash