### PR TITLE
fix sorting with undefined values

### DIFF
--- a/packages/table-core/src/features/Sorting.ts
+++ b/packages/table-core/src/features/Sorting.ts
@@ -162,13 +162,15 @@ export const Sorting: TableFeature = {
 
         return sortingFns.basic
       },
-      getAutoSortDir: () => {
-        const firstRow = table.getFilteredRowModel().flatRows[0]
+      getAutoSortDir: () => {        
+        const rows = table.getFilteredRowModel().flatRows
 
-        const value = firstRow?.getValue(column.id)
+        for (const row of rows) {
+          const value = row?.getValue(column.id)
 
-        if (typeof value === 'string') {
-          return 'asc'
+          if (typeof value === 'string') {
+            return 'asc'
+          }
         }
 
         return 'desc'


### PR DESCRIPTION
Issue #4289 describes a sorting issue with undefined values.

Right now in the ```getAutoSortDir``` function, the value of the first row is used to determine the (first) sort direction. If it's a string, sorting is ```asc```, otherwise ```desc```.

The problem with this is:
If the value of the first row happens to be ```undefined```, than the ```getAutoSortDir``` will return ```desc``` because of the ```typeof value === 'string'``` check.

So the items are sorted descending (putting the undefined ones at the bottom) after the first sort click event.

When you click sorting again, the ```getNextSortingOrder``` function will get called and ```getAutoSortDir``` function will be called again, but now the first row is no longer an undefined value, but a string, so it will return ```asc```.

Making the following statement evaluate to ```true```

https://github.com/TanStack/table/blob/423d46ecce8d1f3f02c78e5d833b54112c21136c/packages/table-core/src/features/Sorting.ts#L298-L304


and thus returning ```false``` when called in the ```setSorting``` function, making it remove the sorting state

https://github.com/TanStack/table/blob/423d46ecce8d1f3f02c78e5d833b54112c21136c/packages/table-core/src/features/Sorting.ts#L235-L238




So what I've done now is iterated over all rows to verify if the type of the column is a string.
I'm not so sure about this implementation **as this will for sure impact performance** (if the column is for example a number, than all rows will be iterated before hitting the final return statement...).
A performance optimization could be to also check for additional types (date, number...) so the function can return early.


I noticed getAutoSortingFn uses .slice(10), not sure where this number comes from?
The same could be used in getAutoSortDir, but the issue will of course still occur if you have more than 10 rows with undefined values.

https://github.com/TanStack/table/blob/423d46ecce8d1f3f02c78e5d833b54112c21136c/packages/table-core/src/features/Sorting.ts#L139





This technique of using the value of the first row is for example also used to determine the filter function, so this might cause issues here as well

https://github.com/TanStack/table/blob/423d46ecce8d1f3f02c78e5d833b54112c21136c/packages/table-core/src/features/Filters.ts#L207


Fixes #4289