### PR TITLE
Fix documentation for ColumnMeta redeclration

### DIFF
--- a/docs/api/core/column-def.md
+++ b/docs/api/core/column-def.md
@@ -97,7 +97,7 @@ The meta data to associated with the column. We can access it anywhere when the 
 ```tsx
 import '@tanstack/react-table'
 
-declare module '@tanstack/table-core' {
+declare module '@tanstack/table-table' {
   interface ColumnMeta<TData extends RowData, TValue> {
     foo: string
   }


### PR DESCRIPTION
Example from the doc doesn't work, meta still has any type. Here is a fix of redeclartion.