### PR TITLE
fixes Minor typo in docs for column accessors

### DIFF
--- a/docs/guide/column-defs.md
+++ b/docs/guide/column-defs.md
@@ -111,7 +111,7 @@ const defaultColumns = [
 
 Data columns are unique in that they must be configured to extract primitive values for each item in your `data` array.
 
-There are 2 ways to do this:
+There are 3 ways to do this:
 
 - If your items are `objects`, use an object-key that corresponds to the value you want to extract.
 - If your items are nested `arrays`, use an array index that corresponds to the value you want to extract.


### PR DESCRIPTION
fixes #4717 
before:
`There are 2 ways to do this:`

after
`There are 3 ways to do this:`