### PR TITLE
fix(docs): clarify default implementation

### DIFF
--- a/docs/api/features/filters.md
+++ b/docs/api/features/filters.md
@@ -15,7 +15,7 @@ The ability for a column to be **column** filtered is determined by the followin
 The ability for a column to be **globally** filtered is determined by the following:
 
 - The column was defined a valid `accessorKey`/`accessorFn`.
-- If provided, `options.getColumnCanGlobalFilter` returns `true` for the given column. If it is not provided, the column is assumed to be globally filterable.
+- If provided, `options.getColumnCanGlobalFilter` returns `true` for the given column. If it is not provided, the column is assumed to be globally filterable if the value in the first row is a `string` or `number` type.
 - `column.enableColumnFilter` is not set to `false`
 - `options.enableColumnFilters` is not set to `false`
 - `options.enableFilters` is not set to `false`
@@ -461,6 +461,7 @@ getColumnCanGlobalFilter?: (column: Column<TData>) => boolean
 ```
 
 If provided, this function will be called with the column and should return `true` or `false` to indicate whether this column should be used for global filtering.
+This is useful if the column can contain data that is not `string` or `number` (i.e. `undefined`).
 
 ## Table API API
 


### PR DESCRIPTION
The [default implementation](https://github.com/TanStack/table/blob/423d46ecce8d1f3f02c78e5d833b54112c21136c/packages/table-core/src/features/Filters.ts#L196) for `getColumnCanGlobalFilter` will return `false` if the value in the first row is not a `string` or `number`. This PR attempts to clarify this.

This is related to #4711 