### PR TITLE
Grouping value accessors

### DIFF
--- a/examples/react/grouping/src/main.tsx
+++ b/examples/react/grouping/src/main.tsx
@@ -25,8 +25,14 @@ function App() {
         header: 'Name',
         columns: [
           {
+            accessorKey: 'id',
+            header: 'id',
+            cell: info => info.getValue(),
+          },
+          {
             accessorKey: 'firstName',
             header: 'First Name',
+            groupingValueAccessorKey: 'id',
             cell: info => info.getValue(),
           },
           {

--- a/examples/react/grouping/src/makeData.ts
+++ b/examples/react/grouping/src/makeData.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker'
 
 export type Person = {
+  id: string
   firstName: string
   lastName: string
   age: number
@@ -11,7 +12,7 @@ export type Person = {
 }
 
 const range = (len: number) => {
-  const arr = []
+  const arr = [] as number[]
   for (let i = 0; i < len; i++) {
     arr.push(i)
   }
@@ -20,6 +21,7 @@ const range = (len: number) => {
 
 const newPerson = (): Person => {
   return {
+    id: faker.database.mongodbObjectId(),
     firstName: faker.name.firstName(),
     lastName: faker.name.lastName(),
     age: faker.datatype.number(40),

--- a/packages/table-core/src/utils/getGroupedRowModel.ts
+++ b/packages/table-core/src/utils/getGroupedRowModel.ts
@@ -82,7 +82,22 @@ export function getGroupedRowModel<TData extends RowData>(): (
                 leafRows,
                 getValue: (columnId: string) => {
                   // Don't aggregate columns that are in the grouping
-                  if (existingGrouping.includes(columnId)) {
+                  const groupedColumns = existingGrouping.map(columnId =>
+                    table.getColumn(columnId)
+                  )
+                  const leafColumnIds = groupedColumns.reduce<string[]>(
+                    (leafColumnIds, column) => {
+                      return [
+                        ...leafColumnIds,
+                        ...(column?.getLeafColumns().map(({ id }) => id) ?? []),
+                      ]
+                    },
+                    []
+                  )
+                  if (
+                    existingGrouping.includes(columnId) ||
+                    leafColumnIds.includes(columnId)
+                  ) {
                     if (row._valuesCache.hasOwnProperty(columnId)) {
                       return row._valuesCache[columnId]
                     }

--- a/packages/table-core/src/utils/getGroupedRowModel.ts
+++ b/packages/table-core/src/utils/getGroupedRowModel.ts
@@ -171,7 +171,7 @@ function groupBy<TData extends RowData>(rows: Row<TData>[], columnId: string) {
   const groupMap = new Map<any, Row<TData>[]>()
 
   return rows.reduce((map, row) => {
-    const resKey = `${row.getValue(columnId)}`
+    const resKey = `${row.getGroupingValue(columnId)}`
     const previous = map.get(resKey)
     if (!previous) {
       map.set(resKey, [row])


### PR DESCRIPTION
This PR is WIP.

It adds optional columnDef options `groupingValueAccessorKey` and `groupingValueAccessorFn` to enable custom values to be used for row grouping.

It also adds a default behaviour to group rows when the row-grouping column is a column group.