### PR TITLE
docs: Fix wording by replacing 'Table API API' with 'Table API'

### DIFF
--- a/docs/api/features/column-ordering.md
+++ b/docs/api/features/column-ordering.md
@@ -25,7 +25,7 @@ onColumnOrderChange?: OnChangeFn<ColumnOrderState>
 
 If provided, this function will be called with an `updaterFn` when `state.columnOrder` changes. This overrides the default internal state management, so you will need to persist the state change either fully or partially outside of the table.
 
-## Table API API
+## Table API
 
 ### `setColumnOrder`
 

--- a/docs/api/features/column-pinning.md
+++ b/docs/api/features/column-pinning.md
@@ -55,7 +55,7 @@ enablePinning?: boolean
 
 Enables/disables pinning for the column.
 
-## Table API API
+## Table API
 
 ### `setColumnPinning`
 

--- a/docs/api/features/column-sizing.md
+++ b/docs/api/features/column-sizing.md
@@ -168,7 +168,7 @@ onColumnSizingInfoChange?: OnChangeFn<ColumnSizingInfoState>
 
 This optional function will be called when the columnSizingInfo state changes. If you provide this function, you will be responsible for maintaining its state yourself. You can pass this state back to the table via the `state.columnSizingInfo` table option.
 
-## Table API API
+## Table API
 
 ### `setColumnSizing`
 

--- a/docs/api/features/column-visibility.md
+++ b/docs/api/features/column-visibility.md
@@ -77,7 +77,7 @@ enableHiding?: boolean
 
 Enables/disables hiding of columns.
 
-## Table API API
+## Table API
 
 ### `getVisibleFlatColumns`
 

--- a/docs/api/features/expanding.md
+++ b/docs/api/features/expanding.md
@@ -117,7 +117,7 @@ If `true` expanded rows will be paginated along with the rest of the table (whic
 
 If `false` expanded rows will not be considered for pagination (which means expanded rows will always render on their parents page. This also means more rows will be rendered than the set page size)
 
-## Table API API
+## Table API
 
 ### `setExpanded`
 

--- a/docs/api/features/filters.md
+++ b/docs/api/features/filters.md
@@ -462,7 +462,7 @@ getColumnCanGlobalFilter?: (column: Column<TData>) => boolean
 
 If provided, this function will be called with the column and should return `true` or `false` to indicate whether this column should be used for global filtering.
 
-## Table API API
+## Table API
 
 ### `setColumnFilters`
 

--- a/docs/api/features/grouping.md
+++ b/docs/api/features/grouping.md
@@ -274,7 +274,7 @@ groupedColumnMode?: false | 'reorder' | 'remove' // default: `reorder`
 
 Grouping columns are automatically reordered by default to the start of the columns list. If you would rather remove them or leave them as-is, set the appropriate mode here.
 
-## Table API API
+## Table API
 
 ### `setGrouping`
 

--- a/docs/api/features/pagination.md
+++ b/docs/api/features/pagination.md
@@ -68,7 +68,7 @@ Returns the row model after pagination has taken place, but no further.
 
 Pagination columns are automatically reordered by default to the start of the columns list. If you would rather remove them or leave them as-is, set the appropriate mode here.
 
-## Table API API
+## Table API
 
 ### `setPagination`
 

--- a/docs/api/features/sorting.md
+++ b/docs/api/features/sorting.md
@@ -336,7 +336,7 @@ isMultiSortEvent?: (e: unknown) => boolean
 
 Pass a custom function that will be used to determine if a multi-sort event should be triggered. It is passed the event from the sort toggle handler and should return `true` if the event should trigger a multi-sort.
 
-## Table API API
+## Table API
 
 ### `setSorting`
 


### PR DESCRIPTION
Fix wording by replacing `Table API API` with `Table API`