### PR TITLE
adding caching for package deps in workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,9 +13,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          cache: 'npm'
 
       - name: Install Dependencies
         run: npm install --legacy-peer-deps

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,10 +16,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Install Dependencies
-        run: npm install --legacy-peer-deps
+        run: yarn --frozen-lockfile
 
       - name: Build the Project
         run: npm run build


### PR DESCRIPTION
## What it does

+ adds caching of the node_modules between github action runs
+ changes to: `yarn install --frozen-lockfile` as the install step in ci (to match our yarn.lock file in source)

## Benchmarks

Control run: https://github.com/TanStack/table/actions/runs/4458215445
New run w/ node_module caching: https://github.com/TanStack/table/actions/runs/4465120375

<table>
  <tr>
    <th></th>
    <th>Control run</th>
    <th>New run w/ node_module caching</th>
  </tr>
  <tr>
    <th>"Install Node.js" Step</th>
    <td>0s</td>
    <td>18s</td>
  </tr>
  <tr>
    <th>"Install Dependencies" Step</th>
    <td>1m 4s</td>
    <td>23s</td>
  </tr>
  <tr>
    <th>Total Time</th>
    <td>3m 52s</td>
    <td>2m 58s</td>
  </tr>
</table>