### PR TITLE
It don't Error when e.target.checked is undefined

### DIFF
--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -327,7 +327,7 @@ export const RowSelection: TableFeature = {
       getToggleAllRowsSelectedHandler: () => {
         return (e: unknown) => {
           table.toggleAllRowsSelected(
-            ((e as MouseEvent).target as HTMLInputElement).checked
+            ((e as MouseEvent).target as HTMLInputElement)?.checked
           )
         }
       },
@@ -335,7 +335,7 @@ export const RowSelection: TableFeature = {
       getToggleAllPageRowsSelectedHandler: () => {
         return (e: unknown) => {
           table.toggleAllPageRowsSelected(
-            ((e as MouseEvent).target as HTMLInputElement).checked
+            ((e as MouseEvent).target as HTMLInputElement)?.checked
           )
         }
       },


### PR DESCRIPTION
Hello maintainer, thank you for your open-source code. I'm using this project and have encountered some confusion. The behaviors of getToggleAllRowsSelectedHandler and getToggleSelectedHandler are similar, but they behave differently in my code. When the params of my checkbox are Boolean, getToggleAllRowsSelectedHandler throws an error. Upon examining the source code, I discovered that using event and undefined as params is the correct choice. I also believe that consistent behavior is preferable, so I have submitted a pull request and hope you will approve it.
This is my code:
```
{
    id: '__select__',
    size: 50,
    header: ({ table }) => (
        <Checkbox
            {...{
                value: table.getIsAllRowsSelected(),
                indeterminate: table.getIsSomeRowsSelected(),
                onChange: (e: boolean) => {
                    table.toggleAllRowsSelected(e);
                }
                // table.getToggleAllRowsSelectedHandler()
            }}
        />
    ),
    cell: ({ row }) => (
        <Checkbox
            {...{
                value: row.getIsSelected(),
                onChange: row.getToggleSelectedHandler()
            }}
        />
    )
}
```