### PR TITLE
Fix for page resetting to initialState pageIndex

### DIFF
--- a/examples/pagination-controlled/src/App.js
+++ b/examples/pagination-controlled/src/App.js
@@ -73,6 +73,7 @@ function Table({
       // This means we'll also have to provide our own
       // pageCount.
       pageCount: controlledPageCount,
+      autoResetPage: false //Resolves error of page resetting to initialState pageIndex during pagination
     },
     usePagination
   )


### PR DESCRIPTION
While using this example to get data from my server, I noticed that when I go to a certain page, it will load the data of that page but then reload back to the pageIndex mentioned in initialState. I noticed that although this fix exists, it hasn't been implemented for this example nor is it mentioned in the docs (https://react-table-v7.tanstack.com/docs/api/useTable).