### PR TITLE
Fixed types import error.

### DIFF
--- a/examples/svelte/basic/src/App.svelte
+++ b/examples/svelte/basic/src/App.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import { writable } from 'svelte/store'
   import {
-    ColumnDef,
     createSvelteTable,
     flexRender,
     getCoreRowModel,
-    TableOptions,
   } from '@tanstack/svelte-table'
+  import type { ColumnDef, TableOptions } from '@tanstack/table-core/src/types';
   import './index.css'
 
   type Person = {


### PR DESCRIPTION
Made this change to fix the following error: 
```
manifest.js?t=1680685613141:48 SyntaxError: The requested module '/node_modules/.vite/deps/@tanstack_svelte-table.js?v=8133f374' does not provide an export named 'ColumnDef'
```