### PR TITLE
fix: handle null/undef values when flexRendering function-type component in svelte-table

### DIFF
--- a/packages/svelte-table/src/index.ts
+++ b/packages/svelte-table/src/index.ts
@@ -53,6 +53,7 @@ export function flexRender(component: any, props: any) {
 
   if (typeof component === 'function') {
     const result = component(props)
+    if (result === null || result === undefined) return null
 
     if (isSvelteComponent(result)) {
       return renderComponent(result, props)


### PR DESCRIPTION
This handles the case when a column is defined like:
```
{
  id: 'columnId',
  header: 'Header',
  accessorKey: 'property',
},
```
but item[accessorKey] is null or undefined.