### PR TITLE
narrow options type to not ask for mutability

### DIFF
--- a/examples/react/basic/src/main.tsx
+++ b/examples/react/basic/src/main.tsx
@@ -19,7 +19,7 @@ type Person = {
   progress: number
 }
 
-const defaultData: Person[] = [
+const defaultData: readonly Person[] = [
   {
     firstName: 'tanner',
     lastName: 'linsley',

--- a/examples/react/basic/src/main.tsx
+++ b/examples/react/basic/src/main.tsx
@@ -79,7 +79,7 @@ const columns = [
 ]
 
 function App() {
-  const [data, setData] = React.useState(() => [...defaultData])
+  const [data, setData] = React.useState<readonly Person[]>(() => [...defaultData])
   const rerender = React.useReducer(() => ({}), {})[1]
 
   const table = useReactTable({

--- a/packages/table-core/src/core/table.ts
+++ b/packages/table-core/src/core/table.ts
@@ -63,7 +63,7 @@ const features = [
 export interface CoreTableState {}
 
 export interface CoreOptions<TData extends RowData> {
-  data: TData[]
+  data: readonly TData[]
   state: Partial<TableState>
   onStateChange: (updater: Updater<TableState>) => void
   debugAll?: boolean

--- a/packages/table-core/src/utils/getCoreRowModel.ts
+++ b/packages/table-core/src/utils/getCoreRowModel.ts
@@ -22,7 +22,7 @@ export function getCoreRowModel<TData extends RowData>(): (
         }
 
         const accessRows = (
-          originalRows: TData[],
+          originalRows: readonly TData[],
           depth = 0,
           parentRow?: Row<TData>
         ): Row<TData>[] => {


### PR DESCRIPTION
This changes the `CoreOptions` type to expect a `readonly TData[]`. The result is that readonly data can be passed into table options. Because it is a type only change, no runtime functionality should be affected.

This has been brought up as an [issue](https://github.com/TanStack/table/issues/3748) and as a [question](https://github.com/TanStack/table/discussions/3648#discussioncomment-2083028) in the past. As long as there are no library functions that _return_ `CoreOptions`, this should strictly allow more usages of the library.