### PR TITLE
docs: Fixed button name to better represent its function

### DIFF
--- a/examples/react/row-selection/src/main.tsx
+++ b/examples/react/row-selection/src/main.tsx
@@ -284,12 +284,12 @@ function App() {
           className="border rounded p-2 mb-2"
           onClick={() =>
             console.info(
-              'table.getSelectedFlatRows()',
+              'table.getSelectedRowModel().flatRows',
               table.getSelectedRowModel().flatRows
             )
           }
         >
-          Log table.getSelectedFlatRows()
+          Log table.getSelectedRowModel().flatRows
         </button>
       </div>
     </div>


### PR DESCRIPTION
Changed `table.getSelectedFlatRows()` to `table.getSelectedRowModel().flatRows` which is what the button does.