### PR TITLE
docs: Fix table method

### DIFF
--- a/docs/api/features/filters.md
+++ b/docs/api/features/filters.md
@@ -333,7 +333,7 @@ const column = columnHelper.data('key', {
   filterFn: 'myCustomFilter',
 })
 
-const table = useTable({
+const table = useReactTable({
   columns: [column],
   filterFns: {
     myCustomFilter: (rows, columnIds, filterValue) => {

--- a/docs/api/features/grouping.md
+++ b/docs/api/features/grouping.md
@@ -240,7 +240,7 @@ const column = columnHelper.data('key', {
   aggregationFn: 'myCustomAggregation',
 })
 
-const table = useTable({
+const table = useReactTable({
   columns: [column],
   aggregationFns: {
     myCustomAggregation: (columnId, leafRows, childRows) => {

--- a/docs/api/features/sorting.md
+++ b/docs/api/features/sorting.md
@@ -245,7 +245,7 @@ const column = columnHelper.data('key', {
   sortingFn: 'myCustomSorting',
 })
 
-const table = useTable({
+const table = useReactTable({
   columns: [column],
   sortingFns: {
     myCustomSorting: (rowA: any, rowB: any, columnId: any): number =>


### PR DESCRIPTION
This pull request replaces the `useTable` method as it has been removed in version 8. The React adapter method has been used as an example.