### PR TITLE
fix: assign parentId to subRows when creating aggregatedRows

### DIFF
--- a/packages/table-core/src/utils/getGroupedRowModel.ts
+++ b/packages/table-core/src/utils/getGroupedRowModel.ts
@@ -118,6 +118,10 @@ export function getGroupedRowModel<TData extends RowData>(): (
               })
 
               subRows.forEach(subRow => {
+                if (!subRow.parentId) {
+                  Object.assign(subRow, { parentId: id });
+                }
+
                 groupedFlatRows.push(subRow)
                 groupedRowsById[subRow.id] = subRow
                 // if (subRow.getIsGrouped?.()) {


### PR DESCRIPTION
Fixes #4881