### PR TITLE
chore: enable vue controlled pagination example

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -365,6 +365,10 @@
           "label": "Pagination"
         },
         {
+          "to": "examples/vue/pagination-controlled",
+          "label": "Pagination Controlled"
+        },
+        {
           "to": "examples/vue/sorting",
           "label": "Sorting"
         }

--- a/examples/vue/pagination-controlled/package.json
+++ b/examples/vue/pagination-controlled/package.json
@@ -8,8 +8,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@faker-js/faker": "^7.6.0",
     "vue": "^3.2.33",
+    "@faker-js/faker": "^7.6.0",
     "@tanstack/vue-table": "8.9.3"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -124,11 +124,11 @@
     {
       "path": "examples/vue/sorting/tsconfig.dev.json"
     },
-    // {
-    //   "path": "examples/vue/pagination-controlled/tsconfig.dev.json" //causing node types error for some reason
-    // },
     {
       "path": "examples/vue/pagination/tsconfig.dev.json"
+    },
+    {
+      "path": "examples/vue/pagination-controlled/tsconfig.dev.json"
     },
     {
       "path": "packages/match-sorter-utils"


### PR DESCRIPTION
In this PR: #4775, @KevinVandy indicated that there are some issues with node types related to this example. However, I haven't been able to replicate these locally -- I was wondering if these issues are picked up during CI and if so, maybe we can fix them and re-enable this example.