### PR TITLE
fix getLeafHeaders

### DIFF
--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/bootstrap/package.json
+++ b/examples/react/bootstrap/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "bootstrap": "^5.2.3",
     "react": "^18.2.0",
     "react-bootstrap": "2.6.0",

--- a/examples/react/column-dnd/package.json
+++ b/examples/react/column-dnd/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",

--- a/examples/react/column-groups/package.json
+++ b/examples/react/column-groups/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/column-ordering/package.json
+++ b/examples/react/column-ordering/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/column-pinning/package.json
+++ b/examples/react/column-pinning/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/column-sizing/package.json
+++ b/examples/react/column-sizing/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/column-visibility/package.json
+++ b/examples/react/column-visibility/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/editable-data/package.json
+++ b/examples/react/editable-data/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/expanding/package.json
+++ b/examples/react/expanding/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/filters/package.json
+++ b/examples/react/filters/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
     "@tanstack/match-sorter-utils": "8.7.6",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/full-width-resizable-table/package.json
+++ b/examples/react/full-width-resizable-table/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/full-width-table/package.json
+++ b/examples/react/full-width-table/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/fully-controlled/package.json
+++ b/examples/react/fully-controlled/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/grouping/package.json
+++ b/examples/react/grouping/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/kitchen-sink/package.json
+++ b/examples/react/kitchen-sink/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@tanstack/match-sorter-utils": "8.7.6",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
     "react": "^18.2.0",

--- a/examples/react/mui-pagination/package.json
+++ b/examples/react/mui-pagination/package.json
@@ -13,7 +13,7 @@
     "@emotion/styled": "^11.9.3",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.6",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/pagination-controlled/package.json
+++ b/examples/react/pagination-controlled/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-query": "^3.39.0"

--- a/examples/react/pagination/package.json
+++ b/examples/react/pagination/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/row-dnd/package.json
+++ b/examples/react/row-dnd/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",

--- a/examples/react/row-selection/package.json
+++ b/examples/react/row-selection/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/sorting/package.json
+++ b/examples/react/sorting/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/sub-components/package.json
+++ b/examples/react/sub-components/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/virtualized-infinite-scrolling/package.json
+++ b/examples/react/virtualized-infinite-scrolling/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
     "@tanstack/react-query": "4.16.1",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-virtual": "^2.10.4"

--- a/examples/react/virtualized-rows/package.json
+++ b/examples/react/virtualized-rows/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/react-table": "8.9.2",
+    "@tanstack/react-table": "8.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-virtual": "^2.10.4"

--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -15,7 +15,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@tanstack/solid-table": "8.9.2",
+    "@tanstack/solid-table": "8.9.3",
     "solid-js": "^1.6.2"
   }
 }

--- a/examples/solid/bootstrap/package.json
+++ b/examples/solid/bootstrap/package.json
@@ -16,7 +16,7 @@
     "vite-plugin-solid": "^2.4.0"
   },
   "dependencies": {
-    "@tanstack/solid-table": "8.9.2",
+    "@tanstack/solid-table": "8.9.3",
     "bootstrap": "^5.2.2",
     "solid-bootstrap": "^1.0.8",
     "solid-js": "^1.6.2"

--- a/examples/solid/column-groups/package.json
+++ b/examples/solid/column-groups/package.json
@@ -15,7 +15,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@tanstack/solid-table": "8.9.2",
+    "@tanstack/solid-table": "8.9.3",
     "solid-js": "^1.6.2"
   }
 }

--- a/examples/solid/column-ordering/package.json
+++ b/examples/solid/column-ordering/package.json
@@ -16,7 +16,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@tanstack/solid-table": "8.9.2",
+    "@tanstack/solid-table": "8.9.3",
     "solid-js": "^1.6.2"
   }
 }

--- a/examples/solid/column-visibility/package.json
+++ b/examples/solid/column-visibility/package.json
@@ -15,7 +15,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@tanstack/solid-table": "8.9.2",
+    "@tanstack/solid-table": "8.9.3",
     "solid-js": "^1.6.2"
   }
 }

--- a/examples/solid/sorting/package.json
+++ b/examples/solid/sorting/package.json
@@ -16,7 +16,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@tanstack/solid-table": "8.9.2",
+    "@tanstack/solid-table": "8.9.3",
     "solid-js": "^1.6.2"
   }
 }

--- a/examples/svelte/basic/package.json
+++ b/examples/svelte/basic/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.2",
+    "@tanstack/svelte-table": "8.9.3",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/basic/package.json
+++ b/examples/svelte/basic/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.3",
+    "@tanstack/svelte-table": "8.9.4",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/column-groups/package.json
+++ b/examples/svelte/column-groups/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.2",
+    "@tanstack/svelte-table": "8.9.3",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/column-groups/package.json
+++ b/examples/svelte/column-groups/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.3",
+    "@tanstack/svelte-table": "8.9.4",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/column-ordering/package.json
+++ b/examples/svelte/column-ordering/package.json
@@ -14,7 +14,7 @@
     "@faker-js/faker": "^7.6.0",
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.2",
+    "@tanstack/svelte-table": "8.9.3",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/column-ordering/package.json
+++ b/examples/svelte/column-ordering/package.json
@@ -14,7 +14,7 @@
     "@faker-js/faker": "^7.6.0",
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.3",
+    "@tanstack/svelte-table": "8.9.4",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/column-pinning/package.json
+++ b/examples/svelte/column-pinning/package.json
@@ -14,7 +14,7 @@
     "@faker-js/faker": "^7.6.0",
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.2",
+    "@tanstack/svelte-table": "8.9.3",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/column-pinning/package.json
+++ b/examples/svelte/column-pinning/package.json
@@ -14,7 +14,7 @@
     "@faker-js/faker": "^7.6.0",
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.3",
+    "@tanstack/svelte-table": "8.9.4",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/column-visibility/package.json
+++ b/examples/svelte/column-visibility/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.2",
+    "@tanstack/svelte-table": "8.9.3",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/column-visibility/package.json
+++ b/examples/svelte/column-visibility/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.3",
+    "@tanstack/svelte-table": "8.9.4",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/sorting/package.json
+++ b/examples/svelte/sorting/package.json
@@ -14,7 +14,7 @@
     "@faker-js/faker": "^7.6.0",
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.2",
+    "@tanstack/svelte-table": "8.9.3",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/svelte/sorting/package.json
+++ b/examples/svelte/sorting/package.json
@@ -14,7 +14,7 @@
     "@faker-js/faker": "^7.6.0",
     "@rollup/plugin-replace": "^5.0.1",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@tanstack/svelte-table": "8.9.3",
+    "@tanstack/svelte-table": "8.9.4",
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.7",

--- a/examples/vue/basic/package.json
+++ b/examples/vue/basic/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "vue": "^3.2.33",
-    "@tanstack/vue-table": "8.9.2"
+    "@tanstack/vue-table": "8.9.3"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",

--- a/examples/vue/column-ordering/package.json
+++ b/examples/vue/column-ordering/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
     "vue": "^3.2.33",
-    "@tanstack/vue-table": "8.9.2"
+    "@tanstack/vue-table": "8.9.3"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",

--- a/examples/vue/column-pinning/package.json
+++ b/examples/vue/column-pinning/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/vue-table": "8.9.2",
+    "@tanstack/vue-table": "8.9.3",
     "vue": "^3.2.33"
   },
   "devDependencies": {

--- a/examples/vue/pagination-controlled/package.json
+++ b/examples/vue/pagination-controlled/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
     "vue": "^3.2.33",
-    "@tanstack/vue-table": "8.9.2"
+    "@tanstack/vue-table": "8.9.3"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",

--- a/examples/vue/pagination/package.json
+++ b/examples/vue/pagination/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "vue": "^3.2.33",
     "@faker-js/faker": "^7.6.0",
-    "@tanstack/vue-table": "8.9.2"
+    "@tanstack/vue-table": "8.9.3"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",

--- a/examples/vue/sorting/package.json
+++ b/examples/vue/sorting/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
     "vue": "^3.2.33",
-    "@tanstack/vue-table": "8.9.2"
+    "@tanstack/vue-table": "8.9.3"
   },
   "devDependencies": {
     "@types/node": "^16.11.27",

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/react-table",
   "author": "Tanner Linsley",
-  "version": "8.9.2",
+  "version": "8.9.3",
   "description": "Headless UI for building powerful tables & datagrids for React.",
   "license": "MIT",
   "homepage": "https://github.com/tanstack/table#readme",
@@ -43,7 +43,7 @@
     "src"
   ],
   "dependencies": {
-    "@tanstack/table-core": "8.9.2"
+    "@tanstack/table-core": "8.9.3"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/solid-table/package.json
+++ b/packages/solid-table/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/solid-table",
   "author": "Tanner Linsley",
-  "version": "8.9.2",
+  "version": "8.9.3",
   "description": "Headless UI for building powerful tables & datagrids for Solid.",
   "license": "MIT",
   "homepage": "https://github.com/tanstack/table#readme",
@@ -44,7 +44,7 @@
     "src"
   ],
   "dependencies": {
-    "@tanstack/table-core": "8.9.2"
+    "@tanstack/table-core": "8.9.3"
   },
   "peerDependencies": {
     "solid-js": "^1.3.13"

--- a/packages/svelte-table/package.json
+++ b/packages/svelte-table/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/svelte-table",
   "author": "Tanner Linsley",
-  "version": "8.9.2",
+  "version": "8.9.3",
   "description": "Headless UI for building powerful tables & datagrids for Svelte.",
   "license": "MIT",
   "homepage": "https://github.com/tanstack/table#readme",
@@ -42,7 +42,7 @@
     "src"
   ],
   "dependencies": {
-    "@tanstack/table-core": "8.9.2"
+    "@tanstack/table-core": "8.9.3"
   },
   "peerDependencies": {
     "svelte": "^3.49.0"

--- a/packages/svelte-table/package.json
+++ b/packages/svelte-table/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/svelte-table",
   "author": "Tanner Linsley",
-  "version": "8.9.3",
+  "version": "8.9.4",
   "description": "Headless UI for building powerful tables & datagrids for Svelte.",
   "license": "MIT",
   "homepage": "https://github.com/tanstack/table#readme",

--- a/packages/svelte-table/src/index.ts
+++ b/packages/svelte-table/src/index.ts
@@ -1,3 +1,4 @@
+import type { ComponentType } from 'svelte'
 import {
   RowData,
   createTable,
@@ -44,7 +45,7 @@ function wrapInPlaceholder(content: any) {
   return renderComponent(Placeholder, { content })
 }
 
-export function flexRender(component: any, props: any) {
+export function flexRender(component: any, props: any): ComponentType | null {
   if (!component) return null
 
   if (isSvelteComponent(component)) {

--- a/packages/svelte-table/src/render-component.ts
+++ b/packages/svelte-table/src/render-component.ts
@@ -64,7 +64,7 @@ function renderClient<T>(
         undefined
       )
     }
-  }
+  } as ComponentType
 }
 
 function renderServer<T>(
@@ -82,7 +82,7 @@ function renderServer<T>(
     }
   )
 
-  return WrapperComp
+  return WrapperComp as unknown as ComponentType
 }
 
 export const renderComponent =

--- a/packages/table-core/package.json
+++ b/packages/table-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/table-core",
   "author": "Tanner Linsley",
-  "version": "8.9.2",
+  "version": "8.9.3",
   "description": "Headless UI for building powerful tables & datagrids for TS/JS.",
   "license": "MIT",
   "homepage": "https://github.com/tanstack/table#readme",

--- a/packages/table-core/src/core/headers.ts
+++ b/packages/table-core/src/core/headers.ts
@@ -82,9 +82,10 @@ function createHeader<TData extends RowData, TValue>(
 
       const recurseHeader = (h: CoreHeader<TData, any>) => {
         if (h.subHeaders && h.subHeaders.length) {
-          h.subHeaders.map(recurseHeader)
+          h.subHeaders.forEach(recurseHeader)
+        } else {
+          leafHeaders.push(h as Header<TData, unknown>)
         }
-        leafHeaders.push(h as Header<TData, unknown>)
       }
 
       recurseHeader(header)

--- a/packages/vue-table/package.json
+++ b/packages/vue-table/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/vue-table",
   "author": "Tanner Linsley",
-  "version": "8.9.2",
+  "version": "8.9.3",
   "description": "Headless UI for building powerful tables & datagrids for Vue.",
   "license": "MIT",
   "homepage": "https://github.com/tanstack/table#readme",
@@ -43,7 +43,7 @@
     "src"
   ],
   "dependencies": {
-    "@tanstack/table-core": "8.9.2"
+    "@tanstack/table-core": "8.9.3"
   },
   "peerDependencies": {
     "vue": "^3.2.33"


### PR DESCRIPTION
I have noticed that `table.getLeafHeaders()` contained headers that had more headers in `subHeaders` and thereby are not leaves. Looking at the code I found this part where the header is added to the array in any case.

The method is used for the column sizing feature but `yarn dev` gave me no errors (could not figure out `yarn test:dev`). I hope this helps anyway or at least points you in the right direction to fix this small issue.