### PR TITLE
fix: vue controlled pagination example

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -365,6 +365,10 @@
           "label": "Pagination"
         },
         {
+          "to": "examples/vue/pagination-controlled",
+          "label": "Pagination Controlled"
+        },
+        {
           "to": "examples/vue/sorting",
           "label": "Sorting"
         }

--- a/examples/vue/pagination-controlled/src/App.vue
+++ b/examples/vue/pagination-controlled/src/App.vue
@@ -92,62 +92,36 @@ function handlePageSizeChange(e) {
   <div class="p-2">
     <table>
       <thead>
-        <tr
-          v-for="headerGroup in table.getHeaderGroups()"
-          :key="headerGroup.id"
-        >
-          <th
-            v-for="header in headerGroup.headers"
-            :key="header.id"
-            :colSpan="header.colSpan"
-          >
-            <FlexRender
-              v-if="!header.isPlaceholder"
-              :render="header.column.columnDef.header"
-              :props="header.getContext()"
-            />
+        <tr v-for="headerGroup in table.getHeaderGroups()" :key="headerGroup.id">
+          <th v-for="header in headerGroup.headers" :key="header.id" :colSpan="header.colSpan">
+            <FlexRender v-if="!header.isPlaceholder" :render="header.column.columnDef.header"
+              :props="header.getContext()" />
           </th>
         </tr>
       </thead>
       <tbody>
         <tr v-for="row in table.getRowModel().rows" :key="row.id">
           <td v-for="cell in row.getVisibleCells()" :key="cell.id">
-            <FlexRender
-              :render="cell.column.columnDef.cell"
-              :props="cell.getContext()"
-            />
+            <FlexRender :render="cell.column.columnDef.cell" :props="cell.getContext()" />
           </td>
         </tr>
       </tbody>
     </table>
     <div className="h-2">
       <div className="flex items-center gap-2">
-        <button
-          className="border rounded p-1"
-          @click="() => table.setPageIndex(0)"
-          :disabled="!table.getCanPreviousPage()"
-        >
+        <button className="border rounded p-1" @click="() => table.setPageIndex(0)"
+          :disabled="!table.getCanPreviousPage()">
           «
         </button>
-        <button
-          className="border rounded p-1"
-          @click="() => table.previousPage()"
-          :disabled="!table.getCanPreviousPage()"
-        >
+        <button className="border rounded p-1" @click="() => table.previousPage()"
+          :disabled="!table.getCanPreviousPage()">
           ‹
         </button>
-        <button
-          className="border rounded p-1"
-          @click="() => table.nextPage()"
-          :disabled="!table.getCanNextPage()"
-        >
+        <button className="border rounded p-1" @click="() => table.nextPage()" :disabled="!table.getCanNextPage()">
           ›
         </button>
-        <button
-          className="border rounded p-1"
-          @click="() => table.setPageIndex(table.getPageCount() - 1)"
-          :disabled="!table.getCanNextPage()"
-        >
+        <button className="border rounded p-1" @click="() => table.setPageIndex(table.getPageCount() - 1)"
+          :disabled="!table.getCanNextPage()">
           »
         </button>
         <span className="flex items-center gap-1">
@@ -159,22 +133,10 @@ function handlePageSizeChange(e) {
         </span>
         <span className="flex items-center gap-1">
           | Go to page:
-          <input
-            type="number"
-            :value="goToPageNumber"
-            @change="handleGoToPage"
-            className="border p-1 rounded w-16"
-          />
+          <input type="number" :value="goToPageNumber" @change="handleGoToPage" className="border p-1 rounded w-16" />
         </span>
-        <select
-          :value="table.getState().pagination.pageSize"
-          @change="handlePageSizeChange"
-        >
-          <option
-            :key="pageSize"
-            :value="pageSize"
-            v-for="pageSize in pageSizes"
-          >
+        <select :value="table.getState().pagination.pageSize" @change="handlePageSizeChange">
+          <option :key="pageSize" :value="pageSize" v-for="pageSize in pageSizes">
             Show {{ pageSize }}
           </option>
         </select>

--- a/examples/vue/pagination-controlled/src/useService.ts
+++ b/examples/vue/pagination-controlled/src/useService.ts
@@ -1,66 +1,66 @@
-import { ref, computed, watchEffect, Ref } from "vue";
-import { type PaginationState } from "@tanstack/vue-table";
+import { ref, computed, watchEffect, Ref } from 'vue'
+import { type PaginationState } from '@tanstack/vue-table'
 
-const DEFAULT_PAGE_COUNT = -1;
-const DEFAULT_RESULT_COUNT = -1;
+const DEFAULT_PAGE_COUNT = -1
+const DEFAULT_RESULT_COUNT = -1
 
-const endpoint = "https://jsonplaceholder.typicode.com/posts";
+const endpoint = 'https://jsonplaceholder.typicode.com/posts'
 
 export default function useService(pagination: Ref<PaginationState>) {
-  const data = ref(null);
-  const totalResultCount = ref(DEFAULT_RESULT_COUNT);
-  const error = ref(null);
-  const isLoading = ref(false);
-  const request = ref<Promise<any> | null>(null);
+  const data = ref(null)
+  const totalResultCount = ref(DEFAULT_RESULT_COUNT)
+  const error = ref(null)
+  const isLoading = ref(false)
+  const request = ref<Promise<any> | null>(null)
 
   const requestParams = computed(() => {
-    const { pageSize, pageIndex } = pagination.value;
-    const currentPage = pageIndex + 1;
+    const { pageSize, pageIndex } = pagination.value
+    const currentPage = pageIndex + 1
 
     return {
       _limit: pageSize.toString(),
       _page: currentPage.toString(),
-    };
-  });
+    }
+  })
 
   const url = computed(() => {
-    const searchParams = new URLSearchParams(requestParams.value);
-    return `${endpoint}?${searchParams}`;
-  });
+    const searchParams = new URLSearchParams(requestParams.value)
+    return `${endpoint}?${searchParams}`
+  })
 
   const pageCount = computed(() => {
-    const { pageSize } = pagination.value;
+    const { pageSize } = pagination.value
 
-    return Math.ceil(totalResultCount.value / pageSize);
+    return Math.ceil(totalResultCount.value / pageSize)
   })
 
   watchEffect(() => {
-    isLoading.value = true;
+    isLoading.value = true
 
     request.value = fetch(url.value)
-      .then(async (response) => {
-        const responseData = await response.json();
+      .then(async response => {
+        const responseData = await response.json()
 
         if (response.ok) {
-          data.value = responseData;
-          error.value = null;
+          data.value = responseData
+          error.value = null
           totalResultCount.value =
-            Number(response.headers.get("x-total-count")) ?? DEFAULT_PAGE_COUNT;
+            Number(response.headers.get('x-total-count')) ?? DEFAULT_PAGE_COUNT
         } else {
-          throw new Error("Network response was not OK");
+          throw new Error('Network response was not OK')
         }
       })
-      .catch((error) => {
-        error.value = error;
-        data.value = null;
-        totalResultCount.value = DEFAULT_PAGE_COUNT;
+      .catch(error => {
+        error.value = error
+        data.value = null
+        totalResultCount.value = DEFAULT_PAGE_COUNT
 
-        console.log("error!", error);
+        console.log('error!', error)
       })
       .finally(() => {
-        isLoading.value = false;
-      });
-  });
+        isLoading.value = false
+      })
+  })
 
   return {
     data,
@@ -68,5 +68,5 @@ export default function useService(pagination: Ref<PaginationState>) {
     pageCount,
     error,
     isLoading,
-  };
+  }
 }

--- a/examples/vue/pagination-controlled/tsconfig.dev.json
+++ b/examples/vue/pagination-controlled/tsconfig.dev.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./build/types",
     "types": [
-      "vite/client"
+      "vite/client",
+      "node"
     ]
   },
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -124,9 +124,9 @@
     {
       "path": "examples/vue/sorting/tsconfig.dev.json"
     },
-    // {
-    //   "path": "examples/vue/pagination-controlled/tsconfig.dev.json" //causing node types error for some reason
-    // },
+    {
+      "path": "examples/vue/pagination-controlled/tsconfig.dev.json"
+    },
     {
       "path": "examples/vue/pagination/tsconfig.dev.json"
     },


### PR DESCRIPTION
This PR fixes a typechecking error related to this example. I've also enabled the example in `tsconfig.json` and added it to `docs/config.json`. Finally, I ran everything through prettier.

See #4956 for more details.