### PR TITLE
fix(filterTypes): handle undefined row values when filtering (v7)

### DIFF
--- a/src/filterTypes.js
+++ b/src/filterTypes.js
@@ -2,9 +2,12 @@ export const text = (rows, ids, filterValue) => {
   rows = rows.filter(row => {
     return ids.some(id => {
       const rowValue = row.values[id]
-      return String(rowValue)
-        .toLowerCase()
-        .includes(String(filterValue).toLowerCase())
+      return Boolean(
+        rowValue
+          ?.toString()
+          .toLowerCase()
+          .includes(String(filterValue).toLowerCase())
+      )
     })
   })
   return rows

--- a/src/tests/filterTypes.test.js
+++ b/src/tests/filterTypes.test.js
@@ -1,0 +1,30 @@
+import { text } from "../filterTypes";
+
+describe('text filter correctly handles undefined row values', () => {
+    const rows = [{values: { test1: 'aaa', test2: 'bbb'}}, {values: { test1: 'aaa', test2: 'uuu'}}, {values: { test1: undefined, test2: 'bbb'}}]
+    const ids = ['test1', 'test2'];
+
+    test('for single character a', () => {
+        const result = text(rows, ids, 'a');
+
+        expect(result).toHaveLength(2)
+        expect(result).toContainEqual({values: { test1: 'aaa', test2: 'bbb'}});
+        expect(result).toContainEqual({values: { test1: 'aaa', test2: 'uuu'}});
+    });
+
+    test('for single character u', () => {
+        const result = text(rows, ids, 'u');
+
+        expect(result).toHaveLength(1)
+        expect(result).toContainEqual({values: { test1: 'aaa', test2: 'uuu'}});
+    });
+
+    test('for string bbb', () => {
+        const result = text(rows, ids, 'bbb');
+
+        expect(result).toHaveLength(2)
+        expect(result).toContainEqual({values: { test1: 'aaa', test2: 'bbb'}});
+        expect(result).toContainEqual({values: { test1: undefined, test2: 'bbb'}});
+    });
+    
+});

--- a/src/tests/filterTypes.test.js
+++ b/src/tests/filterTypes.test.js
@@ -1,30 +1,35 @@
-import { text } from "../filterTypes";
+import { text } from '../filterTypes'
 
 describe('text filter correctly handles undefined row values', () => {
-    const rows = [{values: { test1: 'aaa', test2: 'bbb'}}, {values: { test1: 'aaa', test2: 'uuu'}}, {values: { test1: undefined, test2: 'bbb'}}]
-    const ids = ['test1', 'test2'];
+  const rows = [
+    { values: { test1: 'aaa', test2: 'bbb' } },
+    { values: { test1: 'aaa', test2: 'uuu' } },
+    { values: { test1: undefined, test2: 'bbb' } },
+  ]
+  const ids = ['test1', 'test2']
 
-    test('for single character a', () => {
-        const result = text(rows, ids, 'a');
+  test('for single character a', () => {
+    const result = text(rows, ids, 'a')
 
-        expect(result).toHaveLength(2)
-        expect(result).toContainEqual({values: { test1: 'aaa', test2: 'bbb'}});
-        expect(result).toContainEqual({values: { test1: 'aaa', test2: 'uuu'}});
-    });
+    expect(result).toHaveLength(2)
+    expect(result).toContainEqual({ values: { test1: 'aaa', test2: 'bbb' } })
+    expect(result).toContainEqual({ values: { test1: 'aaa', test2: 'uuu' } })
+  })
 
-    test('for single character u', () => {
-        const result = text(rows, ids, 'u');
+  test('for single character u', () => {
+    const result = text(rows, ids, 'u')
 
-        expect(result).toHaveLength(1)
-        expect(result).toContainEqual({values: { test1: 'aaa', test2: 'uuu'}});
-    });
+    expect(result).toHaveLength(1)
+    expect(result).toContainEqual({ values: { test1: 'aaa', test2: 'uuu' } })
+  })
 
-    test('for string bbb', () => {
-        const result = text(rows, ids, 'bbb');
+  test('for string bbb', () => {
+    const result = text(rows, ids, 'bbb')
 
-        expect(result).toHaveLength(2)
-        expect(result).toContainEqual({values: { test1: 'aaa', test2: 'bbb'}});
-        expect(result).toContainEqual({values: { test1: undefined, test2: 'bbb'}});
-    });
-    
-});
+    expect(result).toHaveLength(2)
+    expect(result).toContainEqual({ values: { test1: 'aaa', test2: 'bbb' } })
+    expect(result).toContainEqual({
+      values: { test1: undefined, test2: 'bbb' },
+    })
+  })
+})


### PR DESCRIPTION
This fixes an issue where undefined values in a row cause the default global filter to not work with characters in the word 'undefined'.

See https://github.com/TanStack/table/issues/4971