### PR TITLE
Add support for Svelte 4

### DIFF
--- a/packages/svelte-table/package.json
+++ b/packages/svelte-table/package.json
@@ -45,6 +45,6 @@
     "@tanstack/table-core": "8.9.2"
   },
   "peerDependencies": {
-    "svelte": "^3.49.0"
+    "svelte": "^4.0.0 || ^3.49.0"
   }
 }


### PR DESCRIPTION
Svelte 4 was announced back in June 2023
https://svelte.dev/blog/svelte-4

But Tanstack table doesn't allow version 4.x.x which is preventing all of us Svelte table users to use Svelte 4 which has been out for a month now. Svelte 4 doesn't have any breaking changes (very minor ones related to custom elements), so I don't expect anything to break for Tanstack, and it should unblock people from using Svelte 4.

There is no bug for this, but there is a discussion thread

https://github.com/TanStack/table/discussions/4944



