### PR TITLE
Fix an issue where pageIndex becomes invalid when data is changed (removed) and autoResetPageIndex is false.

### DIFF
--- a/packages/table-core/src/features/RowPagination.ts
+++ b/packages/table-core/src/features/RowPagination.ts
@@ -224,14 +224,24 @@ export const RowPagination: TableFeature = {
       }
 
       if (
-        table.options.autoResetAll ??
-        table.options.autoResetPageIndex ??
+        table.getState().pagination &&
         !table.options.manualPagination
       ) {
         if (queued) return
         queued = true
         table._queue(() => {
-          table.resetPageIndex()
+          if (
+            table.options.autoResetAll ??
+            table.options.autoResetPageIndex
+          ) {
+            table.resetPageIndex()
+          } else {
+            const currentPageIndex = table.getState().pagination.pageIndex
+            const lastPageIndex = table.getPageCount() - 1
+            if (currentPageIndex > lastPageIndex) {
+              table.setPageIndex(lastPageIndex)
+            }
+          }
           queued = false
         })
       }


### PR DESCRIPTION
This fixes issue #4994 

The pageIndex now gets set to correct value, if invalid, when autoResetPageIndex is false and data changes