### PR TITLE
fix: fix getCanExpand logic

### DIFF
--- a/packages/table-core/src/features/Expanding.ts
+++ b/packages/table-core/src/features/Expanding.ts
@@ -1,6 +1,6 @@
 import { RowModel } from '..'
 import { TableFeature } from '../core/table'
-import { OnChangeFn, Table, Row, Updater, RowData } from '../types'
+import { OnChangeFn, Row, RowData, Table, Updater } from '../types'
 import { makeStateUpdater } from '../utils'
 
 export type ExpandedStateList = Record<string, boolean>
@@ -214,7 +214,8 @@ export const Expanding: TableFeature = {
       getCanExpand: () => {
         return (
           table.options.getRowCanExpand?.(row) ??
-          ((table.options.enableExpanding ?? true) && !!row.subRows?.length)
+          table.options.enableExpanding ??
+          !!row.subRows?.length
         )
       },
       getToggleExpandedHandler: () => {


### PR DESCRIPTION
  In current version we have this logic in getCanExpand:

```
getCanExpand: () => {
        return (
          table.options.getRowCanExpand?.(row) ??
          ((table.options.enableExpanding ?? true) && !!row.subRows?.length)
        )
      },
```

as we can see, if `getRowCanExpand` does not exist, we look for `enableExpanding`. if `enableExpanding` is `true`, we check `row.subRows.length`. I thinks it's a mistake. we should ignore checking `row.subRows.length` when `enableExpanding` is true. 
(as we do it when `getRowCanExpand` returns `true`)
```
getCanExpand: () => {
        return (
          table.options.getRowCanExpand?.(row) ??
          table.options.enableExpanding ??
          !!row.subRows?.length
        )
      },
```