### PR TITLE
fix filtering bug when filterFromLeafRows = true

### DIFF
--- a/packages/table-core/src/utils/filterRowsUtils.ts
+++ b/packages/table-core/src/utils/filterRowsUtils.ts
@@ -47,14 +47,14 @@ export function filterRowModelFromLeafs<TData extends RowData>(
         if (filterRow(row) && !newRow.subRows.length) {
           rows.push(row)
           newFilteredRowsById[row.id] = row
-          newFilteredRowsById[i] = row
+          newFilteredFlatRows.push(row)
           continue
         }
 
         if (filterRow(row) || newRow.subRows.length) {
           rows.push(row)
           newFilteredRowsById[row.id] = row
-          newFilteredRowsById[i] = row
+          newFilteredFlatRows.push(row)
           continue
         }
       } else {
@@ -62,7 +62,7 @@ export function filterRowModelFromLeafs<TData extends RowData>(
         if (filterRow(row)) {
           rows.push(row)
           newFilteredRowsById[row.id] = row
-          newFilteredRowsById[i] = row
+          newFilteredFlatRows.push(row)
         }
       }
     }


### PR DESCRIPTION
I believe there is an obvious typo in the `filterRowsUtils.ts::filterRowModelFromLeafs`, causing the filteredRowModel.flatRows to always be empty, and also `column.uniqueFacetedValues()` to be an empty array (which is what tipped me off). There was no execution path, where the `newFilteredRowsById` array gets populated. 

fixes: #4768 