### PR TITLE
docs: ColumnDef meta documentation

### DIFF
--- a/docs/api/core/column-def.md
+++ b/docs/api/core/column-def.md
@@ -103,3 +103,5 @@ declare module '@tanstack/table-core' {
   }
 }
 ```
+
+For more information, see [editable-data](https://github.com/TanStack/table/blob/main/examples/react/editable-data/src/main.tsx) example.


### PR DESCRIPTION
Adding link to the editable-data example, in regards of meta property.