### PR TITLE
fix: allow empty string as column id

### DIFF
--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -68,7 +68,7 @@ export function createColumn<TData extends RowData, TValue>(
     }
   }
 
-  if (!id) {
+  if (!id && id !== '') {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error(
         resolvedColumnDef.accessorFn


### PR DESCRIPTION
Empty string can be a valid property name in row data objects, it should be allowed as column id. The existing check of `!id` still makes sense for other falsy values that are invalid.