### PR TITLE
add jsdoc comments

### DIFF
--- a/docs/api/core/cell.md
+++ b/docs/api/core/cell.md
@@ -24,6 +24,14 @@ getValue: () => any
 
 Returns the value for the cell, accessed via the associated column's accessor key or accessor function.
 
+### `renderValue`
+
+```tsx
+renderValue: () => any
+```
+
+Renders the value for a cell the same as `getValue`, but will return the `renderFallbackValue` if no value is found.
+
 ### `row`
 
 ```tsx
@@ -48,8 +56,8 @@ getContext: () => {
   column: Column<TData, TValue>
   row: Row<TData>
   cell: Cell<TData, TValue>
-  getValue: <TTValue = TValue>() => TTValue
-  renderValue: <TTValue = TValue>() => TTValue | null
+  getValue: <TTValue = TValue,>() => TTValue
+  renderValue: <TTValue = TValue,>() => TTValue | null
 }
 ```
 

--- a/docs/api/core/header.md
+++ b/docs/api/core/header.md
@@ -111,3 +111,133 @@ Returns the rendering context (or props) for column-based components like header
 ```tsx
 flexRender(header.column.columnDef.header, header.getContext())
 ```
+
+## Table API
+
+### `getHeaderGroups`
+
+```tsx
+type getHeaderGroups = () => HeaderGroup<TData>[]
+```
+
+Returns all header groups for the table.
+
+### `getLeftHeaderGroups`
+
+```tsx
+type getLeftHeaderGroups = () => HeaderGroup<TData>[]
+```
+
+If pinning, returns the header groups for the left pinned columns.
+
+### `getCenterHeaderGroups`
+
+```tsx
+type getCenterHeaderGroups = () => HeaderGroup<TData>[]
+```
+
+If pinning, returns the header groups for columns that are not pinned.
+
+### `getRightHeaderGroups`
+
+```tsx
+type getRightHeaderGroups = () => HeaderGroup<TData>[]
+```
+
+If pinning, returns the header groups for the right pinned columns.
+
+### `getFooterGroups`
+
+```tsx
+type getFooterGroups = () => HeaderGroup<TData>[]
+```
+
+Returns all footer groups for the table.
+
+### `getLeftFooterGroups`
+
+```tsx
+type getLeftFooterGroups = () => HeaderGroup<TData>[]
+```
+
+If pinning, returns the footer groups for the left pinned columns.
+
+### `getCenterFooterGroups`
+
+```tsx
+type getCenterFooterGroups = () => HeaderGroup<TData>[]
+```
+
+If pinning, returns the footer groups for columns that are not pinned.
+
+### `getRightFooterGroups`
+
+```tsx
+type getRightFooterGroups = () => HeaderGroup<TData>[]
+```
+
+If pinning, returns the footer groups for the right pinned columns.
+
+### `getFlatHeaders`
+
+```tsx
+type getFlatHeaders = () => Header<TData, unknown>[]
+```
+
+Returns headers for all columns in the table, including parent headers.
+
+### `getLeftFlatHeaders`
+
+```tsx
+type getLeftFlatHeaders = () => Header<TData, unknown>[]
+```
+
+If pinning, returns headers for all left pinned columns in the table, including parent headers.
+
+### `getCenterFlatHeaders`
+
+```tsx
+type getCenterFlatHeaders = () => Header<TData, unknown>[]
+```
+
+If pinning, returns headers for all columns that are not pinned, including parent headers.
+
+### `getRightFlatHeaders`
+
+```tsx
+type getRightFlatHeaders = () => Header<TData, unknown>[]
+```
+
+If pinning, returns headers for all right pinned columns in the table, including parent headers.
+
+### `getLeafHeaders`
+
+```tsx
+type getLeafHeaders = () => Header<TData, unknown>[]
+```
+
+Returns headers for all leaf columns in the table, (not including parent headers).
+
+### `getLeftLeafHeaders`
+
+```tsx
+type getLeftLeafHeaders = () => Header<TData, unknown>[]
+```
+
+If pinning, returns headers for all left pinned leaf columns in the table, (not including parent headers).
+
+### `getCenterLeafHeaders`
+
+```tsx
+type getCenterLeafHeaders = () => Header<TData, unknown>[]
+```
+
+If pinning, returns headers for all columns that are not pinned, (not including parent headers).
+
+### `getRightLeafHeaders`
+
+```tsx
+type getRightLeafHeaders = () => Header<TData, unknown>[]
+```
+
+If pinning, returns headers for all right pinned leaf columns in the table, (not including parent headers).

--- a/docs/api/core/row.md
+++ b/docs/api/core/row.md
@@ -53,10 +53,26 @@ If nested, this row's parent row id.
 ### `getValue`
 
 ```tsx
-getValue: (columnId: string) => any
+getValue: (columnId: string) => TValue
 ```
 
 Returns the value from the row for a given columnId
+
+### `renderValue`
+
+```tsx
+renderValue: (columnId: string) => TValue
+```
+
+Renders the value from the row for a given columnId, but will return the `renderFallbackValue` if no value is found.
+
+### `getUniqueValues`
+
+```tsx
+getUniqueValues: (columnId: string) => TValue[]
+```
+
+Returns a unique array of values from the row for a given columnId.
 
 ### `subRows`
 

--- a/docs/api/features/column-visibility.md
+++ b/docs/api/features/column-visibility.md
@@ -82,7 +82,7 @@ Enables/disables hiding of columns.
 ### `getVisibleFlatColumns`
 
 ```tsx
-getVisibleFlatColumns: () => Column < TData > []
+getVisibleFlatColumns: () => Column<TData>[]
 ```
 
 Returns a flat array of columns that are visible, including parent columns.
@@ -90,7 +90,7 @@ Returns a flat array of columns that are visible, including parent columns.
 ### `getVisibleLeafColumns`
 
 ```tsx
-getVisibleLeafColumns: () => Column < TData > []
+getVisibleLeafColumns: () => Column<TData>[]
 ```
 
 Returns a flat array of leaf-node columns that are visible.
@@ -98,7 +98,7 @@ Returns a flat array of leaf-node columns that are visible.
 ### `getLeftVisibleLeafColumns`
 
 ```tsx
-getLeftVisibleLeafColumns: () => Column < TData > []
+getLeftVisibleLeafColumns: () => Column<TData>[]
 ```
 
 If column pinning, returns a flat array of leaf-node columns that are visible in the left portion of the table.
@@ -106,7 +106,7 @@ If column pinning, returns a flat array of leaf-node columns that are visible in
 ### `getRightVisibleLeafColumns`
 
 ```tsx
-getRightVisibleLeafColumns: () => Column < TData > []
+getRightVisibleLeafColumns: () => Column<TData>[]
 ```
 
 If column pinning, returns a flat array of leaf-node columns that are visible in the right portion of the table.
@@ -114,7 +114,7 @@ If column pinning, returns a flat array of leaf-node columns that are visible in
 ### `getCenterVisibleLeafColumns`
 
 ```tsx
-getCenterVisibleLeafColumns: () => Column < TData > []
+getCenterVisibleLeafColumns: () => Column<TData>[]
 ```
 
 If column pinning, returns a flat array of leaf-node columns that are visible in the unpinned/center portion of the table.
@@ -166,3 +166,13 @@ getToggleAllColumnsVisibilityHandler: () => ((event: unknown) => void)
 ```
 
 Returns a handler for toggling the visibility of all columns, meant to be bound to a `input[type=checkbox]` element.
+
+## Row API
+
+### `getVisibleCells`
+
+```tsx
+getVisibleCells: () => Cell<TData>[]
+```
+
+Returns an array of cells that account for column visibility for the row.

--- a/docs/api/features/expanding.md
+++ b/docs/api/features/expanding.md
@@ -33,6 +33,14 @@ getIsExpanded: () => boolean
 
 Returns whether the row is expanded.
 
+### `getIsAllParentsExpanded`
+
+```tsx
+getIsAllParentsExpanded: () => boolean
+```
+
+Returns whether all parent rows of the row are expanded.
+
 ### `getCanExpand`
 
 ```tsx

--- a/docs/api/features/filters.md
+++ b/docs/api/features/filters.md
@@ -213,7 +213,7 @@ Returns whether or not the column can be **column** filtered.
 getCanGlobalFilter: () => boolean
 ```
 
-Returns whether or not the column can be **globally** filtered.
+Returns whether or not the column can be **globally** filtered.  Set to `false` to disable a column from being scanned during global filtering.
 
 ### `getFilterIndex`
 

--- a/docs/api/features/grouping.md
+++ b/docs/api/features/grouping.md
@@ -184,6 +184,8 @@ Returns the automatically inferred aggregation function for the column.
 getAggregationFn: () => AggregationFn<TData> | undefined
 ```
 
+Returns the aggregation function for the column.
+
 ## Row API
 
 ### `groupingColumnId`
@@ -323,3 +325,29 @@ getGroupedRowModel: () => RowModel<TData>
 ```
 
 Returns the row model for the table after grouping has been applied.
+
+## Cell API
+
+### `getIsAggregated`
+
+```tsx
+getIsAggregated: () => boolean
+```
+
+Returns whether or not the cell is currently aggregated.
+
+### `getIsGrouped`
+
+```tsx
+getIsGrouped: () => boolean
+```
+
+Returns whether or not the cell is currently grouped.
+
+### `getIsPlaceholder`
+
+```tsx
+getIsPlaceholder: () => boolean
+```
+
+Returns whether or not the cell is currently a placeholder.

--- a/docs/api/features/pinning.md
+++ b/docs/api/features/pinning.md
@@ -49,7 +49,7 @@ export type RowPinningRowState = {
 enablePinning?: boolean
 ```
 
-Enables/disables all pinning for the table.
+Enables/disables all pinning for the table. Defaults to `true`.
 
 ### `enableColumnPinning`
 
@@ -81,7 +81,7 @@ When `false`, pinned rows will not be visible if they are filtered or paginated 
 onColumnPinningChange?: OnChangeFn<ColumnPinningState>
 ```
 
-If provided, this function will be called with an `updaterFn` when `state.columnPinning` changes. This overrides the default internal state management, so you will need to persist the state change either fully or partially outside of the table.
+If provided, this function will be called with an `updaterFn` when `state.columnPinning` changes. This overrides the default internal state management, so you will also need to supply `state.columnPinning` from your own managed state.
 
 ### `onRowPinningChange`
 
@@ -89,7 +89,7 @@ If provided, this function will be called with an `updaterFn` when `state.column
 onRowPinningChange?: OnChangeFn<RowPinningState>
 ```
 
-If provided, this function will be called with an `updaterFn` when `state.rowPinning` changes. This overrides the default internal state management, so you will need to persist the state change either fully or partially outside of the table.
+If provided, this function will be called with an `updaterFn` when `state.rowPinning` changes. This overrides the default internal state management, so you will also need to supply `state.rowPinning` from your own managed state.
 
 ## Column Def Options
 
@@ -156,7 +156,7 @@ Returns whether or not any rows are pinned. Optionally specify to only check for
 ### `getLeftHeaderGroups`
 
 ```tsx
-getLeftHeaderGroups: () => HeaderGroup < TData > []
+getLeftHeaderGroups: () => HeaderGroup<TData>[]
 ```
 
 Returns the left pinned header groups for the table.
@@ -164,7 +164,7 @@ Returns the left pinned header groups for the table.
 ### `getCenterHeaderGroups`
 
 ```tsx
-getCenterHeaderGroups: () => HeaderGroup < TData > []
+getCenterHeaderGroups: () => HeaderGroup<TData>[]
 ```
 
 Returns the unpinned/center header groups for the table.
@@ -172,7 +172,7 @@ Returns the unpinned/center header groups for the table.
 ### `getRightHeaderGroups`
 
 ```tsx
-getRightHeaderGroups: () => HeaderGroup < TData > []
+getRightHeaderGroups: () => HeaderGroup<TData>[]
 ```
 
 Returns the right pinned header groups for the table.
@@ -180,7 +180,7 @@ Returns the right pinned header groups for the table.
 ### `getLeftFooterGroups`
 
 ```tsx
-getLeftFooterGroups: () => HeaderGroup < TData > []
+getLeftFooterGroups: () => HeaderGroup<TData>[]
 ```
 
 Returns the left pinned footer groups for the table.
@@ -188,7 +188,7 @@ Returns the left pinned footer groups for the table.
 ### `getCenterFooterGroups`
 
 ```tsx
-getCenterFooterGroups: () => HeaderGroup < TData > []
+getCenterFooterGroups: () => HeaderGroup<TData>[]
 ```
 
 Returns the unpinned/center footer groups for the table.
@@ -196,7 +196,7 @@ Returns the unpinned/center footer groups for the table.
 ### `getRightFooterGroups`
 
 ```tsx
-getRightFooterGroups: () => HeaderGroup < TData > []
+getRightFooterGroups: () => HeaderGroup<TData>[]
 ```
 
 Returns the right pinned footer groups for the table.
@@ -204,7 +204,7 @@ Returns the right pinned footer groups for the table.
 ### `getLeftFlatHeaders`
 
 ```tsx
-getLeftFlatHeaders: () => Header < TData > []
+getLeftFlatHeaders: () => Header<TData>[]
 ```
 
 Returns a flat array of left pinned headers for the table, including parent headers.
@@ -212,7 +212,7 @@ Returns a flat array of left pinned headers for the table, including parent head
 ### `getCenterFlatHeaders`
 
 ```tsx
-getCenterFlatHeaders: () => Header < TData > []
+getCenterFlatHeaders: () => Header<TData>[]
 ```
 
 Returns a flat array of unpinned/center headers for the table, including parent headers.
@@ -220,7 +220,7 @@ Returns a flat array of unpinned/center headers for the table, including parent 
 ### `getRightFlatHeaders`
 
 ```tsx
-getRightFlatHeaders: () => Header < TData > []
+getRightFlatHeaders: () => Header<TData>[]
 ```
 
 Returns a flat array of right pinned headers for the table, including parent headers.
@@ -228,7 +228,7 @@ Returns a flat array of right pinned headers for the table, including parent hea
 ### `getLeftLeafHeaders`
 
 ```tsx
-getLeftLeafHeaders: () => Header < TData > []
+getLeftLeafHeaders: () => Header<TData>[]
 ```
 
 Returns a flat array of leaf-node left pinned headers for the table.
@@ -236,7 +236,7 @@ Returns a flat array of leaf-node left pinned headers for the table.
 ### `getCenterLeafHeaders`
 
 ```tsx
-getCenterLeafHeaders: () => Header < TData > []
+getCenterLeafHeaders: () => Header<TData>[]
 ```
 
 Returns a flat array of leaf-node unpinned/center headers for the table.
@@ -244,7 +244,7 @@ Returns a flat array of leaf-node unpinned/center headers for the table.
 ### `getRightLeafHeaders`
 
 ```tsx
-getRightLeafHeaders: () => Header < TData > []
+getRightLeafHeaders: () => Header<TData>[]
 ```
 
 Returns a flat array of leaf-node right pinned headers for the table.
@@ -252,7 +252,7 @@ Returns a flat array of leaf-node right pinned headers for the table.
 ### `getLeftLeafColumns`
 
 ```tsx
-getLeftLeafColumns: () => Column < TData > []
+getLeftLeafColumns: () => Column<TData>[]
 ```
 
 Returns all left pinned leaf columns.
@@ -260,7 +260,7 @@ Returns all left pinned leaf columns.
 ### `getRightLeafColumns`
 
 ```tsx
-getRightLeafColumns: () => Column < TData > []
+getRightLeafColumns: () => Column<TData>[]
 ```
 
 Returns all right pinned leaf columns.
@@ -268,7 +268,7 @@ Returns all right pinned leaf columns.
 ### `getCenterLeafColumns`
 
 ```tsx
-getCenterLeafColumns: () => Column < TData > []
+getCenterLeafColumns: () => Column<TData>[]
 ```
 
 Returns all center pinned (unpinned) leaf columns.
@@ -276,7 +276,7 @@ Returns all center pinned (unpinned) leaf columns.
 ### `getTopRows`
 
 ```tsx
-getTopRows: () => Row < TData > []
+getTopRows: () => Row<TData>[]
 ```
 
 Returns all top pinned rows.
@@ -284,7 +284,7 @@ Returns all top pinned rows.
 ### `getBottomRows`
 
 ```tsx
-getBottomRows: () => Row < TData > []
+getBottomRows: () => Row<TData>[]
 ```
 
 Returns all bottom pinned rows.
@@ -292,7 +292,7 @@ Returns all bottom pinned rows.
 ### `getCenterRows`
 
 ```tsx
-getCenterRows: () => Row < TData > []
+getCenterRows: () => Row<TData>[]
 ```
 
 Returns all rows that are not pinned to the top or bottom.
@@ -368,7 +368,7 @@ Returns the numeric pinned index of the row within a pinned row group.
 ### `getLeftVisibleCells`
 
 ```tsx
-getLeftVisibleCells: () => Cell < TData > []
+getLeftVisibleCells: () => Cell<TData>[]
 ```
 
 Returns all left pinned leaf cells in the row.
@@ -376,7 +376,7 @@ Returns all left pinned leaf cells in the row.
 ### `getRightVisibleCells`
 
 ```tsx
-getRightVisibleCells: () => Cell < TData > []
+getRightVisibleCells: () => Cell<TData>[]
 ```
 
 Returns all right pinned leaf cells in the row.
@@ -384,7 +384,7 @@ Returns all right pinned leaf cells in the row.
 ### `getCenterVisibleCells`
 
 ```tsx
-getCenterVisibleCells: () => Cell < TData > []
+getCenterVisibleCells: () => Cell<TData>[]
 ```
 
 Returns all center pinned (unpinned) leaf cells in the row.

--- a/docs/api/features/row-selection.md
+++ b/docs/api/features/row-selection.md
@@ -177,6 +177,14 @@ getIsSomeSelected: () => boolean
 
 Returns whether or not some of the row's sub rows are selected.
 
+### `getIsAllSubRowsSelected`
+
+```tsx
+getIsAllSubRowsSelected: () => boolean
+```
+
+Returns whether or not all of the row's sub rows are selected.
+
 ### `getCanSelect`
 
 ```tsx

--- a/docs/api/features/sorting.md
+++ b/docs/api/features/sorting.md
@@ -199,6 +199,14 @@ getIsSorted: () => false | SortDirection
 
 Returns whether this column is sorted.
 
+### `getFirstSortDir`
+
+```tsx 
+getFirstSortDir: () => SortDirection
+```
+
+Returns the first direction that should be used when sorting this column.
+
 ### `clearSorting`
 
 ```tsx
@@ -285,8 +293,8 @@ enableSortingRemoval?: boolean
 ```
 
 Enables/Disables the ability to remove sorting for the table.
-If `true` then changing sort order will circle like: 'none' -> 'desc' -> 'asc' -> 'none' -> ...
-If `false` then changing sort order will circle like: 'none' -> 'desc' -> 'asc' -> 'desc' -> 'asc' -> ...
+- If `true` then changing sort order will circle like: 'none' -> 'desc' -> 'asc' -> 'none' -> ...
+- If `false` then changing sort order will circle like: 'none' -> 'desc' -> 'asc' -> 'desc' -> 'asc' -> ...
 
 ### `enableMultiRemove`
 

--- a/packages/react-table/src/index.tsx
+++ b/packages/react-table/src/index.tsx
@@ -12,6 +12,9 @@ export type Renderable<TProps> = React.ReactNode | React.ComponentType<TProps>
 
 //
 
+/**
+ * If rendering headers, cells, or footers with custom markup, use flexRender instead of `cell.getValue()` or `cell.renderValue()`.
+ */
 export function flexRender<TProps extends object>(
   Comp: Renderable<TProps>,
   props: TProps

--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -56,7 +56,7 @@ export type ColumnHelper<TData extends RowData> = {
       ? TReturn
       : TAccessor extends DeepKeys<TData>
       ? DeepValue<TData, TAccessor>
-      : never
+      : never,
   >(
     accessor: TAccessor,
     column: TAccessor extends AccessorFn<TData>
@@ -68,7 +68,7 @@ export type ColumnHelper<TData extends RowData> = {
 }
 
 export function createColumnHelper<
-  TData extends RowData
+  TData extends RowData,
 >(): ColumnHelper<TData> {
   return {
     accessor: (accessor, column) => {

--- a/packages/table-core/src/core/cell.ts
+++ b/packages/table-core/src/core/cell.ts
@@ -2,21 +2,51 @@ import { RowData, Cell, Column, Row, Table } from '../types'
 import { Getter, memo } from '../utils'
 
 export interface CellContext<TData extends RowData, TValue> {
-  table: Table<TData>
-  column: Column<TData, TValue>
-  row: Row<TData>
   cell: Cell<TData, TValue>
+  column: Column<TData, TValue>
   getValue: Getter<TValue>
   renderValue: Getter<TValue | null>
+  row: Row<TData>
+  table: Table<TData>
 }
 
 export interface CoreCell<TData extends RowData, TValue> {
-  id: string
-  getValue: CellContext<TData, TValue>['getValue']
-  renderValue: CellContext<TData, TValue>['renderValue']
-  row: Row<TData>
+  /**
+   * The associated Column object for the cell.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/cell#column)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/cells)
+   */
   column: Column<TData, TValue>
+  /**
+   * Returns the rendering context (or props) for cell-based components like cells and aggregated cells. Use these props with your framework's `flexRender` utility to render these using the template of your choice:
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/cell#getcontext)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/cells)
+   */
   getContext: () => CellContext<TData, TValue>
+  /**
+   * Returns the value for the cell, accessed via the associated column's accessor key or accessor function.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/cell#getvalue)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/cells)
+   */
+  getValue: CellContext<TData, TValue>['getValue']
+  /**
+   * The unique ID for the cell across the entire table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/cell#id)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/cells)
+   */
+  id: string
+  /**
+   * Renders the value for a cell the same as `getValue`, but will return the `renderFallbackValue` if no value is found.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/cell#rendervalue)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/cells)
+   */
+  renderValue: CellContext<TData, TValue>['renderValue']
+  /**
+   * The associated Row object for the cell.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/cell#row)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/cells)
+   */
+  row: Row<TData>
 }
 
 export function createCell<TData extends RowData, TValue>(

--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -9,14 +9,57 @@ import {
 import { memo } from '../utils'
 
 export interface CoreColumn<TData extends RowData, TValue> {
-  id: string
-  depth: number
+  /**
+   * The resolved accessor function to use when extracting the value for the column from each row. Will only be defined if the column def has a valid accessor key or function defined.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/column#accessorfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-defs)
+   */
   accessorFn?: AccessorFn<TData, TValue>
+  /**
+   * The original column def used to create the column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/column#columndef)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-defs)
+   */
   columnDef: ColumnDef<TData, TValue>
+  /**
+   * The child column (if the column is a group column). Will be an empty array if the column is not a group column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/column#columns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-defs)
+   */
   columns: Column<TData, TValue>[]
-  parent?: Column<TData, TValue>
+  /**
+   * The depth of the column (if grouped) relative to the root column def array.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/column#depth)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-defs)
+   */
+  depth: number
+  /**
+   * Returns the flattened array of this column and all child/grand-child columns for this column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/column#getflatcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-defs)
+   */
   getFlatColumns: () => Column<TData, TValue>[]
+  /**
+   * Returns an array of all leaf-node columns for this column. If a column has no children, it is considered the only leaf-node column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/column#getleafcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-defs)
+   */
   getLeafColumns: () => Column<TData, TValue>[]
+  /**
+   * The resolved unique identifier for the column resolved in this priority:
+      - A manual `id` property from the column def
+      - The accessor key from the column def
+      - The header string from the column def
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/column#id)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-defs)
+   */
+  id: string
+  /**
+   * The parent column for this column. Will be undefined if this is a root column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/column#parent)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-defs)
+   */
+  parent?: Column<TData, TValue>
 }
 
 export function createColumn<TData extends RowData, TValue>(

--- a/packages/table-core/src/core/headers.ts
+++ b/packages/table-core/src/core/headers.ts
@@ -9,8 +9,17 @@ export interface CoreHeaderGroup<TData extends RowData> {
 }
 
 export interface HeaderContext<TData, TValue> {
+  /**
+   * An instance of a column.
+   */
   column: Column<TData, TValue>
+  /**
+   * An instance of a header.
+   */
   header: Header<TData, TValue>
+  /**
+   * The table instance.
+   */
   table: Table<TData>
 }
 
@@ -90,24 +99,104 @@ export interface CoreHeader<TData extends RowData, TValue> {
 }
 
 export interface HeadersInstance<TData extends RowData> {
+  /**
+   * Returns all header groups for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getheadergroups)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getHeaderGroups: () => HeaderGroup<TData>[]
+  /**
+   * If pinning, returns the header groups for the left pinned columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getleftheadergroups)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getLeftHeaderGroups: () => HeaderGroup<TData>[]
+  /**
+   * If pinning, returns the header groups for columns that are not pinned.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getcenterheadergroups)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getCenterHeaderGroups: () => HeaderGroup<TData>[]
+  /**
+   * If pinning, returns the header groups for the right pinned columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getrightheadergroups)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getRightHeaderGroups: () => HeaderGroup<TData>[]
 
+  /**
+   * Returns the footer groups for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getfootergroups)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getFooterGroups: () => HeaderGroup<TData>[]
+  /**
+   * If pinning, returns the footer groups for the left pinned columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getleftfootergroups)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getLeftFooterGroups: () => HeaderGroup<TData>[]
+  /**
+   * If pinning, returns the footer groups for columns that are not pinned.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getcenterfootergroups)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getCenterFooterGroups: () => HeaderGroup<TData>[]
+  /**
+   * If pinning, returns the footer groups for the right pinned columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getrightfootergroups)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getRightFooterGroups: () => HeaderGroup<TData>[]
 
+  /**
+   * Returns headers for all columns in the table, including parent headers.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getflatheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getFlatHeaders: () => Header<TData, unknown>[]
+  /**
+   * If pinning, returns headers for all left pinned columns in the table, including parent headers.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getleftflatheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getLeftFlatHeaders: () => Header<TData, unknown>[]
+  /**
+   * If pinning, returns headers for all columns that are not pinned, including parent headers.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getcenterflatheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getCenterFlatHeaders: () => Header<TData, unknown>[]
+  /**
+   * If pinning, returns headers for all right pinned columns in the table, including parent headers.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getrightflatheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getRightFlatHeaders: () => Header<TData, unknown>[]
 
+  /**
+   * Returns headers for all leaf columns in the table, (not including parent headers).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getleafheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getLeafHeaders: () => Header<TData, unknown>[]
+  /**
+   * If pinning, returns headers for all left pinned leaf columns in the table, (not including parent headers).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getleftleafheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getLeftLeafHeaders: () => Header<TData, unknown>[]
+  /**
+   * If pinning, returns headers for all columns that are not pinned, (not including parent headers).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getcenterleafheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getCenterLeafHeaders: () => Header<TData, unknown>[]
+  /**
+   * If pinning, returns headers for all right pinned leaf columns in the table, (not including parent headers).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getrightleafheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getRightLeafHeaders: () => Header<TData, unknown>[]
 }
 

--- a/packages/table-core/src/core/headers.ts
+++ b/packages/table-core/src/core/headers.ts
@@ -3,30 +3,90 @@ import { memo } from '../utils'
 import { TableFeature } from './table'
 
 export interface CoreHeaderGroup<TData extends RowData> {
-  id: string
   depth: number
   headers: Header<TData, unknown>[]
+  id: string
 }
 
 export interface HeaderContext<TData, TValue> {
-  table: Table<TData>
-  header: Header<TData, TValue>
   column: Column<TData, TValue>
+  header: Header<TData, TValue>
+  table: Table<TData>
 }
 
 export interface CoreHeader<TData extends RowData, TValue> {
-  id: string
-  index: number
-  depth: number
-  column: Column<TData, TValue>
-  headerGroup: HeaderGroup<TData>
-  subHeaders: Header<TData, TValue>[]
+  /**
+   * The col-span for the header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#colspan)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   colSpan: number
-  rowSpan: number
-  getLeafHeaders: () => Header<TData, unknown>[]
-  isPlaceholder: boolean
-  placeholderId?: string
+  /**
+   * The header's associated column object.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#column)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  column: Column<TData, TValue>
+  /**
+   * The depth of the header, zero-indexed based.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#depth)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  depth: number
+  /**
+   * Returns the rendering context (or props) for column-based components like headers, footers and filters.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#getcontext)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
   getContext: () => HeaderContext<TData, TValue>
+  /**
+   * Returns the leaf headers hierarchically nested under this header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#getleafheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  getLeafHeaders: () => Header<TData, unknown>[]
+  /**
+   * The header's associated header group object.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#headergroup)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  headerGroup: HeaderGroup<TData>
+  /**
+   * The unique identifier for the header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#id)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  id: string
+  /**
+   * The index for the header within the header group.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#index)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  index: number
+  /**
+   * A boolean denoting if the header is a placeholder header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#isplaceholder)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  isPlaceholder: boolean
+  /**
+   * If the header is a placeholder header, this will be a unique header ID that does not conflict with any other headers across the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#placeholderid)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  placeholderId?: string
+  /**
+   * The row-span for the header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#rowspan)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  rowSpan: number
+  /**
+   * The header's hierarchical sub/child headers. Will be empty if the header's associated column is a leaf-column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#subheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  subHeaders: Header<TData, TValue>[]
 }
 
 export interface HeadersInstance<TData extends RowData> {

--- a/packages/table-core/src/core/row.ts
+++ b/packages/table-core/src/core/row.ts
@@ -80,6 +80,8 @@ export interface CoreRow<TData extends RowData> {
   parentId?: string
   /**
    * Renders the value for the row in a given columnId the same as `getValue`, but will return the `renderFallbackValue` if no value is found.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#rendervalue)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
    */
   renderValue: <TValue>(columnId: string) => TValue
   /**

--- a/packages/table-core/src/core/row.ts
+++ b/packages/table-core/src/core/row.ts
@@ -3,23 +3,91 @@ import { flattenBy, memo } from '../utils'
 import { createCell } from './cell'
 
 export interface CoreRow<TData extends RowData> {
-  id: string
-  index: number
-  original: TData
-  depth: number
-  parentId?: string
-  _valuesCache: Record<string, unknown>
-  _uniqueValuesCache: Record<string, unknown>
-  getValue: <TValue>(columnId: string) => TValue
-  getUniqueValues: <TValue>(columnId: string) => TValue[]
-  renderValue: <TValue>(columnId: string) => TValue
-  subRows: Row<TData>[]
-  getLeafRows: () => Row<TData>[]
-  originalSubRows?: TData[]
-  getAllCells: () => Cell<TData, unknown>[]
   _getAllCellsByColumnId: () => Record<string, Cell<TData, unknown>>
+  _uniqueValuesCache: Record<string, unknown>
+  _valuesCache: Record<string, unknown>
+  /**
+   * The depth of the row (if nested or grouped) relative to the root row array.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#depth)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  depth: number
+  /**
+   * Returns all of the cells for the row.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#getallcells)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  getAllCells: () => Cell<TData, unknown>[]
+  /**
+   * Returns the leaf rows for the row, not including any parent rows.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#getleafrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  getLeafRows: () => Row<TData>[]
+  /**
+   * Returns the parent row for the row, if it exists.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#getparentrow)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
   getParentRow: () => Row<TData> | undefined
+  /**
+   * Returns the parent rows for the row, all the way up to a root row.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#getparentrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
   getParentRows: () => Row<TData>[]
+  /**
+   * Returns a unique array of values from the row for a given columnId.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#getuniquevalues)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  getUniqueValues: <TValue>(columnId: string) => TValue[]
+  /**
+   * Returns the value from the row for a given columnId.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#getvalue)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  getValue: <TValue>(columnId: string) => TValue
+  /**
+   * The resolved unique identifier for the row resolved via the `options.getRowId` option. Defaults to the row's index (or relative index if it is a subRow).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#id)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  id: string
+  /**
+   * The index of the row within its parent array (or the root data array).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#index)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  index: number
+  /**
+   * The original row object provided to the table. If the row is a grouped row, the original row object will be the first original in the group.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#original)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  original: TData
+  /**
+   * An array of the original subRows as returned by the `options.getSubRows` option.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#originalsubrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  originalSubRows?: TData[]
+  /**
+   * If nested, this row's parent row id.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#parentid)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  parentId?: string
+  /**
+   * Renders the value for the row in a given columnId the same as `getValue`, but will return the `renderFallbackValue` if no value is found.
+   */
+  renderValue: <TValue>(columnId: string) => TValue
+  /**
+   * An array of subRows for the row as returned and created by the `options.getSubRows` option.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/row#subrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/rows)
+   */
+  subRows: Row<TData>[]
 }
 
 export const createRow = <TData extends RowData>(
@@ -112,10 +180,13 @@ export const createRow = <TData extends RowData>(
     _getAllCellsByColumnId: memo(
       () => [row.getAllCells()],
       allCells => {
-        return allCells.reduce((acc, cell) => {
-          acc[cell.column.id] = cell
-          return acc
-        }, {} as Record<string, Cell<TData, unknown>>)
+        return allCells.reduce(
+          (acc, cell) => {
+            acc[cell.column.id] = cell
+            return acc
+          },
+          {} as Record<string, Cell<TData, unknown>>
+        )
       },
       {
         key:

--- a/packages/table-core/src/core/table.ts
+++ b/packages/table-core/src/core/table.ts
@@ -34,14 +34,14 @@ import { Sorting } from '../features/Sorting'
 import { Visibility } from '../features/Visibility'
 
 export interface TableFeature {
-  getDefaultOptions?: (table: any) => any
-  getInitialState?: (initialState?: InitialTableState) => any
-  createTable?: (table: any) => any
-  getDefaultColumnDef?: () => any
+  createCell?: (cell: any, column: any, row: any, table: any) => any
   createColumn?: (column: any, table: any) => any
   createHeader?: (column: any, table: any) => any
-  createCell?: (cell: any, column: any, row: any, table: any) => any
   createRow?: (row: any, table: any) => any
+  createTable?: (table: any) => any
+  getDefaultColumnDef?: () => any
+  getDefaultOptions?: (table: any) => any
+  getInitialState?: (initialState?: InitialTableState) => any
 }
 
 const features = [
@@ -63,50 +63,210 @@ const features = [
 export interface CoreTableState {}
 
 export interface CoreOptions<TData extends RowData> {
-  data: TData[]
-  state: Partial<TableState>
-  onStateChange: (updater: Updater<TableState>) => void
-  debugAll?: boolean
-  debugTable?: boolean
-  debugHeaders?: boolean
-  debugColumns?: boolean
-  debugRows?: boolean
-  initialState?: InitialTableState
+  /**
+   * Set this option to override any of the `autoReset...` feature options.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#autoresetall)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
   autoResetAll?: boolean
+  /**
+   * The array of column defs to use for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#columns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  columns: ColumnDef<TData, any>[]
+  /**
+   * The data for the table to display. This array should match the type you provided to `table.setRowType<...>`. Columns can access this data via string/index or a functional accessor. When the `data` option changes reference, the table will reprocess the data.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#data)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  data: TData[]
+  /**
+   * Set this option to `true` to output all debugging information to the console.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugall)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  debugAll?: boolean
+  /**
+   * Set this option to `true` to output column debugging information to the console.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  debugColumns?: boolean
+  /**
+   * Set this option to `true` to output header debugging information to the console.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  debugHeaders?: boolean
+  /**
+   * Set this option to `true` to output row debugging information to the console.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  debugRows?: boolean
+  /**
+   * Set this option to `true` to output table debugging information to the console.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugtable)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  debugTable?: boolean
+  /**
+   * Default column options to use for all column defs supplied to the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#defaultcolumn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  defaultColumn?: Partial<ColumnDef<TData, unknown>>
+  /**
+   * This required option is a factory for a function that computes and returns the core row model for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getcorerowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getCoreRowModel: (table: Table<any>) => () => RowModel<any>
+  /**
+   * This optional function is used to derive a unique ID for any given row. If not provided the rows index is used (nested rows join together with `.` using their grandparents' index eg. `index.index.index`). If you need to identify individual rows that are originating from any server-side operations, it's suggested you use this function to return an ID that makes sense regardless of network IO/ambiguity eg. a userId, taskId, database ID field, etc.
+   * @example getRowId: row => row.userId
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getrowid)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string
+  /**
+   * This optional function is used to access the sub rows for any given row. If you are using nested rows, you will need to use this function to return the sub rows object (or undefined) from the row.
+   * @example getSubRows: row => row.subRows
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getsubrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getSubRows?: (originalRow: TData, index: number) => undefined | TData[]
+  /**
+   * Use this option to optionally pass initial state to the table. This state will be used when resetting various table states either automatically by the table (eg. `options.autoResetPageIndex`) or via functions like `table.resetRowSelection()`. Most reset function allow you optionally pass a flag to reset to a blank/default state instead of the initial state. 
+   * 
+   * Table state will not be reset when this object changes, which also means that the initial state object does not need to be stable.
+   * 
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#initialstate)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  initialState?: InitialTableState
+  /**
+   * This option is used to optionally implement the merging of table options.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#mergeoptions)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
   mergeOptions?: (
     defaultOptions: TableOptions<TData>,
     options: Partial<TableOptions<TData>>
   ) => TableOptions<TData>
+  /**
+   * You can pass any object to `options.meta` and access it anywhere the `table` is available via `table.options.meta`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#meta)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
   meta?: TableMeta<TData>
-  getCoreRowModel: (table: Table<any>) => () => RowModel<any>
-  getSubRows?: (originalRow: TData, index: number) => undefined | TData[]
-  getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string
-  columns: ColumnDef<TData, any>[]
-  defaultColumn?: Partial<ColumnDef<TData, unknown>>
+  /**
+   * The `onStateChange` option can be used to optionally listen to state changes within the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#onstatechange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  onStateChange: (updater: Updater<TableState>) => void
+  /**
+   * Value used when the desired value is not found in the data.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#renderfallbackvalue)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
   renderFallbackValue: any
+  /**
+   * The `state` option can be used to optionally _control_ part or all of the table state. The state you pass here will merge with and overwrite the internal automatically-managed state to produce the final state for the table. You can also listen to state changes via the `onStateChange` option.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#state)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  state: Partial<TableState>
 }
 
 export interface CoreInstance<TData extends RowData> {
-  initialState: TableState
-  reset: () => void
-  options: RequiredKeys<TableOptionsResolved<TData>, 'state'>
-  setOptions: (newOptions: Updater<TableOptionsResolved<TData>>) => void
-  getState: () => TableState
-  setState: (updater: Updater<TableState>) => void
   _features: readonly TableFeature[]
-  _queue: (cb: () => void) => void
-  _getRowId: (_: TData, index: number, parent?: Row<TData>) => string
-  getCoreRowModel: () => RowModel<TData>
-  _getCoreRowModel?: () => RowModel<TData>
-  getRowModel: () => RowModel<TData>
-  getRow: (id: string, searchAll?: boolean) => Row<TData>
-  _getDefaultColumnDef: () => Partial<ColumnDef<TData, unknown>>
-  _getColumnDefs: () => ColumnDef<TData, unknown>[]
   _getAllFlatColumnsById: () => Record<string, Column<TData, unknown>>
+  _getColumnDefs: () => ColumnDef<TData, unknown>[]
+  _getCoreRowModel?: () => RowModel<TData>
+  _getDefaultColumnDef: () => Partial<ColumnDef<TData, unknown>>
+  _getRowId: (_: TData, index: number, parent?: Row<TData>) => string
+  _queue: (cb: () => void) => void
+  /**
+   * Returns all columns in the table in their normalized and nested hierarchy.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getallcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
   getAllColumns: () => Column<TData, unknown>[]
+  /**
+   * Returns all columns in the table flattened to a single level.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getallflatcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
   getAllFlatColumns: () => Column<TData, unknown>[]
+  /**
+   * Returns all leaf-node columns in the table flattened to a single level. This does not include parent columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getallleafcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
   getAllLeafColumns: () => Column<TData, unknown>[]
+  /**
+   * Returns a single column by its ID.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getcolumn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
   getColumn: (columnId: string) => Column<TData, unknown> | undefined
+  /**
+   * Returns the core row model before any processing has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getcorerowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getCoreRowModel: () => RowModel<TData>
+  /**
+   * Returns the row with the given ID.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getrow)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getRow: (id: string, searchAll?: boolean) => Row<TData>
+  /**
+   * Returns the final model after all processing from other used features has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getRowModel: () => RowModel<TData>
+  /**
+   * Call this function to get the table's current state. It's recommended to use this function and its state, especially when managing the table state manually. It is the exact same state used internally by the table for every feature and function it provides.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getstate)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getState: () => TableState
+  /**
+   * This is the resolved initial state of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#initialstate)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  initialState: TableState
+  /**
+   * A read-only reference to the table's current options.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#options)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  options: RequiredKeys<TableOptionsResolved<TData>, 'state'>
+  /**
+   * Call this function to reset the table state to the initial state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#reset)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  reset: () => void
+  /**
+   * This function can be used to update the table options.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#setoptions)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  setOptions: (newOptions: Updater<TableOptionsResolved<TData>>) => void
+  /**
+   * Call this function to update the table state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#setstate)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  setState: (updater: Updater<TableState>) => void
 }
 
 export function createTable<TData extends RowData>(

--- a/packages/table-core/src/core/table.ts
+++ b/packages/table-core/src/core/table.ts
@@ -138,10 +138,10 @@ export interface CoreOptions<TData extends RowData> {
    */
   getSubRows?: (originalRow: TData, index: number) => undefined | TData[]
   /**
-   * Use this option to optionally pass initial state to the table. This state will be used when resetting various table states either automatically by the table (eg. `options.autoResetPageIndex`) or via functions like `table.resetRowSelection()`. Most reset function allow you optionally pass a flag to reset to a blank/default state instead of the initial state. 
-   * 
+   * Use this option to optionally pass initial state to the table. This state will be used when resetting various table states either automatically by the table (eg. `options.autoResetPageIndex`) or via functions like `table.resetRowSelection()`. Most reset function allow you optionally pass a flag to reset to a blank/default state instead of the initial state.
+   *
    * Table state will not be reset when this object changes, which also means that the initial state object does not need to be stable.
-   * 
+   *
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#initialstate)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
    */
@@ -175,6 +175,7 @@ export interface CoreOptions<TData extends RowData> {
   renderFallbackValue: any
   /**
    * The `state` option can be used to optionally _control_ part or all of the table state. The state you pass here will merge with and overwrite the internal automatically-managed state to produce the final state for the table. You can also listen to state changes via the `onStateChange` option.
+   * > Note: Any state passed in here will override both the internal state and any other `initialState` you provide.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#state)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
    */
@@ -226,7 +227,7 @@ export interface CoreInstance<TData extends RowData> {
    */
   getRow: (id: string, searchAll?: boolean) => Row<TData>
   /**
-   * Returns the final model after all processing from other used features has been applied.
+   * Returns the final model after all processing from other used features has been applied. This is the row model that is most commonly used for rendering.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getrowmodel)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
    */

--- a/packages/table-core/src/features/ColumnSizing.ts
+++ b/packages/table-core/src/features/ColumnSizing.ts
@@ -13,20 +13,40 @@ export interface ColumnSizingTableState {
 export type ColumnSizingState = Record<string, number>
 
 export interface ColumnSizingInfoState {
-  startOffset: null | number
-  startSize: null | number
+  columnSizingStart: [string, number][]
   deltaOffset: null | number
   deltaPercentage: null | number
   isResizingColumn: false | string
-  columnSizingStart: [string, number][]
+  startOffset: null | number
+  startSize: null | number
 }
 
 export type ColumnResizeMode = 'onChange' | 'onEnd'
 
 export interface ColumnSizingOptions {
-  enableColumnResizing?: boolean
+  /**
+   * Determines when the columnSizing state is updated. `onChange` updates the state when the user is dragging the resize handle. `onEnd` updates the state when the user releases the resize handle.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#columnresizemode)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   columnResizeMode?: ColumnResizeMode
+  /**
+   * Enables or disables column resizing for the column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#enablecolumnresizing)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  enableColumnResizing?: boolean
+  /**
+   * If provided, this function will be called with an `updaterFn` when `state.columnSizing` changes. This overrides the default internal state management, so you will also need to supply `state.columnSizing` from your own managed state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#oncolumnsizingchange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   onColumnSizingChange?: OnChangeFn<ColumnSizingState>
+  /**
+   * If provided, this function will be called with an `updaterFn` when `state.columnSizingInfo` changes. This overrides the default internal state management, so you will also need to supply `state.columnSizingInfo` from your own managed state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#oncolumnsizinginfochange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   onColumnSizingInfoChange?: OnChangeFn<ColumnSizingInfoState>
 }
 
@@ -37,35 +57,139 @@ export interface ColumnSizingDefaultOptions {
 }
 
 export interface ColumnSizingInstance {
-  setColumnSizing: (updater: Updater<ColumnSizingState>) => void
-  setColumnSizingInfo: (updater: Updater<ColumnSizingInfoState>) => void
-  resetColumnSizing: (defaultState?: boolean) => void
-  resetHeaderSizeInfo: (defaultState?: boolean) => void
-  getTotalSize: () => number
-  getLeftTotalSize: () => number
+  /**
+   * If pinning, returns the total size of the center portion of the table by calculating the sum of the sizes of all unpinned/center leaf-columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getcentertotalsize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   getCenterTotalSize: () => number
+  /**
+   * Returns the total size of the left portion of the table by calculating the sum of the sizes of all left leaf-columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getlefttotalsize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  getLeftTotalSize: () => number
+  /**
+   * Returns the total size of the right portion of the table by calculating the sum of the sizes of all right leaf-columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getrighttotalsize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   getRightTotalSize: () => number
+  /**
+   * Returns the total size of the table by calculating the sum of the sizes of all leaf-columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#gettotalsize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  getTotalSize: () => number
+  /**
+   * Resets column sizing to its initial state. If `defaultState` is `true`, the default state for the table will be used instead of the initialValue provided to the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#resetcolumnsizing)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  resetColumnSizing: (defaultState?: boolean) => void
+  /**
+   * Resets column sizing info to its initial state. If `defaultState` is `true`, the default state for the table will be used instead of the initialValue provided to the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#resetheadersizeinfo)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  resetHeaderSizeInfo: (defaultState?: boolean) => void
+  /**
+   * Sets the column sizing state using an updater function or a value. This will trigger the underlying `onColumnSizingChange` function if one is passed to the table options, otherwise the state will be managed automatically by the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#setcolumnsizing)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  setColumnSizing: (updater: Updater<ColumnSizingState>) => void
+  /**
+   * Sets the column sizing info state using an updater function or a value. This will trigger the underlying `onColumnSizingInfoChange` function if one is passed to the table options, otherwise the state will be managed automatically by the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#setcolumnsizinginfo)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  setColumnSizingInfo: (updater: Updater<ColumnSizingInfoState>) => void
 }
 
 export interface ColumnSizingColumnDef {
+  /**
+   * Enables or disables column resizing for the column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#enableresizing)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   enableResizing?: boolean
-  size?: number
-  minSize?: number
+  /**
+   * The maximum allowed size for the column
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#maxsize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   maxSize?: number
+  /**
+   * The minimum allowed size for the column
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#minsize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  minSize?: number
+  /**
+   * The desired size for the column
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#size)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  size?: number
 }
 
 export interface ColumnSizingColumn {
-  getSize: () => number
-  getStart: (position?: ColumnPinningPosition) => number
+  /**
+   * Returns `true` if the column can be resized.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getcanresize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   getCanResize: () => boolean
+  /**
+   * Returns `true` if the column is currently being resized.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getisresizing)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   getIsResizing: () => boolean
+  /**
+   * Returns the current size of the column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getsize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  getSize: () => number
+  /**
+   * Returns the offset measurement along the row-axis (usually the x-axis for standard tables) for the header. This is effectively a sum of the offset measurements of all preceding headers.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getstart)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  getStart: (position?: ColumnPinningPosition) => number
+  /**
+   * Resets the column to its initial size.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#resetsize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   resetSize: () => void
 }
 
 export interface ColumnSizingHeader {
-  getSize: () => number
-  getStart: (position?: ColumnPinningPosition) => number
+  /**
+   * Returns an event handler function that can be used to resize the header. It can be used as an:
+   * - `onMouseDown` handler
+   * - `onTouchStart` handler
+   * 
+   * The dragging and release events are automatically handled for you.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getresizehandler)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
   getResizeHandler: () => (event: unknown) => void
+  /**
+   * Returns the current size of the header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getsize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  getSize: () => number
+  /**
+   * Returns the offset measurement along the row-axis (usually the x-axis for standard tables) for the header. This is effectively a sum of the offset measurements of all preceding headers.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getstart)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)
+   */
+  getStart: (position?: ColumnPinningPosition) => number
 }
 
 //

--- a/packages/table-core/src/features/ColumnSizing.ts
+++ b/packages/table-core/src/features/ColumnSizing.ts
@@ -50,11 +50,10 @@ export interface ColumnSizingOptions {
   onColumnSizingInfoChange?: OnChangeFn<ColumnSizingInfoState>
 }
 
-export interface ColumnSizingDefaultOptions {
-  columnResizeMode: ColumnResizeMode
-  onColumnSizingChange: OnChangeFn<ColumnSizingState>
-  onColumnSizingInfoChange: OnChangeFn<ColumnSizingInfoState>
-}
+export type ColumnSizingDefaultOptions = Pick<
+  ColumnSizingOptions,
+  'columnResizeMode' | 'onColumnSizingChange' | 'onColumnSizingInfoChange'
+>
 
 export interface ColumnSizingInstance {
   /**
@@ -172,7 +171,7 @@ export interface ColumnSizingHeader {
    * Returns an event handler function that can be used to resize the header. It can be used as an:
    * - `onMouseDown` handler
    * - `onTouchStart` handler
-   * 
+   *
    * The dragging and release events are automatically handled for you.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-sizing#getresizehandler)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-sizing)

--- a/packages/table-core/src/features/Expanding.ts
+++ b/packages/table-core/src/features/Expanding.ts
@@ -10,37 +10,152 @@ export interface ExpandedTableState {
 }
 
 export interface ExpandedRow {
-  toggleExpanded: (expanded?: boolean) => void
-  getIsExpanded: () => boolean
+  /**
+   * Returns whether the row can be expanded.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getcanexpand)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
   getCanExpand: () => boolean
+  /**
+   * Returns whether all parent rows of the row are expanded.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getisallparentsexpanded)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
   getIsAllParentsExpanded: () => boolean
+  /**
+   * Returns whether the row is expanded.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getisexpanded)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  getIsExpanded: () => boolean
+  /**
+   * Returns a function that can be used to toggle the expanded state of the row. This function can be used to bind to an event handler to a button.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#gettoggleexpandedhandler)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
   getToggleExpandedHandler: () => () => void
+  /**
+   * Toggles the expanded state (or sets it if `expanded` is provided) for the row.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#toggleexpanded)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  toggleExpanded: (expanded?: boolean) => void
 }
 
 export interface ExpandedOptions<TData extends RowData> {
-  manualExpanding?: boolean
-  onExpandedChange?: OnChangeFn<ExpandedState>
+  /**
+   * Enable this setting to automatically reset the expanded state of the table when expanding state changes.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#autoresetexpanded)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
   autoResetExpanded?: boolean
+  /**
+   * Enable/disable expanding for all rows.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#enableexpanding)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
   enableExpanding?: boolean
+  /**
+   * This function is responsible for returning the expanded row model. If this function is not provided, the table will not expand rows. You can use the default exported `getExpandedRowModel` function to get the expanded row model or implement your own.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getexpandedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
   getExpandedRowModel?: (table: Table<any>) => () => RowModel<any>
+  /**
+   * If provided, allows you to override the default behavior of determining whether a row is currently expanded.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getisrowexpanded)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
   getIsRowExpanded?: (row: Row<TData>) => boolean
+  /**
+   * If provided, allows you to override the default behavior of determining whether a row can be expanded.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getrowcanexpand)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
   getRowCanExpand?: (row: Row<TData>) => boolean
+  /**
+   * Enables manual row expansion. If this is set to `true`, `getExpandedRowModel` will not be used to expand rows and you would be expected to perform the expansion in your own data model. This is useful if you are doing server-side expansion.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#manualexpanding)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  manualExpanding?: boolean
+  /**
+   * This function is called when the `expanded` table state changes. If a function is provided, you will be responsible for managing this state on your own. To pass the managed state back to the table, use the `tableOptions.state.expanded` option.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#manualexpanding)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  onExpandedChange?: OnChangeFn<ExpandedState>
+  /**
+   * If `true` expanded rows will be paginated along with the rest of the table (which means expanded rows may span multiple pages). If `false` expanded rows will not be considered for pagination (which means expanded rows will always render on their parents page. This also means more rows will be rendered than the set page size)
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#paginateexpandedrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
   paginateExpandedRows?: boolean
 }
 
 export interface ExpandedInstance<TData extends RowData> {
   _autoResetExpanded: () => void
-  setExpanded: (updater: Updater<ExpandedState>) => void
-  toggleAllRowsExpanded: (expanded?: boolean) => void
-  resetExpanded: (defaultState?: boolean) => void
-  getCanSomeRowsExpand: () => boolean
-  getToggleAllRowsExpandedHandler: () => (event: unknown) => void
-  getIsSomeRowsExpanded: () => boolean
-  getIsAllRowsExpanded: () => boolean
-  getExpandedDepth: () => number
-  getExpandedRowModel: () => RowModel<TData>
   _getExpandedRowModel?: () => RowModel<TData>
+  /**
+   * Returns whether there are any rows that can be expanded.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getcansomerowsexpand)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  getCanSomeRowsExpand: () => boolean
+  /**
+   * Returns the maximum depth of the expanded rows.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getexpandeddepth)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  getExpandedDepth: () => number
+  /**
+   * Returns the row model after expansion has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getexpandedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  getExpandedRowModel: () => RowModel<TData>
+  /**
+   * Returns whether all rows are currently expanded.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getisallrowsexpanded)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  getIsAllRowsExpanded: () => boolean
+  /**
+   * Returns whether there are any rows that are currently expanded.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getissomerowsexpanded)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  getIsSomeRowsExpanded: () => boolean
+  /**
+   * Returns the row model before expansion has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#getpreexpandedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
   getPreExpandedRowModel: () => RowModel<TData>
+  /**
+   * Returns a handler that can be used to toggle the expanded state of all rows. This handler is meant to be used with an `input[type=checkbox]` element.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#gettoggleallrowsexpandedhandler)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  getToggleAllRowsExpandedHandler: () => (event: unknown) => void
+  /**
+   * Resets the expanded state of the table to the initial state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#resetexpanded)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  resetExpanded: (defaultState?: boolean) => void
+  /**
+   * Updates the expanded state of the table via an update function or value.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#setexpanded)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  setExpanded: (updater: Updater<ExpandedState>) => void
+  /**
+   * Toggles the expanded state for all rows.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#toggleallrowsexpanded)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
+   */
+  toggleAllRowsExpanded: (expanded?: boolean) => void
 }
 
 //

--- a/packages/table-core/src/features/Expanding.ts
+++ b/packages/table-core/src/features/Expanding.ts
@@ -81,7 +81,7 @@ export interface ExpandedOptions<TData extends RowData> {
   manualExpanding?: boolean
   /**
    * This function is called when the `expanded` table state changes. If a function is provided, you will be responsible for managing this state on your own. To pass the managed state back to the table, use the `tableOptions.state.expanded` option.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#manualexpanding)
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/expanding#onexpandedchange)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/expanding)
    */
   onExpandedChange?: OnChangeFn<ExpandedState>

--- a/packages/table-core/src/features/Filters.ts
+++ b/packages/table-core/src/features/Filters.ts
@@ -176,20 +176,84 @@ export interface FiltersRow<TData extends RowData> {
 }
 
 interface FiltersOptionsBase<TData extends RowData> {
+  /**
+   * Enables/disables all filtering for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#enablefilters)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   enableFilters?: boolean
+  /**
+   * By default, filtering is done from parent rows down (so if a parent row is filtered out, all of its children will be filtered out as well). Setting this option to `true` will cause filtering to be done from leaf rows up (which means parent rows will be included so long as one of their child or grand-child rows is also included).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#filterfromleafrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   filterFromLeafRows?: boolean
+  /**
+   * If provided, this function is called **once** per table and should return a **new function** which will calculate and return the row model for the table when it's filtered.
+   * - For server-side filtering, this function is unnecessary and can be ignored since the server should already return the filtered row model.
+   * - For client-side filtering, this function is required. A default implementation is provided via any table adapter's `{ getFilteredRowModel }` export.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getfilteredrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   getFilteredRowModel?: (table: Table<any>) => () => RowModel<any>
+  /**
+   * Disables the `getFilteredRowModel` from being used to filter data. This may be useful if your table needs to dynamically support both client-side and server-side filtering.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#manualfiltering)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   manualFiltering?: boolean
+  /**
+   * By default, filtering is done for all rows (max depth of 100), no matter if they are root level parent rows or the child leaf rows of a parent row. Setting this option to `0` will cause filtering to only be applied to the root level parent rows, with all sub-rows remaining unfiltered. Similarly, setting this option to `1` will cause filtering to only be applied to child leaf rows 1 level deep, and so on.
+
+   * This is useful for situations where you want a row's entire child hierarchy to be visible regardless of the applied filter.
+    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#maxleafrowfilterdepth)
+    * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   maxLeafRowFilterDepth?: number
 
   // Column
+  /**
+   * Enables/disables **column** filtering for all columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#enablecolumnfilters)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   enableColumnFilters?: boolean
+  /**
+   * If provided, this function will be called with an `updaterFn` when `state.columnFilters` changes. This overrides the default internal state management, so you will need to persist the state change either fully or partially outside of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#oncolumnfilterschange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   onColumnFiltersChange?: OnChangeFn<ColumnFiltersState>
 
   // Global
+  /**
+   * Enables/disables **global** filtering for all columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#enableglobalfilter)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   enableGlobalFilter?: boolean
+  /**
+   * If provided, this function will be called with the column and should return `true` or `false` to indicate whether this column should be used for global filtering.
+   * 
+   * This is useful if the column can contain data that is not `string` or `number` (i.e. `undefined`).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getcolumncanglobalfilter)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   getColumnCanGlobalFilter?: (column: Column<TData, unknown>) => boolean
+  /**
+   * The filter function to use for global filtering.
+   * - A `string` referencing a built-in filter function
+   * - A `string` that references a custom filter functions provided via the `tableOptions.filterFns` option
+   * - A custom filter function
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#globalfilterfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   globalFilterFn?: FilterFnOption<TData>
+  /**
+   * If provided, this function will be called with an `updaterFn` when `state.globalFilter` changes. This overrides the default internal state management, so you will need to persist the state change either fully or partially outside of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#onglobalfilterchange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   onGlobalFilterChange?: OnChangeFn<any>
 
   // Faceting

--- a/packages/table-core/src/features/Filters.ts
+++ b/packages/table-core/src/features/Filters.ts
@@ -65,49 +65,132 @@ export type FilterFnOption<TData extends RowData> =
   | FilterFn<TData>
 
 export interface FiltersColumnDef<TData extends RowData> {
+  /**
+   * The filter function to use with this column. Can be the name of a built-in filter function or a custom filter function.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#filterfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   filterFn?: FilterFnOption<TData>
+  /**
+   * Enables/disables the **column** filter for this column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#enablecolumnfilter)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   enableColumnFilter?: boolean
+  /**
+   * Enables/disables the **global** filter for this column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#enableglobalfilter)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   enableGlobalFilter?: boolean
 }
 
 export interface FiltersColumn<TData extends RowData> {
-  getAutoFilterFn: () => FilterFn<TData> | undefined
-  getFilterFn: () => FilterFn<TData> | undefined
-  setFilterValue: (updater: Updater<any>) => void
-  getCanFilter: () => boolean
-  getCanGlobalFilter: () => boolean
-  getFacetedRowModel: () => RowModel<TData>
-  _getFacetedRowModel?: () => RowModel<TData>
-  getIsFiltered: () => boolean
-  getFilterValue: () => unknown
-  getFilterIndex: () => number
-  getFacetedUniqueValues: () => Map<any, number>
-  _getFacetedUniqueValues?: () => Map<any, number>
-  getFacetedMinMaxValues: () => undefined | [number, number]
   _getFacetedMinMaxValues?: () => undefined | [number, number]
+  _getFacetedRowModel?: () => RowModel<TData>
+  _getFacetedUniqueValues?: () => Map<any, number>
+  /**
+   * Returns an automatically calculated filter function for the column based off of the columns first known value.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getautofilterfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getAutoFilterFn: () => FilterFn<TData> | undefined
+  /**
+   * Returns whether or not the column can be **column** filtered.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getcanfilter)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getCanFilter: () => boolean
+  /**
+   * Returns whether or not the column can be **globally** filtered. Set to `false` to disable a column from being scanned during global filtering.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getcanglobalfilter)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getCanGlobalFilter: () => boolean
+  /**
+   * A function that **computes and returns** a min/max tuple derived from `column.getFacetedRowModel`. Useful for displaying faceted result values.
+   * > ⚠️ Requires that you pass a valid `getFacetedMinMaxValues` function to `options.getFacetedMinMaxValues`. A default implementation is provided via the exported `getFacetedMinMaxValues` function.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getfacetedminmaxvalues)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getFacetedMinMaxValues: () => undefined | [number, number]
+  /**
+   * Returns the row model with all other column filters applied, excluding its own filter. Useful for displaying faceted result counts.
+   * > ⚠️ Requires that you pass a valid `getFacetedRowModel` function to `options.facetedRowModel`. A default implementation is provided via the exported `getFacetedRowModel` function.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getfacetedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getFacetedRowModel: () => RowModel<TData>
+  /**
+   * A function that **computes and returns** a `Map` of unique values and their occurrences derived from `column.getFacetedRowModel`. Useful for displaying faceted result values.
+   * > ⚠️ Requires that you pass a valid `getFacetedUniqueValues` function to `options.getFacetedUniqueValues`. A default implementation is provided via the exported `getFacetedUniqueValues` function.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getfaceteduniquevalues)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getFacetedUniqueValues: () => Map<any, number>
+  /**
+   * Returns the filter function (either user-defined or automatic, depending on configuration) for the columnId specified.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getfilterfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getFilterFn: () => FilterFn<TData> | undefined
+  /**
+   * Returns the index (including `-1`) of the column filter in the table's `state.columnFilters` array.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getfilterindex)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getFilterIndex: () => number
+  /**
+   * Returns the current filter value for the column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getfiltervalue)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getFilterValue: () => unknown
+  /**
+   * Returns whether or not the column is currently filtered.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getisfiltered)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getIsFiltered: () => boolean
+  /**
+   * A function that sets the current filter value for the column. You can pass it a value or an updater function for immutability-safe operations on existing values.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#setfiltervalue)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  setFilterValue: (updater: Updater<any>) => void
 }
 
 export interface FiltersRow<TData extends RowData> {
+  /**
+   * The column filters map for the row. This object tracks whether a row is passing/failing specific filters by their column ID.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#columnfilters)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   columnFilters: Record<string, boolean>
+  /**
+   * The column filters meta map for the row. This object tracks any filter meta for a row as optionally provided during the filtering process.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#columnfiltersmeta)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   columnFiltersMeta: Record<string, FilterMeta>
 }
 
 interface FiltersOptionsBase<TData extends RowData> {
   enableFilters?: boolean
-  manualFiltering?: boolean
   filterFromLeafRows?: boolean
-  maxLeafRowFilterDepth?: number
   getFilteredRowModel?: (table: Table<any>) => () => RowModel<any>
+  manualFiltering?: boolean
+  maxLeafRowFilterDepth?: number
 
   // Column
-  onColumnFiltersChange?: OnChangeFn<ColumnFiltersState>
   enableColumnFilters?: boolean
+  onColumnFiltersChange?: OnChangeFn<ColumnFiltersState>
 
   // Global
-  globalFilterFn?: FilterFnOption<TData>
-  onGlobalFilterChange?: OnChangeFn<any>
   enableGlobalFilter?: boolean
   getColumnCanGlobalFilter?: (column: Column<TData, unknown>) => boolean
+  globalFilterFn?: FilterFnOption<TData>
+  onGlobalFilterChange?: OnChangeFn<any>
 
   // Faceting
   getFacetedRowModel?: (
@@ -137,26 +220,80 @@ export interface FiltersOptions<TData extends RowData>
     ResolvedFilterFns {}
 
 export interface FiltersInstance<TData extends RowData> {
+  /**
+   * Sets or updates the `state.columnFilters` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#setcolumnfilters)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   setColumnFilters: (updater: Updater<ColumnFiltersState>) => void
-
+  /**
+   * Resets the **columnFilters** state to `initialState.columnFilters`, or `true` can be passed to force a default blank state reset to `[]`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#resetcolumnfilters)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
   resetColumnFilters: (defaultState?: boolean) => void
 
   // Column Filters
-  getPreFilteredRowModel: () => RowModel<TData>
-  getFilteredRowModel: () => RowModel<TData>
   _getFilteredRowModel?: () => RowModel<TData>
+  /**
+   * Returns the row model for the table after **column** filtering has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getfilteredrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getFilteredRowModel: () => RowModel<TData>
+  /**
+   * Returns the row model for the table before any **column** filtering has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getprefilteredrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getPreFilteredRowModel: () => RowModel<TData>
 
   // Global Filters
-  setGlobalFilter: (updater: Updater<any>) => void
-  resetGlobalFilter: (defaultState?: boolean) => void
-  getGlobalAutoFilterFn: () => FilterFn<TData> | undefined
-  getGlobalFilterFn: () => FilterFn<TData> | undefined
-  getGlobalFacetedRowModel: () => RowModel<TData>
-  _getGlobalFacetedRowModel?: () => RowModel<TData>
-  getGlobalFacetedUniqueValues: () => Map<any, number>
-  _getGlobalFacetedUniqueValues?: () => Map<any, number>
-  getGlobalFacetedMinMaxValues: () => undefined | [number, number]
   _getGlobalFacetedMinMaxValues?: () => undefined | [number, number]
+  _getGlobalFacetedRowModel?: () => RowModel<TData>
+  _getGlobalFacetedUniqueValues?: () => Map<any, number>
+  /**
+   * Currently, this function returns the built-in `includesString` filter function. In future releases, it may return more dynamic filter functions based on the nature of the data provided.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getglobalautofilterfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getGlobalAutoFilterFn: () => FilterFn<TData> | undefined
+  /**
+   * Returns the faceted min and max values for the global filter.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getglobalfacetedminmaxvalues)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getGlobalFacetedMinMaxValues: () => undefined | [number, number]
+  /**
+   * Returns the row model for the table after **global** filtering has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getglobalfacetedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getGlobalFacetedRowModel: () => RowModel<TData>
+  /**
+   * Returns the faceted unique values for the global filter.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getglobalfaceteduniquevalues)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getGlobalFacetedUniqueValues: () => Map<any, number>
+  /**
+   * Returns the filter function (either user-defined or automatic, depending on configuration) for the global filter.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#getglobalfilterfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  getGlobalFilterFn: () => FilterFn<TData> | undefined
+  /**
+   * Resets the **globalFilter** state to `initialState.globalFilter`, or `true` can be passed to force a default blank state reset to `undefined`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#resetglobalfilter)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  resetGlobalFilter: (defaultState?: boolean) => void
+  /**
+   * Sets or updates the `state.globalFilter` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/filters#setglobalfilter)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/filters)
+   */
+  setGlobalFilter: (updater: Updater<any>) => void
 }
 
 //

--- a/packages/table-core/src/features/Grouping.ts
+++ b/packages/table-core/src/features/Grouping.ts
@@ -35,50 +35,164 @@ export type AggregationFnOption<TData extends RowData> =
   | AggregationFn<TData>
 
 export interface GroupingColumnDef<TData extends RowData, TValue> {
-  aggregationFn?: AggregationFnOption<TData>
+  /**
+   * The cell to display each row for the column if the cell is an aggregate. If a function is passed, it will be passed a props object with the context of the cell and should return the property type for your adapter (the exact type depends on the adapter being used).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#aggregatedcell)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
   aggregatedCell?: ColumnDefTemplate<
     ReturnType<Cell<TData, TValue>['getContext']>
   >
+  /**
+   * The resolved aggregation function for the column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#aggregationfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  aggregationFn?: AggregationFnOption<TData>
+  /**
+   * Enables/disables grouping for this column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#enablegrouping)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
   enableGrouping?: boolean
+  /**
+   * Specify a value to be used for grouping rows on this column. If this option is not specified, the value derived from `accessorKey` / `accessorFn` will be used instead.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getgroupingvalue)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
   getGroupingValue?: (row: TData) => any
 }
 
 export interface GroupingColumn<TData extends RowData> {
-  getCanGroup: () => boolean
-  getIsGrouped: () => boolean
-  getGroupedIndex: () => number
-  toggleGrouping: () => void
-  getToggleGroupingHandler: () => () => void
-  getAutoAggregationFn: () => AggregationFn<TData> | undefined
+  /**
+   * Returns the aggregation function for the column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getaggregationfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
   getAggregationFn: () => AggregationFn<TData> | undefined
+  /**
+   * Returns the automatically inferred aggregation function for the column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getautoaggregationfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getAutoAggregationFn: () => AggregationFn<TData> | undefined
+  /**
+   * Returns whether or not the column can be grouped.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getcangroup)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getCanGroup: () => boolean
+  /**
+   * Returns the index of the column in the grouping state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getgroupedindex)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getGroupedIndex: () => number
+  /**
+   * Returns whether or not the column is currently grouped.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getisgrouped)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getIsGrouped: () => boolean
+  /**
+   * Returns a function that toggles the grouping state of the column. This is useful for passing to the `onClick` prop of a button.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#gettogglegroupinghandler)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getToggleGroupingHandler: () => () => void
+  /**
+   * Toggles the grouping state of the column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#togglegrouping)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  toggleGrouping: () => void
 }
 
 export interface GroupingRow {
-  groupingColumnId?: string
-  groupingValue?: unknown
-  getIsGrouped: () => boolean
-  getGroupingValue: (columnId: string) => unknown
   _groupingValuesCache: Record<string, any>
+  /**
+   * Returns the grouping value for any row and column (including leaf rows).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getgroupingvalue)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getGroupingValue: (columnId: string) => unknown
+  /**
+   * Returns whether or not the row is currently grouped.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getisgrouped)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getIsGrouped: () => boolean
+  /**
+   * If this row is grouped, this is the id of the column that this row is grouped by.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getgroupingcolumnid)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  groupingColumnId?: string
+  /**
+   * If this row is grouped, this is the unique/shared value for the `groupingColumnId` for all of the rows in this group.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getgroupingvalue)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  groupingValue?: unknown
 }
 
 export interface GroupingCell {
-  getIsGrouped: () => boolean
-  getIsPlaceholder: () => boolean
+  /**
+   * Returns whether or not the cell is currently aggregated.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getisaggregated)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
   getIsAggregated: () => boolean
+  /**
+   * Returns whether or not the cell is currently grouped.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getisgrouped)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getIsGrouped: () => boolean
+  /**
+   * Returns whether or not the cell is currently a placeholder cell.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getisplaceholder)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getIsPlaceholder: () => boolean
 }
 
 export interface ColumnDefaultOptions {
-  // Column
-  onGroupingChange: OnChangeFn<GroupingState>
   enableGrouping: boolean
+  onGroupingChange: OnChangeFn<GroupingState>
 }
 
 interface GroupingOptionsBase {
-  manualGrouping?: boolean
-  onGroupingChange?: OnChangeFn<GroupingState>
+  /**
+   * Enables/disables grouping for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#enablegrouping)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
   enableGrouping?: boolean
+  /**
+   * Returns the row model after grouping has taken place, but no further.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getgroupedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
   getGroupedRowModel?: (table: Table<any>) => () => RowModel<any>
+  /**
+   * Grouping columns are automatically reordered by default to the start of the columns list. If you would rather remove them or leave them as-is, set the appropriate mode here.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#groupedcolumnmode)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
   groupedColumnMode?: false | 'reorder' | 'remove'
+  /**
+   * Enables manual grouping. If this option is set to `true`, the table will not automatically group rows using `getGroupedRowModel()` and instead will expect you to manually group the rows before passing them to the table. This is useful if you are doing server-side grouping and aggregation.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#manualgrouping)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  manualGrouping?: boolean
+  /**
+   * If this function is provided, it will be called when the grouping state changes and you will be expected to manage the state yourself. You can pass the managed state back to the table via the `tableOptions.state.grouping` option.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#ongroupingchange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  onGroupingChange?: OnChangeFn<GroupingState>
 }
 
 type ResolvedAggregationFns = keyof AggregationFns extends never
@@ -96,11 +210,31 @@ export interface GroupingOptions
 export type GroupingColumnMode = false | 'reorder' | 'remove'
 
 export interface GroupingInstance<TData extends RowData> {
-  setGrouping: (updater: Updater<GroupingState>) => void
-  resetGrouping: (defaultState?: boolean) => void
-  getPreGroupedRowModel: () => RowModel<TData>
-  getGroupedRowModel: () => RowModel<TData>
   _getGroupedRowModel?: () => RowModel<TData>
+  /**
+   * Returns the row model for the table after grouping has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getgroupedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getGroupedRowModel: () => RowModel<TData>
+  /**
+   * Returns the row model for the table before any grouping has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getpregroupedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  getPreGroupedRowModel: () => RowModel<TData>
+  /**
+   * Resets the **grouping** state to `initialState.grouping`, or `true` can be passed to force a default blank state reset to `[]`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#resetgrouping)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  resetGrouping: (defaultState?: boolean) => void
+  /**
+   * Updates the grouping state of the table via an update function or value.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#setgrouping)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
+   */
+  setGrouping: (updater: Updater<GroupingState>) => void
 }
 
 //

--- a/packages/table-core/src/features/Grouping.ts
+++ b/packages/table-core/src/features/Grouping.ts
@@ -124,13 +124,13 @@ export interface GroupingRow {
   getIsGrouped: () => boolean
   /**
    * If this row is grouped, this is the id of the column that this row is grouped by.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getgroupingcolumnid)
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#groupingcolumnid)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
    */
   groupingColumnId?: string
   /**
    * If this row is grouped, this is the unique/shared value for the `groupingColumnId` for all of the rows in this group.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#getgroupingvalue)
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#groupingvalue)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/grouping)
    */
   groupingValue?: unknown

--- a/packages/table-core/src/features/Ordering.ts
+++ b/packages/table-core/src/features/Ordering.ts
@@ -12,6 +12,11 @@ export interface ColumnOrderTableState {
 export type ColumnOrderState = string[]
 
 export interface ColumnOrderOptions {
+  /**
+   * If provided, this function will be called with an `updaterFn` when `state.columnOrder` changes. This overrides the default internal state management, so you will need to persist the state change either fully or partially outside of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-ordering#oncolumnorderchange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-ordering)
+   */
   onColumnOrderChange?: OnChangeFn<ColumnOrderState>
 }
 
@@ -20,11 +25,21 @@ export interface ColumnOrderDefaultOptions {
 }
 
 export interface ColumnOrderInstance<TData extends RowData> {
-  setColumnOrder: (updater: Updater<ColumnOrderState>) => void
-  resetColumnOrder: (defaultState?: boolean) => void
   _getOrderColumnsFn: () => (
     columns: Column<TData, unknown>[]
   ) => Column<TData, unknown>[]
+  /**
+   * Resets the **columnOrder** state to `initialState.columnOrder`, or `true` can be passed to force a default blank state reset to `[]`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-ordering#resetcolumnorder)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-ordering)
+   */
+  resetColumnOrder: (defaultState?: boolean) => void
+  /**
+   * Sets or updates the `state.columnOrder` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-ordering#setcolumnorder)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-ordering)
+   */
+  setColumnOrder: (updater: Updater<ColumnOrderState>) => void
 }
 
 //

--- a/packages/table-core/src/features/Pagination.ts
+++ b/packages/table-core/src/features/Pagination.ts
@@ -16,11 +16,38 @@ export interface PaginationInitialTableState {
 }
 
 export interface PaginationOptions {
-  pageCount?: number
-  manualPagination?: boolean
-  onPaginationChange?: OnChangeFn<PaginationState>
+  /**
+   * If set to `true`, pagination will be reset to the first page when page-altering state changes eg. `data` is updated, filters change, grouping changes, etc.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#autoresetpageindex)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
   autoResetPageIndex?: boolean
+  /**
+   * Returns the row model after pagination has taken place, but no further.
+   *
+   * Pagination columns are automatically reordered by default to the start of the columns list. If you would rather remove them or leave them as-is, set the appropriate mode here.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#getpaginationrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
   getPaginationRowModel?: (table: Table<any>) => () => RowModel<any>
+  /**
+   * Enables manual pagination. If this option is set to `true`, the table will not automatically paginate rows using `getPaginationRowModel()` and instead will expect you to manually paginate the rows before passing them to the table. This is useful if you are doing server-side pagination and aggregation.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#manualpagination)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  manualPagination?: boolean
+  /**
+   * If this function is provided, it will be called when the pagination state changes and you will be expected to manage the state yourself. You can pass the managed state back to the table via the `tableOptions.state.pagination` option.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#onpaginationchange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  onPaginationChange?: OnChangeFn<PaginationState>
+  /**
+   * When manually controlling pagination, you should supply a total `pageCount` value to the table if you know it. If you do not know how many pages there are, you can set this to `-1`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#pagecount)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  pageCount?: number
 }
 
 export interface PaginationDefaultOptions {
@@ -29,22 +56,97 @@ export interface PaginationDefaultOptions {
 
 export interface PaginationInstance<TData extends RowData> {
   _autoResetPageIndex: () => void
-  setPagination: (updater: Updater<PaginationState>) => void
-  resetPagination: (defaultState?: boolean) => void
-  setPageIndex: (updater: Updater<number>) => void
-  resetPageIndex: (defaultState?: boolean) => void
-  setPageSize: (updater: Updater<number>) => void
-  resetPageSize: (defaultState?: boolean) => void
-  setPageCount: (updater: Updater<number>) => void
-  getPageOptions: () => number[]
-  getCanPreviousPage: () => boolean
-  getCanNextPage: () => boolean
-  previousPage: () => void
-  nextPage: () => void
-  getPrePaginationRowModel: () => RowModel<TData>
-  getPaginationRowModel: () => RowModel<TData>
   _getPaginationRowModel?: () => RowModel<TData>
+  /**
+   * Returns whether the table can go to the next page.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#getcannextpage)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  getCanNextPage: () => boolean
+  /**
+   * Returns whether the table can go to the previous page.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#getcanpreviouspage)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  getCanPreviousPage: () => boolean
+  /**
+   * Returns the page count. If manually paginating or controlling the pagination state, this will come directly from the `options.pageCount` table option, otherwise it will be calculated from the table data using the total row count and current page size.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#getpagecount)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
   getPageCount: () => number
+  /**
+   * Returns an array of page options (zero-index-based) for the current page size.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#getpageoptions)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  getPageOptions: () => number[]
+  /**
+   * Returns the row model for the table after pagination has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#getpaginationrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  getPaginationRowModel: () => RowModel<TData>
+  /**
+   * Returns the row model for the table before any pagination has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#getprepaginationrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  getPrePaginationRowModel: () => RowModel<TData>
+  /**
+   * Increments the page index by one, if possible.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#nextpage)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  nextPage: () => void
+  /**
+   * Decrements the page index by one, if possible.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#previouspage)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  previousPage: () => void
+  /**
+   * Resets the page index to its initial state. If `defaultState` is `true`, the page index will be reset to `0` regardless of initial state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#resetpageindex)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  resetPageIndex: (defaultState?: boolean) => void
+  /**
+   * Resets the page size to its initial state. If `defaultState` is `true`, the page size will be reset to `10` regardless of initial state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#resetpagesize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  resetPageSize: (defaultState?: boolean) => void
+  /**
+   * Resets the **pagination** state to `initialState.pagination`, or `true` can be passed to force a default blank state reset to `[]`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#resetpagination)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  resetPagination: (defaultState?: boolean) => void
+  /**
+   * Updates the page count using the provided function or value.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#setpagination)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  setPageCount: (updater: Updater<number>) => void
+  /**
+   * Updates the page index using the provided function or value in the `state.pagination.pageIndex` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#setpageindex)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  setPageIndex: (updater: Updater<number>) => void
+  /**
+   * Updates the page size using the provided function or value in the `state.pagination.pageSize` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#setpagesize)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  setPageSize: (updater: Updater<number>) => void
+  /**
+   * Sets or updates the `state.pagination` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#setpagination)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
+   */
+  setPagination: (updater: Updater<PaginationState>) => void
 }
 
 //

--- a/packages/table-core/src/features/Pagination.ts
+++ b/packages/table-core/src/features/Pagination.ts
@@ -125,7 +125,7 @@ export interface PaginationInstance<TData extends RowData> {
   resetPagination: (defaultState?: boolean) => void
   /**
    * Updates the page count using the provided function or value.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#setpagination)
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pagination#setpagecount)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/pagination)
    */
   setPageCount: (updater: Updater<number>) => void

--- a/packages/table-core/src/features/Pinning.ts
+++ b/packages/table-core/src/features/Pinning.ts
@@ -178,6 +178,8 @@ export interface ColumnPinningInstance<TData extends RowData> {
   getCenterLeafColumns: () => Column<TData, unknown>[]
   /**
    * Returns whether or not any columns are pinned. Optionally specify to only check for pinned columns in either the `left` or `right` position.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getissomecolumnspinned)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
    */
   getIsSomeColumnsPinned: (position?: ColumnPinningPosition) => boolean
   /**

--- a/packages/table-core/src/features/Pinning.ts
+++ b/packages/table-core/src/features/Pinning.ts
@@ -19,8 +19,8 @@ export interface ColumnPinningState {
 }
 
 export interface RowPinningState {
-  top?: string[]
   bottom?: string[]
+  top?: string[]
 }
 
 export interface ColumnPinningTableState {
@@ -32,15 +32,45 @@ export interface RowPinningTableState {
 }
 
 export interface ColumnPinningOptions {
-  onColumnPinningChange?: OnChangeFn<ColumnPinningState>
-  enablePinning?: boolean
+  /**
+   * Enables/disables column pinning for the table. Defaults to `true`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#enablecolumnpinning)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   enableColumnPinning?: boolean
+  /**
+   * Enables/disables all pinning for the table. Defaults to `true`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#enablepinning)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  enablePinning?: boolean
+  /**
+   * If provided, this function will be called with an `updaterFn` when `state.columnPinning` changes. This overrides the default internal state management, so you will also need to supply `state.columnPinning` from your own managed state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#oncolumnpinningchange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/oncolumnpinningchange)
+   */
+  onColumnPinningChange?: OnChangeFn<ColumnPinningState>
 }
 
 export interface RowPinningOptions<TData extends RowData> {
-  onRowPinningChange?: OnChangeFn<RowPinningState>
+  /**
+   * Enables/disables row pinning for the table. Defaults to `true`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#enablerowpinning)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   enableRowPinning?: boolean | ((row: Row<TData>) => boolean)
+  /**
+   * When `false`, pinned rows will not be visible if they are filtered or paginated out of the table. When `true`, pinned rows will always be visible regardless of filtering or pagination. Defaults to `true`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#keeppinnedrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   keepPinnedRows?: boolean
+  /**
+   * If provided, this function will be called with an `updaterFn` when `state.rowPinning` changes. This overrides the default internal state management, so you will also need to supply `state.rowPinning` from your own managed state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#onrowpinningchange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/onrowpinningchange)
+   */
+  onRowPinningChange?: OnChangeFn<RowPinningState>
 }
 
 export interface ColumnPinningDefaultOptions {
@@ -52,26 +82,86 @@ export interface RowPinningDefaultOptions {
 }
 
 export interface ColumnPinningColumnDef {
+  /**
+   * Enables/disables column pinning for this column. Defaults to `true`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#enablepinning-1)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   enablePinning?: boolean
 }
 
 export interface ColumnPinningColumn {
+  /**
+   * Returns whether or not the column can be pinned.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getcanpin)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   getCanPin: () => boolean
-  getPinnedIndex: () => number
+  /**
+   * Returns the pinned position of the column. (`'left'`, `'right'` or `false`)
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getispinned)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   getIsPinned: () => ColumnPinningPosition
+  /**
+   * Returns the numeric pinned index of the column within a pinned column group.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getpinnedindex)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  getPinnedIndex: () => number
+  /**
+   * Pins a column to the `'left'` or `'right'`, or unpins the column to the center if `false` is passed.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#pin)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   pin: (position: ColumnPinningPosition) => void
 }
 
 export interface ColumnPinningRow<TData extends RowData> {
-  getLeftVisibleCells: () => Cell<TData, unknown>[]
+  /**
+   * Returns all center pinned (unpinned) leaf cells in the row.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getcentervisiblecells)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   getCenterVisibleCells: () => Cell<TData, unknown>[]
+  /**
+   * Returns all left pinned leaf cells in the row.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getleftvisiblecells)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  getLeftVisibleCells: () => Cell<TData, unknown>[]
+  /**
+   * Returns all right pinned leaf cells in the row.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getrightvisiblecells)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   getRightVisibleCells: () => Cell<TData, unknown>[]
 }
 
 export interface RowPinningRow {
+  /**
+   * Returns whether or not the row can be pinned.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getcanpin-1)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   getCanPin: () => boolean
+  /**
+   * Returns the pinned position of the row. (`'top'`, `'bottom'` or `false`)
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getispinned-1)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   getIsPinned: () => RowPinningPosition
+  /**
+   * Returns the numeric pinned index of the row within a pinned row group.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getpinnedindex-1)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   getPinnedIndex: () => number
+  /**
+   * Pins a row to the `'top'` or `'bottom'`, or unpins the row to the center if `false` is passed.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#pin-1)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   pin: (
     position: RowPinningPosition,
     includeLeafRows?: boolean,
@@ -80,22 +170,80 @@ export interface RowPinningRow {
 }
 
 export interface ColumnPinningInstance<TData extends RowData> {
-  setColumnPinning: (updater: Updater<ColumnPinningState>) => void
-  resetColumnPinning: (defaultState?: boolean) => void
-  getIsSomeColumnsPinned: (position?: ColumnPinningPosition) => boolean
-  getLeftLeafColumns: () => Column<TData, unknown>[]
-  getRightLeafColumns: () => Column<TData, unknown>[]
+  /**
+   * Returns all center pinned (unpinned) leaf columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getcenterleafcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   getCenterLeafColumns: () => Column<TData, unknown>[]
+  /**
+   * Returns whether or not any columns are pinned. Optionally specify to only check for pinned columns in either the `left` or `right` position.
+   */
+  getIsSomeColumnsPinned: (position?: ColumnPinningPosition) => boolean
+  /**
+   * Returns all left pinned leaf columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getleftleafcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  getLeftLeafColumns: () => Column<TData, unknown>[]
+  /**
+   * Returns all right pinned leaf columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getrightleafcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  getRightLeafColumns: () => Column<TData, unknown>[]
+  /**
+   * Resets the **columnPinning** state to `initialState.columnPinning`, or `true` can be passed to force a default blank state reset to `{ left: [], right: [], }`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#resetcolumnpinning)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  resetColumnPinning: (defaultState?: boolean) => void
+  /**
+   * Sets or updates the `state.columnPinning` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#setcolumnpinning)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  setColumnPinning: (updater: Updater<ColumnPinningState>) => void
 }
 
 export interface RowPinningInstance<TData extends RowData> {
-  setRowPinning: (updater: Updater<RowPinningState>) => void
-  resetRowPinning: (defaultState?: boolean) => void
-  getIsSomeRowsPinned: (position?: RowPinningPosition) => boolean
   _getPinnedRows: (position: 'top' | 'bottom') => Row<TData>[]
-  getTopRows: () => Row<TData>[]
+  /**
+   * Returns all bottom pinned rows.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getbottomrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   getBottomRows: () => Row<TData>[]
+  /**
+   * Returns all rows that are not pinned to the top or bottom.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getcenterrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
   getCenterRows: () => Row<TData>[]
+  /**
+   * Returns whether or not any rows are pinned. Optionally specify to only check for pinned rows in either the `top` or `bottom` position.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#getissomerowspinned)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  getIsSomeRowsPinned: (position?: RowPinningPosition) => boolean
+  /**
+   * Returns all top pinned rows.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#gettoprows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  getTopRows: () => Row<TData>[]
+  /**
+   * Resets the **rowPinning** state to `initialState.rowPinning`, or `true` can be passed to force a default blank state reset to `{ top: [], bottom: [], }`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#resetrowpinning)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  resetRowPinning: (defaultState?: boolean) => void
+  /**
+   * Sets or updates the `state.rowPinning` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/pinning#setrowpinning)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/pinning)
+   */
+  setRowPinning: (updater: Updater<RowPinningState>) => void
 }
 
 //

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -9,9 +9,32 @@ export interface RowSelectionTableState {
 }
 
 export interface RowSelectionOptions<TData extends RowData> {
-  enableRowSelection?: boolean | ((row: Row<TData>) => boolean)
+  /**
+   * - Enables/disables multiple row selection for all rows in the table OR
+   * - A function that given a row, returns whether to enable/disable multiple row selection for that row's children/grandchildren
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#enablemultirowselection)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
   enableMultiRowSelection?: boolean | ((row: Row<TData>) => boolean)
+  /**
+   * - Enables/disables row selection for all rows in the table OR
+   * - A function that given a row, returns whether to enable/disable row selection for that row
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#enablerowselection)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  enableRowSelection?: boolean | ((row: Row<TData>) => boolean)
+  /**
+   * Enables/disables automatic sub-row selection when a parent row is selected, or a function that enables/disables automatic sub-row selection for each row.
+   * (Use in combination with expanding or grouping features)
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#enablesubrowselection)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
   enableSubRowSelection?: boolean | ((row: Row<TData>) => boolean)
+  /**
+   * If provided, this function will be called with an `updaterFn` when `state.rowSelection` changes. This overrides the default internal state management, so you will need to persist the state change either fully or partially outside of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#onrowselectionchange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
   onRowSelectionChange?: OnChangeFn<RowSelectionState>
   // enableGroupingRowSelection?:
   //   | boolean
@@ -27,31 +50,141 @@ export interface RowSelectionOptions<TData extends RowData> {
 }
 
 export interface RowSelectionRow {
-  getIsSelected: () => boolean
-  getIsSomeSelected: () => boolean
-  getIsAllSubRowsSelected: () => boolean
-  getCanSelect: () => boolean
+  /**
+   * Returns whether or not the row can multi-select.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getcanmultiselect)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
   getCanMultiSelect: () => boolean
+  /**
+   * Returns whether or not the row can be selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getcanselect)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getCanSelect: () => boolean
+  /**
+   * Returns whether or not the row can select sub rows automatically when the parent row is selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getcanselectsubrows)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
   getCanSelectSubRows: () => boolean
-  toggleSelected: (value?: boolean) => void
+  /**
+   * Returns whether or not the row is selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getisselected)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getIsAllSubRowsSelected: () => boolean
+  /**
+   * Returns whether or not the row is selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getisselected)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getIsSelected: () => boolean
+  /**
+   * Returns whether or not some of the row's sub rows are selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getissomeselected)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getIsSomeSelected: () => boolean
+  /**
+   * Returns a handler that can be used to toggle the row.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#gettoggleselectedhandler)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
   getToggleSelectedHandler: () => (event: unknown) => void
+  /**
+   * Selects/deselects the row.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#toggleselected)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  toggleSelected: (value?: boolean) => void
 }
 
 export interface RowSelectionInstance<TData extends RowData> {
-  getToggleAllRowsSelectedHandler: () => (event: unknown) => void
-  getToggleAllPageRowsSelectedHandler: () => (event: unknown) => void
-  setRowSelection: (updater: Updater<RowSelectionState>) => void
-  resetRowSelection: (defaultState?: boolean) => void
-  getIsAllRowsSelected: () => boolean
-  getIsAllPageRowsSelected: () => boolean
-  getIsSomeRowsSelected: () => boolean
-  getIsSomePageRowsSelected: () => boolean
-  toggleAllRowsSelected: (value?: boolean) => void
-  toggleAllPageRowsSelected: (value?: boolean) => void
-  getPreSelectedRowModel: () => RowModel<TData>
-  getSelectedRowModel: () => RowModel<TData>
+  /**
+   * Returns the row model of all rows that are selected after filtering has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getfilteredselectedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
   getFilteredSelectedRowModel: () => RowModel<TData>
+  /**
+   * Returns the row model of all rows that are selected after grouping has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getgroupedselectedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
   getGroupedSelectedRowModel: () => RowModel<TData>
+  /**
+   * Returns whether or not all rows on the current page are selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getisallpagerowsselected)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getIsAllPageRowsSelected: () => boolean
+  /**
+   * Returns whether or not all rows in the table are selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getisallrowsselected)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getIsAllRowsSelected: () => boolean
+  /**
+   * Returns whether or not all rows on the current page are selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getissomepagerowsselected)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getIsSomePageRowsSelected: () => boolean
+  /**
+   * Returns whether or not all rows in the table are selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getissomerowsselected)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getIsSomeRowsSelected: () => boolean
+  /**
+   * Returns the core row model of all rows before row selection has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getpreselectedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getPreSelectedRowModel: () => RowModel<TData>
+  /**
+   * Returns the row model of all rows that are selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getselectedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getSelectedRowModel: () => RowModel<TData>
+  /**
+   * Returns a handler that can be used to toggle all rows on the current page.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#gettoggleallpagerowsselectedhandler)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getToggleAllPageRowsSelectedHandler: () => (event: unknown) => void
+  /**
+   * Returns a handler that can be used to toggle all rows in the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#gettoggleallrowsselectedhandler)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  getToggleAllRowsSelectedHandler: () => (event: unknown) => void
+  /**
+   * Resets the **rowSelection** state to the `initialState.rowSelection`, or `true` can be passed to force a default blank state reset to `{}`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#resetrowselection)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  resetRowSelection: (defaultState?: boolean) => void
+  /**
+   * Sets or updates the `state.rowSelection` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#setrowselection)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  setRowSelection: (updater: Updater<RowSelectionState>) => void
+  /**
+   * Selects/deselects all rows on the current page.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#toggleallpagerowsselected)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  toggleAllPageRowsSelected: (value?: boolean) => void
+  /**
+   * Selects/deselects all rows in the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#toggleallrowsselected)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
+   */
+  toggleAllRowsSelected: (value?: boolean) => void
 }
 
 //
@@ -497,7 +630,7 @@ export function isSubRowSelected<TData extends RowData>(
   table: Table<TData>
 ): boolean | 'some' | 'all' {
   if (!row.subRows?.length) return false
-  
+
   let allChildrenSelected = true
   let someSelected = false
 

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -69,8 +69,8 @@ export interface RowSelectionRow {
    */
   getCanSelectSubRows: () => boolean
   /**
-   * Returns whether or not the row is selected.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getisselected)
+   * Returns whether or not all of the row's sub rows are selected.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getisallsubrowsselected)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
    */
   getIsAllSubRowsSelected: () => boolean

--- a/packages/table-core/src/features/Sorting.ts
+++ b/packages/table-core/src/features/Sorting.ts
@@ -21,8 +21,8 @@ import { isFunction, makeStateUpdater } from '../utils'
 export type SortDirection = 'asc' | 'desc'
 
 export interface ColumnSort {
-  id: string
   desc: boolean
+  id: string
 }
 
 export type SortingState = ColumnSort[]
@@ -47,40 +47,187 @@ export type SortingFnOption<TData extends RowData> =
   | SortingFn<TData>
 
 export interface SortingColumnDef<TData extends RowData> {
-  sortingFn?: SortingFnOption<TData>
-  sortDescFirst?: boolean
-  enableSorting?: boolean
+  /**
+   * Enables/Disables multi-sorting for this column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#enablemultisort)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
   enableMultiSort?: boolean
+  /**
+   * Enables/Disables sorting for this column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#enablesorting)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  enableSorting?: boolean
+  /**
+   * Inverts the order of the sorting for this column. This is useful for values that have an inverted best/worst scale where lower numbers are better, eg. a ranking (1st, 2nd, 3rd) or golf-like scoring
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#sortdescfirst)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
   invertSorting?: boolean
+  /**
+   * Set to `true` for sorting toggles on this column to start in the descending direction.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#sortdescfirst)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  sortDescFirst?: boolean
+  /**
+   * The sorting function to use with this column.
+   * - A `string` referencing a built-in sorting function
+   * - A custom sorting function
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#sortingfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  sortingFn?: SortingFnOption<TData>
+  /**
+   * - `false`
+   *   - Undefined values will be considered tied and need to be sorted by the next column filter or original index (whichever applies)
+   * - `-1`
+   *   - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
+   * - `1`
+   *   - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
+   */
   sortUndefined?: false | -1 | 1
 }
 
 export interface SortingColumn<TData extends RowData> {
-  getAutoSortingFn: () => SortingFn<TData>
-  getAutoSortDir: () => SortDirection
-  getSortingFn: () => SortingFn<TData>
-  getFirstSortDir: () => SortDirection
-  getNextSortingOrder: () => SortDirection | false
-  getCanSort: () => boolean
-  getCanMultiSort: () => boolean
-  getSortIndex: () => number
-  getIsSorted: () => false | SortDirection
+  /**
+   * Removes this column from the table's sorting state
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#clearsorting)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
   clearSorting: () => void
-  toggleSorting: (desc?: boolean, isMulti?: boolean) => void
+  /**
+   * Returns a sort direction automatically inferred based on the columns values.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getautosortdir)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getAutoSortDir: () => SortDirection
+  /**
+   * Returns a sorting function automatically inferred based on the columns values.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getautosortingfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getAutoSortingFn: () => SortingFn<TData>
+  /**
+   * Returns whether this column can be multi-sorted.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getcanmultisort)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getCanMultiSort: () => boolean
+  /**
+   * Returns whether this column can be sorted.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getcansort)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getCanSort: () => boolean
+  /**
+   * Returns the first direction that should be used when sorting this column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getfirstsortdir)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getFirstSortDir: () => SortDirection
+  /**
+   * Returns the current sort direction of this column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getissorted)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getIsSorted: () => false | SortDirection
+  /**
+   * Returns the next sorting order.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getnextsortingorder)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getNextSortingOrder: () => SortDirection | false
+  /**
+   * Returns the index position of this column's sorting within the sorting state
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getsortindex)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getSortIndex: () => number
+  /**
+   * Returns the resolved sorting function to be used for this column
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getsortingfn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getSortingFn: () => SortingFn<TData>
+  /**
+   * Returns a function that can be used to toggle this column's sorting state. This is useful for attaching a click handler to the column header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#gettogglesortinghandler)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
   getToggleSortingHandler: () => undefined | ((event: unknown) => void)
+  /**
+   * Toggles this columns sorting state. If `desc` is provided, it will force the sort direction to that value. If `isMulti` is provided, it will additivity multi-sort the column (or toggle it if it is already sorted).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#togglesorting)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  toggleSorting: (desc?: boolean, isMulti?: boolean) => void
 }
 
 interface SortingOptionsBase {
-  manualSorting?: boolean
-  onSortingChange?: OnChangeFn<SortingState>
-  enableSorting?: boolean
-  enableSortingRemoval?: boolean
+  /**
+   * Enables/disables the ability to remove multi-sorts
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#enablemultiremove)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
   enableMultiRemove?: boolean
+  /**
+   * Enables/Disables multi-sorting for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#enablemultisort)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
   enableMultiSort?: boolean
-  sortDescFirst?: boolean
+  /**
+   * Enables/Disables sorting for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#enablesorting)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  enableSorting?: boolean
+  /**
+   * Enables/Disables the ability to remove sorting for the table.
+   * - If `true` then changing sort order will circle like: 'none' -> 'desc' -> 'asc' -> 'none' -> ...
+   * - If `false` then changing sort order will circle like: 'none' -> 'desc' -> 'asc' -> 'desc' -> 'asc' -> ...
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#enablesortingremoval)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  enableSortingRemoval?: boolean
+  /**
+   * This function is used to retrieve the sorted row model. If using server-side sorting, this function is not required. To use client-side sorting, pass the exported `getSortedRowModel()` from your adapter to your table or implement your own.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getsortedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
   getSortedRowModel?: (table: Table<any>) => () => RowModel<any>
-  maxMultiSortColCount?: number
+  /**
+   * Pass a custom function that will be used to determine if a multi-sort event should be triggered. It is passed the event from the sort toggle handler and should return `true` if the event should trigger a multi-sort.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#ismultisortevent)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
   isMultiSortEvent?: (e: unknown) => boolean
+  /**
+   * Enables manual sorting for the table. If this is `true`, you will be expected to sort your data before it is passed to the table. This is useful if you are doing server-side sorting.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#manualsorting)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  manualSorting?: boolean
+  /**
+   * Set a maximum number of columns that can be multi-sorted.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#maxmultisortcolcount)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  maxMultiSortColCount?: number
+  /**
+   * If provided, this function will be called with an `updaterFn` when `state.sorting` changes. This overrides the default internal state management, so you will need to persist the state change either fully or partially outside of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#onsortingchange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  onSortingChange?: OnChangeFn<SortingState>
+  /**
+   * If `true`, all sorts will default to descending as their first toggle state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#sortdescfirst)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  sortDescFirst?: boolean
 }
 
 type ResolvedSortingFns = keyof SortingFns extends never
@@ -96,11 +243,31 @@ export interface SortingOptions<TData extends RowData>
     ResolvedSortingFns {}
 
 export interface SortingInstance<TData extends RowData> {
-  setSorting: (updater: Updater<SortingState>) => void
-  resetSorting: (defaultState?: boolean) => void
-  getPreSortedRowModel: () => RowModel<TData>
-  getSortedRowModel: () => RowModel<TData>
   _getSortedRowModel?: () => RowModel<TData>
+  /**
+   * Returns the row model for the table before any sorting has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getpresortedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getPreSortedRowModel: () => RowModel<TData>
+  /**
+   * Returns the row model for the table after sorting has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#getsortedrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  getSortedRowModel: () => RowModel<TData>
+  /**
+   * Resets the **sorting** state to `initialState.sorting`, or `true` can be passed to force a default blank state reset to `[]`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#resetsorting)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  resetSorting: (defaultState?: boolean) => void
+  /**
+   * Sets or updates the `state.sorting` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#setsorting)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
+   */
+  setSorting: (updater: Updater<SortingState>) => void
 }
 
 //

--- a/packages/table-core/src/features/Sorting.ts
+++ b/packages/table-core/src/features/Sorting.ts
@@ -61,7 +61,7 @@ export interface SortingColumnDef<TData extends RowData> {
   enableSorting?: boolean
   /**
    * Inverts the order of the sorting for this column. This is useful for values that have an inverted best/worst scale where lower numbers are better, eg. a ranking (1st, 2nd, 3rd) or golf-like scoring
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#sortdescfirst)
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/sorting#invertsorting)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/sorting)
    */
   invertSorting?: boolean

--- a/packages/table-core/src/features/Visibility.ts
+++ b/packages/table-core/src/features/Visibility.ts
@@ -17,8 +17,13 @@ export interface VisibilityTableState {
 }
 
 export interface VisibilityOptions {
-  onColumnVisibilityChange?: OnChangeFn<VisibilityState>
   enableHiding?: boolean
+  /**
+   * If provided, this function will be called with an `updaterFn` when `state.columnVisibility` changes. This overrides the default internal state management, so you will need to persist the state change either fully or partially outside of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#oncolumnvisibilitychange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
+  onColumnVisibilityChange?: OnChangeFn<VisibilityState>
 }
 
 export interface VisibilityDefaultOptions {
@@ -26,17 +31,70 @@ export interface VisibilityDefaultOptions {
 }
 
 export interface VisibilityInstance<TData extends RowData> {
-  getVisibleFlatColumns: () => Column<TData, unknown>[]
-  getVisibleLeafColumns: () => Column<TData, unknown>[]
-  getLeftVisibleLeafColumns: () => Column<TData, unknown>[]
-  getRightVisibleLeafColumns: () => Column<TData, unknown>[]
+  /**
+   * If column pinning, returns a flat array of leaf-node columns that are visible in the unpinned/center portion of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#getcentervisibleleafcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
   getCenterVisibleLeafColumns: () => Column<TData, unknown>[]
-  setColumnVisibility: (updater: Updater<VisibilityState>) => void
-  resetColumnVisibility: (defaultState?: boolean) => void
-  toggleAllColumnsVisible: (value?: boolean) => void
+  /**
+   * Returns whether all columns are visible
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#getisallcolumnsvisible)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
   getIsAllColumnsVisible: () => boolean
+  /**
+   * Returns whether any columns are visible
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#getissomecolumnsvisible)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
   getIsSomeColumnsVisible: () => boolean
+  /**
+   * If column pinning, returns a flat array of leaf-node columns that are visible in the left portion of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#getleftvisibleleafcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
+  getLeftVisibleLeafColumns: () => Column<TData, unknown>[]
+  /**
+   * If column pinning, returns a flat array of leaf-node columns that are visible in the right portion of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#getrightvisibleleafcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
+  getRightVisibleLeafColumns: () => Column<TData, unknown>[]
+  /**
+   * Returns a handler for toggling the visibility of all columns, meant to be bound to a `input[type=checkbox]` element.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#gettoggleallcolumnsvisibilityhandler)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
   getToggleAllColumnsVisibilityHandler: () => (event: unknown) => void
+  /**
+   * Returns a flat array of columns that are visible, including parent columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#getvisibleflatcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
+  getVisibleFlatColumns: () => Column<TData, unknown>[]
+  /**
+   * Returns a flat array of leaf-node columns that are visible.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#getvisibleleafcolumns)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
+  getVisibleLeafColumns: () => Column<TData, unknown>[]
+  /**
+   * Resets the column visibility state to the initial state. If `defaultState` is provided, the state will be reset to `{}`
+   */
+  resetColumnVisibility: (defaultState?: boolean) => void
+  /**
+   * Sets or updates the `state.columnVisibility` state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#setcolumnvisibility)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
+  setColumnVisibility: (updater: Updater<VisibilityState>) => void
+  /**
+   * Toggles the visibility of all columns.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#toggleallcolumnsvisible)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
+  toggleAllColumnsVisible: (value?: boolean) => void
 }
 
 export interface VisibilityColumnDef {
@@ -45,14 +103,39 @@ export interface VisibilityColumnDef {
 
 export interface VisibilityRow<TData extends RowData> {
   _getAllVisibleCells: () => Cell<TData, unknown>[]
+  /**
+   * Returns an array of cells that account for column visibility for the row.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#getvisiblecells)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
   getVisibleCells: () => Cell<TData, unknown>[]
 }
 
 export interface VisibilityColumn {
+  /**
+   * Returns whether the column can be hidden
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#getcanhide)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
   getCanHide: () => boolean
+  /**
+   * Returns whether the column is visible
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#getisvisible)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
   getIsVisible: () => boolean
-  toggleVisibility: (value?: boolean) => void
+  /**
+   * Returns a function that can be used to toggle the column visibility. This function can be used to bind to an event handler to a checkbox.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#gettogglevisibilityhandler)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
   getToggleVisibilityHandler: () => (event: unknown) => void
+  /**
+   * Toggles the visibility of the column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#togglevisibility)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
+   */
+  toggleVisibility: (value?: boolean) => void
 }
 
 //

--- a/packages/table-core/src/features/Visibility.ts
+++ b/packages/table-core/src/features/Visibility.ts
@@ -26,9 +26,10 @@ export interface VisibilityOptions {
   onColumnVisibilityChange?: OnChangeFn<VisibilityState>
 }
 
-export interface VisibilityDefaultOptions {
-  onColumnVisibilityChange: OnChangeFn<VisibilityState>
-}
+export type VisibilityDefaultOptions = Pick<
+  VisibilityOptions,
+  'onColumnVisibilityChange'
+>
 
 export interface VisibilityInstance<TData extends RowData> {
   /**
@@ -81,6 +82,8 @@ export interface VisibilityInstance<TData extends RowData> {
   getVisibleLeafColumns: () => Column<TData, unknown>[]
   /**
    * Resets the column visibility state to the initial state. If `defaultState` is provided, the state will be reset to `{}`
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-visibility#resetcolumnvisibility)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-visibility)
    */
   resetColumnVisibility: (defaultState?: boolean) => void
   /**

--- a/packages/table-core/src/filterFns.ts
+++ b/packages/table-core/src/filterFns.ts
@@ -69,8 +69,8 @@ const arrIncludesSome: FilterFn<any> = (
   columnId: string,
   filterValue: unknown[]
 ) => {
-  return filterValue.some(val =>
-    row.getValue<unknown[]>(columnId)?.includes(val)
+  return filterValue.some(
+    val => row.getValue<unknown[]>(columnId)?.includes(val)
   )
 }
 

--- a/packages/table-core/src/types.ts
+++ b/packages/table-core/src/types.ts
@@ -242,7 +242,7 @@ export interface IdentifiedColumnDef<TData extends RowData, TValue = unknown>
 
 export type DisplayColumnDef<
   TData extends RowData,
-  TValue = unknown
+  TValue = unknown,
 > = ColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
 
 interface GroupColumnDefBase<TData extends RowData, TValue = unknown>
@@ -252,7 +252,7 @@ interface GroupColumnDefBase<TData extends RowData, TValue = unknown>
 
 export type GroupColumnDef<
   TData extends RowData,
-  TValue = unknown
+  TValue = unknown,
 > = GroupColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
 
 interface AccessorFnColumnDefBase<TData extends RowData, TValue = unknown>
@@ -262,7 +262,7 @@ interface AccessorFnColumnDefBase<TData extends RowData, TValue = unknown>
 
 export type AccessorFnColumnDef<
   TData extends RowData,
-  TValue = unknown
+  TValue = unknown,
 > = AccessorFnColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
 
 interface AccessorKeyColumnDefBase<TData extends RowData, TValue = unknown>
@@ -273,7 +273,7 @@ interface AccessorKeyColumnDefBase<TData extends RowData, TValue = unknown>
 
 export type AccessorKeyColumnDef<
   TData extends RowData,
-  TValue = unknown
+  TValue = unknown,
 > = AccessorKeyColumnDefBase<TData, TValue> &
   Partial<ColumnIdentifiers<TData, TValue>>
 
@@ -290,7 +290,7 @@ export type ColumnDef<TData extends RowData, TValue = unknown> =
 
 export type ColumnDefResolved<
   TData extends RowData,
-  TValue = unknown
+  TValue = unknown,
 > = Partial<UnionToIntersection<ColumnDef<TData, TValue>>> & {
   accessorKey?: string
 }

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -20,7 +20,7 @@ export type IsKnown<T, Y, N> = unknown extends T ? N : Y
 
 type ComputeRange<
   N extends number,
-  Result extends Array<unknown> = []
+  Result extends Array<unknown> = [],
 > = Result['length'] extends N
   ? Result
   : ComputeRange<N, [...Result, Result['length']]>
@@ -36,7 +36,7 @@ type IsTuple<T> = T extends readonly any[] & { length: infer Length }
 // If this type is a tuple, what indices are allowed?
 type AllowedIndexes<
   Tuple extends ReadonlyArray<any>,
-  Keys extends number = never
+  Keys extends number = never,
 > = Tuple extends readonly []
   ? Keys
   : Tuple extends readonly [infer _, ...infer Tail]
@@ -62,7 +62,7 @@ export type DeepKeys<T, TDepth extends any[] = []> = TDepth['length'] extends 5
 type DeepKeysPrefix<
   T,
   TPrefix,
-  TDepth extends any[]
+  TDepth extends any[],
 > = TPrefix extends keyof T & (number | string)
   ? `${TPrefix}.${DeepKeys<T[TPrefix], [...TDepth, any]> & string}`
   : never


### PR DESCRIPTION
This PR adds jsdoc descriptions and links to the api reference and guide docs to every option and api in TanStack Table

About a dozen options and apis that were missing from the docs have also been added