### PR TITLE
Fix subrow reset sorting (fix #5103)

### DIFF
--- a/packages/table-core/src/utils/getSortedRowModel.ts
+++ b/packages/table-core/src/utils/getSortedRowModel.ts
@@ -45,7 +45,7 @@ export function getSortedRowModel<TData extends RowData>(): (
         const sortData = (rows: Row<TData>[]) => {
           // This will also perform a stable sorting using the row index
           // if needed.
-          const sortedData = [...rows]
+          const sortedData = rows.map(row => ({...row}))
 
           sortedData.sort((rowA, rowB) => {
             for (let i = 0; i < availableSorting.length; i += 1) {


### PR DESCRIPTION
Full description on the linked issue #5103

* Sorting subrows unintentionally updates CoreRowModel subrows. Do a deeper copy when beginning to sort instead.