### PR TITLE
fix: getParentRow should search all row model rows

### DIFF
--- a/packages/table-core/src/core/row.ts
+++ b/packages/table-core/src/core/row.ts
@@ -154,7 +154,7 @@ export const createRow = <TData extends RowData>(
       row.getValue(columnId) ?? table.options.renderFallbackValue,
     subRows: subRows ?? [],
     getLeafRows: () => flattenBy(row.subRows, d => d.subRows),
-    getParentRow: () => (row.parentId ? table.getRow(row.parentId) : undefined),
+    getParentRow: () => (row.parentId ? table.getRow(row.parentId, true) : undefined),
     getParentRows: () => {
       let parentRows: Row<TData>[] = []
       let currentRow = row


### PR DESCRIPTION
Currently, with certain filtering or pagination features applied, `row.getParentRow()` and `row.getParentRows()` has the possibility to throw an error when trying to find rows that exist, just not in the filtered row model.

Passing in `true` as the second argument to `table.getRow()` should fix this.