### PR TITLE
fix(types): export types IdIdentifier, StringHeaderIdentifier, AccessorKeyColumnDefBase

### DIFF
--- a/packages/table-core/src/types.ts
+++ b/packages/table-core/src/types.ts
@@ -200,12 +200,12 @@ export type StringOrTemplateHeader<TData, TValue> =
   | string
   | ColumnDefTemplate<HeaderContext<TData, TValue>>
 
-interface StringHeaderIdentifier {
+export interface StringHeaderIdentifier {
   header: string
   id?: string
 }
 
-interface IdIdentifier<TData extends RowData, TValue> {
+export interface IdIdentifier<TData extends RowData, TValue> {
   id: string
   header?: StringOrTemplateHeader<TData, TValue>
 }
@@ -265,7 +265,7 @@ export type AccessorFnColumnDef<
   TValue = unknown,
 > = AccessorFnColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
 
-interface AccessorKeyColumnDefBase<TData extends RowData, TValue = unknown>
+export interface AccessorKeyColumnDefBase<TData extends RowData, TValue = unknown>
   extends ColumnDefBase<TData, TValue> {
   id?: string
   accessorKey: (string & {}) | keyof TData


### PR DESCRIPTION
Hello, this is a short pull request to add some missing "export" clauses to some types.

Using a nx monorepo, one of my buildable modules fails to build with the following errors:

```
TS4023: Exported variable 'myHook' has or is using name 'AccessorKeyColumnDefBase' from external module ".../node_modules/@tanstack/table-core/build/lib/types" but cannot be named. 

TS4023: Exported variable 'myHook' has or is using name 'IdIdentifier' from external module ".../node_modules/@tanstack/table-core/build/lib/types" but cannot be named.

TS4023: Exported variable 'myHook' has or is using name 'StringHeaderIdentifier' from external module ".../node_modules/@tanstack/table-core/build/lib/types" but cannot be named.
```

I have yarn linked react-table and table-core, and it resolved my build issues.

Thank you for considering this issue, and I hope you find this helpful.