### PR TITLE
Clarify column id documentation for nested keys

### DIFF
--- a/docs/guide/column-defs.md
+++ b/docs/guide/column-defs.md
@@ -202,6 +202,7 @@ columnHelper.accessor(row => `${row.firstName} ${row.lastName}`, {
 Columns are uniquely identified with 3 strategies:
 
 - If defining an accessor column with an object key or array index, the same will be used to uniquely identify the column.
+  - Any periods (`.`) in an object key will be replaced by underscores (`_`).
 - If defining an accessor column with an accessor function
   - The columns `id` property will be used to uniquely identify the column OR
   - If a primitive `string` header is supplied, that header string will be used to uniquely identify the column


### PR DESCRIPTION
I had some columns whose accessorKeys were nested keys, like `foo.bar`.

I had to go [digging through the code](https://github.com/TanStack/table/blob/a1e9732e6fc3446a2ae80db72a1f2b46a5c11e46/packages/table-core/src/core/column.ts#L82) to figure out why the column id for those columns weren't `foo.bar`, and what they were instead.

Adding this comment to hopefully clarify this for other people! Let me know if there's anything I should change/update.