### PR TITLE
Improve row selection docs

### DIFF
--- a/docs/api/features/row-selection.md
+++ b/docs/api/features/row-selection.md
@@ -15,7 +15,7 @@ export type RowSelectionTableState = {
 }
 ```
 
-By default, row selection uses the index of the row. Row selection state can be tracked with a unique row id by passing in a custom [getRowId](../../api/core/table.md#getrowid) function to the the table. This may be necesssary when deleting rows while using manual pagination.
+By default, the row selection state uses the index of each row as the row identifiers. Row selection state can instead be tracked with a custom unique row id by passing in a custom [getRowId](../../api/core/table.md#getrowid) function to the the table.
 
 ## Table Options
 

--- a/docs/api/features/row-selection.md
+++ b/docs/api/features/row-selection.md
@@ -15,6 +15,8 @@ export type RowSelectionTableState = {
 }
 ```
 
+By default, row selection uses the index of the row. Row selection state can be tracked with a unique row id by passing in a custom [getRowId](../../api/core/table.md#getrowid) function to the the table. This may be necesssary when deleting rows while using manual pagination.
+
 ## Table Options
 
 ### `enableRowSelection`


### PR DESCRIPTION
* Added note about row selection being index based by default
* Added a link for how row selection can be managed with a custom id using the `getRowId` option on the core table api.
* Referenced the use case of manual pagination as it is one of the most likely scenarios that using a custom id is necessary for row selection.

This should help developers understand how row selection is implemented and how it relates to other features within the table.