### PR TITLE
Feat: made custom filterFns optional

### DIFF
--- a/packages/table-core/src/features/Filters.ts
+++ b/packages/table-core/src/features/Filters.ts
@@ -276,7 +276,7 @@ type ResolvedFilterFns = keyof FilterFns extends never
       filterFns?: Record<string, FilterFn<any>>
     }
   : {
-      filterFns: Record<keyof FilterFns, FilterFn<any>>
+      filterFns?: Record<keyof FilterFns, FilterFn<any>>
     }
 
 export interface FiltersOptions<TData extends RowData>


### PR DESCRIPTION
Currently if I define a custom FilterFns type (as described [here](https://tanstack.com/table/v8/docs/api/features/filters#table-options)), I am forced in all the tables I create to have to implement the filterFns field, which seems a bit too forced to me especially if I have several tables that however all depend on the same tanstack table core definitions.

As you can see inside my [repo](https://github.com/osmosis-labs/osmosis-frontend/blob/jonator/assets-page-ui/packages/web/components/earn/table/columns.tsx#L14), when I override `FilterFns` I am forced to define in all the tables I use the field 'filterFns'