### PR TITLE
fix: fixed crash when toggling selection of non-visible row

### DIFF
--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -556,7 +556,7 @@ const mutateRowIsSelected = <TData extends RowData>(
   includeChildren: boolean,
   table: Table<TData>
 ) => {
-  const row = table.getRow(id)
+  const row = table.getRow(id, true)
 
   // const isGrouped = row.getIsGrouped()
 


### PR DESCRIPTION
Currently, if the mutation of a selected row is tried on a row that is not in the current pagination or filtered results, the table will not be able to find the row to toggle and will crash. This can happen more frequently with the new row pinning features. This fix scans all client-side rows to perform the mutation.