### PR TITLE
chore: Migrate from TypeScript 4.9 to 5.2

### DIFF
--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.2.6"
   },

--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.2.6"
   },

--- a/examples/solid/bootstrap/package.json
+++ b/examples/solid/bootstrap/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.4.0"
   },

--- a/examples/solid/bootstrap/package.json
+++ b/examples/solid/bootstrap/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.4.0"
   },

--- a/examples/solid/column-groups/package.json
+++ b/examples/solid/column-groups/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.2.6"
   },

--- a/examples/solid/column-groups/package.json
+++ b/examples/solid/column-groups/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.2.6"
   },

--- a/examples/solid/column-ordering/package.json
+++ b/examples/solid/column-ordering/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.2.6"
   },

--- a/examples/solid/column-ordering/package.json
+++ b/examples/solid/column-ordering/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.2.6"
   },

--- a/examples/solid/column-visibility/package.json
+++ b/examples/solid/column-visibility/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.2.6"
   },

--- a/examples/solid/column-visibility/package.json
+++ b/examples/solid/column-visibility/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.2.6"
   },

--- a/examples/solid/sorting/package.json
+++ b/examples/solid/sorting/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.2.6"
   },

--- a/examples/solid/sorting/package.json
+++ b/examples/solid/sorting/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3",
     "vite-plugin-solid": "^2.2.6"
   },

--- a/examples/svelte/basic/package.json
+++ b/examples/svelte/basic/package.json
@@ -19,7 +19,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/basic/package.json
+++ b/examples/svelte/basic/package.json
@@ -19,7 +19,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/column-groups/package.json
+++ b/examples/svelte/column-groups/package.json
@@ -19,7 +19,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/column-groups/package.json
+++ b/examples/svelte/column-groups/package.json
@@ -19,7 +19,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/column-ordering/package.json
+++ b/examples/svelte/column-ordering/package.json
@@ -20,7 +20,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/column-ordering/package.json
+++ b/examples/svelte/column-ordering/package.json
@@ -20,7 +20,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/column-pinning/package.json
+++ b/examples/svelte/column-pinning/package.json
@@ -20,7 +20,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/column-pinning/package.json
+++ b/examples/svelte/column-pinning/package.json
@@ -20,7 +20,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/column-visibility/package.json
+++ b/examples/svelte/column-visibility/package.json
@@ -19,7 +19,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/column-visibility/package.json
+++ b/examples/svelte/column-visibility/package.json
@@ -19,7 +19,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/sorting/package.json
+++ b/examples/svelte/sorting/package.json
@@ -20,7 +20,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^3.2.3"
   }
 }

--- a/examples/svelte/sorting/package.json
+++ b/examples/svelte/sorting/package.json
@@ -20,7 +20,7 @@
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
     "tslib": "^2.3.1",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^3.2.3"
   }
 }

--- a/examples/vue/basic/package.json
+++ b/examples/vue/basic/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/basic/package.json
+++ b/examples/vue/basic/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/column-ordering/package.json
+++ b/examples/vue/column-ordering/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/column-ordering/package.json
+++ b/examples/vue/column-ordering/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/column-pinning/package.json
+++ b/examples/vue/column-pinning/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/column-pinning/package.json
+++ b/examples/vue/column-pinning/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/pagination-controlled/package.json
+++ b/examples/vue/pagination-controlled/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/pagination-controlled/package.json
+++ b/examples/vue/pagination-controlled/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/pagination/package.json
+++ b/examples/vue/pagination/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/pagination/package.json
+++ b/examples/vue/pagination/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/row-selection/package.json
+++ b/examples/vue/row-selection/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^4.4.0",
     "@vitejs/plugin-vue-jsx": "^3.0.2",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^4.4.11",
     "vue-tsc": "^1.8.19"
   }

--- a/examples/vue/sorting/package.json
+++ b/examples/vue/sorting/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/examples/vue/sorting/package.json
+++ b/examples/vue/sorting/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.27",
     "@vitejs/plugin-vue": "^2.3.3",
-    "typescript": "^4.9.5",
+    "typescript": "5.2.2",
     "vite": "^2.9.9",
     "vue-tsc": "^0.34.7"
   }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "stream-to-array": "^2.3.0",
     "svelte": "^3.49.0",
     "ts-node": "^10.9.2",
-    "typescript": "5.2.2",
+    "typescript": "5.3.3",
     "vitest": "^0.29.3",
     "vue": "^3.2.33"
   }

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
     "solid-js": "^1.6.2",
     "stream-to-array": "^2.3.0",
     "svelte": "^3.49.0",
-    "ts-node": "^10.7.0",
-    "typescript": "^4.9.5",
+    "ts-node": "^10.9.2",
+    "typescript": "5.2.2",
     "vitest": "^0.29.3",
     "vue": "^3.2.33"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8935,10 +8935,10 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-ts-node@^10.7.0:
-  version "10.9.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
-  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"
@@ -9048,10 +9048,10 @@ typescript@*:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
   integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 ufo@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9048,10 +9048,10 @@ typescript@*:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
   integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
-typescript@5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+typescript@5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 ufo@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
An incremental step to bringing the workspace config more in line with TanStack Query. TS version is pinned so it doesn't auto update (TS doesn't use semantic versioning).