### PR TITLE
chore: Update Nx caching inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   test-and-publish:
     name: Test & Publish
+    if: github.repository == 'TanStack/table'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +32,7 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run Tests
         run: pnpm run test:ci
       - name: Publish

--- a/nx.json
+++ b/nx.json
@@ -11,23 +11,40 @@
   },
   "parallel": 5,
   "namedInputs": {
-    "packageSources": [
-      "{workspaceRoot}/packages/**/src/**/*.ts",
-      "{workspaceRoot}/packages/**/tsconfig.json"
+    "sharedGlobals": [
+      "{workspaceRoot}/.nvmrc",
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/scripts/getRollupConfig.js",
+      "{workspaceRoot}/tsconfig.json"
     ],
-    "buildDeps": ["{projectRoot}/**/*", "!{projectRoot}/__tests__/**/*"]
+    "default": [
+      "sharedGlobals",
+      "{projectRoot}/**/*",
+      "!{projectRoot}/**/*.md"
+    ],
+    "public": [
+      "default",
+      "{projectRoot}/build",
+      "{projectRoot}/dist",
+      "!{projectRoot}/.eslintrc.cjs",
+      "!{projectRoot}/tsconfig.eslint.json"
+    ]
   },
   "targetDefaults": {
     "test:lib": {
       "dependsOn": ["^build"],
+      "inputs": ["default", "^public"],
+      "outputs": ["{projectRoot}/coverage"],
       "cache": true
     },
     "test:types": {
       "dependsOn": ["^build"],
+      "inputs": ["default", "^public"],
       "cache": true
     },
     "build": {
       "dependsOn": ["^build"],
+      "inputs": ["default", "^public"],
       "outputs": ["{projectRoot}/build", "{projectRoot}/dist"],
       "cache": true
     }


### PR DESCRIPTION
- Uses `"namedInputs"` config from query repo.
- Set CI to only run on main repo.