### PR TITLE
chore: Remove Vite aliases and tsconfig composite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
     if: github.repository == 'TanStack/table'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       - name: Setup pnpm

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   test:
-    name: 'Test'
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,9 +33,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Get appropriate base and head commits for `nx affected` commands
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Get base and head commits for `nx affected`
         uses: nrwl/nx-set-shas@v3
         with:
           main-branch-name: 'main'

--- a/examples/react/basic/tsconfig.dev.json
+++ b/examples/react/basic/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/basic/vite.config.js
+++ b/examples/react/basic/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/bootstrap/tsconfig.dev.json
+++ b/examples/react/bootstrap/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/bootstrap/vite.config.js
+++ b/examples/react/bootstrap/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/column-dnd/tsconfig.dev.json
+++ b/examples/react/column-dnd/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/column-dnd/vite.config.js
+++ b/examples/react/column-dnd/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/column-groups/tsconfig.dev.json
+++ b/examples/react/column-groups/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/column-groups/vite.config.js
+++ b/examples/react/column-groups/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/column-ordering/tsconfig.dev.json
+++ b/examples/react/column-ordering/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/column-ordering/vite.config.js
+++ b/examples/react/column-ordering/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/column-pinning/tsconfig.dev.json
+++ b/examples/react/column-pinning/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/column-pinning/vite.config.js
+++ b/examples/react/column-pinning/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/column-resizing-performant/tsconfig.dev.json
+++ b/examples/react/column-resizing-performant/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/column-resizing-performant/vite.config.js
+++ b/examples/react/column-resizing-performant/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/column-sizing/tsconfig.dev.json
+++ b/examples/react/column-sizing/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/column-sizing/vite.config.js
+++ b/examples/react/column-sizing/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/column-visibility/tsconfig.dev.json
+++ b/examples/react/column-visibility/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/column-visibility/vite.config.js
+++ b/examples/react/column-visibility/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/editable-data/tsconfig.dev.json
+++ b/examples/react/editable-data/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/editable-data/vite.config.js
+++ b/examples/react/editable-data/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/expanding/tsconfig.dev.json
+++ b/examples/react/expanding/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/expanding/vite.config.js
+++ b/examples/react/expanding/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/filters/tsconfig.dev.json
+++ b/examples/react/filters/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/filters/vite.config.js
+++ b/examples/react/filters/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/full-width-resizable-table/tsconfig.dev.json
+++ b/examples/react/full-width-resizable-table/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/full-width-resizable-table/vite.config.js
+++ b/examples/react/full-width-resizable-table/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/full-width-table/tsconfig.dev.json
+++ b/examples/react/full-width-table/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/full-width-table/vite.config.js
+++ b/examples/react/full-width-table/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/fully-controlled/tsconfig.dev.json
+++ b/examples/react/fully-controlled/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/fully-controlled/vite.config.js
+++ b/examples/react/fully-controlled/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/grouping/tsconfig.dev.json
+++ b/examples/react/grouping/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/grouping/vite.config.js
+++ b/examples/react/grouping/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/kitchen-sink/tsconfig.dev.json
+++ b/examples/react/kitchen-sink/tsconfig.dev.json
@@ -2,7 +2,6 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "composite": true,
     "outDir": "./build/types"
   },
   "jsxImportSource": "@emotion/react",

--- a/examples/react/kitchen-sink/vite.config.js
+++ b/examples/react/kitchen-sink/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -29,11 +28,4 @@ export default defineConfig({
       },
     }),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/material-ui-pagination/tsconfig.dev.json
+++ b/examples/react/material-ui-pagination/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/material-ui-pagination/vite.config.js
+++ b/examples/react/material-ui-pagination/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/pagination-controlled/tsconfig.dev.json
+++ b/examples/react/pagination-controlled/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/pagination-controlled/vite.config.js
+++ b/examples/react/pagination-controlled/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/pagination/tsconfig.dev.json
+++ b/examples/react/pagination/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/pagination/vite.config.js
+++ b/examples/react/pagination/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/row-dnd/tsconfig.dev.json
+++ b/examples/react/row-dnd/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/row-dnd/vite.config.js
+++ b/examples/react/row-dnd/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/row-pinning/tsconfig.dev.json
+++ b/examples/react/row-pinning/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/row-pinning/vite.config.js
+++ b/examples/react/row-pinning/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/row-selection/tsconfig.dev.json
+++ b/examples/react/row-selection/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/row-selection/vite.config.js
+++ b/examples/react/row-selection/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/sorting/tsconfig.dev.json
+++ b/examples/react/sorting/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/sorting/vite.config.js
+++ b/examples/react/sorting/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/sub-components/tsconfig.dev.json
+++ b/examples/react/sub-components/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/sub-components/vite.config.js
+++ b/examples/react/sub-components/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/virtualized-columns/tsconfig.dev.json
+++ b/examples/react/virtualized-columns/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/virtualized-columns/vite.config.js
+++ b/examples/react/virtualized-columns/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/virtualized-infinite-scrolling/tsconfig.dev.json
+++ b/examples/react/virtualized-infinite-scrolling/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/virtualized-infinite-scrolling/vite.config.js
+++ b/examples/react/virtualized-infinite-scrolling/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/react/virtualized-rows/tsconfig.dev.json
+++ b/examples/react/virtualized-rows/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types"
   },
   "files": ["src/main.tsx"],

--- a/examples/react/virtualized-rows/vite.config.js
+++ b/examples/react/virtualized-rows/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     react(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'react-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/solid/basic/tsconfig.dev.json
+++ b/examples/solid/basic/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "jsxImportSource": "solid-js",
     "jsx": "preserve"

--- a/examples/solid/bootstrap/tsconfig.dev.json
+++ b/examples/solid/bootstrap/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "jsxImportSource": "solid-js",
     "jsx": "preserve"

--- a/examples/solid/column-groups/tsconfig.dev.json
+++ b/examples/solid/column-groups/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "jsxImportSource": "solid-js",
     "jsx": "preserve"

--- a/examples/solid/column-ordering/tsconfig.dev.json
+++ b/examples/solid/column-ordering/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "jsxImportSource": "solid-js",
     "jsx": "preserve"

--- a/examples/solid/column-visibility/tsconfig.dev.json
+++ b/examples/solid/column-visibility/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "jsxImportSource": "solid-js",
     "jsx": "preserve"

--- a/examples/solid/sorting/tsconfig.dev.json
+++ b/examples/solid/sorting/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "jsxImportSource": "solid-js",
     "jsx": "preserve"

--- a/examples/svelte/basic/tsconfig.dev.json
+++ b/examples/svelte/basic/tsconfig.dev.json
@@ -2,7 +2,6 @@
   "extends": "../../../tsconfig.json",
   // "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "target": "esnext",
     "useDefineForClassFields": true,
     "module": "esnext",

--- a/examples/svelte/basic/vite.config.js
+++ b/examples/svelte/basic/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     svelte(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'svelte-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/svelte/column-groups/tsconfig.dev.json
+++ b/examples/svelte/column-groups/tsconfig.dev.json
@@ -2,7 +2,6 @@
   "extends": "../../../tsconfig.json",
   // "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "target": "esnext",
     "useDefineForClassFields": true,
     "module": "esnext",

--- a/examples/svelte/column-groups/vite.config.js
+++ b/examples/svelte/column-groups/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     svelte(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'svelte-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/svelte/column-ordering/tsconfig.dev.json
+++ b/examples/svelte/column-ordering/tsconfig.dev.json
@@ -2,7 +2,6 @@
   "extends": "../../../tsconfig.json",
   // "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "target": "esnext",
     "useDefineForClassFields": true,
     "module": "esnext",

--- a/examples/svelte/column-ordering/vite.config.js
+++ b/examples/svelte/column-ordering/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     svelte(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'svelte-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/svelte/column-pinning/tsconfig.dev.json
+++ b/examples/svelte/column-pinning/tsconfig.dev.json
@@ -2,7 +2,6 @@
   "extends": "../../../tsconfig.json",
   // "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "target": "esnext",
     "useDefineForClassFields": true,
     "module": "esnext",

--- a/examples/svelte/column-pinning/vite.config.js
+++ b/examples/svelte/column-pinning/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     svelte(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'svelte-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/svelte/column-visibility/tsconfig.dev.json
+++ b/examples/svelte/column-visibility/tsconfig.dev.json
@@ -2,7 +2,6 @@
   "extends": "../../../tsconfig.json",
   // "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "target": "esnext",
     "useDefineForClassFields": true,
     "module": "esnext",

--- a/examples/svelte/column-visibility/vite.config.js
+++ b/examples/svelte/column-visibility/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     svelte(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'svelte-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/svelte/sorting/tsconfig.dev.json
+++ b/examples/svelte/sorting/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "target": "esnext",
     "useDefineForClassFields": true,
     "module": "esnext",

--- a/examples/svelte/sorting/vite.config.js
+++ b/examples/svelte/sorting/vite.config.js
@@ -1,4 +1,3 @@
-import * as path from 'path'
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import rollupReplace from '@rollup/plugin-replace'
@@ -15,11 +14,4 @@ export default defineConfig({
     }),
     svelte(),
   ],
-  resolve: process.env.USE_SOURCE
-    ? {
-        alias: {
-          'svelte-table': path.resolve(__dirname, '../../../src/index.ts'),
-        },
-      }
-    : {},
 })

--- a/examples/vue/basic/tsconfig.dev.json
+++ b/examples/vue/basic/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "types": ["vite/client"]
   },

--- a/examples/vue/basic/tsconfig.node.json
+++ b/examples/vue/basic/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "module": "esnext",
     "moduleResolution": "node"
   },

--- a/examples/vue/column-ordering/tsconfig.dev.json
+++ b/examples/vue/column-ordering/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "types": ["vite/client"]
   },

--- a/examples/vue/column-ordering/tsconfig.node.json
+++ b/examples/vue/column-ordering/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "module": "esnext",
     "moduleResolution": "node"
   },

--- a/examples/vue/column-pinning/tsconfig.dev.json
+++ b/examples/vue/column-pinning/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "types": ["vite/client"]
   },

--- a/examples/vue/column-pinning/tsconfig.node.json
+++ b/examples/vue/column-pinning/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "module": "esnext",
     "moduleResolution": "node"
   },

--- a/examples/vue/pagination-controlled/tsconfig.node.json
+++ b/examples/vue/pagination-controlled/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "module": "esnext",
     "moduleResolution": "node"
   },

--- a/examples/vue/pagination/tsconfig.dev.json
+++ b/examples/vue/pagination/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "types": ["vite/client"]
   },

--- a/examples/vue/pagination/tsconfig.node.json
+++ b/examples/vue/pagination/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "module": "esnext",
     "moduleResolution": "node"
   },

--- a/examples/vue/row-selection/tsconfig.node.json
+++ b/examples/vue/row-selection/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "module": "esnext",
     "moduleResolution": "node"
   },

--- a/examples/vue/sorting/tsconfig.dev.json
+++ b/examples/vue/sorting/tsconfig.dev.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build/types",
     "types": ["vite/client"]
   },

--- a/examples/vue/sorting/tsconfig.node.json
+++ b/examples/vue/sorting/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "module": "esnext",
     "moduleResolution": "node"
   },

--- a/packages/match-sorter-utils/tsconfig.json
+++ b/packages/match-sorter-utils/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
-    "outDir": "./build/lib",
-    "tsBuildInfoFile": "./build/.tsbuildinfo"
+    "outDir": "./build/lib"
   },
   "include": ["src"]
 }

--- a/packages/react-table-devtools/tsconfig.json
+++ b/packages/react-table-devtools/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
-    "outDir": "./build/lib",
-    "tsBuildInfoFile": "./build/.tsbuildinfo"
+    "outDir": "./build/lib"
   },
   "include": ["src"]
 }

--- a/packages/react-table/tsconfig.json
+++ b/packages/react-table/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
-    "outDir": "./build/lib",
-    "tsBuildInfoFile": "./build/.tsbuildinfo"
+    "outDir": "./build/lib"
   },
   "include": ["src"]
 }

--- a/packages/react-table/vitest.config.ts
+++ b/packages/react-table/vitest.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from 'vitest/config'
-import { resolve } from 'node:path'
 
 export default defineConfig({
   test: {
@@ -8,10 +7,5 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     dir: '__tests__',
-  },
-  resolve: {
-    alias: {
-      '@tanstack/table-core': resolve(__dirname, '../table-core/src'),
-    },
   },
 })

--- a/packages/solid-table/tsconfig.json
+++ b/packages/solid-table/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
-    "outDir": "./build/lib",
-    "tsBuildInfoFile": "./build/.tsbuildinfo"
+    "outDir": "./build/lib"
   },
   "include": ["src"]
 }

--- a/packages/svelte-table/tsconfig.json
+++ b/packages/svelte-table/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
-    "outDir": "./build/lib",
-    "tsBuildInfoFile": "./build/.tsbuildinfo"
+    "outDir": "./build/lib"
   },
   "include": ["src"]
 }

--- a/packages/table-core/tsconfig.json
+++ b/packages/table-core/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
-    "outDir": "./build/lib",
-    "tsBuildInfoFile": "./build/.tsbuildinfo"
+    "outDir": "./build/lib"
   },
   "include": ["src/**/*"]
 }

--- a/packages/vue-table/tsconfig.json
+++ b/packages/vue-table/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
-    "outDir": "./build/lib",
-    "tsBuildInfoFile": "./build/.tsbuildinfo"
+    "outDir": "./build/lib"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Not used anymore, since resolution is handled by Node and pnpm, and packages typecheck independently.