### PR TITLE
docs: fix meta data example

### DIFF
--- a/docs/api/core/column-def.md
+++ b/docs/api/core/column-def.md
@@ -95,7 +95,7 @@ meta?: ColumnMeta // This interface is extensible via declaration merging. See b
 The meta data to associated with the column. We can access it anywhere when the column is available via `column.columnDef.meta`. This type is global to all tables and can be extended like so:
 
 ```tsx
-import '@tanstack/react-table'
+import '@tanstack/react-table' //or vue, svelte, solid, etc.
 
 declare module '@tanstack/react-table' {
   interface ColumnMeta<TData extends RowData, TValue> {

--- a/docs/api/core/column-def.md
+++ b/docs/api/core/column-def.md
@@ -97,7 +97,7 @@ The meta data to associated with the column. We can access it anywhere when the 
 ```tsx
 import '@tanstack/react-table'
 
-declare module '@tanstack/table-core' {
+declare module '@tanstack/react-table' {
   interface ColumnMeta<TData extends RowData, TValue> {
     foo: string
   }


### PR DESCRIPTION
Using `@tanstack/table-core` doesn't work with `@tanstack/react-table`.  

I found this fix here: https://github.com/TanStack/table/discussions/4157#discussioncomment-3224614

I'm open to feedback, but I would like to fix the docs so it easy to copy the example into projects. 