### PR TITLE
chore: Update examples to use Vite v4

### DIFF
--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/bootstrap/package.json
+++ b/examples/react/bootstrap/package.json
@@ -20,7 +20,7 @@
     "@rollup/plugin-replace": "^5.0.5",
     "@types/bootstrap": "^5.2.6",
     "@types/react-bootstrap": "^0.32.32",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.4"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/column-dnd/package.json
+++ b/examples/react/column-dnd/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/column-groups/package.json
+++ b/examples/react/column-groups/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/column-ordering/package.json
+++ b/examples/react/column-ordering/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/column-pinning/package.json
+++ b/examples/react/column-pinning/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/column-resizing-performant/package.json
+++ b/examples/react/column-resizing-performant/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/column-sizing/package.json
+++ b/examples/react/column-sizing/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/column-visibility/package.json
+++ b/examples/react/column-visibility/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/editable-data/package.json
+++ b/examples/react/editable-data/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/expanding/package.json
+++ b/examples/react/expanding/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/filters/package.json
+++ b/examples/react/filters/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/full-width-resizable-table/package.json
+++ b/examples/react/full-width-resizable-table/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/full-width-table/package.json
+++ b/examples/react/full-width-table/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/fully-controlled/package.json
+++ b/examples/react/fully-controlled/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/grouping/package.json
+++ b/examples/react/grouping/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/kitchen-sink/package.json
+++ b/examples/react/kitchen-sink/package.json
@@ -13,8 +13,6 @@
     "@emotion/styled": "^11.10.5",
     "@tanstack/match-sorter-utils": "^8.11.3",
     "@tanstack/react-table": "^8.11.3",
-    "@types/react": "^18.2.45",
-    "@types/react-dom": "^18.2.18",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -23,7 +21,9 @@
     "@emotion/babel-plugin-jsx-pragmatic": "^0.2.0",
     "@faker-js/faker": "^8.3.1",
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.4"
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/material-ui-pagination/package.json
+++ b/examples/react/material-ui-pagination/package.json
@@ -9,8 +9,8 @@
     "start": "vite"
   },
   "dependencies": {
-    "@emotion/react": "^11.9.3",
-    "@emotion/styled": "^11.9.3",
+    "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.6",
     "@tanstack/react-table": "^8.11.3",

--- a/examples/react/material-ui-pagination/package.json
+++ b/examples/react/material-ui-pagination/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.3.1",
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/pagination-controlled/package.json
+++ b/examples/react/pagination-controlled/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/pagination/package.json
+++ b/examples/react/pagination/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/row-dnd/package.json
+++ b/examples/react/row-dnd/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/row-pinning/package.json
+++ b/examples/react/row-pinning/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/row-selection/package.json
+++ b/examples/react/row-selection/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/sorting/package.json
+++ b/examples/react/sorting/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/sub-components/package.json
+++ b/examples/react/sub-components/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/react/virtualized-infinite-scrolling/package.json
+++ b/examples/react/virtualized-infinite-scrolling/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",
-    "@vitejs/plugin-react": "^2.2.0",
-    "vite": "^3.2.3"
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^4.5.1"
   }
 }

--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -11,8 +11,8 @@
   "license": "MIT",
   "devDependencies": {
     "typescript": "5.2.2",
-    "vite": "^3.2.3",
-    "vite-plugin-solid": "^2.2.6"
+    "vite": "^4.5.1",
+    "vite-plugin-solid": "^2.4.0"
   },
   "dependencies": {
     "@tanstack/solid-table": "^8.11.3",

--- a/examples/solid/bootstrap/package.json
+++ b/examples/solid/bootstrap/package.json
@@ -12,12 +12,12 @@
   "devDependencies": {
     "@faker-js/faker": "^8.3.1",
     "typescript": "5.2.2",
-    "vite": "^3.2.3",
+    "vite": "^4.5.1",
     "vite-plugin-solid": "^2.4.0"
   },
   "dependencies": {
     "@tanstack/solid-table": "^8.11.3",
-    "bootstrap": "^5.2.2",
+    "bootstrap": "^5.2.3",
     "solid-bootstrap": "^1.0.8",
     "solid-js": "^1.6.2"
   }

--- a/examples/solid/column-groups/package.json
+++ b/examples/solid/column-groups/package.json
@@ -11,8 +11,8 @@
   "license": "MIT",
   "devDependencies": {
     "typescript": "5.2.2",
-    "vite": "^3.2.3",
-    "vite-plugin-solid": "^2.2.6"
+    "vite": "^4.5.1",
+    "vite-plugin-solid": "^2.4.0"
   },
   "dependencies": {
     "@tanstack/solid-table": "^8.11.3",

--- a/examples/solid/column-ordering/package.json
+++ b/examples/solid/column-ordering/package.json
@@ -12,8 +12,8 @@
   "devDependencies": {
     "@faker-js/faker": "^8.3.1",
     "typescript": "5.2.2",
-    "vite": "^3.2.3",
-    "vite-plugin-solid": "^2.2.6"
+    "vite": "^4.5.1",
+    "vite-plugin-solid": "^2.4.0"
   },
   "dependencies": {
     "@tanstack/solid-table": "^8.11.3",

--- a/examples/solid/column-visibility/package.json
+++ b/examples/solid/column-visibility/package.json
@@ -11,8 +11,8 @@
   "license": "MIT",
   "devDependencies": {
     "typescript": "5.2.2",
-    "vite": "^3.2.3",
-    "vite-plugin-solid": "^2.2.6"
+    "vite": "^4.5.1",
+    "vite-plugin-solid": "^2.4.0"
   },
   "dependencies": {
     "@tanstack/solid-table": "^8.11.3",

--- a/examples/solid/filters/package.json
+++ b/examples/solid/filters/package.json
@@ -12,8 +12,8 @@
   "devDependencies": {
     "@faker-js/faker": "^8.3.1",
     "typescript": "5.2.2",
-    "vite": "^3.2.3",
-    "vite-plugin-solid": "^2.2.6"
+    "vite": "^4.5.1",
+    "vite-plugin-solid": "^2.4.0"
   },
   "dependencies": {
     "@solid-primitives/scheduled": "^1.4.1",

--- a/examples/solid/sorting/package.json
+++ b/examples/solid/sorting/package.json
@@ -12,8 +12,8 @@
   "devDependencies": {
     "@faker-js/faker": "^8.3.1",
     "typescript": "5.2.2",
-    "vite": "^3.2.3",
-    "vite-plugin-solid": "^2.2.6"
+    "vite": "^4.5.1",
+    "vite-plugin-solid": "^2.4.0"
   },
   "dependencies": {
     "@tanstack/solid-table": "^8.11.3",

--- a/examples/svelte/basic/package.json
+++ b/examples/svelte/basic/package.json
@@ -19,6 +19,6 @@
     "svelte-check": "^2.2.7",
     "tslib": "^2.3.1",
     "typescript": "5.2.2",
-    "vite": "^3.2.3"
+    "vite": "^4.5.1"
   }
 }

--- a/examples/svelte/column-groups/package.json
+++ b/examples/svelte/column-groups/package.json
@@ -19,6 +19,6 @@
     "svelte-check": "^2.2.7",
     "tslib": "^2.3.1",
     "typescript": "5.2.2",
-    "vite": "^3.2.3"
+    "vite": "^4.5.1"
   }
 }

--- a/examples/svelte/column-ordering/package.json
+++ b/examples/svelte/column-ordering/package.json
@@ -20,6 +20,6 @@
     "svelte-check": "^2.2.7",
     "tslib": "^2.3.1",
     "typescript": "5.2.2",
-    "vite": "^3.2.3"
+    "vite": "^4.5.1"
   }
 }

--- a/examples/svelte/column-pinning/package.json
+++ b/examples/svelte/column-pinning/package.json
@@ -20,6 +20,6 @@
     "svelte-check": "^2.2.7",
     "tslib": "^2.3.1",
     "typescript": "5.2.2",
-    "vite": "^3.2.3"
+    "vite": "^4.5.1"
   }
 }

--- a/examples/svelte/column-visibility/package.json
+++ b/examples/svelte/column-visibility/package.json
@@ -19,6 +19,6 @@
     "svelte-check": "^2.2.7",
     "tslib": "^2.3.1",
     "typescript": "5.2.2",
-    "vite": "^3.2.3"
+    "vite": "^4.5.1"
   }
 }

--- a/examples/svelte/sorting/package.json
+++ b/examples/svelte/sorting/package.json
@@ -20,6 +20,6 @@
     "svelte-check": "^2.2.7",
     "tslib": "^2.3.1",
     "typescript": "5.2.2",
-    "vite": "^3.2.3"
+    "vite": "^4.5.1"
   }
 }

--- a/examples/vue/basic/package.json
+++ b/examples/vue/basic/package.json
@@ -13,9 +13,9 @@
   },
   "devDependencies": {
     "@types/node": "^18.19.4",
-    "@vitejs/plugin-vue": "^2.3.3",
+    "@vitejs/plugin-vue": "^4.4.0",
     "typescript": "5.2.2",
-    "vite": "^2.9.9",
-    "vue-tsc": "^0.35.0"
+    "vite": "^4.5.1",
+    "vue-tsc": "^1.8.19"
   }
 }

--- a/examples/vue/column-ordering/package.json
+++ b/examples/vue/column-ordering/package.json
@@ -14,9 +14,9 @@
   },
   "devDependencies": {
     "@types/node": "^18.19.4",
-    "@vitejs/plugin-vue": "^2.3.3",
+    "@vitejs/plugin-vue": "^4.4.0",
     "typescript": "5.2.2",
-    "vite": "^2.9.9",
-    "vue-tsc": "^0.35.0"
+    "vite": "^4.5.1",
+    "vue-tsc": "^1.8.19"
   }
 }

--- a/examples/vue/column-pinning/package.json
+++ b/examples/vue/column-pinning/package.json
@@ -14,9 +14,9 @@
   },
   "devDependencies": {
     "@types/node": "^18.19.4",
-    "@vitejs/plugin-vue": "^2.3.3",
+    "@vitejs/plugin-vue": "^4.4.0",
     "typescript": "5.2.2",
-    "vite": "^2.9.9",
-    "vue-tsc": "^0.35.0"
+    "vite": "^4.5.1",
+    "vue-tsc": "^1.8.19"
   }
 }

--- a/examples/vue/pagination-controlled/package.json
+++ b/examples/vue/pagination-controlled/package.json
@@ -14,9 +14,9 @@
   },
   "devDependencies": {
     "@types/node": "^18.19.4",
-    "@vitejs/plugin-vue": "^2.3.3",
+    "@vitejs/plugin-vue": "^4.4.0",
     "typescript": "5.2.2",
-    "vite": "^2.9.9",
-    "vue-tsc": "^0.35.0"
+    "vite": "^4.5.1",
+    "vue-tsc": "^1.8.19"
   }
 }

--- a/examples/vue/pagination/package.json
+++ b/examples/vue/pagination/package.json
@@ -14,9 +14,9 @@
   },
   "devDependencies": {
     "@types/node": "^18.19.4",
-    "@vitejs/plugin-vue": "^2.3.3",
+    "@vitejs/plugin-vue": "^4.4.0",
     "typescript": "5.2.2",
-    "vite": "^2.9.9",
-    "vue-tsc": "^0.35.0"
+    "vite": "^4.5.1",
+    "vue-tsc": "^1.8.19"
   }
 }

--- a/examples/vue/row-selection/package.json
+++ b/examples/vue/row-selection/package.json
@@ -16,7 +16,7 @@
     "@vitejs/plugin-vue": "^4.4.0",
     "@vitejs/plugin-vue-jsx": "^3.0.2",
     "typescript": "5.2.2",
-    "vite": "^4.4.11",
+    "vite": "^4.5.1",
     "vue-tsc": "^1.8.19"
   }
 }

--- a/examples/vue/sorting/package.json
+++ b/examples/vue/sorting/package.json
@@ -14,9 +14,9 @@
   },
   "devDependencies": {
     "@types/node": "^18.19.4",
-    "@vitejs/plugin-vue": "^2.3.3",
+    "@vitejs/plugin-vue": "^4.4.0",
     "typescript": "5.2.2",
-    "vite": "^2.9.9",
-    "vue-tsc": "^0.35.0"
+    "vite": "^4.5.1",
+    "vue-tsc": "^1.8.19"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 0.4.4(rollup@3.29.4)
       '@tanstack/config':
         specifier: ^0.1.6
-        version: 0.1.6(@types/node@18.19.4)(esbuild@0.19.10)(rollup@3.29.4)(typescript@5.2.2)(vite@3.2.5)
+        version: 0.1.6(@types/node@18.19.4)(esbuild@0.19.10)(rollup@3.29.4)(typescript@5.2.2)(vite@5.0.10)
       '@testing-library/jest-dom':
         specifier: ^5.16.4
         version: 5.16.5
@@ -130,11 +130,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/bootstrap:
     dependencies:
@@ -167,11 +167,11 @@ importers:
         specifier: ^0.32.32
         version: 0.32.32
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.4
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/column-dnd:
     dependencies:
@@ -198,11 +198,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/column-groups:
     dependencies:
@@ -220,11 +220,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/column-ordering:
     dependencies:
@@ -245,11 +245,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/column-pinning:
     dependencies:
@@ -270,11 +270,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/column-resizing-performant:
     dependencies:
@@ -295,11 +295,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/column-sizing:
     dependencies:
@@ -317,11 +317,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/column-visibility:
     dependencies:
@@ -339,11 +339,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/editable-data:
     dependencies:
@@ -364,11 +364,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/expanding:
     dependencies:
@@ -389,11 +389,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/filters:
     dependencies:
@@ -417,11 +417,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/full-width-resizable-table:
     dependencies:
@@ -442,11 +442,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/full-width-table:
     dependencies:
@@ -467,11 +467,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/fully-controlled:
     dependencies:
@@ -492,11 +492,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/grouping:
     dependencies:
@@ -517,11 +517,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/kitchen-sink:
     dependencies:
@@ -537,12 +537,6 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.11.3
         version: link:../../../packages/react-table
-      '@types/react':
-        specifier: ^18.2.45
-        version: 18.2.45
-      '@types/react-dom':
-        specifier: ^18.2.18
-        version: 18.2.18
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -562,12 +556,18 @@ importers:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
+      '@types/react':
+        specifier: ^18.2.45
+        version: 18.2.45
+      '@types/react-dom':
+        specifier: ^18.2.18
+        version: 18.2.18
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.4
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/material-ui-pagination:
     dependencies:
@@ -600,11 +600,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/pagination:
     dependencies:
@@ -625,11 +625,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/pagination-controlled:
     dependencies:
@@ -653,11 +653,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/row-dnd:
     dependencies:
@@ -684,11 +684,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/row-pinning:
     dependencies:
@@ -709,11 +709,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/row-selection:
     dependencies:
@@ -734,11 +734,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/sorting:
     dependencies:
@@ -759,11 +759,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/sub-components:
     dependencies:
@@ -784,11 +784,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/virtualized-columns:
     dependencies:
@@ -843,11 +843,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-react':
-        specifier: ^2.2.0
-        version: 2.2.0(vite@3.2.5)
+        specifier: ^4.2.1
+        version: 4.2.1(vite@4.5.1)
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/react/virtualized-rows:
     dependencies:
@@ -890,11 +890,11 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vite-plugin-solid:
-        specifier: ^2.2.6
-        version: 2.6.1(solid-js@1.6.15)(vite@3.2.5)
+        specifier: ^2.4.0
+        version: 2.6.1(solid-js@1.6.15)(vite@4.5.1)
 
   examples/solid/bootstrap:
     dependencies:
@@ -902,7 +902,7 @@ importers:
         specifier: ^8.11.3
         version: link:../../../packages/solid-table
       bootstrap:
-        specifier: ^5.2.2
+        specifier: ^5.2.3
         version: 5.2.3(@popperjs/core@2.11.7)
       solid-bootstrap:
         specifier: ^1.0.8
@@ -918,11 +918,11 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vite-plugin-solid:
         specifier: ^2.4.0
-        version: 2.6.1(solid-js@1.6.15)(vite@3.2.5)
+        version: 2.6.1(solid-js@1.6.15)(vite@4.5.1)
 
   examples/solid/column-groups:
     dependencies:
@@ -937,11 +937,11 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vite-plugin-solid:
-        specifier: ^2.2.6
-        version: 2.6.1(solid-js@1.6.15)(vite@3.2.5)
+        specifier: ^2.4.0
+        version: 2.6.1(solid-js@1.6.15)(vite@4.5.1)
 
   examples/solid/column-ordering:
     dependencies:
@@ -959,11 +959,11 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vite-plugin-solid:
-        specifier: ^2.2.6
-        version: 2.6.1(solid-js@1.6.15)(vite@3.2.5)
+        specifier: ^2.4.0
+        version: 2.6.1(solid-js@1.6.15)(vite@4.5.1)
 
   examples/solid/column-visibility:
     dependencies:
@@ -978,11 +978,11 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vite-plugin-solid:
-        specifier: ^2.2.6
-        version: 2.6.1(solid-js@1.6.15)(vite@3.2.5)
+        specifier: ^2.4.0
+        version: 2.6.1(solid-js@1.6.15)(vite@4.5.1)
 
   examples/solid/filters:
     dependencies:
@@ -1003,11 +1003,11 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vite-plugin-solid:
-        specifier: ^2.2.6
-        version: 2.6.1(solid-js@1.6.15)(vite@3.2.5)
+        specifier: ^2.4.0
+        version: 2.6.1(solid-js@1.6.15)(vite@4.5.1)
 
   examples/solid/sorting:
     dependencies:
@@ -1025,11 +1025,11 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vite-plugin-solid:
-        specifier: ^2.2.6
-        version: 2.6.1(solid-js@1.6.15)(vite@3.2.5)
+        specifier: ^2.4.0
+        version: 2.6.1(solid-js@1.6.15)(vite@4.5.1)
 
   examples/svelte/basic:
     devDependencies:
@@ -1038,7 +1038,7 @@ importers:
         version: 5.0.5(rollup@3.29.4)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^1.0.0-next.42
-        version: 1.4.0(svelte@3.57.0)(vite@3.2.5)
+        version: 1.4.0(svelte@3.57.0)(vite@4.5.1)
       '@tanstack/svelte-table':
         specifier: ^8.11.3
         version: link:../../../packages/svelte-table
@@ -1058,8 +1058,8 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/svelte/column-groups:
     devDependencies:
@@ -1068,7 +1068,7 @@ importers:
         version: 5.0.5(rollup@3.29.4)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^1.0.0-next.42
-        version: 1.4.0(svelte@3.57.0)(vite@3.2.5)
+        version: 1.4.0(svelte@3.57.0)(vite@4.5.1)
       '@tanstack/svelte-table':
         specifier: ^8.11.3
         version: link:../../../packages/svelte-table
@@ -1088,8 +1088,8 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/svelte/column-ordering:
     devDependencies:
@@ -1101,7 +1101,7 @@ importers:
         version: 5.0.5(rollup@3.29.4)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^1.0.0-next.42
-        version: 1.4.0(svelte@3.57.0)(vite@3.2.5)
+        version: 1.4.0(svelte@3.57.0)(vite@4.5.1)
       '@tanstack/svelte-table':
         specifier: ^8.11.3
         version: link:../../../packages/svelte-table
@@ -1121,8 +1121,8 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/svelte/column-pinning:
     devDependencies:
@@ -1134,7 +1134,7 @@ importers:
         version: 5.0.5(rollup@3.29.4)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^1.0.0-next.42
-        version: 1.4.0(svelte@3.57.0)(vite@3.2.5)
+        version: 1.4.0(svelte@3.57.0)(vite@4.5.1)
       '@tanstack/svelte-table':
         specifier: ^8.11.3
         version: link:../../../packages/svelte-table
@@ -1154,8 +1154,8 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/svelte/column-visibility:
     devDependencies:
@@ -1164,7 +1164,7 @@ importers:
         version: 5.0.5(rollup@3.29.4)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^1.0.0-next.42
-        version: 1.4.0(svelte@3.57.0)(vite@3.2.5)
+        version: 1.4.0(svelte@3.57.0)(vite@4.5.1)
       '@tanstack/svelte-table':
         specifier: ^8.11.3
         version: link:../../../packages/svelte-table
@@ -1184,8 +1184,8 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/svelte/sorting:
     devDependencies:
@@ -1197,7 +1197,7 @@ importers:
         version: 5.0.5(rollup@3.29.4)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^1.0.0-next.42
-        version: 1.4.0(svelte@3.57.0)(vite@3.2.5)
+        version: 1.4.0(svelte@3.57.0)(vite@4.5.1)
       '@tanstack/svelte-table':
         specifier: ^8.11.3
         version: link:../../../packages/svelte-table
@@ -1217,8 +1217,8 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^3.2.3
-        version: 3.2.5(@types/node@18.19.4)
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
 
   examples/vue/basic:
     dependencies:
@@ -1233,17 +1233,17 @@ importers:
         specifier: ^18.19.4
         version: 18.19.4
       '@vitejs/plugin-vue':
-        specifier: ^2.3.3
-        version: 2.3.4(vite@2.9.15)(vue@3.2.47)
+        specifier: ^4.4.0
+        version: 4.6.0(vite@4.5.1)(vue@3.2.47)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^2.9.9
-        version: 2.9.15
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vue-tsc:
-        specifier: ^0.35.0
-        version: 0.35.2(typescript@5.2.2)
+        specifier: ^1.8.19
+        version: 1.8.27(typescript@5.2.2)
 
   examples/vue/column-ordering:
     dependencies:
@@ -1261,17 +1261,17 @@ importers:
         specifier: ^18.19.4
         version: 18.19.4
       '@vitejs/plugin-vue':
-        specifier: ^2.3.3
-        version: 2.3.4(vite@2.9.15)(vue@3.2.47)
+        specifier: ^4.4.0
+        version: 4.6.0(vite@4.5.1)(vue@3.2.47)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^2.9.9
-        version: 2.9.15
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vue-tsc:
-        specifier: ^0.35.0
-        version: 0.35.2(typescript@5.2.2)
+        specifier: ^1.8.19
+        version: 1.8.27(typescript@5.2.2)
 
   examples/vue/column-pinning:
     dependencies:
@@ -1289,17 +1289,17 @@ importers:
         specifier: ^18.19.4
         version: 18.19.4
       '@vitejs/plugin-vue':
-        specifier: ^2.3.3
-        version: 2.3.4(vite@2.9.15)(vue@3.2.47)
+        specifier: ^4.4.0
+        version: 4.6.0(vite@4.5.1)(vue@3.2.47)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^2.9.9
-        version: 2.9.15
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vue-tsc:
-        specifier: ^0.35.0
-        version: 0.35.2(typescript@5.2.2)
+        specifier: ^1.8.19
+        version: 1.8.27(typescript@5.2.2)
 
   examples/vue/pagination:
     dependencies:
@@ -1317,17 +1317,17 @@ importers:
         specifier: ^18.19.4
         version: 18.19.4
       '@vitejs/plugin-vue':
-        specifier: ^2.3.3
-        version: 2.3.4(vite@2.9.15)(vue@3.2.47)
+        specifier: ^4.4.0
+        version: 4.6.0(vite@4.5.1)(vue@3.2.47)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^2.9.9
-        version: 2.9.15
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vue-tsc:
-        specifier: ^0.35.0
-        version: 0.35.2(typescript@5.2.2)
+        specifier: ^1.8.19
+        version: 1.8.27(typescript@5.2.2)
 
   examples/vue/pagination-controlled:
     dependencies:
@@ -1345,17 +1345,17 @@ importers:
         specifier: ^18.19.4
         version: 18.19.4
       '@vitejs/plugin-vue':
-        specifier: ^2.3.3
-        version: 2.3.4(vite@2.9.15)(vue@3.2.47)
+        specifier: ^4.4.0
+        version: 4.6.0(vite@4.5.1)(vue@3.2.47)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^2.9.9
-        version: 2.9.15
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vue-tsc:
-        specifier: ^0.35.0
-        version: 0.35.2(typescript@5.2.2)
+        specifier: ^1.8.19
+        version: 1.8.27(typescript@5.2.2)
 
   examples/vue/row-selection:
     dependencies:
@@ -1379,7 +1379,7 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^4.4.11
+        specifier: ^4.5.1
         version: 4.5.1(@types/node@18.19.4)
       vue-tsc:
         specifier: ^1.8.19
@@ -1401,17 +1401,17 @@ importers:
         specifier: ^18.19.4
         version: 18.19.4
       '@vitejs/plugin-vue':
-        specifier: ^2.3.3
-        version: 2.3.4(vite@2.9.15)(vue@3.2.47)
+        specifier: ^4.4.0
+        version: 4.6.0(vite@4.5.1)(vue@3.2.47)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
-        specifier: ^2.9.9
-        version: 2.9.15
+        specifier: ^4.5.1
+        version: 4.5.1(@types/node@18.19.4)
       vue-tsc:
-        specifier: ^0.35.0
-        version: 0.35.2(typescript@5.2.2)
+        specifier: ^1.8.19
+        version: 1.8.27(typescript@5.2.2)
 
   packages/match-sorter-utils:
     dependencies:
@@ -1507,37 +1507,9 @@ packages:
       chalk: 2.4.2
     dev: true
 
-  /@babel/compat-data@7.21.0:
-    resolution: {integrity: sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
   /@babel/compat-data@7.23.5:
     resolution: {integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==}
     engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/core@7.21.3:
-    resolution: {integrity: sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.21.3
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.3)
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helpers': 7.21.0
-      '@babel/parser': 7.21.3
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.3
-      convert-source-map: 1.9.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/core@7.23.6:
@@ -1606,13 +1578,6 @@ packages:
       jsesc: 2.5.2
     dev: true
 
-  /@babel/helper-annotate-as-pure@7.18.6:
-    resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.3
-    dev: true
-
   /@babel/helper-annotate-as-pure@7.22.5:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
     engines: {node: '>=6.9.0'}
@@ -1627,20 +1592,6 @@ packages:
       '@babel/types': 7.23.6
     dev: true
 
-  /@babel/helper-compilation-targets@7.20.7(@babel/core@7.21.3):
-    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.21.0
-      '@babel/core': 7.21.3
-      '@babel/helper-validator-option': 7.21.0
-      browserslist: 4.21.5
-      lru-cache: 5.1.1
-      semver: 6.3.1
-    dev: true
-
   /@babel/helper-compilation-targets@7.23.6:
     resolution: {integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==}
     engines: {node: '>=6.9.0'}
@@ -1650,25 +1601,6 @@ packages:
       browserslist: 4.22.2
       lru-cache: 5.1.1
       semver: 6.3.1
-    dev: true
-
-  /@babel/helper-create-class-features-plugin@7.21.0(@babel/core@7.21.3):
-    resolution: {integrity: sha512-Q8wNiMIdwsv5la5SPxNYzzkPnjgC0Sy0i7jLkVOCdllu/xcVNkr3TeZzbHBJrj+XXRqzX5uCyCoV9eu6xUG7KQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/helper-create-class-features-plugin@7.23.6(@babel/core@7.23.6):
@@ -1734,22 +1666,9 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-environment-visitor@7.18.9:
-    resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
   /@babel/helper-environment-visitor@7.22.20:
     resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
     engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-function-name@7.21.0:
-    resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.20.7
-      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-function-name@7.23.0:
@@ -1760,25 +1679,11 @@ packages:
       '@babel/types': 7.23.6
     dev: true
 
-  /@babel/helper-hoist-variables@7.18.6:
-    resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.3
-    dev: true
-
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.6
-    dev: true
-
-  /@babel/helper-member-expression-to-functions@7.21.0:
-    resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.23.0:
@@ -1799,22 +1704,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.6
-    dev: true
-
-  /@babel/helper-module-transforms@7.21.2:
-    resolution: {integrity: sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-simple-access': 7.20.2
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.6):
@@ -1843,13 +1732,6 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
-    dev: true
-
-  /@babel/helper-optimise-call-expression@7.18.6:
-    resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-optimise-call-expression@7.22.5:
@@ -1881,20 +1763,6 @@ packages:
       '@babel/helper-wrap-function': 7.22.20
     dev: true
 
-  /@babel/helper-replace-supers@7.20.7:
-    resolution: {integrity: sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/helper-replace-supers@7.22.20(@babel/core@7.23.6):
     resolution: {integrity: sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==}
     engines: {node: '>=6.9.0'}
@@ -1919,13 +1787,6 @@ packages:
       '@babel/helper-optimise-call-expression': 7.22.5
     dev: true
 
-  /@babel/helper-simple-access@7.20.2:
-    resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.23.6
-    dev: true
-
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
@@ -1933,22 +1794,8 @@ packages:
       '@babel/types': 7.23.6
     dev: true
 
-  /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
-    resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.21.3
-    dev: true
-
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.23.6
-    dev: true
-
-  /@babel/helper-split-export-declaration@7.18.6:
-    resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.6
@@ -1979,11 +1826,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-validator-option@7.21.0:
-    resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
   /@babel/helper-validator-option@7.23.5:
     resolution: {integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==}
     engines: {node: '>=6.9.0'}
@@ -1996,17 +1838,6 @@ packages:
       '@babel/helper-function-name': 7.23.0
       '@babel/template': 7.22.15
       '@babel/types': 7.23.6
-    dev: true
-
-  /@babel/helpers@7.21.0:
-    resolution: {integrity: sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/helpers@7.23.6:
@@ -2189,16 +2020,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.21.3):
-    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.23.7):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
@@ -2301,16 +2122,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
-    dev: true
-
-  /@babel/plugin-syntax-typescript@7.20.0(@babel/core@7.21.3):
-    resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.23.6):
@@ -2772,16 +2583,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-react-jsx-development@7.18.6(@babel/core@7.21.3):
-    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/plugin-transform-react-jsx': 7.21.0(@babel/core@7.21.3)
-    dev: true
-
   /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.7):
     resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
     engines: {node: '>=6.9.0'}
@@ -2790,16 +2591,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.7)
-    dev: true
-
-  /@babel/plugin-transform-react-jsx-self@7.21.0(@babel/core@7.21.3):
-    resolution: {integrity: sha512-f/Eq+79JEu+KUANFks9UZCcvydOOGMgF7jBrcwjHa5jTZD8JivnhCJYvmlhR/WTXBWonDExPoW0eO/CR4QJirA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.6):
@@ -2812,14 +2603,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-react-jsx-source@7.19.6(@babel/core@7.21.3):
-    resolution: {integrity: sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==}
+  /@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.7):
+    resolution: {integrity: sha512-qXRvbeKDSfwnlJnanVRp0SfuWE5DQhwQr5xtLBzp56Wabyo+4CMosF6Kfp+eOD/4FYpql64XVJ2W0pVLlJZxOQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.23.6):
@@ -2832,18 +2623,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-react-jsx@7.21.0(@babel/core@7.21.3):
-    resolution: {integrity: sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==}
+  /@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.23.7):
+    resolution: {integrity: sha512-91RS0MDnAWDNvGC6Wio5XYkyWI39FMFO+JK9+4AlgaTH+yWwVTsw7/sn6LK0lH7c5F+TFkpv/3LfCJ1Ydwof/g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.3)
-      '@babel/types': 7.21.3
+      '@babel/core': 7.23.7
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.23.7):
@@ -2941,21 +2728,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.22.5
-    dev: true
-
-  /@babel/plugin-transform-typescript@7.21.3(@babel/core@7.21.3):
-    resolution: {integrity: sha512-RQxPz6Iqt8T0uw/WsJNReuBpWpBqs/n7mNo18sKLoTbMp+UrEekhH+pKSVC7gWz+DNjo9gryfV8YzCiT45RgMw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.21.0(@babel/core@7.21.3)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.21.3)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-typescript@7.23.6(@babel/core@7.23.6):
@@ -3144,20 +2916,6 @@ packages:
       '@babel/plugin-transform-react-pure-annotations': 7.23.3(@babel/core@7.23.7)
     dev: true
 
-  /@babel/preset-typescript@7.21.0(@babel/core@7.21.3):
-    resolution: {integrity: sha512-myc9mpoVA5m1rF8K8DgLEatOYFDpwC+RkMkjZ0Du6uI62YvDe8uxIEYVs/VCdSJ097nlALiU/yBC7//3nI+hNg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-transform-typescript': 7.21.3(@babel/core@7.21.3)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/preset-typescript@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-17oIGVlqz6CchO9RFYn5U6ZpWRZIngayYCtrPRSgANSwC2V1Jb+iP74nVxzzXJte8b8BYxrL1yY96xfhTBrNNQ==}
     engines: {node: '>=6.9.0'}
@@ -3182,15 +2940,6 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.11
 
-  /@babel/template@7.20.7:
-    resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.21.3
-    dev: true
-
   /@babel/template@7.22.15:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
@@ -3198,24 +2947,6 @@ packages:
       '@babel/code-frame': 7.23.5
       '@babel/parser': 7.23.6
       '@babel/types': 7.23.6
-    dev: true
-
-  /@babel/traverse@7.21.3:
-    resolution: {integrity: sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.21.3
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.21.3
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/traverse@7.23.6:
@@ -3433,15 +3164,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.15.18:
-    resolution: {integrity: sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-arm@0.18.20:
     resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
     engines: {node: '>=12'}
@@ -3599,24 +3321,6 @@ packages:
     resolution: {integrity: sha512-4ub1YwXxYjj9h1UIZs2hYbnTZBtenPw5NfXCRgEkGb0b6OJ2gpkMvDqRDYIDRjRdWSe/TBiZltm3Y3Q8SN1xNg==}
     engines: {node: '>=12'}
     cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.14.54:
-    resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.15.18:
-    resolution: {integrity: sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -4636,7 +4340,7 @@ packages:
       solid-js: 1.6.15
     dev: false
 
-  /@sveltejs/vite-plugin-svelte@1.4.0(svelte@3.57.0)(vite@3.2.5):
+  /@sveltejs/vite-plugin-svelte@1.4.0(svelte@3.57.0)(vite@4.5.1):
     resolution: {integrity: sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -4649,8 +4353,8 @@ packages:
       magic-string: 0.26.7
       svelte: 3.57.0
       svelte-hmr: 0.15.1(svelte@3.57.0)
-      vite: 3.2.5(@types/node@18.19.4)
-      vitefu: 0.2.4(vite@3.2.5)
+      vite: 4.5.1(@types/node@18.19.4)
+      vitefu: 0.2.4(vite@4.5.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4661,7 +4365,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@tanstack/config@0.1.6(@types/node@18.19.4)(esbuild@0.19.10)(rollup@3.29.4)(typescript@5.2.2)(vite@3.2.5):
+  /@tanstack/config@0.1.6(@types/node@18.19.4)(esbuild@0.19.10)(rollup@3.29.4)(typescript@5.2.2)(vite@5.0.10):
     resolution: {integrity: sha512-QNyg/wawvs/idXFdECbHfyDC3TZ8nznrM/Zz75J41+YU1TUcBy7QZvjVw2NT97SPsKvnoXxWJjg/YPzxn9p1ZQ==}
     engines: {node: '>=18'}
     hasBin: true
@@ -4680,8 +4384,8 @@ packages:
       semver: 7.5.4
       stream-to-array: 2.3.0
       v8flags: 4.0.1
-      vite-plugin-dts: 3.7.0(@types/node@18.19.4)(rollup@3.29.4)(typescript@5.2.2)(vite@3.2.5)
-      vite-plugin-externalize-deps: 0.8.0(vite@3.2.5)
+      vite-plugin-dts: 3.7.0(@types/node@18.19.4)(rollup@3.29.4)(typescript@5.2.2)(vite@5.0.10)
+      vite-plugin-externalize-deps: 0.8.0(vite@5.0.10)
     transitivePeerDependencies:
       - '@types/node'
       - esbuild
@@ -4810,16 +4514,6 @@ packages:
     resolution: {integrity: sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==}
     dev: true
 
-  /@types/babel__core@7.20.0:
-    resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
-    dependencies:
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.21.3
-      '@types/babel__generator': 7.6.4
-      '@types/babel__template': 7.4.1
-      '@types/babel__traverse': 7.18.3
-    dev: true
-
   /@types/babel__core@7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
@@ -4923,6 +4617,7 @@ packages:
     resolution: {integrity: sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==}
     dependencies:
       '@types/react': 18.2.45
+    dev: true
 
   /@types/react-is@17.0.3:
     resolution: {integrity: sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==}
@@ -5003,20 +4698,18 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@vitejs/plugin-react@2.2.0(vite@3.2.5):
-    resolution: {integrity: sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==}
+  /@vitejs/plugin-react@4.2.1(vite@4.5.1):
+    resolution: {integrity: sha512-oojO9IDc4nCUUi8qIR11KoQm0XFFLIwsRBwHRR4d/88IWghn1y6ckz/bJ8GHDCsYEJee8mDzqtJxh15/cisJNQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^3.0.0
+      vite: ^4.2.0 || ^5.0.0
     dependencies:
-      '@babel/core': 7.21.3
-      '@babel/plugin-transform-react-jsx': 7.21.0(@babel/core@7.21.3)
-      '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.21.3)
-      '@babel/plugin-transform-react-jsx-self': 7.21.0(@babel/core@7.21.3)
-      '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.21.3)
-      magic-string: 0.26.7
+      '@babel/core': 7.23.7
+      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.7)
+      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
+      '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 3.2.5(@types/node@18.19.4)
+      vite: 4.5.1(@types/node@18.19.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5051,17 +4744,6 @@ packages:
       vue: 3.2.47
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@vitejs/plugin-vue@2.3.4(vite@2.9.15)(vue@3.2.47):
-    resolution: {integrity: sha512-IfFNbtkbIm36O9KB8QodlwwYvTEsJb4Lll4c2IwB3VHc2gie2mSPtSzL0eYay7X2jd/2WX02FjSGTWR6OPr/zg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      vite: ^2.5.10
-      vue: ^3.2.25
-    dependencies:
-      vite: 2.9.15
-      vue: 3.2.47
     dev: true
 
   /@vitejs/plugin-vue@4.6.0(vite@4.5.1)(vue@3.2.47):
@@ -5106,20 +4788,10 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@volar/code-gen@0.35.2:
-    resolution: {integrity: sha512-MoZHuNnPfUWnCNkQUI5+U+gvLTxrU+XlCTusdNOTFYUUAa+M68MH0RxFIS9Ybj4uAUWTcZx0Ow1q5t/PZozo+Q==}
-    dependencies:
-      '@volar/source-map': 0.35.2
-    dev: true
-
   /@volar/language-core@1.11.1:
     resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
     dependencies:
       '@volar/source-map': 1.11.1
-    dev: true
-
-  /@volar/source-map@0.35.2:
-    resolution: {integrity: sha512-PFHh9wN/qMkOWYyvmB8ckvIzolrpNOvK5EBdxxdTpiPJhfYjW82rMDBnYf6RxCe7yQxrUrmve6BWVO7flxWNVQ==}
     dev: true
 
   /@volar/source-map@1.11.1:
@@ -5133,28 +4805,6 @@ packages:
     dependencies:
       '@volar/language-core': 1.11.1
       path-browserify: 1.0.1
-    dev: true
-
-  /@volar/vue-code-gen@0.35.2:
-    resolution: {integrity: sha512-8H6P8EtN06eSVGjtcJhGqZzFIg6/nWoHVOlnhc5vKqC7tXwpqPbyMQae0tO7pLBd5qSb/dYU5GQcBAHsi2jgyA==}
-    deprecated: 'WARNING: This project has been renamed to @vue/language-core. Install using @vue/language-core instead.'
-    dependencies:
-      '@volar/code-gen': 0.35.2
-      '@volar/source-map': 0.35.2
-      '@vue/compiler-core': 3.3.13
-      '@vue/compiler-dom': 3.3.13
-      '@vue/shared': 3.3.13
-    dev: true
-
-  /@volar/vue-typescript@0.35.2:
-    resolution: {integrity: sha512-PZI6Urb+Vr5Dvgf9xysM8X7TP09inWDy1wjDtprBoBhxS7r0Dg3V0qZuJa7sSGz7M0QMa5R/CBaZPhlxFCfJBw==}
-    deprecated: 'WARNING: This project has been renamed to @vue/typescript. Install using @vue/typescript instead.'
-    dependencies:
-      '@volar/code-gen': 0.35.2
-      '@volar/source-map': 0.35.2
-      '@volar/vue-code-gen': 0.35.2
-      '@vue/compiler-sfc': 3.2.47
-      '@vue/reactivity': 3.2.47
     dev: true
 
   /@vue/babel-helper-vue-transform-on@1.1.5:
@@ -5487,14 +5137,14 @@ packages:
     resolution: {integrity: sha512-3AN/9V/rKuv90NG65m4tTHsI04XrCKsWbztIcW7a8H5iIN7WlvWucRtVV0V/rT4QvtA11n5Vmp20fLwfMWqp6g==}
     dev: true
 
-  /babel-plugin-jsx-dom-expressions@0.35.19(@babel/core@7.21.3):
+  /babel-plugin-jsx-dom-expressions@0.35.19(@babel/core@7.23.7):
     resolution: {integrity: sha512-Y1Qg6Yt5XaRfGewxmF0ac6bnqo2xdsIdPd1J6/El4E+7m5Ej76jcHYeHWJsoPbVmbZXc5TGenwZMP9ueHjja/g==}
     peerDependencies:
       '@babel/core': ^7.20.12
     dependencies:
-      '@babel/core': 7.21.3
+      '@babel/core': 7.23.7
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.3)
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.23.7)
       '@babel/types': 7.21.3
       html-entities: 2.3.3
       validate-html-nesting: 1.2.1
@@ -5548,13 +5198,13 @@ packages:
     resolution: {integrity: sha512-WpOrF76nUHijnNn10eBGOHZmXQC8JYRME9rOLxStOga7Av2VO53ehVFvVNImMksVtQuL2/7ZNxEgxnx7oo/3Hw==}
     dev: true
 
-  /babel-preset-solid@1.6.13(@babel/core@7.21.3):
+  /babel-preset-solid@1.6.13(@babel/core@7.23.7):
     resolution: {integrity: sha512-W78rLK4xv48k2Jb/VFynu42oCQufcDYFz6gmhMYslKy/PJCfNxdp85QCg1wTcrmCoPQK2TcHMVcL8nVvvTBHxQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.3
-      babel-plugin-jsx-dom-expressions: 0.35.19(@babel/core@7.21.3)
+      '@babel/core': 7.23.7
+      babel-plugin-jsx-dom-expressions: 0.35.19(@babel/core@7.23.7)
     dev: true
 
   /balanced-match@1.0.2:
@@ -5622,17 +5272,6 @@ packages:
       unload: 2.2.0
     dev: false
 
-  /browserslist@4.21.5:
-    resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001470
-      electron-to-chromium: 1.4.340
-      node-releases: 2.0.10
-      update-browserslist-db: 1.0.10(browserslist@4.21.5)
-    dev: true
-
   /browserslist@4.22.2:
     resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -5683,10 +5322,6 @@ packages:
   /camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-    dev: true
-
-  /caniuse-lite@1.0.30001470:
-    resolution: {integrity: sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==}
     dev: true
 
   /caniuse-lite@1.0.30001571:
@@ -6129,10 +5764,6 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /electron-to-chromium@1.4.340:
-    resolution: {integrity: sha512-zx8hqumOqltKsv/MF50yvdAlPF9S/4PXbyfzJS6ZGhbddGkRegdwImmfSVqCkEziYzrIGZ/TlrzBND4FysfkDg==}
-    dev: true
-
   /electron-to-chromium@1.4.616:
     resolution: {integrity: sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg==}
     dev: true
@@ -6186,294 +5817,6 @@ packages:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
     dev: true
 
-  /esbuild-android-64@0.14.54:
-    resolution: {integrity: sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-android-64@0.15.18:
-    resolution: {integrity: sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-android-arm64@0.14.54:
-    resolution: {integrity: sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-android-arm64@0.15.18:
-    resolution: {integrity: sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-64@0.14.54:
-    resolution: {integrity: sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-64@0.15.18:
-    resolution: {integrity: sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-arm64@0.14.54:
-    resolution: {integrity: sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-arm64@0.15.18:
-    resolution: {integrity: sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-64@0.14.54:
-    resolution: {integrity: sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-64@0.15.18:
-    resolution: {integrity: sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-arm64@0.14.54:
-    resolution: {integrity: sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-arm64@0.15.18:
-    resolution: {integrity: sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-32@0.14.54:
-    resolution: {integrity: sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-32@0.15.18:
-    resolution: {integrity: sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-64@0.14.54:
-    resolution: {integrity: sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-64@0.15.18:
-    resolution: {integrity: sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm64@0.14.54:
-    resolution: {integrity: sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm64@0.15.18:
-    resolution: {integrity: sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm@0.14.54:
-    resolution: {integrity: sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm@0.15.18:
-    resolution: {integrity: sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-mips64le@0.14.54:
-    resolution: {integrity: sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-mips64le@0.15.18:
-    resolution: {integrity: sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-ppc64le@0.14.54:
-    resolution: {integrity: sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-ppc64le@0.15.18:
-    resolution: {integrity: sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-riscv64@0.14.54:
-    resolution: {integrity: sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-riscv64@0.15.18:
-    resolution: {integrity: sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-s390x@0.14.54:
-    resolution: {integrity: sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-s390x@0.15.18:
-    resolution: {integrity: sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-netbsd-64@0.14.54:
-    resolution: {integrity: sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-netbsd-64@0.15.18:
-    resolution: {integrity: sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-openbsd-64@0.14.54:
-    resolution: {integrity: sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-openbsd-64@0.15.18:
-    resolution: {integrity: sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-register@3.5.0(esbuild@0.19.10):
     resolution: {integrity: sha512-+4G/XmakeBAsvJuDugJvtyF1x+XJT4FMocynNpxrvEBViirpfUn2PgNpCHedfWhF4WokNsO/OvMKrmJOIJsI5A==}
     peerDependencies:
@@ -6483,137 +5826,6 @@ packages:
       esbuild: 0.19.10
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /esbuild-sunos-64@0.14.54:
-    resolution: {integrity: sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-sunos-64@0.15.18:
-    resolution: {integrity: sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-32@0.14.54:
-    resolution: {integrity: sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-32@0.15.18:
-    resolution: {integrity: sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-64@0.14.54:
-    resolution: {integrity: sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-64@0.15.18:
-    resolution: {integrity: sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-arm64@0.14.54:
-    resolution: {integrity: sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-arm64@0.15.18:
-    resolution: {integrity: sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild@0.14.54:
-    resolution: {integrity: sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/linux-loong64': 0.14.54
-      esbuild-android-64: 0.14.54
-      esbuild-android-arm64: 0.14.54
-      esbuild-darwin-64: 0.14.54
-      esbuild-darwin-arm64: 0.14.54
-      esbuild-freebsd-64: 0.14.54
-      esbuild-freebsd-arm64: 0.14.54
-      esbuild-linux-32: 0.14.54
-      esbuild-linux-64: 0.14.54
-      esbuild-linux-arm: 0.14.54
-      esbuild-linux-arm64: 0.14.54
-      esbuild-linux-mips64le: 0.14.54
-      esbuild-linux-ppc64le: 0.14.54
-      esbuild-linux-riscv64: 0.14.54
-      esbuild-linux-s390x: 0.14.54
-      esbuild-netbsd-64: 0.14.54
-      esbuild-openbsd-64: 0.14.54
-      esbuild-sunos-64: 0.14.54
-      esbuild-windows-32: 0.14.54
-      esbuild-windows-64: 0.14.54
-      esbuild-windows-arm64: 0.14.54
-    dev: true
-
-  /esbuild@0.15.18:
-    resolution: {integrity: sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.15.18
-      '@esbuild/linux-loong64': 0.15.18
-      esbuild-android-64: 0.15.18
-      esbuild-android-arm64: 0.15.18
-      esbuild-darwin-64: 0.15.18
-      esbuild-darwin-arm64: 0.15.18
-      esbuild-freebsd-64: 0.15.18
-      esbuild-freebsd-arm64: 0.15.18
-      esbuild-linux-32: 0.15.18
-      esbuild-linux-64: 0.15.18
-      esbuild-linux-arm: 0.15.18
-      esbuild-linux-arm64: 0.15.18
-      esbuild-linux-mips64le: 0.15.18
-      esbuild-linux-ppc64le: 0.15.18
-      esbuild-linux-riscv64: 0.15.18
-      esbuild-linux-s390x: 0.15.18
-      esbuild-netbsd-64: 0.15.18
-      esbuild-openbsd-64: 0.15.18
-      esbuild-sunos-64: 0.15.18
-      esbuild-windows-32: 0.15.18
-      esbuild-windows-64: 0.15.18
-      esbuild-windows-arm64: 0.15.18
     dev: true
 
   /esbuild@0.18.20:
@@ -7971,10 +7183,6 @@ packages:
     resolution: {integrity: sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==}
     dev: true
 
-  /node-releases@2.0.10:
-    resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
-    dev: true
-
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
     dev: true
@@ -8765,22 +7973,6 @@ packages:
       rollup: 3.29.4
       source-map: 0.7.4
       yargs: 17.7.1
-    dev: true
-
-  /rollup@2.77.3:
-    resolution: {integrity: sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
-  /rollup@2.79.1:
-    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.3
     dev: true
 
   /rollup@3.29.4:
@@ -9605,17 +8797,6 @@ packages:
       detect-node: 2.1.0
     dev: false
 
-  /update-browserslist-db@1.0.10(browserslist@4.21.5):
-    resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.21.5
-      escalade: 3.1.1
-      picocolors: 1.0.0
-    dev: true
-
   /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -9676,10 +8857,11 @@ packages:
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      vite: 3.2.5(@types/node@18.19.4)
+      vite: 4.5.1(@types/node@18.19.4)
     transitivePeerDependencies:
       - '@types/node'
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -9687,7 +8869,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@3.7.0(@types/node@18.19.4)(rollup@3.29.4)(typescript@5.2.2)(vite@3.2.5):
+  /vite-plugin-dts@3.7.0(@types/node@18.19.4)(rollup@3.29.4)(typescript@5.2.2)(vite@5.0.10):
     resolution: {integrity: sha512-np1uPaYzu98AtPReB8zkMnbjwcNHOABsLhqVOf81b3ol9b5M2wPcAVs8oqPnOpr6Us+7yDXVauwkxsk5+ldmRA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -9703,7 +8885,7 @@ packages:
       debug: 4.3.4
       kolorist: 1.8.0
       typescript: 5.2.2
-      vite: 3.2.5(@types/node@18.19.4)
+      vite: 5.0.10(@types/node@18.19.4)
       vue-tsc: 1.8.27(typescript@5.2.2)
     transitivePeerDependencies:
       - '@types/node'
@@ -9711,89 +8893,31 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-externalize-deps@0.8.0(vite@3.2.5):
+  /vite-plugin-externalize-deps@0.8.0(vite@5.0.10):
     resolution: {integrity: sha512-MdC8kRNQ1ZjhUicU2HcqGVhL0UUFqv83Zp1JZdHjE82PoPR8wsSWZ3axpot7B6img3sW6g8shYJikE0CKA0chA==}
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
     dependencies:
-      vite: 3.2.5(@types/node@18.19.4)
+      vite: 5.0.10(@types/node@18.19.4)
     dev: true
 
-  /vite-plugin-solid@2.6.1(solid-js@1.6.15)(vite@3.2.5):
+  /vite-plugin-solid@2.6.1(solid-js@1.6.15)(vite@4.5.1):
     resolution: {integrity: sha512-/khM/ha3B5/pTWQWVJd/0n6ODPIrOcajwhbrD8Gnv37XmJJssu+KA8ssN73raMIicf2eiQKiTAV39w7dSl4Irg==}
     peerDependencies:
       solid-js: ^1.3.17 || ^1.4.0 || ^1.5.0 || ^1.6.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@babel/core': 7.21.3
-      '@babel/preset-typescript': 7.21.0(@babel/core@7.21.3)
-      '@types/babel__core': 7.20.0
-      babel-preset-solid: 1.6.13(@babel/core@7.21.3)
+      '@babel/core': 7.23.7
+      '@babel/preset-typescript': 7.23.3(@babel/core@7.23.7)
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 1.6.13(@babel/core@7.23.7)
       merge-anything: 5.1.4
       solid-js: 1.6.15
       solid-refresh: 0.5.2(solid-js@1.6.15)
-      vite: 3.2.5(@types/node@18.19.4)
-      vitefu: 0.2.4(vite@3.2.5)
+      vite: 4.5.1(@types/node@18.19.4)
+      vitefu: 0.2.4(vite@4.5.1)
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /vite@2.9.15:
-    resolution: {integrity: sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==}
-    engines: {node: '>=12.2.0'}
-    hasBin: true
-    peerDependencies:
-      less: '*'
-      sass: '*'
-      stylus: '*'
-    peerDependenciesMeta:
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-    dependencies:
-      esbuild: 0.14.54
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 2.77.3
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
-  /vite@3.2.5(@types/node@18.19.4):
-    resolution: {integrity: sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.19.4
-      esbuild: 0.15.18
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 2.79.1
-    optionalDependencies:
-      fsevents: 2.3.3
     dev: true
 
   /vite@4.5.1(@types/node@18.19.4):
@@ -9868,7 +8992,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitefu@0.2.4(vite@3.2.5):
+  /vitefu@0.2.4(vite@4.5.1):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
@@ -9876,7 +9000,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 3.2.5(@types/node@18.19.4)
+      vite: 4.5.1(@types/node@18.19.4)
     dev: true
 
   /vitest@0.29.7(jsdom@21.1.1):
@@ -9929,11 +9053,12 @@ packages:
       tinybench: 2.4.0
       tinypool: 0.4.0
       tinyspy: 1.1.1
-      vite: 3.2.5(@types/node@18.19.4)
+      vite: 4.5.1(@types/node@18.19.4)
       vite-node: 0.29.7(@types/node@18.19.4)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -9946,16 +9071,6 @@ packages:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
-    dev: true
-
-  /vue-tsc@0.35.2(typescript@5.2.2):
-    resolution: {integrity: sha512-aqY16VlODHzqtKGUkqdumNpH+s5ABCkufRyvMKQlL/mua+N2DfSVnHufzSNNUMr7vmOO0YsNg27jsspBMq4iGA==}
-    hasBin: true
-    peerDependencies:
-      typescript: '*'
-    dependencies:
-      '@volar/vue-typescript': 0.35.2
-      typescript: 5.2.2
     dev: true
 
   /vue-tsc@1.8.27(typescript@5.2.2):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -572,10 +572,10 @@ importers:
   examples/react/material-ui-pagination:
     dependencies:
       '@emotion/react':
-        specifier: ^11.9.3
+        specifier: ^11.10.5
         version: 11.10.6(@types/react@18.2.45)(react@18.2.0)
       '@emotion/styled':
-        specifier: ^11.9.3
+        specifier: ^11.10.5
         version: 11.10.6(@emotion/react@11.10.6)(@types/react@18.2.45)(react@18.2.0)
       '@mui/icons-material':
         specifier: ^5.8.4


### PR DESCRIPTION
- Bumped Vite versions from v2/v3 to v4
- Used [sherif](https://github.com/QuiiBz/sherif) to identify packages with different semver ranges
