### PR TITLE
fix: Correctly exit publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
-    "@tanstack/config": "^0.1.6",
+    "@tanstack/config": "^0.1.7",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/react-hooks": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^0.4.4
         version: 0.4.4(rollup@4.9.2)
       '@tanstack/config':
-        specifier: ^0.1.6
-        version: 0.1.6(@types/node@18.19.4)(esbuild@0.19.10)(rollup@4.9.2)(typescript@5.2.2)(vite@5.0.10)
+        specifier: ^0.1.7
+        version: 0.1.7(@types/node@18.19.4)(esbuild@0.19.10)(rollup@4.9.2)(typescript@5.2.2)(vite@5.0.10)
       '@testing-library/jest-dom':
         specifier: ^6.2.0
         version: 6.2.0(vitest@1.1.2)
@@ -4146,8 +4146,8 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@tanstack/config@0.1.6(@types/node@18.19.4)(esbuild@0.19.10)(rollup@4.9.2)(typescript@5.2.2)(vite@5.0.10):
-    resolution: {integrity: sha512-QNyg/wawvs/idXFdECbHfyDC3TZ8nznrM/Zz75J41+YU1TUcBy7QZvjVw2NT97SPsKvnoXxWJjg/YPzxn9p1ZQ==}
+  /@tanstack/config@0.1.7(@types/node@18.19.4)(esbuild@0.19.10)(rollup@4.9.2)(typescript@5.2.2)(vite@5.0.10):
+    resolution: {integrity: sha512-+IbRTGbIEuWSNbouink96KL9aEGwhNzzy7DXtYg6CgCU5fpiGCIuNm7pGddEloTW1hHv+vvlqhlfx63F6ueWuA==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
@@ -8453,7 +8453,7 @@ packages:
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
-      punycode: 2.3.0
+      punycode: 2.3.1
     dev: true
 
   /url-parse@1.5.10:

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,16 +3,11 @@
 import { publish } from '@tanstack/config/publish'
 import { branchConfigs, packages, rootDir } from './config.js'
 
-try {
-  await publish({
-    branchConfigs,
-    packages,
-    rootDir,
-    branch: process.env.BRANCH,
-    tag: process.env.TAG,
-    ghToken: process.env.GH_TOKEN,
-  })
-} catch (error) {
-  console.error(error)
-  process.exit(1)
-}
+await publish({
+  branchConfigs,
+  packages,
+  rootDir,
+  branch: process.env.BRANCH,
+  tag: process.env.TAG,
+  ghToken: process.env.GH_TOKEN,
+})

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,14 +3,16 @@
 import { publish } from '@tanstack/config/publish'
 import { branchConfigs, packages, rootDir } from './config.js'
 
-publish({
-  branchConfigs,
-  packages,
-  rootDir,
-  branch: process.env.BRANCH,
-  tag: process.env.TAG,
-  ghToken: process.env.GH_TOKEN,
-}).catch(err => {
-  console.info(err)
+try {
+  await publish({
+    branchConfigs,
+    packages,
+    rootDir,
+    branch: process.env.BRANCH,
+    tag: process.env.TAG,
+    ghToken: process.env.GH_TOKEN,
+  })
+} catch (error) {
+  console.error(error)
   process.exit(1)
-})
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "noEmit": true
+  },
+  "include": ["**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "allowJs": true,
     "checkJs": true
   },
-  "include": ["prettier.config.cjs", "scripts"]
+  "include": ["prettier.config.cjs"]
 }


### PR DESCRIPTION
There is an async/await error in `scripts/publish.js` which manifested in the TanStack Form repo. This change ensures the script continues to wait for successful promise resolution from the publish function.

I've added a `scripts/tsconfig.json` file to use `"module": "ES2022"`, since this permits top-level await.