### PR TITLE
fix: column.getCanSort() returns true when no sorting option is passed to options

### DIFF
--- a/packages/table-core/src/features/Sorting.ts
+++ b/packages/table-core/src/features/Sorting.ts
@@ -474,8 +474,8 @@ export const Sorting: TableFeature = {
 
     column.getCanSort = () => {
       return (
-        (column.columnDef.enableSorting ?? true) &&
-        (table.options.enableSorting ?? true) &&
+        (table.options.enableSorting ?? false) &&
+        (column.columnDef.enableSorting ?? false) &&
         !!column.accessorFn
       )
     }


### PR DESCRIPTION
`column.getCanSort()` returns true when no sorting option is passed to options
#### CASE 1:
when there is no mention of `enableSorting` property explicitly in table options or columunDef, `column.getCanSort()` is returning 
`true`

#### CASE 2:
when `enableSorting : true` is passed to table options , column.getCanSort() is returning `true` for all the columns unless `enableSorting : false`  is passed to columnDef's

#### Fix
if there is no mention of `enableSorting` property it should return `false` by default when `column.getCanSort()` is called.