### PR TITLE
fix(table-core): Do not select subrows if enableSubRowSelection is set to false

### DIFF
--- a/packages/table-core/__tests__/RowSelection.test.ts
+++ b/packages/table-core/__tests__/RowSelection.test.ts
@@ -355,6 +355,45 @@ describe('RowSelection', () => {
       expect(allRows).toEqual([true, false, true, false])
     })
 
+    test('it should not select subrows if enableSubRowSelection is a function and it evaluates to false', () => {
+      const data = makeData(2, 2, 1)
+      const columns = generateColumns(data)
+
+      const state: Partial<TableState> = {
+        rowSelection: {},
+      }
+
+      const table = createTable<Person>({
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        columns,
+        getSubRows: row => row.subRows,
+        state,
+        onRowSelectionChange(updater) {
+          state.rowSelection =
+            typeof updater === 'function'
+              ? updater(state.rowSelection ?? {})
+              : updater
+        },
+        enableRowSelection: true,
+        enableSubRowSelection: row =>
+          row.id === '0' || row.id.startsWith('0.0'),
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      table.toggleAllRowsSelected(true)
+      const selectionState = table.getState().rowSelection
+
+      expect(selectionState).toEqual({
+        '0': true,
+        '0.0': true,
+        '0.0.0': true,
+        '0.1': true,
+        '1': true,
+      })
+    })
+
     test('it should select subrows if enableSubRowSelection is set to true', () => {
       const data = makeData(2, 1)
       const columns = generateColumns(data)

--- a/packages/table-core/__tests__/RowSelection.test.ts
+++ b/packages/table-core/__tests__/RowSelection.test.ts
@@ -326,7 +326,7 @@ describe('RowSelection', () => {
       const data = makeData(2, 1)
       const columns = generateColumns(data)
 
-      let state: Partial<TableState> = {
+      const state: Partial<TableState> = {
         rowSelection: {},
       }
 
@@ -359,7 +359,7 @@ describe('RowSelection', () => {
       const data = makeData(2, 1)
       const columns = generateColumns(data)
 
-      let state: Partial<TableState> = {
+      const state: Partial<TableState> = {
         rowSelection: {},
       }
 

--- a/packages/table-core/__tests__/RowSelection.test.ts
+++ b/packages/table-core/__tests__/RowSelection.test.ts
@@ -1,5 +1,6 @@
 import {
   ColumnDef,
+  TableState,
   createColumnHelper,
   createTable,
   getCoreRowModel,
@@ -317,6 +318,74 @@ describe('RowSelection', () => {
       )
 
       expect(result).toEqual('some')
+    })
+  })
+
+  describe('toggleAllRowsSelected', () => {
+    test('it should not select subrows if enableSubRowSelection is set to false', () => {
+      const data = makeData(2, 1)
+      const columns = generateColumns(data)
+
+      let state: Partial<TableState> = {
+        rowSelection: {},
+      }
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        columns,
+        getSubRows: row => row.subRows,
+        state,
+        onRowSelectionChange(updater) {
+          state.rowSelection =
+            typeof updater === 'function'
+              ? updater(state.rowSelection ?? {})
+              : updater
+        },
+        enableSubRowSelection: false,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      table.toggleAllRowsSelected(true)
+      const allRows = table
+        .getCoreRowModel()
+        .flatRows.map(v => v.getIsSelected())
+      expect(allRows).toEqual([true, false, true, false])
+    })
+
+    test('it should select subrows if enableSubRowSelection is set to true', () => {
+      const data = makeData(2, 1)
+      const columns = generateColumns(data)
+
+      let state: Partial<TableState> = {
+        rowSelection: {},
+      }
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        columns,
+        getSubRows: row => row.subRows,
+        state,
+        onRowSelectionChange(updater) {
+          state.rowSelection =
+            typeof updater === 'function'
+              ? updater(state.rowSelection ?? {})
+              : updater
+        },
+        enableSubRowSelection: true,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      table.toggleAllRowsSelected(true)
+      const allRows = table
+        .getCoreRowModel()
+        .flatRows.map(v => v.getIsSelected())
+      expect(allRows).toEqual([true, true, true, true])
     })
   })
 })

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -225,7 +225,9 @@ export const RowSelection: TableFeature = {
 
         const rowSelection = { ...old }
 
-        const preGroupedFlatRows = table.getPreGroupedRowModel().flatRows
+        const preGroupedFlatRows = table.options.enableSubRowSelection
+          ? table.getPreGroupedRowModel().flatRows
+          : table.getPreGroupedRowModel().rows
 
         // We don't use `mutateRowIsSelected` here for performance reasons.
         // All of the rows are flat already, so it wouldn't be worth it

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -225,23 +225,40 @@ export const RowSelection: TableFeature = {
 
         const rowSelection = { ...old }
 
-        const preGroupedFlatRows = table.options.enableSubRowSelection
-          ? table.getPreGroupedRowModel().flatRows
-          : table.getPreGroupedRowModel().rows
-
-        // We don't use `mutateRowIsSelected` here for performance reasons.
-        // All of the rows are flat already, so it wouldn't be worth it
-        if (value) {
-          preGroupedFlatRows.forEach(row => {
-            if (!row.getCanSelect()) {
-              return
-            }
-            rowSelection[row.id] = true
+        if (typeof table.options.enableSubRowSelection === 'function') {
+          // There's no easy workaround like using flat rows here in the case enableSubRowSelection is a function
+          // We need to recursively check if the current row/subrow can be selected so just
+          // using mutateRowIsSelected is easier
+          table.getFilteredRowModel().rows.forEach(row => {
+            mutateRowIsSelected(
+              rowSelection,
+              row.id,
+              value ?? false,
+              true,
+              table
+            )
           })
         } else {
-          preGroupedFlatRows.forEach(row => {
-            delete rowSelection[row.id]
-          })
+          // Here we check if only the first level of rows should be selected (enableSubRowSelection is true.)
+          // If that's the case we just get the first level of rows, otherwise we get the flat rows.
+          const preGroupedFlatRows = table.options.enableSubRowSelection
+            ? table.getPreGroupedRowModel().flatRows
+            : table.getPreGroupedRowModel().rows
+
+          // We don't use `mutateRowIsSelected` here for performance reasons.
+          // The rows are either flat or just the first level is being selected, so it wouldn't be worth it
+          if (value) {
+            preGroupedFlatRows.forEach(row => {
+              if (!row.getCanSelect()) {
+                return
+              }
+              rowSelection[row.id] = true
+            })
+          } else {
+            preGroupedFlatRows.forEach(row => {
+              delete rowSelection[row.id]
+            })
+          }
         }
 
         return rowSelection


### PR DESCRIPTION
Fixes #5116.

There are two cases here that were not being covered by the current code:
- If `enableSubRowSelection` is a boolean and is set to true, then only the first level of rows should be selected. We can  easily achieve this by iterating over `rows` instead of `flatRows`.
- The more complicated case is when `enableSubRowSelection` is a function. In this scenario we must run the check recursively for all subrows. The easiest way I've found to solve this was to just iterate over rows using the `mutateRowIsSelected` helper function.

In order to not losing the performance improvement that was already implemented, I've kept the old flow and just in case enableRowSeleciton is a function, we will reach the slower path (which might not be very common anyway)