### PR TITLE
docs: Use type imports for svelte examples

### DIFF
--- a/examples/svelte/basic/src/App.svelte
+++ b/examples/svelte/basic/src/App.svelte
@@ -5,7 +5,7 @@
     flexRender,
     getCoreRowModel,
   } from '@tanstack/svelte-table'
-  import type { ColumnDef, TableOptions } from '@tanstack/table-core/src/types'
+  import type { ColumnDef, TableOptions } from '@tanstack/svelte-table'
   import './index.css'
 
   type Person = {

--- a/examples/svelte/basic/tsconfig.json
+++ b/examples/svelte/basic/tsconfig.json
@@ -6,6 +6,7 @@
     "useDefineForClassFields": true,
     "module": "esnext",
     "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
     "baseUrl": "."
   },
   "files": ["src/main.ts"],

--- a/examples/svelte/column-groups/src/App.svelte
+++ b/examples/svelte/column-groups/src/App.svelte
@@ -5,7 +5,7 @@
     flexRender,
     getCoreRowModel,
   } from '@tanstack/svelte-table'
-  import type { ColumnDef, TableOptions } from '@tanstack/table-core/src/types'
+  import type { ColumnDef, TableOptions } from '@tanstack/svelte-table'
   import './index.css'
 
   type Person = {

--- a/examples/svelte/column-groups/tsconfig.json
+++ b/examples/svelte/column-groups/tsconfig.json
@@ -6,6 +6,7 @@
     "useDefineForClassFields": true,
     "module": "esnext",
     "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
     "baseUrl": "."
   },
   "files": ["src/main.ts"],

--- a/examples/svelte/column-ordering/src/App.svelte
+++ b/examples/svelte/column-ordering/src/App.svelte
@@ -6,7 +6,7 @@
     getSortedRowModel,
     flexRender,
   } from '@tanstack/svelte-table'
-  import type { ColumnDef, TableOptions } from '@tanstack/table-core/src/types'
+  import type { ColumnDef, TableOptions } from '@tanstack/svelte-table'
   import { makeData, Person } from './makeData'
   import { faker } from '@faker-js/faker'
   import './index.css'

--- a/examples/svelte/column-ordering/src/App.svelte
+++ b/examples/svelte/column-ordering/src/App.svelte
@@ -7,7 +7,7 @@
     flexRender,
   } from '@tanstack/svelte-table'
   import type { ColumnDef, TableOptions } from '@tanstack/svelte-table'
-  import { makeData, Person } from './makeData'
+  import { makeData, type Person } from './makeData'
   import { faker } from '@faker-js/faker'
   import './index.css'
 

--- a/examples/svelte/column-ordering/tsconfig.json
+++ b/examples/svelte/column-ordering/tsconfig.json
@@ -6,6 +6,7 @@
     "useDefineForClassFields": true,
     "module": "esnext",
     "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
     "baseUrl": "."
   },
   "files": ["src/main.ts"],

--- a/examples/svelte/column-pinning/src/App.svelte
+++ b/examples/svelte/column-pinning/src/App.svelte
@@ -6,7 +6,7 @@
     getSortedRowModel,
     flexRender,
   } from '@tanstack/svelte-table'
-  import type { ColumnDef, TableOptions } from '@tanstack/table-core/src/types'
+  import type { ColumnDef, TableOptions } from '@tanstack/svelte-table'
   import { makeData, Person } from './makeData'
   import { faker } from '@faker-js/faker'
   import './index.css'

--- a/examples/svelte/column-pinning/src/App.svelte
+++ b/examples/svelte/column-pinning/src/App.svelte
@@ -7,7 +7,7 @@
     flexRender,
   } from '@tanstack/svelte-table'
   import type { ColumnDef, TableOptions } from '@tanstack/svelte-table'
-  import { makeData, Person } from './makeData'
+  import { makeData, type Person } from './makeData'
   import { faker } from '@faker-js/faker'
   import './index.css'
 

--- a/examples/svelte/column-pinning/tsconfig.json
+++ b/examples/svelte/column-pinning/tsconfig.json
@@ -6,6 +6,7 @@
     "useDefineForClassFields": true,
     "module": "esnext",
     "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
     "baseUrl": "."
   },
   "files": ["src/main.ts"],

--- a/examples/svelte/column-visibility/src/App.svelte
+++ b/examples/svelte/column-visibility/src/App.svelte
@@ -6,7 +6,7 @@
     getSortedRowModel,
     flexRender,
   } from '@tanstack/svelte-table'
-  import type { ColumnDef, TableOptions } from '@tanstack/table-core/src/types'
+  import type { ColumnDef, TableOptions } from '@tanstack/svelte-table'
   import './index.css'
 
   type Person = {

--- a/examples/svelte/column-visibility/tsconfig.json
+++ b/examples/svelte/column-visibility/tsconfig.json
@@ -6,6 +6,7 @@
     "useDefineForClassFields": true,
     "module": "esnext",
     "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
     "baseUrl": "."
   },
   "files": ["src/main.ts"],

--- a/examples/svelte/sorting/src/App.svelte
+++ b/examples/svelte/sorting/src/App.svelte
@@ -7,7 +7,7 @@
     flexRender,
   } from '@tanstack/svelte-table'
   import type { ColumnDef, TableOptions } from '@tanstack/svelte-table'
-  import { makeData, Person } from './makeData'
+  import { makeData, type Person } from './makeData'
   import './index.css'
 
   const columns: ColumnDef<Person>[] = [

--- a/examples/svelte/sorting/src/App.svelte
+++ b/examples/svelte/sorting/src/App.svelte
@@ -6,7 +6,7 @@
     getSortedRowModel,
     flexRender,
   } from '@tanstack/svelte-table'
-  import type { ColumnDef, TableOptions } from '@tanstack/table-core/src/types'
+  import type { ColumnDef, TableOptions } from '@tanstack/svelte-table'
   import { makeData, Person } from './makeData'
   import './index.css'
 

--- a/examples/svelte/sorting/tsconfig.json
+++ b/examples/svelte/sorting/tsconfig.json
@@ -5,6 +5,7 @@
     "useDefineForClassFields": true,
     "module": "esnext",
     "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
     "baseUrl": "."
   },
   "files": ["src/main.ts"],


### PR DESCRIPTION
Fixes #5279 

Svelte types need to be marked as type imports rather than regular imports

Enabled verbatimModuleSyntax in the svelte examples to detect these errors during development