### PR TITLE
docs(example): Use tsconfig from create-vite (Part II)

### DIFF
--- a/examples/react/editable-data/tsconfig.json
+++ b/examples/react/editable-data/tsconfig.json
@@ -1,11 +1,24 @@
 {
-  "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build/types"
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   },
-  "files": ["src/main.tsx"],
-  "include": [
-    "src"
-    // "__tests__/**/*.test.*"
-  ]
+  "include": ["src"]
 }

--- a/examples/react/expanding/tsconfig.json
+++ b/examples/react/expanding/tsconfig.json
@@ -1,11 +1,24 @@
 {
-  "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build/types"
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   },
-  "files": ["src/main.tsx"],
-  "include": [
-    "src"
-    // "__tests__/**/*.test.*"
-  ]
+  "include": ["src"]
 }

--- a/examples/react/filters/tsconfig.json
+++ b/examples/react/filters/tsconfig.json
@@ -1,11 +1,24 @@
 {
-  "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build/types"
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   },
-  "files": ["src/main.tsx"],
-  "include": [
-    "src"
-    // "__tests__/**/*.test.*"
-  ]
+  "include": ["src"]
 }

--- a/examples/solid/column-ordering/tsconfig.json
+++ b/examples/solid/column-ordering/tsconfig.json
@@ -1,13 +1,25 @@
 {
-  "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./build/types",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "jsx": "preserve"
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   },
-  "files": ["src/index.tsx"],
-  "include": [
-    "src"
-    // "__tests__/**/*.test.*"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Continuation of @lachlancollins' work: https://github.com/TanStack/table/pull/5286

In this follow-up, I have completed the replacement of `tsconfig.json` files eliminating the use of `extends` to resolve local packages across these examples:
- react/editable-data
- react/expanding
- react/filters
- solid/column-ordering 

**Screenshots:**
`react/editable-data` example render issue:
![image](https://github.com/TanStack/table/assets/881905/96013768-97ef-4d5c-80c3-ce0e2065b495)
