### PR TITLE
doc: Update Installation Instructions: Remove '$' from the Copiable Bash Code

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,29 +9,29 @@ Install your table adapter as a dependency using your favorite npm package manag
 ## React Table
 
 ```bash
-$ npm install @tanstack/react-table
+npm install @tanstack/react-table
 ```
 
 ## Solid Table
 
 ```bash
-$ npm install @tanstack/solid-table
+npm install @tanstack/solid-table
 ```
 
 ## Svelte Table
 
 ```bash
-$ npm install @tanstack/svelte-table
+npm install @tanstack/svelte-table
 ```
 
 ## Vue Table
 
 ```bash
-$ npm install @tanstack/vue-table
+npm install @tanstack/vue-table
 ```
 
 ## Table Core (no framework)
 
 ```bash
-$ npm install @tanstack/table-core
+npm install @tanstack/table-core
 ```


### PR DESCRIPTION
This commit focuses on improving the installation instructions by ensuring that the '$' symbol is not included when users copy the bash code. The change enhances the user experience and prevents potential issues during the installation process.

Changes:
- Updated installation instructions to exclude the '$' symbol from the copiable bash code.

This adjustment makes the installation process more straightforward and aligns with user expectations when copying and pasting the provided commands.