### PR TITLE
feat: new column pinning, sizing, ordering APIs for easier sticky pinning

### DIFF
--- a/docs/api/features/column-ordering.md
+++ b/docs/api/features/column-ordering.md
@@ -42,3 +42,29 @@ resetColumnOrder: (defaultState?: boolean) => void
 ```
 
 Resets the **columnOrder** state to `initialState.columnOrder`, or `true` can be passed to force a default blank state reset to `[]`.
+
+## Column API
+
+### `getIndex`
+
+```tsx
+getIndex: (position?: ColumnPinningPosition) => number
+```
+
+Returns the index of the column in the order of the visible columns. Optionally pass a `position` parameter to get the index of the column in a sub-section of the table.
+
+### `getIsFirstColumn`
+
+```tsx
+getIsFirstColumn: (position?: ColumnPinningPosition) => boolean
+```
+
+Returns `true` if the column is the first column in the order of the visible columns. Optionally pass a `position` parameter to check if the column is the first in a sub-section of the table.
+
+### `getIsLastColumn`
+
+```tsx
+getIsLastColumn: (position?: ColumnPinningPosition) => boolean
+```
+
+Returns `true` if the column is the last column in the order of the visible columns. Optionally pass a `position` parameter to check if the column is the last in a sub-section of the table.

--- a/docs/api/features/column-sizing.md
+++ b/docs/api/features/column-sizing.md
@@ -61,8 +61,6 @@ The maximum allowed size for the column
 
 ## Column API
 
-## Table Options
-
 ### `getSize`
 
 ```tsx
@@ -77,7 +75,19 @@ Returns the current size of the column
 getStart: (position?: ColumnPinningPosition) => number
 ```
 
-Returns the offset measurement along the row-axis (usually the x-axis for standard tables) for the column.
+Returns the offset measurement along the row-axis (usually the x-axis for standard tables) for the column, measuring the size of all preceding columns.
+
+Useful for sticky or absolute positioning of columns. (e.g. `left` or `transform`)
+
+### `getAfter`
+
+```tsx
+getAfter: (position?: ColumnPinningPosition) => number
+```
+
+Returns the offset measurement along the row-axis (usually the x-axis for standard tables) for the column, measuring the size of all succeeding columns.
+
+Useful for sticky or absolute positioning of columns. (e.g. `right` or `transform`)
 
 ### `getCanResize`
 
@@ -134,7 +144,7 @@ Returns an event handler function that can be used to resize the header. It can 
 
 The dragging and release events are automatically handled for you.
 
-## Table API Options
+## Table Options
 
 ### `enableColumnResizing`
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -253,6 +253,10 @@
               "label": "Column Pinning"
             },
             {
+              "to": "framework/react/examples/column-pinning-sticky",
+              "label": "Sticky Column Pinning"
+            },
+            {
               "to": "framework/react/examples/column-sizing",
               "label": "Column Sizing"
             },

--- a/docs/guide/column-pinning.md
+++ b/docs/guide/column-pinning.md
@@ -15,8 +15,16 @@ Want to skip to the implementation? Check out these examples:
 
 ## Column Pinning Guide
 
+TanStack Table offers state and APIs helpful for implementing column pinning features in your table UI. You can implement column pinning in multiple ways. You can either split pinned columns into their own separate tables, or you can keep all columns in the same table, but use the pinning state to order the columns correctly and use sticky CSS to pin the columns to the left or right.
+
+### How Column Pinning Affects Column Order
+
 There are 3 table features that can reorder columns, which happen in the following order:
 
 1. **Column Pinning** - If pinning, columns are split into left, center (unpinned), and right pinned columns.
 2. Manual [Column Ordering](../guide/column-ordering) - A manually specified column order is applied.
 3. [Grouping](../guide/grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.columnGroupingMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
+
+### Column Pinning State
+
+Managing the `columnPinning` state is optional, and usually not necessary unless you are adding persistent state features. TanStack Table will already keep track of the column pinning state for you. 

--- a/docs/guide/column-pinning.md
+++ b/docs/guide/column-pinning.md
@@ -10,6 +10,11 @@ Want to skip to the implementation? Check out these examples:
 - [sticky-column-pinning](../framework/react/examples/column-pinning/sticky)
 - [row-pinning](../framework/react/examples/row-pinning)
 
+ ### Other Examples
+ 
+- [Svelte column-pinning](../framework/svelte/examples/column-pinning)
+- [Vue column-pinning](../framework/vue/examples/column-pinning)
+
 ## API
 
 [Pinning API](../api/features/pinning)

--- a/docs/guide/column-pinning.md
+++ b/docs/guide/column-pinning.md
@@ -7,6 +7,7 @@ title: Column Pinning
 Want to skip to the implementation? Check out these examples:
 
 - [column-pinning](../framework/react/examples/column-pinning)
+- [sticky-column-pinning](../framework/react/examples/column-pinning/sticky)
 - [row-pinning](../framework/react/examples/row-pinning)
 
 ## API
@@ -25,6 +26,63 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual [Column Ordering](../guide/column-ordering) - A manually specified column order is applied.
 3. [Grouping](../guide/grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.columnGroupingMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
+The only way to change the order of the pinned columns is in the `columnPinning.left` and `columnPinning.right` state itself. `columnOrder` state will only affect the order of the unpinned ("center") columns.
+
 ### Column Pinning State
 
-Managing the `columnPinning` state is optional, and usually not necessary unless you are adding persistent state features. TanStack Table will already keep track of the column pinning state for you. 
+Managing the `columnPinning` state is optional, and usually not necessary unless you are adding persistent state features. TanStack Table will already keep track of the column pinning state for you. Manage the `columnPinning` state just like any other table state if you need to.
+
+```jsx
+const [columnPinning, setColumnPinning] = useState<ColumnPinningState>({
+  left: [],
+  right: [],
+});
+//...
+const table = useReactTable({
+  //...
+  state: {
+    columnPinning,
+    //...
+  }
+  onColumnPinningChange: setColumnPinning,
+  //...
+});
+```
+
+### Pin Columns by Default
+
+A very common use case is to pin some columns by default. You can do this by either initializing the `columnPinning` state with the pinned columnIds, or by using the `initialState` table option
+
+```jsx
+const table = useReactTable({
+  //...
+  initialState: {
+    columnPinning: {
+      left: ['expand-column'],
+      right: ['actions-column'],
+    },
+    //...
+  }
+  //...
+});
+```
+
+### Useful Column Pinning APIs
+
+> Note: Some of these APIs are new in v8.12.0
+
+There are a handful of useful Column API methods to help you implement column pinning features:
+
+- [`column.getCanPin`](../api/features/pinning#getcanpin): Use to determine if a column can be pinned.
+- [`column.pin`](../api/features/pinning#pin): Use to pin a column to the left or right. Or use to unpin a column.
+- [`column.getIsPinned`](../api/features/pinning#getispinned): Use to determine where a column is pinned.
+- [`column.getStart`](../api/features/pinning#getstart): Use to provide the correct `left` CSS value for a pinned column.
+- [`column.getAfter`](../api/features/pinning#getafter): Use to provide the correct `right` CSS value for a pinned column.
+- [`column.getIsLastColumn`](../api/features/pinning#getislastcolumn): Use to determine if a column is the last column in its pinned group. Useful for adding a box-shadow
+- [`column.getIsFirstColumn`](../api/features/pinning#getisfirstcolumn): Use to determine if a column is the first column in its pinned group. Useful for adding a box-shadow
+
+### Split Table Column Pinning
+
+If you are just using sticky CSS to pin columns, you can for the most part, just render the table as you normally would with the `table.getHeaderGroups` and `row.getVisibleCells` methods.
+
+However, if you are splitting up pinned columns into their own separate tables, you can make use of the `table.getLeftHeaderGroups`, `table.getCenterHeaderGroups`, `table.getRightHeaderGroups`, `row.getLeftVisibleCells`, `row.getCenterVisibleCells`, and `row.getRightVisibleCells` methods to only render the columns that are relevant to the current table.

--- a/docs/guide/virtualization.md
+++ b/docs/guide/virtualization.md
@@ -8,7 +8,7 @@ Want to skip to the implementation? Check out these examples:
 
 - [virtualized-columns](../framework/react/examples/virtualized-columns)
 - [virtualized-rows (dynamic row height)](../framework/react/examples/virtualized-rows)
-- [virtualized-rows (fixed row height)](../../../../virtual/v3/docs/examples/react/table)
+- [virtualized-rows (fixed row height)](../../../../virtual/v3/docs/framework/react/examples/table)
 - [virtualized-infinite-scrolling](../framework/react/examples/virtualized-infinite-scrolling)
 
 ## API

--- a/examples/react/column-dnd/src/main.tsx
+++ b/examples/react/column-dnd/src/main.tsx
@@ -39,7 +39,6 @@ const defaultColumns: ColumnDef<Person>[] = [
     header: 'Age',
     footer: props => props.column.id,
   },
-
   {
     accessorKey: 'visits',
     id: 'visits',

--- a/examples/react/column-pinning-sticky/.gitignore
+++ b/examples/react/column-pinning-sticky/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+dist-ssr
+*.local

--- a/examples/react/column-pinning-sticky/README.md
+++ b/examples/react/column-pinning-sticky/README.md
@@ -1,0 +1,6 @@
+# Example
+
+To run this example:
+
+- `npm install` or `yarn`
+- `npm run start` or `yarn start`

--- a/examples/react/column-pinning-sticky/index.html
+++ b/examples/react/column-pinning-sticky/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+    <script type="module" src="https://cdn.skypack.dev/twind/shim"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react/column-pinning-sticky/package.json
+++ b/examples/react/column-pinning-sticky/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "tanstack-table-example-column-pinning-sticky",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview --port 3000",
+    "start": "vite"
+  },
+  "dependencies": {
+    "@faker-js/faker": "^8.3.1",
+    "@tanstack/react-table": "^8.11.8",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-replace": "^5.0.5",
+    "@types/react": "^18.2.48",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.0.11"
+  }
+}

--- a/examples/react/column-pinning-sticky/src/index.css
+++ b/examples/react/column-pinning-sticky/src/index.css
@@ -7,12 +7,14 @@ html {
   border: 1px solid lightgray;
   overflow-x: scroll;
   width: 100%;
-  max-width: 1000px;
+  max-width: 960px;
   position: relative;
 }
 
 table {
-  border-collapse: collapse;
+  /* box-shadow and borders will not work with positon: sticky otherwise */
+  border-collapse: separate !important;
+  border-spacing: 0;
 }
 
 th {
@@ -27,7 +29,6 @@ th {
 
 td {
   background-color: white;
-  border-right: 1px solid lightgray;
   padding: 2px 4px;
 }
 

--- a/examples/react/column-pinning-sticky/src/index.css
+++ b/examples/react/column-pinning-sticky/src/index.css
@@ -1,0 +1,49 @@
+html {
+  font-family: sans-serif;
+  font-size: 14px;
+}
+
+.table-container {
+  border: 1px solid lightgray;
+  overflow-x: scroll;
+  width: 100%;
+  max-width: 1000px;
+  position: relative;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+th {
+  background-color: lightgray;
+  border-bottom: 1px solid lightgray;
+  font-weight: bold;
+  height: 30px;
+  padding: 2px 4px;
+  position: relative;
+  text-align: center;
+}
+
+td {
+  background-color: white;
+  border-right: 1px solid lightgray;
+  padding: 2px 4px;
+}
+
+.resizer {
+  background: rgba(0, 0, 0, 0.5);
+  cursor: col-resize;
+  height: 100%;
+  position: absolute;
+  right: 0;
+  top: 0;
+  touch-action: none;
+  user-select: none;
+  width: 5px;
+}
+
+.resizer.isResizing {
+  background: blue;
+  opacity: 1;
+}

--- a/examples/react/column-pinning-sticky/src/main.tsx
+++ b/examples/react/column-pinning-sticky/src/main.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { CSSProperties } from 'react'
 import ReactDOM from 'react-dom/client'
 
 import './index.css'
 
 import {
+  Column,
   ColumnDef,
   flexRender,
   getCoreRowModel,
@@ -11,6 +12,31 @@ import {
 } from '@tanstack/react-table'
 import { makeData, Person } from './makeData'
 import { faker } from '@faker-js/faker'
+
+//These are the important styles to make sticky column pinning work!
+//Apply styles like this using your CSS strategy of choice with this kind of logic to head cells, data cells, footer cells, etc.
+//View the index.css file for more needed styles such as border-collapse: separate
+const getCommonPinningStyles = (column: Column<Person>): CSSProperties => {
+  const isPinned = column.getIsPinned()
+  const isLastLeftPinnedColumn =
+    isPinned === 'left' && column.getIsLastColumn('left')
+  const isFirstRightPinnedColumn =
+    isPinned === 'right' && column.getIsFirstColumn('right')
+
+  return {
+    boxShadow: isLastLeftPinnedColumn
+      ? '-4px 0 4px -4px gray inset'
+      : isFirstRightPinnedColumn
+        ? '4px 0 4px -4px gray inset'
+        : undefined,
+    left: isPinned === 'left' ? `${column.getStart('left')}px` : undefined,
+    right: isPinned === 'right' ? `${column.getAfter('right')}px` : undefined,
+    opacity: isPinned ? 0.95 : 1,
+    position: isPinned ? 'sticky' : 'relative',
+    width: column.getSize(),
+    zIndex: isPinned ? 1 : 0,
+  }
+}
 
 const defaultColumns: ColumnDef<Person>[] = [
   {
@@ -125,7 +151,6 @@ function App() {
       <div className="h-4" />
       <div className="table-container">
         <table
-          className="border-2"
           style={{
             width: table.getTotalSize(),
           }}
@@ -135,35 +160,13 @@ function App() {
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map(header => {
                   const { column } = header
-                  const isPinned = column.getIsPinned()
-                  const isLastLeftPinnedColumn =
-                    isPinned === 'left' && column.getIsLastColumn('left')
-                  const isFirstRightPinnedColumn =
-                    isPinned === 'right' && column.getIsFirstColumn('right')
+
                   return (
                     <th
                       key={header.id}
                       colSpan={header.colSpan}
-                      style={{
-                        borderRight: isLastLeftPinnedColumn
-                          ? '2px solid red'
-                          : undefined,
-                        borderLeft: isFirstRightPinnedColumn
-                          ? '2px solid blue'
-                          : undefined,
-                        left:
-                          isPinned === 'left'
-                            ? `${column.getStart('left')}px`
-                            : undefined,
-                        right:
-                          isPinned === 'right'
-                            ? `${column.getAfter('right')}px`
-                            : undefined,
-                        opacity: isPinned ? 0.95 : 1,
-                        position: isPinned ? 'sticky' : 'relative',
-                        width: column.getSize(),
-                        zIndex: isPinned ? 1 : 0,
-                      }}
+                      //IMPORTANT: This is where the magic happens!
+                      style={{ ...getCommonPinningStyles(column) }}
                     >
                       <div className="whitespace-nowrap">
                         {header.isPlaceholder
@@ -172,7 +175,7 @@ function App() {
                               header.column.columnDef.header,
                               header.getContext()
                             )}{' '}
-                        {/* Demo getIndex */}
+                        {/* Demo getIndex behavior */}
                         {column.getIndex(column.getIsPinned() || 'center')}
                       </div>
                       {!header.isPlaceholder && header.column.getCanPin() && (
@@ -230,35 +233,11 @@ function App() {
               <tr key={row.id}>
                 {row.getVisibleCells().map(cell => {
                   const { column } = cell
-                  const isPinned = column.getIsPinned()
-                  const isLastLeftPinnedColumn =
-                    isPinned === 'left' && column.getIsLastColumn('left')
-                  const isFirstRightPinnedColumn =
-                    isPinned === 'right' && column.getIsFirstColumn('right')
-
                   return (
                     <td
                       key={cell.id}
-                      style={{
-                        borderRight: isLastLeftPinnedColumn
-                          ? '2px solid red'
-                          : undefined,
-                        borderLeft: isFirstRightPinnedColumn
-                          ? '2px solid blue'
-                          : undefined,
-                        left:
-                          isPinned === 'left'
-                            ? `${column.getStart('left')}px`
-                            : undefined,
-                        right:
-                          isPinned === 'right'
-                            ? `${column.getAfter('right')}px`
-                            : undefined,
-                        opacity: isPinned ? 0.95 : 1,
-                        position: isPinned ? 'sticky' : 'relative',
-                        width: column.getSize(),
-                        zIndex: isPinned ? 1 : 0,
-                      }}
+                      //IMPORTANT: This is where the magic happens!
+                      style={{ ...getCommonPinningStyles(column) }}
                     >
                       {flexRender(
                         cell.column.columnDef.cell,

--- a/examples/react/column-pinning-sticky/src/main.tsx
+++ b/examples/react/column-pinning-sticky/src/main.tsx
@@ -1,0 +1,287 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+
+import './index.css'
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { makeData, Person } from './makeData'
+import { faker } from '@faker-js/faker'
+
+const defaultColumns: ColumnDef<Person>[] = [
+  {
+    accessorKey: 'firstName',
+    id: 'firstName',
+    header: 'First Name',
+    cell: info => info.getValue(),
+    footer: props => props.column.id,
+    size: 180,
+  },
+  {
+    accessorFn: row => row.lastName,
+    id: 'lastName',
+    cell: info => info.getValue(),
+    header: () => <span>Last Name</span>,
+    footer: props => props.column.id,
+    size: 180,
+  },
+  {
+    accessorKey: 'age',
+    id: 'age',
+    header: 'Age',
+    footer: props => props.column.id,
+    size: 180,
+  },
+  {
+    accessorKey: 'visits',
+    id: 'visits',
+    header: 'Visits',
+    footer: props => props.column.id,
+    size: 180,
+  },
+  {
+    accessorKey: 'status',
+    id: 'status',
+    header: 'Status',
+    footer: props => props.column.id,
+    size: 180,
+  },
+  {
+    accessorKey: 'progress',
+    id: 'progress',
+    header: 'Profile Progress',
+    footer: props => props.column.id,
+    size: 180,
+  },
+]
+
+function App() {
+  const [data, setData] = React.useState(() => makeData(30))
+  const [columns] = React.useState(() => [...defaultColumns])
+
+  const rerender = () => setData(() => makeData(30))
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    debugTable: true,
+    debugHeaders: true,
+    debugColumns: true,
+    columnResizeMode: 'onChange',
+  })
+
+  const randomizeColumns = () => {
+    table.setColumnOrder(
+      faker.helpers.shuffle(table.getAllLeafColumns().map(d => d.id))
+    )
+  }
+
+  return (
+    <div className="p-2">
+      <div className="inline-block border border-black shadow rounded">
+        <div className="px-1 border-b border-black">
+          <label>
+            <input
+              {...{
+                type: 'checkbox',
+                checked: table.getIsAllColumnsVisible(),
+                onChange: table.getToggleAllColumnsVisibilityHandler(),
+              }}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map(column => {
+          return (
+            <div key={column.id} className="px-1">
+              <label>
+                <input
+                  {...{
+                    type: 'checkbox',
+                    checked: column.getIsVisible(),
+                    onChange: column.getToggleVisibilityHandler(),
+                  }}
+                />{' '}
+                {column.id}
+              </label>
+            </div>
+          )
+        })}
+      </div>
+      <div className="h-4" />
+      <div className="flex flex-wrap gap-2">
+        <button onClick={() => rerender()} className="border p-1">
+          Regenerate
+        </button>
+        <button onClick={() => randomizeColumns()} className="border p-1">
+          Shuffle Columns
+        </button>
+      </div>
+      <div className="h-4" />
+      <div className="table-container">
+        <table
+          className="border-2"
+          style={{
+            width: table.getTotalSize(),
+          }}
+        >
+          <thead>
+            {table.getHeaderGroups().map(headerGroup => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map(header => {
+                  const { column } = header
+                  const isPinned = column.getIsPinned()
+                  const isLastLeftPinnedColumn =
+                    isPinned === 'left' && column.getIsLastColumn('left')
+                  const isFirstRightPinnedColumn =
+                    isPinned === 'right' && column.getIsFirstColumn('right')
+                  return (
+                    <th
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      style={{
+                        borderRight: isLastLeftPinnedColumn
+                          ? '2px solid red'
+                          : undefined,
+                        borderLeft: isFirstRightPinnedColumn
+                          ? '2px solid blue'
+                          : undefined,
+                        left:
+                          isPinned === 'left'
+                            ? `${column.getStart('left')}px`
+                            : undefined,
+                        right:
+                          isPinned === 'right'
+                            ? `${column.getAfter('right')}px`
+                            : undefined,
+                        opacity: isPinned ? 0.95 : 1,
+                        position: isPinned ? 'sticky' : 'relative',
+                        width: column.getSize(),
+                        zIndex: isPinned ? 1 : 0,
+                      }}
+                    >
+                      <div className="whitespace-nowrap">
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext()
+                            )}{' '}
+                        {/* Demo getIndex */}
+                        {column.getIndex(column.getIsPinned() || 'center')}
+                      </div>
+                      {!header.isPlaceholder && header.column.getCanPin() && (
+                        <div className="flex gap-1 justify-center">
+                          {header.column.getIsPinned() !== 'left' ? (
+                            <button
+                              className="border rounded px-2"
+                              onClick={() => {
+                                header.column.pin('left')
+                              }}
+                            >
+                              {'<='}
+                            </button>
+                          ) : null}
+                          {header.column.getIsPinned() ? (
+                            <button
+                              className="border rounded px-2"
+                              onClick={() => {
+                                header.column.pin(false)
+                              }}
+                            >
+                              X
+                            </button>
+                          ) : null}
+                          {header.column.getIsPinned() !== 'right' ? (
+                            <button
+                              className="border rounded px-2"
+                              onClick={() => {
+                                header.column.pin('right')
+                              }}
+                            >
+                              {'=>'}
+                            </button>
+                          ) : null}
+                        </div>
+                      )}
+                      <div
+                        {...{
+                          onDoubleClick: () => header.column.resetSize(),
+                          onMouseDown: header.getResizeHandler(),
+                          onTouchStart: header.getResizeHandler(),
+                          className: `resizer ${
+                            header.column.getIsResizing() ? 'isResizing' : ''
+                          }`,
+                        }}
+                      />
+                    </th>
+                  )
+                })}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map(row => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map(cell => {
+                  const { column } = cell
+                  const isPinned = column.getIsPinned()
+                  const isLastLeftPinnedColumn =
+                    isPinned === 'left' && column.getIsLastColumn('left')
+                  const isFirstRightPinnedColumn =
+                    isPinned === 'right' && column.getIsFirstColumn('right')
+
+                  return (
+                    <td
+                      key={cell.id}
+                      style={{
+                        borderRight: isLastLeftPinnedColumn
+                          ? '2px solid red'
+                          : undefined,
+                        borderLeft: isFirstRightPinnedColumn
+                          ? '2px solid blue'
+                          : undefined,
+                        left:
+                          isPinned === 'left'
+                            ? `${column.getStart('left')}px`
+                            : undefined,
+                        right:
+                          isPinned === 'right'
+                            ? `${column.getAfter('right')}px`
+                            : undefined,
+                        opacity: isPinned ? 0.95 : 1,
+                        position: isPinned ? 'sticky' : 'relative',
+                        width: column.getSize(),
+                        zIndex: isPinned ? 1 : 0,
+                      }}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <pre>{JSON.stringify(table.getState().columnPinning, null, 2)}</pre>
+    </div>
+  )
+}
+
+const rootElement = document.getElementById('root')
+if (!rootElement) throw new Error('Failed to find the root element')
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/examples/react/column-pinning-sticky/src/makeData.ts
+++ b/examples/react/column-pinning-sticky/src/makeData.ts
@@ -1,0 +1,48 @@
+import { faker } from '@faker-js/faker'
+
+export type Person = {
+  firstName: string
+  lastName: string
+  age: number
+  visits: number
+  progress: number
+  status: 'relationship' | 'complicated' | 'single'
+  subRows?: Person[]
+}
+
+const range = (len: number) => {
+  const arr: number[] = []
+  for (let i = 0; i < len; i++) {
+    arr.push(i)
+  }
+  return arr
+}
+
+const newPerson = (): Person => {
+  return {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    age: faker.number.int(40),
+    visits: faker.number.int(1000),
+    progress: faker.number.int(100),
+    status: faker.helpers.shuffle<Person['status']>([
+      'relationship',
+      'complicated',
+      'single',
+    ])[0]!,
+  }
+}
+
+export function makeData(...lens: number[]) {
+  const makeDataLevel = (depth = 0): Person[] => {
+    const len = lens[depth]!
+    return range(len).map((d): Person => {
+      return {
+        ...newPerson(),
+        subRows: lens[depth + 1] ? makeDataLevel(depth + 1) : undefined,
+      }
+    })
+  }
+
+  return makeDataLevel()
+}

--- a/examples/react/column-pinning-sticky/tsconfig.json
+++ b/examples/react/column-pinning-sticky/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/examples/react/column-pinning-sticky/vite.config.js
+++ b/examples/react/column-pinning-sticky/vite.config.js
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import rollupReplace from '@rollup/plugin-replace'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    rollupReplace({
+      preventAssignment: true,
+      values: {
+        __DEV__: JSON.stringify(true),
+        'process.env.NODE_ENV': JSON.stringify('development'),
+      },
+    }),
+    react(),
+  ],
+})

--- a/packages/table-core/src/core/cell.ts
+++ b/packages/table-core/src/core/cell.ts
@@ -1,5 +1,5 @@
 import { RowData, Cell, Column, Row, Table } from '../types'
-import { Getter, memo } from '../utils'
+import { Getter, getMemoOptions, memo } from '../utils'
 
 export interface CellContext<TData extends RowData, TValue> {
   cell: Cell<TData, TValue>
@@ -74,10 +74,7 @@ export function createCell<TData extends RowData, TValue>(
         getValue: cell.getValue,
         renderValue: cell.renderValue,
       }),
-      {
-        key: process.env.NODE_ENV === 'development' && 'cell.getContext',
-        debug: () => table.options.debugAll,
-      }
+      getMemoOptions(table.options, 'debugCells', 'cell.getContext')
     ),
   }
 

--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -6,7 +6,7 @@ import {
   RowData,
   ColumnDefResolved,
 } from '../types'
-import { memo } from '../utils'
+import { getMemoOptions, memo } from '../utils'
 
 export interface CoreColumn<TData extends RowData, TValue> {
   /**
@@ -137,10 +137,7 @@ export function createColumn<TData extends RowData, TValue>(
           ...column.columns?.flatMap(d => d.getFlatColumns()),
         ]
       },
-      {
-        key: process.env.NODE_ENV === 'production' && 'column.getFlatColumns',
-        debug: () => table.options.debugAll ?? table.options.debugColumns,
-      }
+      getMemoOptions(table.options, 'debugColumns', 'column.getFlatColumns')
     ),
     getLeafColumns: memo(
       () => [table._getOrderColumnsFn()],
@@ -155,10 +152,7 @@ export function createColumn<TData extends RowData, TValue>(
 
         return [column as Column<TData, TValue>]
       },
-      {
-        key: process.env.NODE_ENV === 'production' && 'column.getLeafColumns',
-        debug: () => table.options.debugAll ?? table.options.debugColumns,
-      }
+      getMemoOptions(table.options, 'debugColumns', 'column.getLeafColumns')
     ),
   }
 

--- a/packages/table-core/src/core/headers.ts
+++ b/packages/table-core/src/core/headers.ts
@@ -1,6 +1,8 @@
 import { RowData, Column, Header, HeaderGroup, Table } from '../types'
-import { memo } from '../utils'
+import { getMemoOptions, memo } from '../utils'
 import { TableFeature } from './table'
+
+const debug = 'debugHeaders'
 
 export interface CoreHeaderGroup<TData extends RowData> {
   depth: number
@@ -288,10 +290,7 @@ export const Headers: TableFeature = {
 
         return headerGroups
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getHeaderGroups',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getHeaderGroups')
     )
 
     table.getCenterHeaderGroups = memo(
@@ -307,10 +306,7 @@ export const Headers: TableFeature = {
         )
         return buildHeaderGroups(allColumns, leafColumns, table, 'center')
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getCenterHeaderGroups',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getCenterHeaderGroups')
     )
 
     table.getLeftHeaderGroups = memo(
@@ -327,10 +323,7 @@ export const Headers: TableFeature = {
 
         return buildHeaderGroups(allColumns, orderedLeafColumns, table, 'left')
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getLeftHeaderGroups',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getLeftHeaderGroups')
     )
 
     table.getRightHeaderGroups = memo(
@@ -347,10 +340,7 @@ export const Headers: TableFeature = {
 
         return buildHeaderGroups(allColumns, orderedLeafColumns, table, 'right')
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getRightHeaderGroups',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getRightHeaderGroups')
     )
 
     // Footer Groups
@@ -360,10 +350,7 @@ export const Headers: TableFeature = {
       headerGroups => {
         return [...headerGroups].reverse()
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getFooterGroups',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getFooterGroups')
     )
 
     table.getLeftFooterGroups = memo(
@@ -371,10 +358,7 @@ export const Headers: TableFeature = {
       headerGroups => {
         return [...headerGroups].reverse()
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getLeftFooterGroups',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getLeftFooterGroups')
     )
 
     table.getCenterFooterGroups = memo(
@@ -382,10 +366,7 @@ export const Headers: TableFeature = {
       headerGroups => {
         return [...headerGroups].reverse()
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getCenterFooterGroups',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getCenterFooterGroups')
     )
 
     table.getRightFooterGroups = memo(
@@ -393,10 +374,7 @@ export const Headers: TableFeature = {
       headerGroups => {
         return [...headerGroups].reverse()
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getRightFooterGroups',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getRightFooterGroups')
     )
 
     // Flat Headers
@@ -410,10 +388,7 @@ export const Headers: TableFeature = {
           })
           .flat()
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getFlatHeaders',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getFlatHeaders')
     )
 
     table.getLeftFlatHeaders = memo(
@@ -425,10 +400,7 @@ export const Headers: TableFeature = {
           })
           .flat()
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getLeftFlatHeaders',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getLeftFlatHeaders')
     )
 
     table.getCenterFlatHeaders = memo(
@@ -440,10 +412,7 @@ export const Headers: TableFeature = {
           })
           .flat()
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getCenterFlatHeaders',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getCenterFlatHeaders')
     )
 
     table.getRightFlatHeaders = memo(
@@ -455,10 +424,7 @@ export const Headers: TableFeature = {
           })
           .flat()
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getRightFlatHeaders',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getRightFlatHeaders')
     )
 
     // Leaf Headers
@@ -468,10 +434,7 @@ export const Headers: TableFeature = {
       flatHeaders => {
         return flatHeaders.filter(header => !header.subHeaders?.length)
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getCenterLeafHeaders',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getCenterLeafHeaders')
     )
 
     table.getLeftLeafHeaders = memo(
@@ -479,10 +442,7 @@ export const Headers: TableFeature = {
       flatHeaders => {
         return flatHeaders.filter(header => !header.subHeaders?.length)
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getLeftLeafHeaders',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getLeftLeafHeaders')
     )
 
     table.getRightLeafHeaders = memo(
@@ -490,10 +450,7 @@ export const Headers: TableFeature = {
       flatHeaders => {
         return flatHeaders.filter(header => !header.subHeaders?.length)
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getRightLeafHeaders',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getRightLeafHeaders')
     )
 
     table.getLeafHeaders = memo(
@@ -513,10 +470,7 @@ export const Headers: TableFeature = {
           })
           .flat()
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getLeafHeaders',
-        debug: () => table.options.debugAll ?? table.options.debugHeaders,
-      }
+      getMemoOptions(table.options, debug, 'getLeafHeaders')
     )
   },
 }

--- a/packages/table-core/src/core/row.ts
+++ b/packages/table-core/src/core/row.ts
@@ -1,5 +1,5 @@
 import { RowData, Cell, Row, Table } from '../types'
-import { flattenBy, memo } from '../utils'
+import { flattenBy, getMemoOptions, memo } from '../utils'
 import { createCell } from './cell'
 
 export interface CoreRow<TData extends RowData> {
@@ -174,10 +174,7 @@ export const createRow = <TData extends RowData>(
           return createCell(table, row as Row<TData>, column, column.id)
         })
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'row.getAllCells',
-        debug: () => table.options.debugAll ?? table.options.debugRows,
-      }
+      getMemoOptions(table.options, 'debugRows', 'getAllCells')
     ),
 
     _getAllCellsByColumnId: memo(
@@ -191,11 +188,7 @@ export const createRow = <TData extends RowData>(
           {} as Record<string, Cell<TData, unknown>>
         )
       },
-      {
-        key:
-          process.env.NODE_ENV === 'production' && 'row.getAllCellsByColumnId',
-        debug: () => table.options.debugAll ?? table.options.debugRows,
-      }
+      getMemoOptions(table.options, 'debugRows', 'getAllCellsByColumnId')
     ),
   }
 

--- a/packages/table-core/src/core/table.ts
+++ b/packages/table-core/src/core/table.ts
@@ -1,4 +1,4 @@
-import { functionalUpdate, memo, RequiredKeys } from '../utils'
+import { functionalUpdate, getMemoOptions, memo, RequiredKeys } from '../utils'
 
 import {
   Updater,
@@ -87,6 +87,12 @@ export interface CoreOptions<TData extends RowData> {
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
    */
   debugAll?: boolean
+  /**
+   * Set this option to `true` to output cell debugging information to the console.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugcells]
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  debugCells?: boolean
   /**
    * Set this option to `true` to output column debugging information to the console.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugcolumns)
@@ -422,10 +428,7 @@ export function createTable<TData extends RowData>(
           ...defaultColumn,
         } as Partial<ColumnDef<TData, unknown>>
       },
-      {
-        debug: () => table.options.debugAll ?? table.options.debugColumns,
-        key: process.env.NODE_ENV === 'development' && 'getDefaultColumnDef',
-      }
+      getMemoOptions(options, 'debugColumns', '_getDefaultColumnDef')
     ),
 
     _getColumnDefs: () => table.options.columns,
@@ -456,10 +459,7 @@ export function createTable<TData extends RowData>(
 
         return recurseColumns(columnDefs)
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getAllColumns',
-        debug: () => table.options.debugAll ?? table.options.debugColumns,
-      }
+      getMemoOptions(options, 'debugColumns', 'getAllColumns')
     ),
 
     getAllFlatColumns: memo(
@@ -469,10 +469,7 @@ export function createTable<TData extends RowData>(
           return column.getFlatColumns()
         })
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getAllFlatColumns',
-        debug: () => table.options.debugAll ?? table.options.debugColumns,
-      }
+      getMemoOptions(options, 'debugColumns', 'getAllFlatColumns')
     ),
 
     _getAllFlatColumnsById: memo(
@@ -486,10 +483,7 @@ export function createTable<TData extends RowData>(
           {} as Record<string, Column<TData, unknown>>
         )
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getAllFlatColumnsById',
-        debug: () => table.options.debugAll ?? table.options.debugColumns,
-      }
+      getMemoOptions(options, 'debugColumns', 'getAllFlatColumnsById')
     ),
 
     getAllLeafColumns: memo(
@@ -498,10 +492,7 @@ export function createTable<TData extends RowData>(
         let leafColumns = allColumns.flatMap(column => column.getLeafColumns())
         return orderColumns(leafColumns)
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getAllLeafColumns',
-        debug: () => table.options.debugAll ?? table.options.debugColumns,
-      }
+      getMemoOptions(options, 'debugColumns', 'getAllLeafColumns')
     ),
 
     getColumn: columnId => {

--- a/packages/table-core/src/features/ColumnSizing.ts
+++ b/packages/table-core/src/features/ColumnSizing.ts
@@ -269,13 +269,10 @@ export const ColumnSizing: TableFeature = {
         _getVisibleLeafColumns(table, position),
         table.getState().columnSizing,
       ],
-      (position, columns) => {
-        const index = column.getIndex(position)
-
-        return columns
-          .slice(0, index)
-          .reduce((sum, column) => sum + column.getSize(), 0)
-      },
+      (position, columns) =>
+        columns
+          .slice(0, column.getIndex(position))
+          .reduce((sum, column) => sum + column.getSize(), 0),
       getMemoOptions(table.options, 'debugColumns', 'getStart')
     )
 
@@ -285,13 +282,10 @@ export const ColumnSizing: TableFeature = {
         _getVisibleLeafColumns(table, position),
         table.getState().columnSizing,
       ],
-      (position, columns) => {
-        const index = column.getIndex(position)
-
-        return columns
-          .slice(index + 1)
-          .reduce((sum, column) => sum + column.getSize(), 0)
-      },
+      (position, columns) =>
+        columns
+          .slice(column.getIndex(position) + 1)
+          .reduce((sum, column) => sum + column.getSize(), 0),
       getMemoOptions(table.options, 'debugColumns', 'getAfter')
     )
 

--- a/packages/table-core/src/features/ColumnSizing.ts
+++ b/packages/table-core/src/features/ColumnSizing.ts
@@ -265,11 +265,12 @@ export const ColumnSizing: TableFeature = {
 
     column.getStart = memo(
       position => [
+        position,
         _getVisibleLeafColumns(table, position),
         table.getState().columnSizing,
       ],
-      columns => {
-        const index = columns.findIndex(d => d.id === column.id)
+      (position, columns) => {
+        const index = column.getIndex(position)
 
         return columns
           .slice(0, index)
@@ -280,11 +281,12 @@ export const ColumnSizing: TableFeature = {
 
     column.getAfter = memo(
       position => [
+        position,
         _getVisibleLeafColumns(table, position),
         table.getState().columnSizing,
       ],
-      columns => {
-        const index = columns.findIndex(d => d.id === column.id)
+      (position, columns) => {
+        const index = column.getIndex(position)
 
         return columns
           .slice(index + 1)

--- a/packages/table-core/src/features/Ordering.ts
+++ b/packages/table-core/src/features/Ordering.ts
@@ -1,9 +1,10 @@
-import { makeStateUpdater, memo } from '../utils'
+import { getMemoOptions, makeStateUpdater, memo } from '../utils'
 
 import { Table, OnChangeFn, Updater, Column, RowData } from '../types'
 
 import { orderColumns } from './Grouping'
 import { TableFeature } from '../core/table'
+import { ColumnPinningPosition, _getVisibleLeafColumns } from '..'
 
 export interface ColumnOrderTableState {
   columnOrder: ColumnOrderState
@@ -18,6 +19,27 @@ export interface ColumnOrderOptions {
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-ordering)
    */
   onColumnOrderChange?: OnChangeFn<ColumnOrderState>
+}
+
+export interface ColumnOrderColumn {
+  /**
+   * Returns the index of the column in the order of the visible columns. Optionally pass a `position` parameter to get the index of the column in a sub-section of the table
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-ordering#getindex)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-ordering)
+   */
+  getIndex: (position?: ColumnPinningPosition | 'center') => number
+  /**
+   * Returns `true` if the column is the first column in the order of the visible columns. Optionally pass a `position` parameter to check if the column is the first in a sub-section of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-ordering#getisfirstcolumn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-ordering)
+   */
+  getIsFirstColumn: (position?: ColumnPinningPosition | 'center') => boolean
+  /**
+   * Returns `true` if the column is the last column in the order of the visible columns. Optionally pass a `position` parameter to check if the column is the last in a sub-section of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/column-ordering#getislastcolumn)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/column-ordering)
+   */
+  getIsLastColumn: (position?: ColumnPinningPosition | 'center') => boolean
 }
 
 export interface ColumnOrderDefaultOptions {
@@ -60,6 +82,29 @@ export const Ordering: TableFeature = {
     }
   },
 
+  createColumn: <TData extends RowData>(
+    column: Column<TData, unknown>,
+    table: Table<TData>
+  ): void => {
+    column.getIndex = memo(
+      position => [
+        _getVisibleLeafColumns(table, position),
+        table.getState().columnPinning,
+        table.getState().columnPinning,
+      ],
+      columns => columns.findIndex(d => d.id === column.id),
+      getMemoOptions(table.options, 'debugColumns', 'getIndex')
+    )
+    column.getIsFirstColumn = position => {
+      const columns = _getVisibleLeafColumns(table, position)
+      return columns[0]?.id === column.id
+    }
+    column.getIsLastColumn = position => {
+      const columns = _getVisibleLeafColumns(table, position)
+      return columns[columns.length - 1]?.id === column.id
+    }
+  },
+
   createTable: <TData extends RowData>(table: Table<TData>): void => {
     table.setColumnOrder = updater =>
       table.options.onColumnOrderChange?.(updater)
@@ -74,43 +119,41 @@ export const Ordering: TableFeature = {
         table.getState().grouping,
         table.options.groupedColumnMode,
       ],
-      (columnOrder, grouping, groupedColumnMode) => columns => {
-        // Sort grouped columns to the start of the column list
-        // before the headers are built
-        let orderedColumns: Column<TData, unknown>[] = []
+      (columnOrder, grouping, groupedColumnMode) =>
+        (columns: Column<TData, unknown>[]) => {
+          // Sort grouped columns to the start of the column list
+          // before the headers are built
+          let orderedColumns: Column<TData, unknown>[] = []
 
-        // If there is no order, return the normal columns
-        if (!columnOrder?.length) {
-          orderedColumns = columns
-        } else {
-          const columnOrderCopy = [...columnOrder]
+          // If there is no order, return the normal columns
+          if (!columnOrder?.length) {
+            orderedColumns = columns
+          } else {
+            const columnOrderCopy = [...columnOrder]
 
-          // If there is an order, make a copy of the columns
-          const columnsCopy = [...columns]
+            // If there is an order, make a copy of the columns
+            const columnsCopy = [...columns]
 
-          // And make a new ordered array of the columns
+            // And make a new ordered array of the columns
 
-          // Loop over the columns and place them in order into the new array
-          while (columnsCopy.length && columnOrderCopy.length) {
-            const targetColumnId = columnOrderCopy.shift()
-            const foundIndex = columnsCopy.findIndex(
-              d => d.id === targetColumnId
-            )
-            if (foundIndex > -1) {
-              orderedColumns.push(columnsCopy.splice(foundIndex, 1)[0]!)
+            // Loop over the columns and place them in order into the new array
+            while (columnsCopy.length && columnOrderCopy.length) {
+              const targetColumnId = columnOrderCopy.shift()
+              const foundIndex = columnsCopy.findIndex(
+                d => d.id === targetColumnId
+              )
+              if (foundIndex > -1) {
+                orderedColumns.push(columnsCopy.splice(foundIndex, 1)[0]!)
+              }
             }
+
+            // If there are any columns left, add them to the end
+            orderedColumns = [...orderedColumns, ...columnsCopy]
           }
 
-          // If there are any columns left, add them to the end
-          orderedColumns = [...orderedColumns, ...columnsCopy]
-        }
-
-        return orderColumns(orderedColumns, grouping, groupedColumnMode)
-      },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getOrderColumnsFn',
-        // debug: () => table.options.debugAll ?? table.options.debugTable,
-      }
+          return orderColumns(orderedColumns, grouping, groupedColumnMode)
+        },
+      getMemoOptions(table.options, 'debugTable', '_getOrderColumnsFn')
     )
   },
 }

--- a/packages/table-core/src/features/Ordering.ts
+++ b/packages/table-core/src/features/Ordering.ts
@@ -87,11 +87,7 @@ export const Ordering: TableFeature = {
     table: Table<TData>
   ): void => {
     column.getIndex = memo(
-      position => [
-        _getVisibleLeafColumns(table, position),
-        table.getState().columnPinning,
-        table.getState().columnPinning,
-      ],
+      position => [_getVisibleLeafColumns(table, position)],
       columns => columns.findIndex(d => d.id === column.id),
       getMemoOptions(table.options, 'debugColumns', 'getIndex')
     )

--- a/packages/table-core/src/features/Pagination.ts
+++ b/packages/table-core/src/features/Pagination.ts
@@ -1,6 +1,11 @@
 import { TableFeature } from '../core/table'
 import { OnChangeFn, Table, RowModel, Updater, RowData } from '../types'
-import { functionalUpdate, makeStateUpdater, memo } from '../utils'
+import {
+  functionalUpdate,
+  getMemoOptions,
+  makeStateUpdater,
+  memo,
+} from '../utils'
 
 export interface PaginationState {
   pageIndex: number
@@ -290,10 +295,7 @@ export const Pagination: TableFeature = {
         }
         return pageOptions
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getPageOptions',
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-      }
+      getMemoOptions(table.options, 'debugTable', 'getPageOptions')
     )
 
     table.getCanPreviousPage = () => table.getState().pagination.pageIndex > 0

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -1,6 +1,6 @@
 import { TableFeature } from '../core/table'
 import { OnChangeFn, Table, Row, RowModel, Updater, RowData } from '../types'
-import { makeStateUpdater, memo } from '../utils'
+import { getMemoOptions, makeStateUpdater, memo } from '../utils'
 
 export type RowSelectionState = Record<string, boolean>
 
@@ -333,10 +333,7 @@ export const RowSelection: TableFeature = {
 
         return selectRowsFn(table, rowModel)
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getSelectedRowModel',
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-      }
+      getMemoOptions(table.options, 'debugTable', 'getSelectedRowModel')
     )
 
     table.getFilteredSelectedRowModel = memo(
@@ -352,12 +349,7 @@ export const RowSelection: TableFeature = {
 
         return selectRowsFn(table, rowModel)
       },
-      {
-        key:
-          process.env.NODE_ENV === 'production' &&
-          'getFilteredSelectedRowModel',
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-      }
+      getMemoOptions(table.options, 'debugTable', 'getFilteredSelectedRowModel')
     )
 
     table.getGroupedSelectedRowModel = memo(
@@ -373,11 +365,7 @@ export const RowSelection: TableFeature = {
 
         return selectRowsFn(table, rowModel)
       },
-      {
-        key:
-          process.env.NODE_ENV === 'production' && 'getGroupedSelectedRowModel',
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-      }
+      getMemoOptions(table.options, 'debugTable', 'getGroupedSelectedRowModel')
     )
 
     ///

--- a/packages/table-core/src/types.ts
+++ b/packages/table-core/src/types.ts
@@ -8,6 +8,7 @@ import {
   VisibilityRow,
 } from './features/Visibility'
 import {
+  ColumnOrderColumn,
   ColumnOrderInstance,
   ColumnOrderOptions,
   ColumnOrderTableState,
@@ -304,7 +305,8 @@ export interface Column<TData extends RowData, TValue = unknown>
     FiltersColumn<TData>,
     SortingColumn<TData>,
     GroupingColumn<TData>,
-    ColumnSizingColumn {}
+    ColumnSizingColumn,
+    ColumnOrderColumn {}
 
 export interface Cell<TData extends RowData, TValue>
   extends CoreCell<TData, TValue>,

--- a/packages/table-core/src/utils/getCoreRowModel.ts
+++ b/packages/table-core/src/utils/getCoreRowModel.ts
@@ -1,6 +1,6 @@
 import { createRow } from '../core/row'
 import { Table, Row, RowModel, RowData } from '../types'
-import { memo } from '../utils'
+import { getMemoOptions, memo } from '../utils'
 
 export function getCoreRowModel<TData extends RowData>(): (
   table: Table<TData>
@@ -75,12 +75,8 @@ export function getCoreRowModel<TData extends RowData>(): (
 
         return rowModel
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getRowModel',
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-        onChange: () => {
-          table._autoResetPageIndex()
-        },
-      }
+      getMemoOptions(table.options, 'debugTable', 'getRowModel', () =>
+        table._autoResetPageIndex()
+      )
     )
 }

--- a/packages/table-core/src/utils/getExpandedRowModel.ts
+++ b/packages/table-core/src/utils/getExpandedRowModel.ts
@@ -1,5 +1,5 @@
 import { Table, Row, RowModel, RowData } from '../types'
-import { memo } from '../utils'
+import { getMemoOptions, memo } from '../utils'
 
 export function getExpandedRowModel<TData extends RowData>(): (
   table: Table<TData>
@@ -26,10 +26,7 @@ export function getExpandedRowModel<TData extends RowData>(): (
 
         return expandRows(rowModel)
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getExpandedRowModel',
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-      }
+      getMemoOptions(table.options, 'debugTable', 'getExpandedRowModel')
     )
 }
 

--- a/packages/table-core/src/utils/getFacetedMinMaxValues.ts
+++ b/packages/table-core/src/utils/getFacetedMinMaxValues.ts
@@ -1,5 +1,5 @@
 import { Table, RowData } from '../types'
-import { memo } from '../utils'
+import { getMemoOptions, memo } from '../utils'
 
 export function getFacetedMinMaxValues<TData extends RowData>(): (
   table: Table<TData>,
@@ -37,12 +37,6 @@ export function getFacetedMinMaxValues<TData extends RowData>(): (
 
         return facetedMinMaxValues
       },
-      {
-        key:
-          process.env.NODE_ENV === 'development' &&
-          'getFacetedMinMaxValues_' + columnId,
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-        onChange: () => {},
-      }
+      getMemoOptions(table.options, 'debugTable', 'getFacetedMinMaxValues')
     )
 }

--- a/packages/table-core/src/utils/getFacetedRowModel.ts
+++ b/packages/table-core/src/utils/getFacetedRowModel.ts
@@ -1,5 +1,5 @@
 import { Table, RowModel, Row, RowData } from '../types'
-import { memo } from '../utils'
+import { getMemoOptions, memo } from '../utils'
 import { filterRows } from './filterRowsUtils'
 
 export function getFacetedRowModel<TData extends RowData>(): (
@@ -39,12 +39,6 @@ export function getFacetedRowModel<TData extends RowData>(): (
 
         return filterRows(preRowModel.rows, filterRowsImpl, table)
       },
-      {
-        key:
-          process.env.NODE_ENV === 'development' &&
-          'getFacetedRowModel_' + columnId,
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-        onChange: () => {},
-      }
+      getMemoOptions(table.options, 'debugTable', 'getFacetedRowModel')
     )
 }

--- a/packages/table-core/src/utils/getFacetedUniqueValues.ts
+++ b/packages/table-core/src/utils/getFacetedUniqueValues.ts
@@ -1,5 +1,5 @@
 import { Table, RowData } from '../types'
-import { memo } from '../utils'
+import { getMemoOptions, memo } from '../utils'
 
 export function getFacetedUniqueValues<TData extends RowData>(): (
   table: Table<TData>,
@@ -33,12 +33,10 @@ export function getFacetedUniqueValues<TData extends RowData>(): (
 
         return facetedUniqueValues
       },
-      {
-        key:
-          process.env.NODE_ENV === 'development' &&
-          'getFacetedUniqueValues_' + columnId,
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-        onChange: () => {},
-      }
+      getMemoOptions(
+        table.options,
+        'debugTable',
+        `getFacetedUniqueValues_${columnId}`
+      )
     )
 }

--- a/packages/table-core/src/utils/getFilteredRowModel.ts
+++ b/packages/table-core/src/utils/getFilteredRowModel.ts
@@ -1,6 +1,6 @@
 import { ResolvedColumnFilter } from '../features/Filters'
 import { Table, RowModel, Row, RowData } from '../types'
-import { memo } from '../utils'
+import { getMemoOptions, memo } from '../utils'
 import { filterRows } from './filterRowsUtils'
 
 export function getFilteredRowModel<TData extends RowData>(): (
@@ -144,12 +144,8 @@ export function getFilteredRowModel<TData extends RowData>(): (
         // Filter final rows using all of the active filters
         return filterRows(rowModel.rows, filterRowsImpl, table)
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getFilteredRowModel',
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-        onChange: () => {
-          table._autoResetPageIndex()
-        },
-      }
+      getMemoOptions(table.options, 'debugTable', 'getFilteredRowModel', () =>
+        table._autoResetPageIndex()
+      )
     )
 }

--- a/packages/table-core/src/utils/getGroupedRowModel.ts
+++ b/packages/table-core/src/utils/getGroupedRowModel.ts
@@ -1,6 +1,6 @@
 import { createRow } from '../core/row'
 import { Table, Row, RowModel, RowData } from '../types'
-import { flattenBy, memo } from '../utils'
+import { flattenBy, getMemoOptions, memo } from '../utils'
 
 export function getGroupedRowModel<TData extends RowData>(): (
   table: Table<TData>
@@ -156,16 +156,12 @@ export function getGroupedRowModel<TData extends RowData>(): (
           rowsById: groupedRowsById,
         }
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getGroupedRowModel',
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-        onChange: () => {
-          table._queue(() => {
-            table._autoResetExpanded()
-            table._autoResetPageIndex()
-          })
-        },
-      }
+      getMemoOptions(table.options, 'debugTable', 'getGroupedRowModel', () => {
+        table._queue(() => {
+          table._autoResetExpanded()
+          table._autoResetPageIndex()
+        })
+      })
     )
 }
 

--- a/packages/table-core/src/utils/getPaginationRowModel.ts
+++ b/packages/table-core/src/utils/getPaginationRowModel.ts
@@ -1,5 +1,5 @@
 import { Table, RowModel, Row, RowData } from '../types'
-import { memo } from '../utils'
+import { getMemoOptions, memo } from '../utils'
 import { expandRows } from './getExpandedRowModel'
 
 export function getPaginationRowModel<TData extends RowData>(opts?: {
@@ -55,9 +55,6 @@ export function getPaginationRowModel<TData extends RowData>(opts?: {
 
         return paginatedRowModel
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getPaginationRowModel',
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-      }
+      getMemoOptions(table.options, 'debugTable', 'getPaginationRowModel')
     )
 }

--- a/packages/table-core/src/utils/getSortedRowModel.ts
+++ b/packages/table-core/src/utils/getSortedRowModel.ts
@@ -1,6 +1,6 @@
 import { Table, Row, RowModel, RowData } from '../types'
 import { SortingFn } from '../features/Sorting'
-import { memo } from '../utils'
+import { getMemoOptions, memo } from '../utils'
 
 export function getSortedRowModel<TData extends RowData>(): (
   table: Table<TData>
@@ -111,12 +111,8 @@ export function getSortedRowModel<TData extends RowData>(): (
           rowsById: rowModel.rowsById,
         }
       },
-      {
-        key: process.env.NODE_ENV === 'development' && 'getSortedRowModel',
-        debug: () => table.options.debugAll ?? table.options.debugTable,
-        onChange: () => {
-          table._autoResetPageIndex()
-        },
-      }
+      getMemoOptions(table.options, 'debugTable', 'getSortedRowModel', () =>
+        table._autoResetPageIndex()
+      )
     )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,37 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/node@18.19.7)
 
+  examples/react/column-pinning-sticky:
+    dependencies:
+      '@faker-js/faker':
+        specifier: ^8.3.1
+        version: 8.3.1
+      '@tanstack/react-table':
+        specifier: ^8.11.8
+        version: link:../../../packages/react-table
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@rollup/plugin-replace':
+        specifier: ^5.0.5
+        version: 5.0.5(rollup@4.9.5)
+      '@types/react':
+        specifier: ^18.2.48
+        version: 18.2.48
+      '@types/react-dom':
+        specifier: ^18.2.18
+        version: 18.2.18
+      '@vitejs/plugin-react':
+        specifier: ^4.2.1
+        version: 4.2.1(vite@5.0.11)
+      vite:
+        specifier: ^5.0.11
+        version: 5.0.11(@types/node@18.19.7)
+
   examples/react/column-resizing-performant:
     dependencies:
       '@faker-js/faker':
@@ -1632,14 +1663,6 @@ packages:
     resolution: {integrity: sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==}
     dev: true
 
-  /@ampproject/remapping@2.2.0:
-    resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.17
-    dev: true
-
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
@@ -1672,7 +1695,7 @@ packages:
     resolution: {integrity: sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@ampproject/remapping': 2.2.0
+      '@ampproject/remapping': 2.2.1
       '@babel/code-frame': 7.23.5
       '@babel/generator': 7.23.6
       '@babel/helper-compilation-targets': 7.23.6
@@ -3379,14 +3402,6 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@sinclair/typebox': 0.27.8
-    dev: true
-
-  /@jridgewell/gen-mapping@0.1.1:
-    resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
   /@jridgewell/gen-mapping@0.3.2:
@@ -8887,8 +8902,8 @@ packages:
     dependencies:
       '@types/node': 20.11.2
       esbuild: 0.19.10
-      postcss: 8.4.32
-      rollup: 4.9.2
+      postcss: 8.4.33
+      rollup: 4.9.5
     optionalDependencies:
       fsevents: 2.3.3
     dev: true


### PR DESCRIPTION
**perf**: getMemoOptions method to reduce memo boilerplate
**feat**: new ColumnSizing getAfter API (similar to getStart)
**perf**: added memoization to column.getStart method
**feat**: new Ordering column.getIndex API
**feat**: new Ordering column.getIsFirstColumn API
**feat**: new Ordering column.getIsLastColumn API
**perf**: improved table._getPinnedRows memo performance
**docs**: new sticky column pinning example
**docs**: new column pinning guide

<img width="1004" alt="image" src="https://github.com/TanStack/table/assets/28243511/71b4992f-1538-4b2b-9430-93fd38a90ba4">
