### PR TITLE
fix: column-pinning docs wrong link

### DIFF
--- a/docs/guide/column-pinning.md
+++ b/docs/guide/column-pinning.md
@@ -7,7 +7,7 @@ title: Column Pinning
 Want to skip to the implementation? Check out these examples:
 
 - [column-pinning](../framework/react/examples/column-pinning)
-- [sticky-column-pinning](../framework/react/examples/column-pinning/sticky)
+- [sticky-column-pinning](../framework/react/examples/column-pinning-sticky)
 - [row-pinning](../framework/react/examples/row-pinning)
 
  ### Other Examples


### PR DESCRIPTION
Fixed wrong link to column-pinning-sticky example. The original link would load the page but the example was not working.