### PR TITLE
Fix: Add missing faker-js dependency for a "Vue Example: Row Selection"

### DIFF
--- a/examples/vue/row-selection/package.json
+++ b/examples/vue/row-selection/package.json
@@ -8,8 +8,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.4.14",
-    "@tanstack/vue-table": "^8.12.0"
+    "@faker-js/faker": "^8.4.1",
+    "@tanstack/vue-table": "^8.12.0",
+    "vue": "^3.4.14"
   },
   "devDependencies": {
     "@types/node": "^20.11.2",


### PR DESCRIPTION
Adding a missing dependency for a [Vue Example: Row Selection](https://tanstack.com/table/latest/docs/framework/vue/examples/row-selection)

<img width="967" alt="Screenshot 2024-02-25 at 12 19 52" src="https://github.com/TanStack/table/assets/16000629/a4161530-e63e-4029-a1ec-af241d82c54b">
