### PR TITLE
fix(table-core): Avoid process not defined in environments not setting a process variable

### DIFF
--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -96,7 +96,7 @@ export function createColumn<TData extends RowData, TValue>(
 
         for (const key of accessorKey.split('.')) {
           result = result?.[key]
-          if (process.env.NODE_ENV !== 'production' && result === undefined) {
+          if (typeof process !== "undefined" && process.env.NODE_ENV !== 'production' && result === undefined) {
             console.warn(
               `"${key}" in deeply nested key "${accessorKey}" returned undefined.`
             )
@@ -112,7 +112,7 @@ export function createColumn<TData extends RowData, TValue>(
   }
 
   if (!id) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (typeof process !== "undefined" && process.env.NODE_ENV !== 'production') {
       throw new Error(
         resolvedColumnDef.accessorFn
           ? `Columns require an id when using an accessorFn`

--- a/packages/table-core/src/core/table.ts
+++ b/packages/table-core/src/core/table.ts
@@ -389,7 +389,7 @@ export function createTable<TData extends RowData>(
       if (!row) {
         row = table.getCoreRowModel().rowsById[id]
         if (!row) {
-          if (process.env.NODE_ENV !== 'production') {
+          if (typeof process !== "undefined" && process.env.NODE_ENV !== 'production') {
             throw new Error(`getRow could not find row with ID: ${id}`)
           }
           throw new Error()
@@ -498,7 +498,7 @@ export function createTable<TData extends RowData>(
     getColumn: columnId => {
       const column = table._getAllFlatColumnsById()[columnId]
 
-      if (process.env.NODE_ENV !== 'production' && !column) {
+      if (typeof process !== "undefined" && process.env.NODE_ENV !== 'production' && !column) {
         console.error(`[Table] Column with id '${columnId}' does not exist.`)
       }
 

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -214,7 +214,10 @@ export function getMemoOptions(
 ) {
   return {
     debug: () => tableOptions?.debugAll ?? tableOptions[debugLevel],
-    key: process.env.NODE_ENV === 'development' && key,
+    key:
+          typeof process !== "undefined"
+            ? process.env.NODE_ENV === "development" && key
+            : !key,
     onChange,
   }
 }

--- a/packages/table-core/src/utils/getCoreRowModel.ts
+++ b/packages/table-core/src/utils/getCoreRowModel.ts
@@ -31,7 +31,7 @@ export function getCoreRowModel<TData extends RowData>(): (
           for (let i = 0; i < originalRows.length; i++) {
             // This could be an expensive check at scale, so we should move it somewhere else, but where?
             // if (!id) {
-            //   if (process.env.NODE_ENV !== 'production') {
+            //   if (typeof process !== "undefined" && process.env.NODE_ENV !== 'production') {
             //     throw new Error(`getRowId expected an ID, but got ${id}`)
             //   }
             // }

--- a/packages/table-core/src/utils/getFilteredRowModel.ts
+++ b/packages/table-core/src/utils/getFilteredRowModel.ts
@@ -38,7 +38,7 @@ export function getFilteredRowModel<TData extends RowData>(): (
           const filterFn = column.getFilterFn()
 
           if (!filterFn) {
-            if (process.env.NODE_ENV !== 'production') {
+            if (typeof process !== "undefined" && process.env.NODE_ENV !== 'production') {
               console.warn(
                 `Could not find a valid 'column.filterFn' for column with the ID: ${column.id}.`
               )


### PR DESCRIPTION
When running the library in an environment that is not setting the process variable, the library throws a not defined error and breaks the render. This change checks to see if the variable exists before attempting to read it to avoid this.