### PR TITLE
feat: pagination row count apis, new pagination docs

### DIFF
--- a/docs/api/features/pagination.md
+++ b/docs/api/features/pagination.md
@@ -38,7 +38,15 @@ Enables manual pagination. If this option is set to `true`, the table will not a
 pageCount?: number
 ```
 
-When manually controlling pagination, you should supply a total `pageCount` value to the table if you know it. If you do not know how many pages there are, you can set this to `-1`.
+When manually controlling pagination, you can supply a total `pageCount` value to the table if you know it. If you do not know how many pages there are, you can set this to `-1`. Alternatively, you can provide a `rowCount` value and the table will calculate the `pageCount` internally.
+
+### `rowCount`
+
+```tsx
+rowCount?: number
+```
+
+When manually controlling pagination, you can supply a total `rowCount` value to the table if you know it. `pageCount` will be calculated internally from `rowCount` and `pageSize`.
 
 ### `autoResetPageIndex`
 
@@ -118,14 +126,6 @@ resetPageSize: (defaultState?: boolean) => void
 
 Resets the page size to its initial state. If `defaultState` is `true`, the page size will be reset to `10` regardless of initial state.
 
-### `setPageCount`
-
-```tsx
-setPageCount: (updater: Updater<number>) => void
-```
-
-Updates the page count using the provided function or value.
-
 ### `getPageOptions`
 
 ```tsx
@@ -165,6 +165,22 @@ nextPage: () => void
 ```
 
 Increments the page index by one, if possible.
+
+### `firstPage`
+
+```tsx
+firstPage: () => void
+```
+
+Sets the page index to `0`.
+
+### `lastPage`
+
+```tsx
+lastPage: () => void
+```
+
+Sets the page index to the last available page.
 
 ### `getPageCount`
 

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -7,7 +7,7 @@ title: Pagination Guide
 Want to skip to the implementation? Check out these examples:
 
 - [pagination](../framework/react/examples/pagination)
-- [pagination-controlled](../framework/react/examples/pagination-controlled)
+- [pagination-controlled (React Query)](../framework/react/examples/pagination-controlled)
 - [editable-data](../framework/react/examples/editable-data)
 - [expanding](../framework/react/examples/expanding)
 - [filters](../framework/react/examples/filters)
@@ -19,3 +19,204 @@ Want to skip to the implementation? Check out these examples:
 [Pagination API](../api/features/pagination)
 
 ## Pagination Guide
+
+TanStack Table has great support for both client-side and server-side pagination. This guide will walk you through the different ways to implement pagination in your table.
+
+### Client-Side Pagination
+
+Using client-side pagination means that the `data` that you fetch will contain ***ALL*** of the rows for the table, and the table instance will handle pagination logic in the front-end.
+
+#### Should You Use Client-Side Pagination?
+
+Client-side pagination is usually the simplest way to implement pagination when using TanStack Table, but it might not be practical for very large datasets.
+
+However, a lot of people underestimate just how much data can be handled client-side. If your table will only ever have a few thousand rows or less, client-side pagination can still be a viable option. TanStack Table is designed to scale up to 10s of thousands of rows with decent performance for pagination, filtering, sorting, and grouping. The [official pagination example](../framework/react/examples/pagination) loads 100,000 rows and still performs well, albeit with only handful of columns.
+
+Every use-case is different and will depend on the complexity of the table, how many columns you have, how large every piece of data is, etc. The main bottlenecks to pay attention to are:
+
+1. Can your server query all of the data in a reasonable amount of time (and cost)?
+2. What is the total size of the fetch? (This might not scale as badly as you think if you don't have many columns.)
+3. Is the client's browser using too much memory if all of the data is loaded at once?
+
+If you're not sure, you can always start with client-side pagination and then switch to server-side pagination in the future as your data grows.
+
+#### Should You Use Virtualization Instead?
+
+Alternatively, instead of paginating the data, you can render all rows of a large dataset on the same page, but only use the browser's resources to render the rows that are visible in the viewport. This strategy is often called "virtualization" or "windowing". TanStack offers a virtualization library called [TanStack Virtual](https://tanstack.com/virtual/latest) that can work well with TanStack Table. The UI/UX of both virtualization and pagination have their own trade-offs, so see which one works best for your use-case.
+
+#### Pagination Row Model
+
+If you want to take advantage of the built-in client-side pagination in TanStack Table, you first need to pass in the pagination row model.
+
+```jsx
+import { useReactTable, getCoreRowModel, getPaginationRowModel } from '@tanstack/react-table';
+//...
+const table = useReactTable({
+  columns,
+  data,
+  getCoreRowModel: getCoreRowModel(),
+  getPaginationRowModel: getPaginationRowModel(), //load client-side pagination code
+});
+```
+
+### Manual Server-Side Pagination
+
+If you decide that you need to use server-side pagination, here is how you can implement it.
+
+No pagination row model is needed for server-side pagination, but if you have provided it for other tables that do need it in a shared component, you can still turn off the client-side pagination by setting the `manualPagination` option to `true`. Setting to the `manualPagination` option to `true` will tell the table instance to use the `table.getPrePaginationRowModel` row model under the hood, and it will make the table instance assume that the `data` that you pass in is already paginated.
+
+#### Page Count and Row Count
+
+Also, the table instance will have no way of knowing how many rows/pages there are in total in your back-end unless you tell it. Provide either the `rowCount` or `pageCount` table option to let the table instance know how many pages there are in total. If you provide a `rowCount`, the table instance will calculate the `pageCount` internally from `rowCount` and `pageSize`. Otherwise, you can directly provide the `pageCount` if you already have it. If you don't know the page count, you can just pass in `-1` for the `pageCount`, but the `getCanNextPage` and `getCanPreviousPage` row model functions will always return `true` in this case.
+
+```jsx
+import { useReactTable, getCoreRowModel, getPaginationRowModel } from '@tanstack/react-table';
+//...
+const table = useReactTable({
+  columns,
+  data,
+  getCoreRowModel: getCoreRowModel(),
+  // getPaginationRowModel: getPaginationRowModel(), //not needed for server-side pagination
+  manualPagination: true, //turn off client-side pagination
+  rowCount: dataQuery.data?.rowCount, //pass in the total row count so the table knows how many pages there are (pageCount calculated internally if not provided)
+  // pageCount: dataQuery.data?.pageCount, //alternatively directly pass in pageCount instead of rowCount
+});
+```
+
+> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+
+### Pagination State
+
+Whether or not you are using client-side or manual server-side pagination, you can use the built-in `pagination` state state and APIs.
+
+The `pagination` state is an object that contains the following properties:
+
+- `pageIndex`: The current page index (zero-based).
+- `pageSize`: The current page size.
+
+You can manage the `pagination` state just like any other state in the table instance.
+
+```jsx
+import { useReactTable, getCoreRowModel, getPaginationRowModel } from '@tanstack/react-table';
+//...
+const [pagination, setPagination] = useState({
+  pageIndex: 0, //initial page index
+  pageSize: 10, //default page size
+});
+
+const table = useReactTable({
+  columns,
+  data,
+  getCoreRowModel: getCoreRowModel(),
+  getPaginationRowModel: getPaginationRowModel(),
+  onPaginationChange: setPagination, //update the pagination state when internal APIs mutate the pagination state
+  state: {
+    //...
+    pagination,
+  },
+});
+```
+
+Alternatively, if you have no need for managing the `pagination` state in your own scope, but you need to set different initial values for the `pageIndex` and `pageSize`, you can use the `initialState` option.
+
+```jsx
+const table = useReactTable({
+  columns,
+  data,
+  getCoreRowModel: getCoreRowModel(),
+  getPaginationRowModel: getPaginationRowModel(),
+  initialState: {
+    pagination: {
+      pageIndex: 2, //custom initial page index
+      pageSize: 25, //custom default page size
+    },
+  },
+});
+```
+
+> **Note**: Do NOT pass the `pagination` state to both the `state` and `initialState` options. `state` will overwrite `initialState`. Only use one or the other.
+
+### Pagination Options
+
+Besides the `manualPagination`, `pageCount`, and `rowCount` options which are useful for manual server-side pagination (and discussed [above](#manual-server-side-pagination)), there is one other table option that is useful to understand.
+
+#### Auto Reset Page Index
+
+The `autoResetPageIndex` table option is true by default, and it will reset the `pageIndex` to `0` when page-altering state changes occur, such as when the `data` is updated, filters change, grouping changes, etc. This is useful to prevent the table from showing an empty page when the `pageIndex` is out of range.
+
+However, you can opt out of this behavior by setting the `autoResetPageIndex` option to `false`.
+
+```jsx
+const table = useReactTable({
+  columns,
+  data,
+  getCoreRowModel: getCoreRowModel(),
+  getPaginationRowModel: getPaginationRowModel(),
+  autoResetPageIndex: false, //turn off auto reset of pageIndex
+});
+```
+
+Be aware, however, that if you turn off `autoResetPageIndex`, you may need to add some logic to handle resetting the `pageIndex` yourself to avoid showing empty pages.
+
+### Pagination APIs
+
+There are several pagination table instance APIs that are useful for hooking up your pagination UI components.
+
+#### Pagination Button APIs
+
+- `getCanPreviousPage`: Useful for disabling the "previous page" button when on the first page.
+- `getCanNextPage`: Useful for disabling the "next page" button when there are no more pages.
+- `previousPage`: Useful for going to the previous page. (Button click handler)
+- `nextPage`: Useful for going to the next page. (Button click handler)
+- `firstPage`: Useful for going to the first page. (Button click handler)
+- `lastPage`: Useful for going to the last page. (Button click handler)
+- `setPageIndex`: uUseful for a "go to page" input.
+- `resetPageIndex`: Useful for resetting the table state to the original page index.
+- `setPageSize`: Useful for a "page size" input/select
+- `resetPageSize`: Useful for resetting the table state to the original page size.
+- `setPagination`: Useful for setting all of the pagination state at once.
+- `resetPagination`: Useful for resetting the table state to the original pagination state.
+
+```jsx
+<Button
+  onClick={() => table.firstPage()}
+  disabled={!table.getCanPreviousPage()}
+>
+  {'<<'}
+</Button>
+<Button
+  onClick={() => table.previousPage()}
+  disabled={!table.getCanPreviousPage()}
+>
+  {'<'}
+</Button>
+<Button
+  onClick={() => table.nextPage()}
+  disabled={!table.getCanNextPage()}
+>
+  {'>'}
+</Button>
+<Button
+  onClick={() => table.lastPage()}
+  disabled={!table.getCanNextPage()}
+>
+  {'>>'}
+</Button>
+ <select
+  value={table.getState().pagination.pageSize}
+  onChange={e => {
+    table.setPageSize(Number(e.target.value))
+  }}
+>
+  {[10, 20, 30, 40, 50].map(pageSize => (
+    <option key={pageSize} value={pageSize}>
+      {pageSize}
+    </option>
+  ))}
+</select>
+```
+
+#### Pagination Info APIs
+
+- `getPageCount`: Useful for showing the total number of pages.
+- `getRowCount`: Useful for showing the total number of rows.

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -177,6 +177,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
+> **Note**: Some of these APIs are new in `v8.13.0`
+
 ```jsx
 <Button
   onClick={() => table.firstPage()}

--- a/examples/react/bootstrap/package.json
+++ b/examples/react/bootstrap/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@rollup/plugin-replace": "^5.0.5",
     "@types/bootstrap": "^5.2.10",
     "@types/react": "^18.2.48",

--- a/examples/react/column-dnd/package.json
+++ b/examples/react/column-dnd/package.json
@@ -13,7 +13,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/column-ordering/package.json
+++ b/examples/react/column-ordering/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/column-pinning-sticky/package.json
+++ b/examples/react/column-pinning-sticky/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/column-pinning/package.json
+++ b/examples/react/column-pinning/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/column-resizing-performant/package.json
+++ b/examples/react/column-resizing-performant/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/editable-data/package.json
+++ b/examples/react/editable-data/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/expanding/package.json
+++ b/examples/react/expanding/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/filters/package.json
+++ b/examples/react/filters/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/match-sorter-utils": "^8.11.8",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",

--- a/examples/react/full-width-resizable-table/package.json
+++ b/examples/react/full-width-resizable-table/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/full-width-table/package.json
+++ b/examples/react/full-width-table/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/fully-controlled/package.json
+++ b/examples/react/fully-controlled/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/grouping/package.json
+++ b/examples/react/grouping/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/kitchen-sink/package.json
+++ b/examples/react/kitchen-sink/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@emotion/babel-plugin": "^11.11.0",
     "@emotion/babel-plugin-jsx-pragmatic": "^0.2.1",
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@rollup/plugin-replace": "^5.0.5",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",

--- a/examples/react/material-ui-pagination/package.json
+++ b/examples/react/material-ui-pagination/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@rollup/plugin-replace": "^5.0.5",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",

--- a/examples/react/pagination-controlled/package.json
+++ b/examples/react/pagination-controlled/package.json
@@ -10,10 +10,10 @@
   },
   "dependencies": {
     "@faker-js/faker": "^8.3.1",
+    "@tanstack/react-query": "^5.24.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@tanstack/react-query": "^5.24.1"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",

--- a/examples/react/pagination-controlled/package.json
+++ b/examples/react/pagination-controlled/package.json
@@ -13,7 +13,7 @@
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-query": "^3.39.3"
+    "@tanstack/react-query": "^5.24.1"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.5",

--- a/examples/react/pagination-controlled/package.json
+++ b/examples/react/pagination-controlled/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-query": "^5.24.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",

--- a/examples/react/pagination-controlled/src/fetchData.ts
+++ b/examples/react/pagination-controlled/src/fetchData.ts
@@ -36,7 +36,7 @@ const newPerson = (): Person => {
 export function makeData(...lens: number[]) {
   const makeDataLevel = (depth = 0): Person[] => {
     const len = lens[depth]!
-    return range(len).map((d): Person => {
+    return range(len).map((_d): Person => {
       return {
         ...newPerson(),
         subRows: lens[depth + 1] ? makeDataLevel(depth + 1) : undefined,
@@ -62,5 +62,6 @@ export async function fetchData(options: {
       (options.pageIndex + 1) * options.pageSize
     ),
     pageCount: Math.ceil(data.length / options.pageSize),
+    rowCount: data.length,
   }
 }

--- a/examples/react/pagination-controlled/src/index.css
+++ b/examples/react/pagination-controlled/src/index.css
@@ -24,3 +24,7 @@ tfoot {
 tfoot th {
   font-weight: normal;
 }
+
+button:disabled {
+  opacity: 0.5;
+}

--- a/examples/react/pagination/package.json
+++ b/examples/react/pagination/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/pagination/src/index.css
+++ b/examples/react/pagination/src/index.css
@@ -24,3 +24,7 @@ tfoot {
 tfoot th {
   font-weight: normal;
 }
+
+button:disabled {
+  opacity: 0.5;
+}

--- a/examples/react/row-dnd/package.json
+++ b/examples/react/row-dnd/package.json
@@ -13,7 +13,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/row-pinning/package.json
+++ b/examples/react/row-pinning/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/row-selection/package.json
+++ b/examples/react/row-selection/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/sorting/package.json
+++ b/examples/react/sorting/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/sub-components/package.json
+++ b/examples/react/sub-components/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/react/virtualized-columns/package.json
+++ b/examples/react/virtualized-columns/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "@tanstack/react-virtual": "^3.0.1",
     "react": "^18.2.0",

--- a/examples/react/virtualized-infinite-scrolling/package.json
+++ b/examples/react/virtualized-infinite-scrolling/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^8.3.1",
-    "@tanstack/react-query": "5.17.12",
+    "@tanstack/react-query": "^5.24.1",
     "@tanstack/react-table": "^8.12.0",
     "@tanstack/react-virtual": "^3.0.1",
     "react": "^18.2.0",

--- a/examples/react/virtualized-infinite-scrolling/package.json
+++ b/examples/react/virtualized-infinite-scrolling/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-query": "^5.24.1",
     "@tanstack/react-table": "^8.12.0",
     "@tanstack/react-virtual": "^3.0.1",

--- a/examples/react/virtualized-rows/package.json
+++ b/examples/react/virtualized-rows/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/react-table": "^8.12.0",
     "@tanstack/react-virtual": "^3.0.1",
     "react": "^18.2.0",

--- a/examples/solid/bootstrap/package.json
+++ b/examples/solid/bootstrap/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "typescript": "5.3.3",
     "vite": "^5.0.11",
     "vite-plugin-solid": "^2.8.0"

--- a/examples/solid/column-ordering/package.json
+++ b/examples/solid/column-ordering/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "typescript": "5.3.3",
     "vite": "^5.0.11",
     "vite-plugin-solid": "^2.8.0"

--- a/examples/solid/filters/package.json
+++ b/examples/solid/filters/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "typescript": "5.3.3",
     "vite": "^5.0.11",
     "vite-plugin-solid": "^2.8.0"

--- a/examples/solid/sorting/package.json
+++ b/examples/solid/sorting/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "typescript": "5.3.3",
     "vite": "^5.0.11",
     "vite-plugin-solid": "^2.8.0"

--- a/examples/svelte/column-ordering/package.json
+++ b/examples/svelte/column-ordering/package.json
@@ -10,7 +10,7 @@
     "test:types": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@rollup/plugin-replace": "^5.0.5",
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@tanstack/svelte-table": "^8.12.0",

--- a/examples/svelte/column-pinning/package.json
+++ b/examples/svelte/column-pinning/package.json
@@ -10,7 +10,7 @@
     "test:types": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@rollup/plugin-replace": "^5.0.5",
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@tanstack/svelte-table": "^8.12.0",

--- a/examples/svelte/filtering/package.json
+++ b/examples/svelte/filtering/package.json
@@ -10,7 +10,7 @@
     "test:types": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@rollup/plugin-replace": "^5.0.5",
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@tanstack/match-sorter-utils": "^8.11.8",

--- a/examples/svelte/sorting/package.json
+++ b/examples/svelte/sorting/package.json
@@ -10,7 +10,7 @@
     "test:types": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@rollup/plugin-replace": "^5.0.5",
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@tanstack/svelte-table": "^8.12.0",

--- a/examples/vue/column-ordering/package.json
+++ b/examples/vue/column-ordering/package.json
@@ -7,7 +7,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "vue": "^3.4.14",
     "@tanstack/vue-table": "^8.12.0"
   },

--- a/examples/vue/column-pinning/package.json
+++ b/examples/vue/column-pinning/package.json
@@ -7,7 +7,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/vue-table": "^8.12.0",
     "vue": "^3.4.14"
   },

--- a/examples/vue/pagination-controlled/package.json
+++ b/examples/vue/pagination-controlled/package.json
@@ -9,7 +9,7 @@
     "test:types": "vue-tsc"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "vue": "^3.4.14",
     "@tanstack/vue-table": "^8.12.0"
   },

--- a/examples/vue/pagination/package.json
+++ b/examples/vue/pagination/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "vue": "^3.4.14",
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@tanstack/vue-table": "^8.12.0"
   },
   "devDependencies": {

--- a/examples/vue/sorting/package.json
+++ b/examples/vue/sorting/package.json
@@ -9,7 +9,7 @@
     "test:types": "vue-tsc"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "vue": "^3.4.14",
     "@tanstack/vue-table": "^8.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/preset-env": "^7.23.8",
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
-    "@faker-js/faker": "^8.3.1",
+    "@faker-js/faker": "^8.4.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^7.23.3
         version: 7.23.3(@babel/core@7.23.7)
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.0.4(@babel/core@7.23.7)(rollup@4.9.5)
@@ -161,8 +161,8 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.9.5)
@@ -200,8 +200,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@18.2.0)
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -259,8 +259,8 @@ importers:
   examples/react/column-ordering:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -290,8 +290,8 @@ importers:
   examples/react/column-pinning:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -321,8 +321,8 @@ importers:
   examples/react/column-pinning-sticky:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -352,8 +352,8 @@ importers:
   examples/react/column-resizing-performant:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -439,8 +439,8 @@ importers:
   examples/react/editable-data:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -470,8 +470,8 @@ importers:
   examples/react/expanding:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -501,8 +501,8 @@ importers:
   examples/react/filters:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/match-sorter-utils':
         specifier: ^8.11.8
         version: link:../../../packages/match-sorter-utils
@@ -535,8 +535,8 @@ importers:
   examples/react/full-width-resizable-table:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -566,8 +566,8 @@ importers:
   examples/react/full-width-table:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -597,8 +597,8 @@ importers:
   examples/react/fully-controlled:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -628,8 +628,8 @@ importers:
   examples/react/grouping:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -684,8 +684,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1(@babel/core@7.23.7)
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.9.5)
@@ -727,8 +727,8 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.9.5)
@@ -748,8 +748,8 @@ importers:
   examples/react/pagination:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -779,8 +779,8 @@ importers:
   examples/react/pagination-controlled:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-query':
         specifier: ^5.24.1
         version: 5.24.1(react@18.2.0)
@@ -825,8 +825,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@18.2.0)
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -856,8 +856,8 @@ importers:
   examples/react/row-pinning:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -887,8 +887,8 @@ importers:
   examples/react/row-selection:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -918,8 +918,8 @@ importers:
   examples/react/sorting:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -949,8 +949,8 @@ importers:
   examples/react/sub-components:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -980,8 +980,8 @@ importers:
   examples/react/virtualized-columns:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -1014,8 +1014,8 @@ importers:
   examples/react/virtualized-infinite-scrolling:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-query':
         specifier: ^5.24.1
         version: 5.24.1(react@18.2.0)
@@ -1051,8 +1051,8 @@ importers:
   examples/react/virtualized-rows:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -1117,8 +1117,8 @@ importers:
         version: 1.8.11
     devDependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       typescript:
         specifier: 5.3.3
         version: 5.3.3
@@ -1158,8 +1158,8 @@ importers:
         version: 1.8.11
     devDependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       typescript:
         specifier: 5.3.3
         version: 5.3.3
@@ -1202,8 +1202,8 @@ importers:
         version: 1.8.11
     devDependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       typescript:
         specifier: 5.3.3
         version: 5.3.3
@@ -1224,8 +1224,8 @@ importers:
         version: 1.8.11
     devDependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       typescript:
         specifier: 5.3.3
         version: 5.3.3
@@ -1293,8 +1293,8 @@ importers:
   examples/svelte/column-ordering:
     devDependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.9.5)
@@ -1323,8 +1323,8 @@ importers:
   examples/svelte/column-pinning:
     devDependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.9.5)
@@ -1380,8 +1380,8 @@ importers:
   examples/svelte/filtering:
     devDependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.9.5)
@@ -1413,8 +1413,8 @@ importers:
   examples/svelte/sorting:
     devDependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@rollup/plugin-replace':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.9.5)
@@ -1468,8 +1468,8 @@ importers:
   examples/vue/column-ordering:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.12.0
         version: link:../../../packages/vue-table
@@ -1496,8 +1496,8 @@ importers:
   examples/vue/column-pinning:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.12.0
         version: link:../../../packages/vue-table
@@ -1524,8 +1524,8 @@ importers:
   examples/vue/pagination:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.12.0
         version: link:../../../packages/vue-table
@@ -1552,8 +1552,8 @@ importers:
   examples/vue/pagination-controlled:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.12.0
         version: link:../../../packages/vue-table
@@ -1611,8 +1611,8 @@ importers:
   examples/vue/sorting:
     dependencies:
       '@faker-js/faker':
-        specifier: ^8.3.1
-        version: 8.3.1
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.12.0
         version: link:../../../packages/vue-table
@@ -3671,14 +3671,9 @@ packages:
     dev: true
     optional: true
 
-  /@faker-js/faker@8.3.1:
-    resolution: {integrity: sha512-FdgpFxY6V6rLZE9mmIBb9hM0xpfvQOSNOLnzolzKwsE1DH+gC7lEKV1p1IbR0lAYyvYd5a4u3qWJzowUkw1bIw==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
-
   /@faker-js/faker@8.4.1:
     resolution: {integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
-    dev: false
 
   /@floating-ui/core@1.5.3:
     resolution: {integrity: sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1017,8 +1017,8 @@ importers:
         specifier: ^8.3.1
         version: 8.3.1
       '@tanstack/react-query':
-        specifier: 5.17.12
-        version: 5.17.12(react@18.2.0)
+        specifier: ^5.24.1
+        version: 5.24.1(react@18.2.0)
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -4895,21 +4895,8 @@ packages:
       - vite
     dev: true
 
-  /@tanstack/query-core@5.17.10:
-    resolution: {integrity: sha512-bJ2oQUDBftvHcEkLS3gyzzShSeZpJyzNNRu8oHK13iNdsofyaDXtNO/c1Zy/PZYVX+PhqOXwoT42gMiEMRSSfQ==}
-    dev: false
-
   /@tanstack/query-core@5.24.1:
     resolution: {integrity: sha512-DZ6Nx9p7BhjkG50ayJ+MKPgff+lMeol7QYXkvuU5jr2ryW/4ok5eanaS9W5eooA4xN0A/GPHdLGOZGzArgf5Cg==}
-    dev: false
-
-  /@tanstack/react-query@5.17.12(react@18.2.0):
-    resolution: {integrity: sha512-mJQ+3da1ug4t9b+GycUuNzMs5hd6t+F4tJ1hqyaN/dlETP+bWwYwrv2GXFIbZIfI1K1Hu+XWZ6HUhRPbNtZ4QQ==}
-    peerDependencies:
-      react: ^18.0.0
-    dependencies:
-      '@tanstack/query-core': 5.17.10
-      react: 18.2.0
     dev: false
 
   /@tanstack/react-query@5.24.1(react@18.2.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -781,6 +781,9 @@ importers:
       '@faker-js/faker':
         specifier: ^8.3.1
         version: 8.3.1
+      '@tanstack/react-query':
+        specifier: ^5.24.1
+        version: 5.24.1(react@18.2.0)
       '@tanstack/react-table':
         specifier: ^8.12.0
         version: link:../../../packages/react-table
@@ -790,9 +793,6 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
-      react-query:
-        specifier: ^3.39.3
-        version: 3.39.3(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
@@ -4899,12 +4899,25 @@ packages:
     resolution: {integrity: sha512-bJ2oQUDBftvHcEkLS3gyzzShSeZpJyzNNRu8oHK13iNdsofyaDXtNO/c1Zy/PZYVX+PhqOXwoT42gMiEMRSSfQ==}
     dev: false
 
+  /@tanstack/query-core@5.24.1:
+    resolution: {integrity: sha512-DZ6Nx9p7BhjkG50ayJ+MKPgff+lMeol7QYXkvuU5jr2ryW/4ok5eanaS9W5eooA4xN0A/GPHdLGOZGzArgf5Cg==}
+    dev: false
+
   /@tanstack/react-query@5.17.12(react@18.2.0):
     resolution: {integrity: sha512-mJQ+3da1ug4t9b+GycUuNzMs5hd6t+F4tJ1hqyaN/dlETP+bWwYwrv2GXFIbZIfI1K1Hu+XWZ6HUhRPbNtZ4QQ==}
     peerDependencies:
       react: ^18.0.0
     dependencies:
       '@tanstack/query-core': 5.17.10
+      react: 18.2.0
+    dev: false
+
+  /@tanstack/react-query@5.24.1(react@18.2.0):
+    resolution: {integrity: sha512-4+09JEdO4d6+Gc8Y/g2M/MuxDK5IY0QV8+2wL2304wPKJgJ54cBbULd3nciJ5uvh/as8rrxx6s0mtIwpRuGd1g==}
+    peerDependencies:
+      react: ^18.0.0
+    dependencies:
+      '@tanstack/query-core': 5.24.1
       react: 18.2.0
     dev: false
 
@@ -5735,6 +5748,7 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -5745,11 +5759,6 @@ packages:
     dependencies:
       require-from-string: 2.0.2
     dev: true
-
-  /big-integer@1.6.51:
-    resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
-    engines: {node: '>=0.6'}
-    dev: false
 
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -5784,6 +5793,7 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+    dev: true
 
   /brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -5797,19 +5807,6 @@ packages:
     dependencies:
       fill-range: 7.0.1
     dev: true
-
-  /broadcast-channel@3.7.0:
-    resolution: {integrity: sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==}
-    dependencies:
-      '@babel/runtime': 7.21.0
-      detect-node: 2.1.0
-      js-sha3: 0.8.0
-      microseconds: 0.2.0
-      nano-time: 1.0.0
-      oblivious-set: 1.0.0
-      rimraf: 3.0.2
-      unload: 2.2.0
-    dev: false
 
   /browserslist@4.22.2:
     resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
@@ -6072,6 +6069,7 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
 
   /conventional-changelog-angular@7.0.0:
     resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
@@ -6287,10 +6285,6 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
     dev: true
-
-  /detect-node@2.1.0:
-    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
-    dev: false
 
   /dettle@1.0.1:
     resolution: {integrity: sha512-/oD3At60ZfhgzpofJtyClNTrIACyMdRe+ih0YiHzAniN0IZnLdLpEzgR6RtGs3kowxUkTnvV/4t1FBxXMUdusQ==}
@@ -6768,6 +6762,7 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
 
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -6872,6 +6867,7 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+    dev: true
 
   /glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -7099,9 +7095,11 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+    dev: true
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
 
   /ini-simple-parser@1.0.0:
     resolution: {integrity: sha512-cZUGzkBd1W8FoIbFNMbscMvIGwp+riO/4PaPAy2owQp0sja+ni6Yty11GBNnxaI1ePkSVXzPb8iMOOYuYw/MOQ==}
@@ -7455,10 +7453,6 @@ packages:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
 
-  /js-sha3@0.8.0:
-    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
-    dev: false
-
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -7787,13 +7781,6 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /match-sorter@6.3.1:
-    resolution: {integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==}
-    dependencies:
-      '@babel/runtime': 7.21.0
-      remove-accents: 0.4.2
-    dev: false
-
   /mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
     dev: true
@@ -7843,10 +7830,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /microseconds@0.2.0:
-    resolution: {integrity: sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==}
-    dev: false
-
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -7889,6 +7872,7 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
+    dev: true
 
   /minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
@@ -7941,12 +7925,6 @@ packages:
   /muggle-string@0.3.1:
     resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
     dev: true
-
-  /nano-time@1.0.0:
-    resolution: {integrity: sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==}
-    dependencies:
-      big-integer: 1.6.51
-    dev: false
 
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
@@ -8197,14 +8175,11 @@ packages:
       isobject: 3.0.1
     dev: true
 
-  /oblivious-set@1.0.0:
-    resolution: {integrity: sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==}
-    dev: false
-
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
+    dev: true
 
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -8322,6 +8297,7 @@ packages:
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /path-key@2.0.1:
     resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
@@ -8644,25 +8620,6 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
 
-  /react-query@3.39.3(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: '*'
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.21.0
-      broadcast-channel: 3.7.0
-      match-sorter: 6.3.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
@@ -8883,6 +8840,7 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+    dev: true
 
   /rimraf@5.0.5:
     resolution: {integrity: sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==}
@@ -9966,13 +9924,6 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unload@2.2.0:
-    resolution: {integrity: sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==}
-    dependencies:
-      '@babel/runtime': 7.21.0
-      detect-node: 2.1.0
-    dev: false
-
   /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -10448,6 +10399,7 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
 
   /ws@8.16.0:
     resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1579,6 +1579,9 @@ importers:
 
   examples/vue/row-selection:
     dependencies:
+      '@faker-js/faker':
+        specifier: ^8.4.1
+        version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.12.0
         version: link:../../../packages/vue-table
@@ -3671,6 +3674,11 @@ packages:
   /@faker-js/faker@8.3.1:
     resolution: {integrity: sha512-FdgpFxY6V6rLZE9mmIBb9hM0xpfvQOSNOLnzolzKwsE1DH+gC7lEKV1p1IbR0lAYyvYd5a4u3qWJzowUkw1bIw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
+
+  /@faker-js/faker@8.4.1:
+    resolution: {integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
+    dev: false
 
   /@floating-ui/core@1.5.3:
     resolution: {integrity: sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==}


### PR DESCRIPTION
feat: Added `rowCount` table option as an alternative to `pageCount`
feat: Added `getRowCount` table instance API
feat: Added `firstPage` table instance API
feat: Added `lastPage` table instance API
feat:  Deprecated `setPageCount` API
docs: Updated pagination API Docs
docs: Wrote new Pagination Guide
docs: Updated the Pagination and Pagination Controlled examples