### PR TITLE
docs: update `columnGroupingMode` to `groupedColumnMode`

### DIFF
--- a/docs/guide/column-ordering.md
+++ b/docs/guide/column-ordering.md
@@ -23,7 +23,7 @@ There are 3 table features that can reorder columns, which happen in the followi
 
 1. [Column Pinning](../guide/column-pinning) - If pinning, columns are split into left, center (unpinned), and right pinned columns.
 2. Manual **Column Ordering** - A manually specified column order is applied.
-3. [Grouping](../guide/grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.columnGroupingMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
+3. [Grouping](../guide/grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
 > **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 

--- a/docs/guide/column-pinning.md
+++ b/docs/guide/column-pinning.md
@@ -29,7 +29,7 @@ There are 3 table features that can reorder columns, which happen in the followi
 
 1. **Column Pinning** - If pinning, columns are split into left, center (unpinned), and right pinned columns.
 2. Manual [Column Ordering](../guide/column-ordering) - A manually specified column order is applied.
-3. [Grouping](../guide/grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.columnGroupingMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
+3. [Grouping](../guide/grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
 The only way to change the order of the pinned columns is in the `columnPinning.left` and `columnPinning.right` state itself. `columnOrder` state will only affect the order of the unpinned ("center") columns.
 

--- a/docs/guide/grouping.md
+++ b/docs/guide/grouping.md
@@ -18,4 +18,4 @@ There are 3 table features that can reorder columns, which happen in the followi
 
 1. [Column Pinning](../guide/column-pinning) - If pinning, columns are split into left, center (unpinned), and right pinned columns.
 2. Manual [Column Ordering](../guide/column-ordering) - A manually specified column order is applied.
-3. **Grouping** - If grouping is enabled, a grouping state is active, and `tableOptions.columnGroupingMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
+3. **Grouping** - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.


### PR DESCRIPTION
The doc mentions `columnGroupingMode`. I believe it refers to `groupedColumnMode`. Looks like the prop was renamed in some previous versions.

Great library btw, thanks a lot!