### PR TITLE
fix: column getIsVisible works for parent group columns

### DIFF
--- a/packages/react-table/__tests__/features/__snapshots__/Visibility.test.tsx.snap
+++ b/packages/react-table/__tests__/features/__snapshots__/Visibility.test.tsx.snap
@@ -4,12 +4,8 @@ exports[`useReactTable > can toggle column visibility > 0 - after toggling all o
 {
   "footers": [
     [],
-    [],
-    [],
   ],
   "headers": [
-    [],
-    [],
     [],
   ],
   "rows": [
@@ -306,20 +302,6 @@ exports[`useReactTable > can toggle column visibility > 3 - after toggling More 
     ],
     [
       [
-        "",
-        "1",
-      ],
-      [
-        "",
-        "1",
-      ],
-      [
-        "",
-        "1",
-      ],
-    ],
-    [
-      [
         "Name",
         "2",
       ],
@@ -337,20 +319,6 @@ exports[`useReactTable > can toggle column visibility > 3 - after toggling More 
       ],
       [
         "Info",
-        "1",
-      ],
-    ],
-    [
-      [
-        "",
-        "1",
-      ],
-      [
-        "",
-        "1",
-      ],
-      [
-        "",
         "1",
       ],
     ],

--- a/packages/table-core/src/features/Visibility.ts
+++ b/packages/table-core/src/features/Visibility.ts
@@ -178,7 +178,12 @@ export const Visibility: TableFeature = {
       }
     }
     column.getIsVisible = () => {
-      return table.getState().columnVisibility?.[column.id] ?? true
+      const childColumns = column.columns
+      return (
+        (childColumns.length
+          ? childColumns.some(c => c.getIsVisible())
+          : table.getState().columnVisibility?.[column.id]) ?? true
+      )
     }
 
     column.getCanHide = () => {


### PR DESCRIPTION
This allows `column.getIsVisible()` to return an accurate value for group columns. Only Leaf columns ids are storied in the `columnVisibility` state by default. Parent columns will only be visible if at least one of their child columns are visible. (recursive)