### PR TITLE
fix(selection): update logic to fix selection of disabled rows

### DIFF
--- a/examples/react/row-selection/src/main.tsx
+++ b/examples/react/row-selection/src/main.tsx
@@ -30,7 +30,7 @@ function App() {
           <IndeterminateCheckbox
             {...{
               checked: table.getIsAllRowsSelected(),
-              indeterminate: table.getIsSomeRowsSelected(),
+              indeterminate: table.getIsSomeRowsSelected(true),
               onChange: table.getToggleAllRowsSelectedHandler(),
             }}
           />
@@ -110,8 +110,8 @@ function App() {
     state: {
       rowSelection,
     },
-    enableRowSelection: true, //enable row selection for all rows
-    // enableRowSelection: row => row.original.age > 18, // or enable row selection conditionally per row
+    // enableRowSelection: true, //enable row selection for all rows
+    enableRowSelection: row => row.original.age > 18, // or enable row selection conditionally per row
     onRowSelectionChange: setRowSelection,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
@@ -180,7 +180,7 @@ function App() {
               <IndeterminateCheckbox
                 {...{
                   checked: table.getIsAllPageRowsSelected(),
-                  indeterminate: table.getIsSomePageRowsSelected(),
+                  indeterminate: table.getIsSomePageRowsSelected(true),
                   onChange: table.getToggleAllPageRowsSelectedHandler(),
                 }}
               />
@@ -344,9 +344,9 @@ function IndeterminateCheckbox({
 
   React.useEffect(() => {
     if (typeof indeterminate === 'boolean') {
-      ref.current.indeterminate = !rest.checked && indeterminate
+      ref.current.indeterminate = indeterminate
     }
-  }, [ref, indeterminate])
+  }, [ref, indeterminate, rest.checked])
 
   return (
     <input

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -447,7 +447,7 @@ export const RowSelection: TableFeature = {
               d => d.getIsSelected() || d.getIsSomeSelected()
             ) &&
               paginationFlatRows.some(
-                d => !d.getIsSelected() && !d.getIsSomeSelected()
+                d => !d.getIsSelected() || !d.getIsSomeSelected()
               )
           : paginationFlatRows
               .filter(row => row.getCanSelect())

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -1,5 +1,5 @@
 import { TableFeature } from '../core/table'
-import { OnChangeFn, Table, Row, RowModel, Updater, RowData } from '../types'
+import { OnChangeFn, Row, RowData, RowModel, Table, Updater } from '../types'
 import { getMemoOptions, makeStateUpdater, memo } from '../utils'
 
 export type RowSelectionState = Record<string, boolean>
@@ -118,7 +118,7 @@ export interface RowSelectionInstance<TData extends RowData> {
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getisallpagerowsselected)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
    */
-  getIsAllPageRowsSelected: () => boolean
+  getIsAllPageRowsSelected: (ignoreCanSelect?: boolean) => boolean
   /**
    * Returns whether or not all rows in the table are selected.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getisallrowsselected)
@@ -130,7 +130,7 @@ export interface RowSelectionInstance<TData extends RowData> {
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getissomepagerowsselected)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
    */
-  getIsSomePageRowsSelected: () => boolean
+  getIsSomePageRowsSelected: (ignoreCanSelect?: boolean) => boolean
   /**
    * Returns whether or not any rows in the table are selected.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getissomerowsselected)
@@ -238,6 +238,9 @@ export const RowSelection: TableFeature = {
           })
         } else {
           preGroupedFlatRows.forEach(row => {
+            if (!row.getCanSelect()) {
+              return
+            }
             delete rowSelection[row.id]
           })
         }
@@ -253,7 +256,6 @@ export const RowSelection: TableFeature = {
             : !table.getIsAllPageRowsSelected()
 
         const rowSelection: RowSelectionState = { ...old }
-
         table.getRowModel().rows.forEach(row => {
           mutateRowIsSelected(rowSelection, row.id, resolvedValue, true, table)
         })
@@ -405,17 +407,20 @@ export const RowSelection: TableFeature = {
       return isAllRowsSelected
     }
 
-    table.getIsAllPageRowsSelected = () => {
-      const paginationFlatRows = table
-        .getPaginationRowModel()
-        .flatRows.filter(row => row.getCanSelect())
+    table.getIsAllPageRowsSelected = (ignoreCanSelect?: boolean) => {
+      const paginationFlatRows = table.getPaginationRowModel().flatRows
+
+      const filterPaginationFlatRows = ignoreCanSelect
+        ? paginationFlatRows
+        : paginationFlatRows.filter(row => row.getCanSelect())
+
       const { rowSelection } = table.getState()
 
-      let isAllPageRowsSelected = !!paginationFlatRows.length
+      let isAllPageRowsSelected = !!filterPaginationFlatRows.length
 
       if (
         isAllPageRowsSelected &&
-        paginationFlatRows.some(row => !rowSelection[row.id])
+        filterPaginationFlatRows.some(row => !rowSelection[row.id])
       ) {
         isAllPageRowsSelected = false
       }
@@ -433,13 +438,25 @@ export const RowSelection: TableFeature = {
       )
     }
 
-    table.getIsSomePageRowsSelected = () => {
+    table.getIsSomePageRowsSelected = (ignoreCanSelect?: boolean) => {
       const paginationFlatRows = table.getPaginationRowModel().flatRows
-      return table.getIsAllPageRowsSelected()
+
+      const getSelectedRowsBySelectCondition = () => {
+        return ignoreCanSelect
+          ? paginationFlatRows.some(
+              d => d.getIsSelected() || d.getIsSomeSelected()
+            ) &&
+              paginationFlatRows.some(
+                d => !d.getIsSelected() && !d.getIsSomeSelected()
+              )
+          : paginationFlatRows
+              .filter(row => row.getCanSelect())
+              .some(d => d.getIsSelected() || d.getIsSomeSelected())
+      }
+
+      return table.getIsAllPageRowsSelected(ignoreCanSelect)
         ? false
-        : paginationFlatRows
-            .filter(row => row.getCanSelect())
-            .some(d => d.getIsSelected() || d.getIsSomeSelected())
+        : getSelectedRowsBySelectCondition()
     }
 
     table.getToggleAllRowsSelectedHandler = () => {
@@ -552,14 +569,16 @@ const mutateRowIsSelected = <TData extends RowData>(
   //   !isGrouped ||
   //   (isGrouped && table.options.enableGroupingRowSelection)
   // ) {
+
+  const canSelect = row.getCanSelect()
   if (value) {
     if (!row.getCanMultiSelect()) {
       Object.keys(selectedRowIds).forEach(key => delete selectedRowIds[key])
     }
-    if (row.getCanSelect()) {
+    if (canSelect) {
       selectedRowIds[id] = true
     }
-  } else {
+  } else if (canSelect) {
     delete selectedRowIds[id]
   }
   // }

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -178,7 +178,10 @@ export interface RowSelectionInstance<TData extends RowData> {
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#toggleallpagerowsselected)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
    */
-  toggleAllPageRowsSelected: (value?: boolean) => void
+  toggleAllPageRowsSelected: (
+    value?: boolean,
+    ignoreCanSelect?: boolean
+  ) => void
   /**
    * Selects/deselects all rows in the table.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#toggleallrowsselected)
@@ -248,12 +251,12 @@ export const RowSelection: TableFeature = {
         return rowSelection
       })
     }
-    table.toggleAllPageRowsSelected = value =>
+    table.toggleAllPageRowsSelected = (value, ignoreCanSelect) =>
       table.setRowSelection(old => {
         const resolvedValue =
           typeof value !== 'undefined'
             ? value
-            : !table.getIsAllPageRowsSelected()
+            : !table.getIsAllPageRowsSelected(ignoreCanSelect)
 
         const rowSelection: RowSelectionState = { ...old }
         table.getRowModel().rows.forEach(row => {
@@ -441,7 +444,7 @@ export const RowSelection: TableFeature = {
     table.getIsSomePageRowsSelected = (ignoreCanSelect?: boolean) => {
       const paginationFlatRows = table.getPaginationRowModel().flatRows
 
-      const getSelectedRowsBySelectCondition = () => {
+      const getIsSomeSelectedByCondition = () => {
         return ignoreCanSelect
           ? paginationFlatRows.some(
               d => d.getIsSelected() || d.getIsSomeSelected()
@@ -456,7 +459,7 @@ export const RowSelection: TableFeature = {
 
       return table.getIsAllPageRowsSelected(ignoreCanSelect)
         ? false
-        : getSelectedRowsBySelectCondition()
+        : getIsSomeSelectedByCondition()
     }
 
     table.getToggleAllRowsSelectedHandler = () => {


### PR DESCRIPTION
Fix issue:

https://github.com/TanStack/table/issues/5398

We updated logic for selection of disabled rows (at least for pagination).

Here next possible flows:

1. One row disabled and selected then click on Footer checkbox:
- if all other rows selected - Footer checkbox: SELECTED
- if all other rows unselected - Footer checkbox: INDETERMINATE

2. One row disabled and unselected then click on Footer checkbox:
- if all other rows selected - Footer checkbox: INDETERMINATE
- if all other rows unselected - Footer checkbox: UNSELECTED

3. One row disabled and selected and One row disabled and unselected then click on Footer checkbox:
- if all other rows selected - Footer checkbox: INDETERMINATE
- if all other rows unselected - Footer checkbox: INDETERMINATE

Status of all enabled checkboxes always will be toggled, but sign inside Footer checkbox will show real state of all checkboxes

P.S. Also `getToggleAllRowsSelectedHandler` respect disabled checkboxes