### PR TITLE
fix(table-core): narrow types for columns created by ColumnHelper

### DIFF
--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -1,5 +1,7 @@
 import {
   AccessorFn,
+  AccessorFnColumnDef,
+  AccessorKeyColumnDef,
   ColumnDef,
   DisplayColumnDef,
   GroupColumnDef,
@@ -20,7 +22,7 @@ import { DeepKeys, DeepValue } from './utils'
 //     foo: [
 //       {
 //         bar: 'bar'
-//       }
+//       },
 //     ]
 //     bar: { subBar: boolean }[]
 //     baz: {
@@ -62,9 +64,11 @@ export type ColumnHelper<TData extends RowData> = {
     column: TAccessor extends AccessorFn<TData>
       ? DisplayColumnDef<TData, TValue>
       : IdentifiedColumnDef<TData, TValue>
-  ) => ColumnDef<TData, TValue>
-  display: (column: DisplayColumnDef<TData>) => ColumnDef<TData, unknown>
-  group: (column: GroupColumnDef<TData>) => ColumnDef<TData, unknown>
+  ) => TAccessor extends AccessorFn<TData>
+    ? AccessorFnColumnDef<TData, TValue>
+    : AccessorKeyColumnDef<TData, TValue>
+  display: (column: DisplayColumnDef<TData>) => DisplayColumnDef<TData, unknown>
+  group: (column: GroupColumnDef<TData>) => GroupColumnDef<TData, unknown>
 }
 
 export function createColumnHelper<
@@ -82,7 +86,7 @@ export function createColumnHelper<
             accessorKey: accessor,
           }
     },
-    display: column => column as ColumnDef<TData, unknown>,
-    group: column => column as ColumnDef<TData, unknown>,
+    display: column => column,
+    group: column => column,
   }
 }

--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -2,7 +2,6 @@ import {
   AccessorFn,
   AccessorFnColumnDef,
   AccessorKeyColumnDef,
-  ColumnDef,
   DisplayColumnDef,
   GroupColumnDef,
   IdentifiedColumnDef,

--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -22,7 +22,7 @@ import { DeepKeys, DeepValue } from './utils'
 //     foo: [
 //       {
 //         bar: 'bar'
-//       },
+//       }
 //     ]
 //     bar: { subBar: boolean }[]
 //     baz: {


### PR DESCRIPTION
Fixes https://github.com/TanStack/table/issues/5423

Updates return type of the columns created by
- ColumnHelper.accessor to AccessorFnColumnDef or AccessorKeyColumnDef
- ColumnHelper.display to DisplayColumnDef
- ColumnHelper.group to GroupColumnDef

<img width="499" alt="Screenshot 2024-03-19 at 7 34 38 PM" src="https://github.com/TanStack/table/assets/20136533/7a8e7a65-9ce4-4fd2-abb7-04dbfd100a9d">
