### PR TITLE
feat(angular-table): angular adapter implementation with signals

### DIFF
--- a/examples/angular/basic/angular.json
+++ b/examples/angular/basic/angular.json
@@ -4,6 +4,11 @@
   "newProjectRoot": "projects",
   "projects": {
     "basic": {
+      "cli": {
+        "cache": {
+          "enabled": false
+        }
+      },
       "projectType": "application",
       "schematics": {
         "@schematics/angular:component": {

--- a/examples/angular/basic/src/app/app.component.html
+++ b/examples/angular/basic/src/app/app.component.html
@@ -1,65 +1,61 @@
-@if (table) {
-  <table aria-describedby="tanstack basic implementation in angular">
-    <thead>
-      @for (headerGroup of table.getHeaderGroups(); track headerGroup.id) {
-        <tr>
-          @for (header of headerGroup.headers; track header.id) {
-            @if (!header.isPlaceholder) {
-              <th>
-                <ng-container
-                  *flexRender="
+<table aria-describedby="tanstack basic implementation in angular">
+  <thead>
+    @for (headerGroup of table.getHeaderGroups(); track headerGroup.id) {
+      <tr>
+        @for (header of headerGroup.headers; track header.id) {
+          @if (!header.isPlaceholder) {
+            <th>
+              <ng-container
+                *flexRender="
                     header.column.columnDef.header;
                     props: header.getContext();
                     let header
                   "
-                >
-                  {{ header }}
-                </ng-container>
-              </th>
-            }
+              >
+                {{ header }}
+              </ng-container>
+            </th>
           }
-        </tr>
-      }
-    </thead>
-    <tbody>
-      @for (row of table.getRowModel().rows; track row.id) {
-        <tr>
-          @for (cell of row.getVisibleCells(); track cell.id) {
-            <td>
-              <ng-container
-                *flexRender="
+        }
+      </tr>
+    }
+  </thead>
+  <tbody>
+    @for (row of table.getRowModel().rows; track row.id) {
+      <tr>
+        @for (cell of row.getVisibleCells(); track cell.id) {
+          <td>
+            <ng-container
+              *flexRender="
                   cell.column.columnDef.cell;
                   props: cell.getContext();
                   let cell
                 "
-              >
-                {{ cell }}
-              </ng-container>
-            </td>
-          }
-        </tr>
-      }
-    </tbody>
-    <tfoot>
-      @for (footerGroup of table.getFooterGroups(); track footerGroup.id) {
-        <tr>
-          @for (footer of footerGroup.headers; track footer.id) {
-            <th>
-              <ng-container
-                *flexRender="
+            >
+              {{ cell }}
+            </ng-container>
+          </td>
+        }
+      </tr>
+    }
+  </tbody>
+  <tfoot>
+    @for (footerGroup of table.getFooterGroups(); track footerGroup.id) {
+      <tr>
+        @for (footer of footerGroup.headers; track footer.id) {
+          <th>
+            <ng-container
+              *flexRender="
                   footer.column.columnDef.footer;
                   props: footer.getContext();
                   let footer
                 "
-              >
-                {{ footer }}
-              </ng-container>
-            </th>
-          }
-        </tr>
-      }
-    </tfoot>
-  </table>
-} @else {
-  <p>loading...</p>
-}
+            >
+              {{ footer }}
+            </ng-container>
+          </th>
+        }
+      </tr>
+    }
+  </tfoot>
+</table>

--- a/examples/angular/basic/src/app/app.component.ts
+++ b/examples/angular/basic/src/app/app.component.ts
@@ -1,10 +1,14 @@
-import { Component } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  type OnInit,
+  signal,
+} from '@angular/core'
 import { RouterOutlet } from '@angular/router'
 import {
   ColumnDef,
-  FlexRenderDirective,
-  Table,
   createAngularTable,
+  FlexRenderDirective,
   getCoreRowModel,
 } from '@tanstack/angular-table'
 
@@ -87,16 +91,18 @@ const defaultData: Person[] = [
   imports: [RouterOutlet, FlexRenderDirective],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class AppComponent {
-  data: Person[] = []
-  table!: Table<Person>
+export class AppComponent implements OnInit {
+  data = signal<Person[]>([])
+
+  table = createAngularTable(() => ({
+    data: this.data(),
+    columns: defaultColumns,
+    getCoreRowModel: getCoreRowModel(),
+  }))
+
   ngOnInit() {
-    this.data = [...defaultData]
-    this.table = createAngularTable({
-      data: this.data,
-      columns: defaultColumns,
-      getCoreRowModel: getCoreRowModel(),
-    })
+    this.data.set(defaultData)
   }
 }

--- a/examples/angular/grouping/angular.json
+++ b/examples/angular/grouping/angular.json
@@ -82,5 +82,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false,
+    "cache": {
+      "enabled": false
+    }
   }
 }

--- a/examples/angular/grouping/src/app/app.component.html
+++ b/examples/angular/grouping/src/app/app.component.html
@@ -1,17 +1,16 @@
 <div class="tanstack-table">
   <h2>Grouping</h2>
-  @if (table) {
-    <table aria-describedby="tanstack table grouping implementation in angular">
-      <thead>
-        @for (headerGroup of table.getHeaderGroups(); track headerGroup.id) {
-          <tr>
-            @for (header of headerGroup.headers; track header.id) {
-              <th [attr.colSpan]="header.colSpan">
-                @if (!header.isPlaceholder && header.column.getCanGroup()) {
-                  <button
-                    id="group-btn"
-                    (click)="header.column.toggleGrouping()"
-                  >
+  <table aria-describedby="tanstack table grouping implementation in angular">
+    <thead>
+      @for (headerGroup of table.getHeaderGroups(); track headerGroup.id) {
+        <tr>
+          @for (header of headerGroup.headers; track header.id) {
+            <th [attr.colSpan]="header.colSpan">
+              @if (!header.isPlaceholder && header.column.getCanGroup()) {
+                <button
+                  id="group-btn"
+                  (click)="header.column.toggleGrouping()"
+                >
                     <span class="material-icons-sharp">
                       {{
                         header.column.getIsGrouped()
@@ -19,72 +18,71 @@
                           : 'add_circle_outline'
                       }}
                     </span>
-                  </button>
-                  <ng-container
-                    *flexRender="
+                </button>
+                <ng-container
+                  *flexRender="
                       header.column.columnDef.header;
                       props: header.getContext;
                       let header
                     "
-                  >
-                    <span>{{ header }}</span>
-                  </ng-container>
-                }
-              </th>
-            }
-          </tr>
-        }
-      </thead>
-      <tbody>
-        <ng-container *ngFor="let row of table.getRowModel().rows">
-          <tr>
-            @for (cell of row.getVisibleCells(); track cell.id) {
-              <td>
-                @if (cell.getIsGrouped()) {
-                  <button (click)="row.toggleExpanded()">
+                >
+                  <span>{{ header }}</span>
+                </ng-container>
+              }
+            </th>
+          }
+        </tr>
+      }
+    </thead>
+    <tbody>
+    <ng-container *ngFor="let row of table.getRowModel().rows">
+      <tr>
+        @for (cell of row.getVisibleCells(); track cell.id) {
+          <td>
+            @if (cell.getIsGrouped()) {
+              <button (click)="row.toggleExpanded()">
                     <span class="material-icons-sharp">
                       {{ row.getIsExpanded() ? 'expand_less' : 'expand_more' }}
                     </span>
-                  </button>
-                  <ng-container
-                    *flexRender="
+              </button>
+              <ng-container
+                *flexRender="
                       cell.column.columnDef.cell;
                       props: cell.getContext();
                       let cell
                     "
-                  >
-                    <span>{{ cell }}</span>
-                  </ng-container>
-                } @else if (cell.getIsAggregated()) {
-                  <ng-container
-                    *flexRender="
+              >
+                <span>{{ cell }}</span>
+              </ng-container>
+            } @else if (cell.getIsAggregated()) {
+              <ng-container
+                *flexRender="
                       cell.column.columnDef.aggregatedCell;
                       props: cell.getContext();
                       let aggregatedCell
                     "
-                  >
-                    {{ aggregatedCell }}
-                  </ng-container>
-                } @else if (cell.getIsPlaceholder()) {
-                  <span></span>
-                } @else {
-                  <ng-container
-                    *flexRender="
+              >
+                {{ aggregatedCell }}
+              </ng-container>
+            } @else if (cell.getIsPlaceholder()) {
+              <span></span>
+            } @else {
+              <ng-container
+                *flexRender="
                       cell.column.columnDef.cell;
                       props: cell.getContext();
                       let cell
                     "
-                  >
-                    {{ cell }}
-                  </ng-container>
-                }
-              </td>
+              >
+                {{ cell }}
+              </ng-container>
             }
-          </tr>
-        </ng-container>
-      </tbody>
-    </table>
-  }
+          </td>
+        }
+      </tr>
+    </ng-container>
+    </tbody>
+  </table>
 
   <div class="pagination-container">
     <div class="pagination-actions">
@@ -137,12 +135,14 @@
         class="pagination-select"
         (change)="onPageSizeChange($event)"
       >
-        <option
-          *ngFor="let pageSize of [10, 20, 30, 40, 50]"
-          [value]="pageSize"
-        >
-          Show {{ pageSize }}
-        </option>
+        @for (pageSize of [10, 20, 30, 40, 50]; track pageSize) {
+          <option
+            [value]="pageSize"
+          >
+            Show {{ pageSize }}
+          </option>
+        }
+
       </select>
     </div>
   </div>

--- a/examples/angular/grouping/src/app/app.component.ts
+++ b/examples/angular/grouping/src/app/app.component.ts
@@ -1,5 +1,5 @@
-import { CommonModule, NgFor, NgIf } from '@angular/common'
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core'
+import {CommonModule} from '@angular/common'
+import {ChangeDetectionStrategy, Component, computed, effect, signal} from '@angular/core'
 import {
   createAngularTable,
   ExpandedState,
@@ -13,8 +13,8 @@ import {
   PaginationState,
   Updater,
 } from '@tanstack/angular-table'
-import { columns } from './columns'
-import { mockData } from './mockdata'
+import {columns} from './columns'
+import {mockData} from './mockdata'
 
 @Component({
   selector: 'app-root',
@@ -65,7 +65,29 @@ export class AppComponent {
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-  }))
+  }));
+
+  constructor() {
+    effect(() => {
+      // run on every state/option change
+      this.table().getPageOptions();
+    });
+
+    // more granular state, run on every "getPageOptions" change (e.g. only when pagination state change)
+    effect(() => {
+      this.table.getPageOptions()
+    });
+
+    // granular state is still possible using computed manually, but it must be done manually
+    const pageOptions = computed(() => this.table().getPageOptions());
+    effect(() => {
+      pageOptions()
+    });
+
+    // these two are lines does the same thing, they access to the same table instance property.
+    this.table().setPageSize(...)
+    this.table.setPageSize() // this one is evaluated lazily with proxy
+  }
 
   onPageInputChange(event: any): void {
     const page = event.target.value ? Number(event.target.value) - 1 : 0

--- a/examples/angular/grouping/src/app/app.component.ts
+++ b/examples/angular/grouping/src/app/app.component.ts
@@ -1,105 +1,71 @@
 import { CommonModule, NgFor, NgIf } from '@angular/common'
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core'
 import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  OnDestroy,
-  OnInit,
-} from '@angular/core'
-import {
+  createAngularTable,
   ExpandedState,
   FlexRenderDirective,
-  GroupingState,
-  PaginationState,
-  Table,
-  Updater,
-  createAngularTable,
   getCoreRowModel,
   getExpandedRowModel,
   getFilteredRowModel,
   getGroupedRowModel,
   getPaginationRowModel,
+  GroupingState,
+  PaginationState,
+  Updater,
 } from '@tanstack/angular-table'
-
-import { BehaviorSubject, Subject, combineLatest, takeUntil } from 'rxjs'
-import { Person, columns } from './columns'
+import { columns } from './columns'
 import { mockData } from './mockdata'
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [NgIf, NgFor, FlexRenderDirective, CommonModule],
+  imports: [FlexRenderDirective, CommonModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AppComponent implements OnInit, OnDestroy {
+export class AppComponent {
   title = 'grouping'
-
-  private destroy$ = new Subject<void>()
-  data = mockData(10000)
-  groupingState = new BehaviorSubject<GroupingState>([])
-  expandedState = new BehaviorSubject<ExpandedState>({})
-  paginationState = new BehaviorSubject<PaginationState>({
+  data = signal(mockData(10000))
+  groupingState = signal<GroupingState>([])
+  expandedState = signal<ExpandedState>({})
+  paginationState = signal<PaginationState>({
     pageIndex: 0,
     pageSize: 10,
   } as PaginationState)
-  table!: Table<Person>
-  expanded: ExpandedState = {}
-  constructor(private cdr: ChangeDetectorRef) {}
+  expanded = signal<ExpandedState>({})
 
-  ngOnInit() {
-    this.createTable()
-    combineLatest([
-      this.expandedState,
-      this.groupingState,
-      this.paginationState,
-    ])
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(([expandedState, groupingState, paginationState]) => {
-        this.table.options.state.grouping = groupingState
-        this.table.options.state.expanded = expandedState
-        this.table.options.state.pagination = paginationState
-        this.cdr.detectChanges()
-      })
-  }
-
-  createTable() {
-    this.table = createAngularTable({
-      data: this.data,
-      columns: columns,
-      state: {
-        grouping: this.groupingState.getValue(),
-        expanded: this.expandedState.getValue(),
-        pagination: this.paginationState.getValue(),
-      },
-      onGroupingChange: (updaterOrValue: Updater<GroupingState>) => {
-        const group =
-          typeof updaterOrValue === 'function'
-            ? updaterOrValue([...this.groupingState.getValue()])
-            : updaterOrValue
-        this.groupingState.next(group)
-      },
-      onExpandedChange: updater => {
-        const expand =
-          typeof updater === 'function'
-            ? updater(this.expandedState.getValue())
-            : updater
-        this.expandedState.next(expand)
-      },
-      debugTable: true,
-      onPaginationChange: val => {
-        const page =
-          typeof val === 'function' ? val(this.paginationState.getValue()) : val
-        this.paginationState.next(page)
-      },
-      getExpandedRowModel: getExpandedRowModel(),
-      getGroupedRowModel: getGroupedRowModel(),
-      getCoreRowModel: getCoreRowModel(),
-      getPaginationRowModel: getPaginationRowModel(),
-      getFilteredRowModel: getFilteredRowModel(),
-    })
-  }
+  table = createAngularTable(() => ({
+    data: this.data(),
+    columns: columns,
+    state: {
+      grouping: this.groupingState(),
+      expanded: this.expandedState(),
+      pagination: this.paginationState(),
+    },
+    onGroupingChange: (updaterOrValue: Updater<GroupingState>) => {
+      const group =
+        typeof updaterOrValue === 'function'
+          ? updaterOrValue([...this.groupingState()])
+          : updaterOrValue
+      this.groupingState.set(group)
+    },
+    onExpandedChange: updater => {
+      const expand =
+        typeof updater === 'function' ? updater(this.expandedState()) : updater
+      this.expandedState.set(expand)
+    },
+    onPaginationChange: val => {
+      const page = typeof val === 'function' ? val(this.paginationState()) : val
+      this.paginationState.set(page)
+    },
+    debugTable: true,
+    getExpandedRowModel: getExpandedRowModel(),
+    getGroupedRowModel: getGroupedRowModel(),
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  }))
 
   onPageInputChange(event: any): void {
     const page = event.target.value ? Number(event.target.value) - 1 : 0
@@ -111,10 +77,6 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   refreshData() {
-    this.table.options.data = mockData(1000)
-  }
-  ngOnDestroy(): void {
-    this.destroy$.next()
-    this.destroy$.complete()
+    this.data.set(mockData(1000))
   }
 }

--- a/examples/angular/row-selection/angular.json
+++ b/examples/angular/row-selection/angular.json
@@ -84,6 +84,9 @@
     }
   },
   "cli": {
-    "analytics": false
+    "analytics": false,
+    "cache": {
+      "enabled": false
+    }
   }
 }

--- a/examples/angular/row-selection/src/app/app.component.html
+++ b/examples/angular/row-selection/src/app/app.component.html
@@ -1,107 +1,105 @@
 <h2>Select</h2>
-@if (table) {
-  <table aria-describedby="tanstack table row select implementation in angular">
-    <thead>
-      @for (headerGroup of table.getHeaderGroups(); track headerGroup.id) {
-        <tr>
-          @for (header of headerGroup.headers; track header.id) {
-            <th
-              [attr.colSpan]="header.colSpan"
-              (click)="header.column.toggleSorting()"
-            >
-              @if (!header.isPlaceholder) {
-                @if (header.id == 'select') {
-                  <input
-                    type="checkbox"
-                    id="select"
-                    [checked]="table.getIsAllRowsSelected()"
-                    [indeterminate]="table.getIsSomeRowsSelected()"
-                    (change)="table.toggleAllRowsSelected()"
-                  />
-                } @else {
-                  <ng-container
-                    *flexRender="
-                      header.column.columnDef.header;
-                      props: header.getContext();
-                      let headerCell
-                    "
-                  >
-                    {{ headerCell }}
-                    @if (header.column.getCanSort()) {
-                      <span class="material-icons-sharp">
-                        {{
-                          header.column.getIsSorted() === 'asc'
-                            ? 'arrow_drop_up'
-                            : header.column.getIsSorted() === 'desc'
-                              ? 'arrow_drop_down'
-                              : ''
-                        }}
-                      </span>
-                    }
-                  </ng-container>
-                  @if (header.column.getCanFilter()) {
-                    <Filter [column]="header.column" [table]="table"></Filter>
-                  }
-                }
-              }
-            </th>
-          }
-        </tr>
-      }
-    </thead>
-    <tbody>
-      @for (row of table.getRowModel().rows; track row.id) {
-        <tr>
-          @for (cell of row.getVisibleCells(); track cell.id) {
-            <td>
-              @if (cell.id.endsWith('select')) {
+<table aria-describedby="tanstack table row select implementation in angular">
+  <thead>
+    @for (headerGroup of table.getHeaderGroups(); track headerGroup.id) {
+      <tr>
+        @for (header of headerGroup.headers; track header.id) {
+          <th
+            [attr.colSpan]="header.colSpan"
+            (click)="header.column.toggleSorting()"
+          >
+            @if (!header.isPlaceholder) {
+              @if (header.id == 'select') {
                 <input
                   type="checkbox"
                   id="select"
-                  [checked]="row.getIsSelected()"
-                  [disabled]="!row.getCanSelect()"
-                  [indeterminate]="row.getIsSomeSelected()"
-                  (change)="row.toggleSelected()"
+                  [checked]="table.getIsAllRowsSelected()"
+                  [indeterminate]="table.getIsSomeRowsSelected()"
+                  (change)="table.toggleAllRowsSelected()"
                 />
               } @else {
                 <ng-container
                   *flexRender="
+                      header.column.columnDef.header;
+                      props: header.getContext();
+                      let headerCell
+                    "
+                >
+                  {{ headerCell }}
+                  @if (header.column.getCanSort()) {
+                    <span class="material-icons-sharp">
+                        {{
+                        header.column.getIsSorted() === 'asc'
+                          ? 'arrow_drop_up'
+                          : header.column.getIsSorted() === 'desc'
+                            ? 'arrow_drop_down'
+                            : ''
+                      }}
+                      </span>
+                  }
+                </ng-container>
+                @if (header.column.getCanFilter()) {
+                  <Filter [column]="header.column" [table]="table"></Filter>
+                }
+              }
+            }
+          </th>
+        }
+      </tr>
+    }
+  </thead>
+  <tbody>
+    @for (row of table.getRowModel().rows; track row.id) {
+      <tr>
+        @for (cell of row.getVisibleCells(); track cell.id) {
+          <td>
+            @if (cell.id.endsWith('select')) {
+              <input
+                type="checkbox"
+                id="select"
+                [checked]="row.getIsSelected()"
+                [disabled]="!row.getCanSelect()"
+                [indeterminate]="row.getIsSomeSelected()"
+                (change)="row.toggleSelected()"
+              />
+            } @else {
+              <ng-container
+                *flexRender="
                     cell.column.columnDef.cell;
                     props: cell.getContext();
                     let renderCell
                   "
-                >
-                  {{ renderCell }}
-                </ng-container>
-              }
-            </td>
-          }
-        </tr>
-      }
-    </tbody>
-    <tfoot>
-      <tr>
-        <th>
-          <input
-            type="checkbox"
-            name=""
-            id=""
-            [checked]="table.getIsAllPageRowsSelected()"
-            [indeterminate]="table.getIsSomePageRowsSelected()"
-            (change)="table.toggleAllPageRowsSelected()"
-          />
-        </th>
-        <th [attr.colspan]="6">
-          Page Rows ({{ table.getRowModel().rows.length }})
-        </th>
+              >
+                {{ renderCell }}
+              </ng-container>
+            }
+          </td>
+        }
       </tr>
-    </tfoot>
-  </table>
-}
+    }
+  </tbody>
+  <tfoot>
+  <tr>
+    <th>
+      <input
+        type="checkbox"
+        name=""
+        id=""
+        [checked]="table.getIsAllPageRowsSelected()"
+        [indeterminate]="table.getIsSomePageRowsSelected()"
+        (change)="table.toggleAllPageRowsSelected()"
+      />
+    </th>
+    <th [attr.colspan]="6">
+      Page Rows ({{ table.getRowModel().rows.length }})
+    </th>
+  </tr>
+  </tfoot>
+</table>
 
 <div class="pagination-container">
   <div>
-    {{ getRowSelectionLength() | async }} of
+    {{ rowSelectionLength() }} of
     {{ table.getPreFilteredRowModel().rows.length }} Total Rows Selected
   </div>
   <div class="pagination-actions">
@@ -154,9 +152,11 @@
       class="pagination-select"
       (change)="onPageSizeChange($event)"
     >
-      <option *ngFor="let pageSize of [10, 20, 30, 40, 50]" [value]="pageSize">
-        Show {{ pageSize }}
-      </option>
+      @for (pageSize of [10, 20, 30, 40, 50]; track pageSize) {
+        <option [value]="pageSize">
+          Show {{ pageSize }}
+        </option>
+      }
     </select>
   </div>
 </div>

--- a/packages/angular-table/ng-package.json
+++ b/packages/angular-table/ng-package.json
@@ -4,5 +4,6 @@
   "lib": {
     "entryFile": "src/index.ts"
   },
+  "deleteDestPath": false,
   "allowedNonPeerDependencies": ["@tanstack/table-core"]
 }

--- a/packages/angular-table/src/index.ts
+++ b/packages/angular-table/src/index.ts
@@ -88,7 +88,7 @@ export function createAngularTable<TData extends RowData>(
       }
     })
 
-    const table = signal(createTable(resolvedOptionsSignal()), {
+    const table = signal(createTable(untracked(resolvedOptionsSignal)), {
       equal: () => false,
     })
     const state = signal(untracked(table).initialState)
@@ -108,19 +108,17 @@ export function createAngularTable<TData extends RowData>(
             resolvedOptions.onStateChange?.(updater)
           },
         }))
-        table.update(v => v)
       })
     }
 
     updateOptions()
 
-    let skip = true
     effect(() => {
       void [state(), resolvedOptionsSignal()]
-      if (skip) {
-        return (skip = false)
-      }
-      untracked(() => updateOptions())
+      untracked(() => {
+        updateOptions()
+        table.update(value => ({ ...value }))
+      })
     })
 
     return proxifyTable(table.asReadonly())

--- a/packages/angular-table/src/index.ts
+++ b/packages/angular-table/src/index.ts
@@ -14,12 +14,11 @@ import {
 } from '@angular/core'
 import {
   createTable,
-  getCoreRowModel,
   RowData,
   TableOptions,
   TableOptionsResolved,
 } from '@tanstack/table-core'
-import { proxifyTable, type TableProxy } from './proxy'
+import { proxifyTable, type TableResult } from './proxy'
 
 export * from '@tanstack/table-core'
 
@@ -77,7 +76,7 @@ export class FlexRenderDirective implements OnInit {
 
 export function createAngularTable<TData extends RowData>(
   options: () => TableOptions<TData>
-): TableProxy<TData> {
+): TableResult<TData> {
   const injector = inject(Injector)
   return runInInjectionContext(injector, () => {
     const resolvedOptionsSignal = computed<TableOptionsResolved<TData>>(() => {

--- a/packages/angular-table/src/proxy.ts
+++ b/packages/angular-table/src/proxy.ts
@@ -1,0 +1,71 @@
+import { computed, isSignal, type Signal, untracked } from '@angular/core'
+import type { Table } from '@tanstack/table-core'
+
+type _TableProxyAccessor<T> = T extends () => infer U ? Signal<U> : never
+
+type _TableProxy<T extends Table<any>> = {
+  [K in keyof T]: K extends `get${string}` ? _TableProxyAccessor<T[K]> : T[K]
+} & {
+  options: Signal<T['options']>
+}
+
+export type TableProxy<T> = Signal<Table<T>> & _TableProxy<Table<T>>
+
+// WIP
+export function proxifyTable<T>(tableSignal: Signal<Table<T>>) {
+  const proxyTable = new Proxy(tableSignal, {
+    get(target: Signal<Table<T>>, property: keyof Table<T>): any {
+      const untypedTarget = target as any
+      const table = untracked(target)
+
+      if (!(property in table)) {
+        return untypedTarget[property]
+      }
+
+      if (isSignal(untypedTarget[property])) {
+        return untypedTarget[property]
+      }
+
+      // Try to transform all accessors into computed, skipping
+      // handlers since they don't hold any value
+      if (property.startsWith('get') && !property.endsWith('Handler')) {
+        const maybeFn = table[property] as Function | never
+        if (typeof maybeFn === 'function') {
+          // Accessors with no arguments should be treated as computed functions
+          if (maybeFn.length === 0) {
+            Object.defineProperty(untypedTarget, property, {
+              value: computed(() => untypedTarget()[property]()),
+              configurable: true,
+              enumerable: true,
+            })
+          }
+          // Accessors with one argument could be memoized, e.g. `table.getHeaderGroups`
+          if (maybeFn.length === 1) {
+            Object.defineProperty(untypedTarget, property, {
+              // TODO: check if this make sense
+              //  Computed could run again but emitted value passes through the `memo` fn
+              value: computed(() => untypedTarget()[property](), { equal: () => false }),
+              configurable: true,
+              enumerable: true,
+            })
+          }
+
+          // Accessors with arguments could be impure functions
+          if (maybeFn.length > 1) {
+            Object.defineProperty(untypedTarget, property, {
+              value: target()[property],
+              configurable: true,
+              enumerable: true,
+            })
+          }
+        }
+      }
+
+      return table[property]
+    },
+  })
+
+  return Object.assign(proxyTable, {
+    options: computed(() => tableSignal().options),
+  }) as TableProxy<T>
+}

--- a/packages/angular-table/src/proxy.ts
+++ b/packages/angular-table/src/proxy.ts
@@ -1,10 +1,10 @@
 import { computed, isSignal, type Signal, untracked } from '@angular/core'
 import type { Table } from '@tanstack/table-core'
 
-type _TableProxyAccessor<T> = T extends () => infer U ? Signal<U> : never
+type TableProxyAccessor<T> = T extends () => infer U ? Signal<U> : never
 
 type _TableProxy<T extends Table<any>> = {
-  [K in keyof T]: K extends `get${string}` ? _TableProxyAccessor<T[K]> : T[K]
+  [K in keyof T]: K extends `get${string}` ? TableProxyAccessor<T[K]> : T[K]
 } & {
   options: Signal<T['options']>
 }
@@ -13,21 +13,25 @@ export type TableProxy<T> = Signal<Table<T>> & _TableProxy<Table<T>>
 
 // WIP
 export function proxifyTable<T>(tableSignal: Signal<Table<T>>) {
+  const propertyCache: Record<string, any> = {}
+
   const proxyTable = new Proxy(tableSignal, {
     get(target: Signal<Table<T>>, property: keyof Table<T>): any {
+      if (propertyCache[property]) {
+        return propertyCache[property]
+      }
       const untypedTarget = target as any
-      const table = untracked(target)
+      if (untypedTarget[property]) {
+        return untypedTarget[property]
+      }
 
+      const table = untracked(target)
       if (!(property in table)) {
         return untypedTarget[property]
       }
 
-      if (isSignal(untypedTarget[property])) {
-        return untypedTarget[property]
-      }
-
-      // Try to transform all accessors into computed, skipping
-      // handlers since they don't hold any value
+      // Attempt to convert all accessors into computed ones,
+      // excluding handlers as they do not retain any value.
       if (property.startsWith('get') && !property.endsWith('Handler')) {
         const maybeFn = table[property] as Function | never
         if (typeof maybeFn === 'function') {
@@ -39,18 +43,40 @@ export function proxifyTable<T>(tableSignal: Signal<Table<T>>) {
               enumerable: true,
             })
           }
-          // Accessors with one argument could be memoized, e.g. `table.getHeaderGroups`
+
+          // Accessors with one argument could be a memoized fn (e.g. `getHeaderGroups(memoArgs)`)
+          // or a fn with some dependent parameter in their signature (e.g. `getIsSomeRowsPinned(position)`)
+          // TODO: need to check better this, since there are some fns that have an optional argument
           if (maybeFn.length === 1) {
+            let computedSignal: Signal<unknown> | undefined
+            const maybeComputedTrap = new Proxy(maybeFn, {
+              apply(target: any, thisArg: any, argArray: any[]): any {
+                if (argArray.length === 0) {
+                  if (computedSignal) {
+                    return computedSignal()
+                  }
+                  computedSignal = computed(() =>
+                    Reflect.apply(target, thisArg, argArray)
+                  )
+                  // We don't need the proxy anymore, so we'll override the cache value
+                  // in order to use the existing signal in the next change detection cycle
+                  propertyCache[property] = computedSignal
+                  return computedSignal()
+                }
+                return Reflect.apply(target, thisArg, argArray)
+              },
+            })
+
+            propertyCache[property] = maybeComputedTrap
+
             Object.defineProperty(untypedTarget, property, {
-              // TODO: check if this make sense
-              //  Computed could run again but emitted value passes through the `memo` fn
-              value: computed(() => untypedTarget()[property](), { equal: () => false }),
+              value: maybeComputedTrap,
               configurable: true,
               enumerable: true,
             })
           }
 
-          // Accessors with arguments could be impure functions
+          // Accessors with arguments could be impure functions, so we can't memoize the value
           if (maybeFn.length > 1) {
             Object.defineProperty(untypedTarget, property, {
               value: target()[property],

--- a/packages/angular-table/src/proxy.ts
+++ b/packages/angular-table/src/proxy.ts
@@ -55,9 +55,7 @@ export function proxifyTable<T>(tableSignal: Signal<Table<T>>) {
                   if (computedSignal) {
                     return computedSignal()
                   }
-                  computedSignal = computed(() =>
-                    Reflect.apply(target, thisArg, argArray)
-                  )
+                  computedSignal = computed(() => untypedTarget()[property]())
                   // We don't need the proxy anymore, so we'll override the cache value
                   // in order to use the existing signal in the next change detection cycle
                   propertyCache[property] = computedSignal
@@ -87,7 +85,7 @@ export function proxifyTable<T>(tableSignal: Signal<Table<T>>) {
         }
       }
 
-      return table[property]
+      return untypedTarget[property] || table[property]
     },
   })
 


### PR DESCRIPTION
This is still a wip implementation of the angular adapter with a mixed approach:

The adapter will always return a `signal` table. This is useful if passed as a component input. That signal change on every state/option change. If a signal has been used within the options, the table object will be updated automatically.

```ts
@Component({
  selector: 'app-root',
  standalone: true,
  imports: [FilterComponent, FlexRenderDirective],
  template : `
    <table>
      <thead>
        @for (headerGroup of table().getHeaderGroups(); track headerGroup.id) {
          <tr>
            @for (header of headerGroup.headers; track header.id) {
              ...
            }
          </tr>
        }
      </thead>
      <tbody>
        @for (row of table().getRowModel().rows; track row.id) {
          ...
        }
      </tbody>
    </table>
  `,
  styleUrl: './app.component.scss',
})
export class AppComponent {
  readonly data = signal([]);

  // This will re-run on every "data" change
  readonly table = createAngularTable(() => ({
    data: this.data,
    columns: this.columns,
  })
}
```


I've also added in this pr the `proxy` implementation, where the signal it's extended with a proxified object that allows state slicing. This may not be useful for the adapter, I'm not sure about this and and it would be nice to have some feedback, but maybe "it's too much work" and it's a pain to mantain.

Also, we need to check if there are some caveats with that approach. Internally I'm using `computed` which memoize the value by default, so in case the view will marked as dirty only if the value instance change (Object.is). This could be a premature optimization considering that almost every property would be transformed.

The first one (signal-only) is safer, and even with it you can do "state slicing", you just need to manually use computed.

```ts
class HelloComponent { 
  readonly data = signal([]);
  readonly pagination = signal<PaginationState>({pageIndex: 0, pageSize: 20});

  // This will re-run on every "data" and "pagination" change
  readonly table = createAngularTable(() => ({
    data: this.data,
    columns: this.columns,
    state: {
      pagination: this.pagination()
    },
    onPaginationChange: (updater) => {
      this.pagination.set(...)
    }
    // [..]
  }));

  constructor() {
    effect(() => {
      // run on every state/option change
      this.table().getPageOptions();
    });

    // more granular state, run on every "getPageOptions" change (e.g. only when pagination state change)
    effect(() => {
      this.table.getPageOptions()
    });

    // granular state is still possible using computed, but it must be done manually
    const pageOptions = computed(() => this.table().getPageOptions());
    effect(() => {
      pageOptions()
    });

    // these two are lines does the same thing, they access to the same table instance property. 
    this.table().setPageSize(...)
    this.table.setPageSize() // this one is evaluated lazily with proxy
  }
}

```

I've updated demo code but I may opt to make them simpler as was done for the others. Also, the unit/integration test part is missing. Note also that this implementation doesn't cover required inputs signals (need to wrap with [lazy-signal-initializer](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/util/lazy-signal-initializer/lazy-signal-initializer.ts) / [lazy-init](https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/util/lazy-init/lazy-init.ts) as described [here](https://github.com/TanStack/table/pull/5432#issuecomment-2018990745))