### PR TITLE
fix(types): export AccessorFnColumnDefBase

### DIFF
--- a/packages/table-core/src/types.ts
+++ b/packages/table-core/src/types.ts
@@ -291,8 +291,10 @@ export type GroupColumnDef<
   TValue = unknown,
 > = GroupColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
 
-interface AccessorFnColumnDefBase<TData extends RowData, TValue = unknown>
-  extends ColumnDefBase<TData, TValue> {
+export interface AccessorFnColumnDefBase<
+  TData extends RowData,
+  TValue = unknown,
+> extends ColumnDefBase<TData, TValue> {
   accessorFn: AccessorFn<TData, TValue>
 }
 


### PR DESCRIPTION
Fixes https://github.com/TanStack/table/issues/5444 by exporting the type `AccessorFnColumnDefBase`

Tested by patching to our project. VSCode no longer complains about the type error.
