### PR TITLE
chore: fix link to row-models doc in guide/tables.md

### DIFF
--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -95,4 +95,4 @@ For example, you can find the core table instance API docs here: [Table API](../
 
 ### Table Row Models
 
-There is a special set of table instance APIs for reading rows out of the table instance called row models. TanStack Table has advanced features where the rows that are generated may be very different than the array of `data` that you originally passed in. To learn more about the different row models that you can pass in as a table option, see the [Row Models Guide](../row-models).
+There is a special set of table instance APIs for reading rows out of the table instance called row models. TanStack Table has advanced features where the rows that are generated may be very different than the array of `data` that you originally passed in. To learn more about the different row models that you can pass in as a table option, see the [Row Models Guide](./row-models).


### PR DESCRIPTION
Just a tiny docs fix. "Row Models Guide" link in the docs/guide/tables.md was pointing to wrong path. 