### PR TITLE
Improve typing for RowSelectionState

### DIFF
--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -9,7 +9,7 @@ import {
 } from '../types'
 import { getMemoOptions, makeStateUpdater, memo } from '../utils'
 
-export type RowSelectionState = Record<string, boolean>
+export type RowSelectionState = Record<string, true>
 
 export interface RowSelectionTableState {
   rowSelection: RowSelectionState


### PR DESCRIPTION
Hi everyone. Today I faced a bug while using this project that can be easily avoided by this type change.

### Change explanation

As the `RowSelectionState` is currently typed, if I had a collection of 3 items and I wanted to initially pre-select the second one I'd construct the state as follows:

```typescript
const rowSelectionState: RowSelectionState = {
  "0": false,
  "1": true,
  "2": false,
}
```

The problem with the code above is that it would break the table, because the code expects only the selected rows to be in the state. One example of this can be seen in this piece of code: https://github.com/TanStack/table/blob/c40d734a20c6af7020a50600f1c1b198bf196744/packages/table-core/src/features/RowSelection.ts#L433-L441

By constructing the state like I did above, the condition `totalSelected < table.getFilteredRowModel().flatRows.length` would always be false, although with the state above it should clearly be true.

With this little type change, we can force the user to remove false entries from the state, communicating better the intended behavior of this piece of code.