### PR TITLE
fix(solid-table): flexRender types

### DIFF
--- a/packages/solid-table/src/index.tsx
+++ b/packages/solid-table/src/index.tsx
@@ -8,9 +8,13 @@ import {
 import { createComputed, mergeProps, createComponent } from 'solid-js'
 import { createStore } from 'solid-js/store'
 
+import type { JSX } from 'solid-js'
 export * from '@tanstack/table-core'
 
-export function flexRender<TProps extends {}>(Comp: any, props: TProps) {
+export function flexRender<TProps>(
+  Comp: ((props: TProps) => JSX.Element) | JSX.Element | undefined,
+  props: TProps
+): JSX.Element {
   if (!Comp) return null
 
   if (typeof Comp === 'function') {


### PR DESCRIPTION
`flexRender` param types were taking `any`.
Adding some templating to provide better inference.