### PR TITLE
fix: reduce memory leak by remove memo function

### DIFF
--- a/packages/table-core/src/core/row.ts
+++ b/packages/table-core/src/core/row.ts
@@ -170,7 +170,7 @@ export const createRow = <TData extends RowData>(
     getAllCells: () => {
       const leafColumns = table.getAllLeafColumns()
       return leafColumns.map(column => {
-        return createCell(table, row, column, column.id)
+        return createCell(table, row as Row<TData>, column, column.id)
       })
     },
 

--- a/packages/table-core/src/core/row.ts
+++ b/packages/table-core/src/core/row.ts
@@ -101,7 +101,7 @@ export const createRow = <TData extends RowData>(
   subRows?: Row<TData>[],
   parentId?: string
 ): Row<TData> => {
-  const row: CoreRow<TData> = {
+  let row: CoreRow<TData> = {
     id,
     index: rowIndex,
     original,
@@ -109,9 +109,9 @@ export const createRow = <TData extends RowData>(
     parentId,
     _valuesCache: {},
     _uniqueValuesCache: {},
-    getValue(columnId) {
-      if (this._valuesCache.hasOwnProperty(columnId)) {
-        return this._valuesCache[columnId]
+    getValue: columnId => {
+      if (row._valuesCache.hasOwnProperty(columnId)) {
+        return row._valuesCache[columnId]
       }
 
       const column = table.getColumn(columnId)
@@ -120,16 +120,16 @@ export const createRow = <TData extends RowData>(
         return undefined
       }
 
-      this._valuesCache[columnId] = column.accessorFn(
-        this.original as TData,
+      row._valuesCache[columnId] = column.accessorFn(
+        row.original as TData,
         rowIndex
       )
 
-      return this._valuesCache[columnId] as any
+      return row._valuesCache[columnId] as any
     },
-    getUniqueValues(columnId) {
-      if (this._uniqueValuesCache.hasOwnProperty(columnId)) {
-        return this._uniqueValuesCache[columnId]
+    getUniqueValues: columnId => {
+      if (row._uniqueValuesCache.hasOwnProperty(columnId)) {
+        return row._uniqueValuesCache[columnId]
       }
 
       const column = table.getColumn(columnId)
@@ -139,30 +139,26 @@ export const createRow = <TData extends RowData>(
       }
 
       if (!column.columnDef.getUniqueValues) {
-        this._uniqueValuesCache[columnId] = [this.getValue(columnId)]
-        return this._uniqueValuesCache[columnId]
+        row._uniqueValuesCache[columnId] = [row.getValue(columnId)]
+        return row._uniqueValuesCache[columnId]
       }
 
-      this._uniqueValuesCache[columnId] = column.columnDef.getUniqueValues(
-        this.original as TData,
+      row._uniqueValuesCache[columnId] = column.columnDef.getUniqueValues(
+        row.original as TData,
         rowIndex
       )
 
-      return this._uniqueValuesCache[columnId] as any
+      return row._uniqueValuesCache[columnId] as any
     },
-    renderValue(columnId) {
-      return this.getValue(columnId) ?? table.options.renderFallbackValue
-    },
+    renderValue: columnId =>
+      row.getValue(columnId) ?? table.options.renderFallbackValue,
     subRows: subRows ?? [],
-    getLeafRows() {
-      return flattenBy(this.subRows, d => d.subRows)
-    },
-    getParentRow() {
-      return this.parentId ? table.getRow(this.parentId, true) : undefined
-    },
-    getParentRows() {
-      const parentRows: Row<TData>[] = []
-      let currentRow = this
+    getLeafRows: () => flattenBy(row.subRows, d => d.subRows),
+    getParentRow: () =>
+      row.parentId ? table.getRow(row.parentId, true) : undefined,
+    getParentRows: () => {
+      let parentRows: Row<TData>[] = []
+      let currentRow = row
       while (true) {
         const parentRow = currentRow.getParentRow()
         if (!parentRow) break
@@ -171,23 +167,26 @@ export const createRow = <TData extends RowData>(
       }
       return parentRows.reverse()
     },
-    getAllCells() {
+    getAllCells: () => {
       const leafColumns = table.getAllLeafColumns()
       return leafColumns.map(column => {
-        return createCell(table, this as Row<TData>, column, column.id)
+        return createCell(table, row, column, column.id)
       })
     },
 
-    _getAllCellsByColumnId() {
-      const allCells = this.getAllCells()
-      return allCells.reduce(
-        (acc, cell) => {
-          acc[cell.column.id] = cell
-          return acc
-        },
-        {} as Record<string, Cell<TData, unknown>>
-      )
-    },
+    _getAllCellsByColumnId: memo(
+      () => [row.getAllCells()],
+      allCells => {
+        return allCells.reduce(
+          (acc, cell) => {
+            acc[cell.column.id] = cell
+            return acc
+          },
+          {} as Record<string, Cell<TData, unknown>>
+        )
+      },
+      getMemoOptions(table.options, 'debugRows', 'getAllCellsByColumnId')
+    ),
   }
 
   for (let i = 0; i < table._features.length; i++) {

--- a/packages/table-core/src/features/ColumnPinning.ts
+++ b/packages/table-core/src/features/ColumnPinning.ts
@@ -240,9 +240,9 @@ export const ColumnPinning: TableFeature = {
     row: Row<TData>,
     table: Table<TData>
   ): void => {
-    row.getCenterVisibleCells = function () {
+    row.getCenterVisibleCells = () => {
       const [allCells, left, right] = [
-        this._getAllVisibleCells(),
+        row._getAllVisibleCells(),
         table.getState().columnPinning.left,
         table.getState().columnPinning.right,
       ]
@@ -250,9 +250,9 @@ export const ColumnPinning: TableFeature = {
 
       return allCells.filter(d => !leftAndRight.includes(d.column.id))
     }
-    row.getLeftVisibleCells = function () {
+    row.getLeftVisibleCells = () => {
       const [allCells, left] = [
-        this._getAllVisibleCells(),
+        row._getAllVisibleCells(),
         table.getState().columnPinning.left,
       ]
       const cells = (left ?? [])
@@ -262,9 +262,9 @@ export const ColumnPinning: TableFeature = {
 
       return cells
     }
-    row.getRightVisibleCells = function () {
+    row.getRightVisibleCells = () => {
       const [allCells, right] = [
-        this._getAllVisibleCells(),
+        row._getAllVisibleCells(),
         table.getState().columnPinning.right,
       ]
       const cells = (right ?? [])

--- a/packages/table-core/src/features/ColumnPinning.ts
+++ b/packages/table-core/src/features/ColumnPinning.ts
@@ -240,43 +240,40 @@ export const ColumnPinning: TableFeature = {
     row: Row<TData>,
     table: Table<TData>
   ): void => {
-    row.getCenterVisibleCells = memo(
-      () => [
-        row._getAllVisibleCells(),
+    row.getCenterVisibleCells = function () {
+      const [allCells, left, right] = [
+        this._getAllVisibleCells(),
         table.getState().columnPinning.left,
         table.getState().columnPinning.right,
-      ],
-      (allCells, left, right) => {
-        const leftAndRight: string[] = [...(left ?? []), ...(right ?? [])]
+      ]
+      const leftAndRight: string[] = [...(left ?? []), ...(right ?? [])]
 
-        return allCells.filter(d => !leftAndRight.includes(d.column.id))
-      },
-      getMemoOptions(table.options, 'debugRows', 'getCenterVisibleCells')
-    )
-    row.getLeftVisibleCells = memo(
-      () => [row._getAllVisibleCells(), table.getState().columnPinning.left],
-      (allCells, left) => {
-        const cells = (left ?? [])
-          .map(columnId => allCells.find(cell => cell.column.id === columnId)!)
-          .filter(Boolean)
-          .map(d => ({ ...d, position: 'left' }) as Cell<TData, unknown>)
+      return allCells.filter(d => !leftAndRight.includes(d.column.id))
+    }
+    row.getLeftVisibleCells = function () {
+      const [allCells, left] = [
+        this._getAllVisibleCells(),
+        table.getState().columnPinning.left,
+      ]
+      const cells = (left ?? [])
+        .map(columnId => allCells.find(cell => cell.column.id === columnId)!)
+        .filter(Boolean)
+        .map(d => ({ ...d, position: 'left' }) as Cell<TData, unknown>)
 
-        return cells
-      },
-      getMemoOptions(table.options, 'debugRows', 'getLeftVisibleCells')
-    )
-    row.getRightVisibleCells = memo(
-      () => [row._getAllVisibleCells(), table.getState().columnPinning.right],
-      (allCells, right) => {
-        const cells = (right ?? [])
-          .map(columnId => allCells.find(cell => cell.column.id === columnId)!)
-          .filter(Boolean)
-          .map(d => ({ ...d, position: 'right' }) as Cell<TData, unknown>)
+      return cells
+    }
+    row.getRightVisibleCells = function () {
+      const [allCells, right] = [
+        this._getAllVisibleCells(),
+        table.getState().columnPinning.right,
+      ]
+      const cells = (right ?? [])
+        .map(columnId => allCells.find(cell => cell.column.id === columnId)!)
+        .filter(Boolean)
+        .map(d => ({ ...d, position: 'right' }) as Cell<TData, unknown>)
 
-        return cells
-      },
-      getMemoOptions(table.options, 'debugRows', 'getRightVisibleCells')
-    )
+      return cells
+    }
   },
 
   createTable: <TData extends RowData>(table: Table<TData>): void => {

--- a/packages/table-core/src/features/ColumnVisibility.ts
+++ b/packages/table-core/src/features/ColumnVisibility.ts
@@ -205,15 +205,15 @@ export const ColumnVisibility: TableFeature = {
     row: Row<TData>,
     table: Table<TData>
   ): void => {
-    row._getAllVisibleCells = function () {
-      const cells = this.getAllCells()
+    row._getAllVisibleCells = () => {
+      const cells = row.getAllCells()
       return cells.filter(cell => cell.column.getIsVisible())
     }
-    row.getVisibleCells = function () {
+    row.getVisibleCells = () => {
       return [
-        ...this.getLeftVisibleCells(),
-        ...this.getCenterVisibleCells(),
-        ...this.getRightVisibleCells(),
+        ...row.getLeftVisibleCells(),
+        ...row.getCenterVisibleCells(),
+        ...row.getRightVisibleCells(),
       ]
     }
   },

--- a/packages/table-core/src/features/ColumnVisibility.ts
+++ b/packages/table-core/src/features/ColumnVisibility.ts
@@ -205,22 +205,17 @@ export const ColumnVisibility: TableFeature = {
     row: Row<TData>,
     table: Table<TData>
   ): void => {
-    row._getAllVisibleCells = memo(
-      () => [row.getAllCells(), table.getState().columnVisibility],
-      cells => {
-        return cells.filter(cell => cell.column.getIsVisible())
-      },
-      getMemoOptions(table.options, 'debugRows', '_getAllVisibleCells')
-    )
-    row.getVisibleCells = memo(
-      () => [
-        row.getLeftVisibleCells(),
-        row.getCenterVisibleCells(),
-        row.getRightVisibleCells(),
-      ],
-      (left, center, right) => [...left, ...center, ...right],
-      getMemoOptions(table.options, 'debugRows', 'getVisibleCells')
-    )
+    row._getAllVisibleCells = function () {
+      const cells = this.getAllCells()
+      return cells.filter(cell => cell.column.getIsVisible())
+    }
+    row.getVisibleCells = function () {
+      return [
+        ...this.getLeftVisibleCells(),
+        ...this.getCenterVisibleCells(),
+        ...this.getRightVisibleCells(),
+      ]
+    }
   },
 
   createTable: <TData extends RowData>(table: Table<TData>): void => {


### PR DESCRIPTION
I recently used table-core to complete a virtual table. I rendered it with a dataset of 1000*1000, and found that the memory usage of table-core was unreasonably high. Since no one had fixed this issue（#5352）, I attempted to debug it myself. Upon investigation, I discovered that memo was causing memory leaks in many places. This prevented JavaScript from reclaiming a massive number of rows and cells. Once I removed them, memory could be reclaimed again.

https://github.com/TanStack/table/assets/68177907/4ed24f52-c93f-48c4-bead-3d5d93ba5b80

