### PR TITLE
ensure columnPinning.[property] is not accessed unsafely

### DIFF
--- a/packages/table-core/src/features/ColumnPinning.ts
+++ b/packages/table-core/src/features/ColumnPinning.ts
@@ -243,8 +243,8 @@ export const ColumnPinning: TableFeature = {
     row.getCenterVisibleCells = memo(
       () => [
         row._getAllVisibleCells(),
-        table.getState().columnPinning.left,
-        table.getState().columnPinning.right,
+        table.getState().columnPinning?.left,
+        table.getState().columnPinning?.right,
       ],
       (allCells, left, right) => {
         const leftAndRight: string[] = [...(left ?? []), ...(right ?? [])]
@@ -254,7 +254,7 @@ export const ColumnPinning: TableFeature = {
       getMemoOptions(table.options, 'debugRows', 'getCenterVisibleCells')
     )
     row.getLeftVisibleCells = memo(
-      () => [row._getAllVisibleCells(), table.getState().columnPinning.left],
+      () => [row._getAllVisibleCells(), table.getState().columnPinning?.left],
       (allCells, left) => {
         const cells = (left ?? [])
           .map(columnId => allCells.find(cell => cell.column.id === columnId)!)
@@ -266,7 +266,7 @@ export const ColumnPinning: TableFeature = {
       getMemoOptions(table.options, 'debugRows', 'getLeftVisibleCells')
     )
     row.getRightVisibleCells = memo(
-      () => [row._getAllVisibleCells(), table.getState().columnPinning.right],
+      () => [row._getAllVisibleCells(), table.getState().columnPinning?.right],
       (allCells, right) => {
         const cells = (right ?? [])
           .map(columnId => allCells.find(cell => cell.column.id === columnId)!)
@@ -300,7 +300,7 @@ export const ColumnPinning: TableFeature = {
     }
 
     table.getLeftLeafColumns = memo(
-      () => [table.getAllLeafColumns(), table.getState().columnPinning.left],
+      () => [table.getAllLeafColumns(), table.getState().columnPinning?.left],
       (allColumns, left) => {
         return (left ?? [])
           .map(columnId => allColumns.find(column => column.id === columnId)!)
@@ -310,7 +310,7 @@ export const ColumnPinning: TableFeature = {
     )
 
     table.getRightLeafColumns = memo(
-      () => [table.getAllLeafColumns(), table.getState().columnPinning.right],
+      () => [table.getAllLeafColumns(), table.getState().columnPinning?.right],
       (allColumns, right) => {
         return (right ?? [])
           .map(columnId => allColumns.find(column => column.id === columnId)!)
@@ -322,8 +322,8 @@ export const ColumnPinning: TableFeature = {
     table.getCenterLeafColumns = memo(
       () => [
         table.getAllLeafColumns(),
-        table.getState().columnPinning.left,
-        table.getState().columnPinning.right,
+        table.getState().columnPinning?.left,
+        table.getState().columnPinning?.right,
       ],
       (allColumns, left, right) => {
         const leftAndRight: string[] = [...(left ?? []), ...(right ?? [])]


### PR DESCRIPTION
Had issues with the qwik examples etc... things just didn't really work at all, and it seems like unnecessary processing is being done in the lib.. 

In anycase, I decided to build my own table using the `core` lib directly for qwik.. however I am running into a bug, where if you provide an empty state to start off with the entire app crashes on trying to read the `left` property on `columnPinning` as shown:

![image](https://github.com/TanStack/table/assets/34673206/836b6f84-b0ba-4b1c-87f0-824aba1dbba3)

I notice that most (not all) other functions in the code which do something similar are not accessing it safely with `columnPinning?.[property]`
