### PR TITLE
Fix `filters-fuzzy` Documentation Example URL

### DIFF
--- a/docs/guide/global-filtering.md
+++ b/docs/guide/global-filtering.md
@@ -6,7 +6,7 @@ title: Global Filtering Guide
 
 Want to skip to the implementation? Check out these examples:
 
-- [filters-fuzzy](../../framework/react/examples/filters)
+- [filters-fuzzy](../../framework/react/examples/filters-fuzzy)
 
 ## API
 


### PR DESCRIPTION
The URL pointed to `/examples/filters` which didn't actually include any code involving a global fuzzy filter. This PR simply changes the documentation URL to point to `/examples/filters-fuzzy` which does include a global fuzzy filter example. 