### PR TITLE
feat(angular-table): added injector optional parameter for more flexibility

### DIFF
--- a/examples/angular/grouping/src/app/app.component.ts
+++ b/examples/angular/grouping/src/app/app.component.ts
@@ -3,19 +3,19 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  effect,
   signal,
 } from '@angular/core'
 import {
-  createAngularTable,
   FlexRenderDirective,
+  GroupingState,
+  PaginationState,
+  Updater,
+  createAngularTable,
   getCoreRowModel,
   getExpandedRowModel,
   getFilteredRowModel,
   getGroupedRowModel,
   getPaginationRowModel,
-  GroupingState,
-  Updater,
 } from '@tanstack/angular-table'
 import { columns } from './columns'
 import { makeData } from './makeData'
@@ -31,6 +31,7 @@ export class AppComponent {
   title = 'grouping'
   data = signal(makeData(10000))
   grouping = signal<GroupingState>([])
+  pagination = signal<PaginationState>({ pageIndex: 0, pageSize: 10 })
 
   stringifiedGrouping = computed(() => JSON.stringify(this.grouping(), null, 2))
 
@@ -39,6 +40,7 @@ export class AppComponent {
     columns: columns,
     state: {
       grouping: this.grouping(),
+      pagination: this.pagination(),
     },
     onGroupingChange: (updaterOrValue: Updater<GroupingState>) => {
       const groupingState =
@@ -46,6 +48,13 @@ export class AppComponent {
           ? updaterOrValue([...this.grouping()])
           : updaterOrValue
       this.grouping.set(groupingState)
+    },
+    onPaginationChange: (updaterOrValue: Updater<PaginationState>) => {
+      const paginationState =
+        typeof updaterOrValue === 'function'
+          ? updaterOrValue({ ...this.pagination() })
+          : updaterOrValue
+      this.pagination.set(paginationState)
     },
     getExpandedRowModel: getExpandedRowModel(),
     getGroupedRowModel: getGroupedRowModel(),
@@ -66,5 +75,6 @@ export class AppComponent {
 
   refreshData() {
     this.data.set(makeData(10000))
+    this.pagination.set({ pageIndex: 0, pageSize: 10 })
   }
 }

--- a/examples/angular/grouping/src/app/app.component.ts
+++ b/examples/angular/grouping/src/app/app.component.ts
@@ -33,7 +33,7 @@ export class AppComponent {
 
   stringifiedGrouping = computed(() => JSON.stringify(this.grouping(), null, 2))
 
-  table = createAngularTable(() => ({
+  tableOptions = computed(() => ({
     data: this.data(),
     columns: columns,
     state: {
@@ -53,6 +53,8 @@ export class AppComponent {
     getFilteredRowModel: getFilteredRowModel(),
     debugTable: true,
   }))
+
+  table = createAngularTable(this.tableOptions)
 
   onPageInputChange(event: any): void {
     const page = event.target.value ? Number(event.target.value) - 1 : 0

--- a/examples/angular/grouping/src/app/app.component.ts
+++ b/examples/angular/grouping/src/app/app.component.ts
@@ -8,7 +8,6 @@ import {
 import {
   FlexRenderDirective,
   GroupingState,
-  PaginationState,
   Updater,
   createAngularTable,
   getCoreRowModel,
@@ -31,7 +30,6 @@ export class AppComponent {
   title = 'grouping'
   data = signal(makeData(10000))
   grouping = signal<GroupingState>([])
-  pagination = signal<PaginationState>({ pageIndex: 0, pageSize: 10 })
 
   stringifiedGrouping = computed(() => JSON.stringify(this.grouping(), null, 2))
 
@@ -40,7 +38,6 @@ export class AppComponent {
     columns: columns,
     state: {
       grouping: this.grouping(),
-      pagination: this.pagination(),
     },
     onGroupingChange: (updaterOrValue: Updater<GroupingState>) => {
       const groupingState =
@@ -48,13 +45,6 @@ export class AppComponent {
           ? updaterOrValue([...this.grouping()])
           : updaterOrValue
       this.grouping.set(groupingState)
-    },
-    onPaginationChange: (updaterOrValue: Updater<PaginationState>) => {
-      const paginationState =
-        typeof updaterOrValue === 'function'
-          ? updaterOrValue({ ...this.pagination() })
-          : updaterOrValue
-      this.pagination.set(paginationState)
     },
     getExpandedRowModel: getExpandedRowModel(),
     getGroupedRowModel: getGroupedRowModel(),
@@ -75,6 +65,5 @@ export class AppComponent {
 
   refreshData() {
     this.data.set(makeData(10000))
-    this.pagination.set({ pageIndex: 0, pageSize: 10 })
   }
 }

--- a/packages/angular-table/src/index.ts
+++ b/packages/angular-table/src/index.ts
@@ -1,96 +1,61 @@
-import {
-  computed,
-  effect,
-  inject,
-  Injector,
-  runInInjectionContext,
-  type Signal,
-  signal,
-  untracked,
-} from '@angular/core'
+import { computed, effect, inject, Injector, signal } from '@angular/core'
 import {
   createTable,
   RowData,
-  type Table,
   TableOptions,
   TableOptionsResolved,
+  TableState,
+  type Table,
 } from '@tanstack/table-core'
-import { proxifyTable } from './proxy'
 import { lazyInit } from './lazy-signal-initializer'
 
 export * from '@tanstack/table-core'
 
-export {
-  FlexRenderDirective,
-  FlexRenderComponent,
-  injectFlexRenderContext,
-} from './flex-render'
+export { FlexRenderDirective } from './flex-render'
 
 export function createAngularTable<TData extends RowData>(
-  options: () => TableOptions<TData>
-): Table<TData> & Signal<Table<TData>> {
-  const injector = inject(Injector)
+  options: () => TableOptions<TData>,
+  injector?: Injector
+): Table<TData> {
+  if (!injector) injector = inject(Injector)
 
-  return lazyInit(() =>
-    runInInjectionContext(injector, () => {
-      const resolvedOptionsSignal = computed<TableOptionsResolved<TData>>(
-        () => {
-          return {
-            state: {},
-            onStateChange: () => {},
-            renderFallbackValue: null,
-            ...options(),
-          }
-        }
-      )
+  return lazyInit(() => {
+    // Compose table resolved options as computed.
+    // This will allow the effect to be triggered when options are updated.
+    const resolvedOptionsSignal = computed<TableOptionsResolved<TData>>(() => ({
+      state: {},
+      onStateChange: () => {},
+      renderFallbackValue: null,
+      ...options(),
+    }))
 
-      const notifier = signal([], { equal: () => false })
-      const table = createTable(untracked(resolvedOptionsSignal))
-      const state = signal(table.initialState)
+    const table = createTable(resolvedOptionsSignal())
 
-      function updateOptions() {
-        const tableState = untracked(state)
-        const resolvedOptions = untracked(resolvedOptionsSignal)
-        untracked(() => {
-          table.setOptions(prev => ({
-            ...prev,
-            ...resolvedOptions,
-            state: { ...tableState, ...resolvedOptions.state },
-            onStateChange: updater => {
-              const value =
-                updater instanceof Function ? updater(tableState) : updater
-              state.set(value)
-              resolvedOptions.onStateChange?.(updater)
-            },
-          }))
-        })
-      }
+    // By default, manage table state here using the table's initial state
+    const state = signal<TableState>(table.initialState)
 
-      updateOptions()
-
-      let firstRender = true
-      effect(() => {
-        void [state(), resolvedOptionsSignal()]
-        if (firstRender) {
-          return (firstRender = false)
-        }
-        untracked(() => {
-          updateOptions()
-          notifier.set([])
-        })
-      })
-
-      const tableSignal = computed(
-        () => {
-          notifier()
-          return table
+    function updateOptions() {
+      const tableState = state()
+      const resolvedOptions = resolvedOptionsSignal()
+      table.setOptions(prev => ({
+        ...prev,
+        ...resolvedOptions,
+        state: { ...tableState, ...resolvedOptions.state },
+        onStateChange: updater => {
+          const value =
+            updater instanceof Function ? updater(tableState) : updater
+          state.set(value)
+          resolvedOptions.onStateChange?.(updater)
         },
-        {
-          equal: () => false,
-        }
-      )
+      }))
+    }
 
-      return proxifyTable(tableSignal)
-    })
-  )
+    // set table options again when options are updated
+    effect(() => updateOptions(), { injector })
+
+    // set table options for the first time
+    updateOptions()
+
+    return table
+  })
 }

--- a/packages/angular-table/src/index.ts
+++ b/packages/angular-table/src/index.ts
@@ -55,8 +55,18 @@ export function createAngularTable<TData extends RowData>(
       }))
     }
 
+    // notifier for tableSignal whenever `updateOptions` is invoked
+    // this to make sure that table options is set first before table
+    // instance change is propagated to consumer
+    const tableChangeNotifier = signal([], { equal: () => false })
     // set table options again when options are updated
-    effect(() => updateOptions(), { injector })
+    effect(
+      () => {
+        updateOptions()
+        tableChangeNotifier.set([])
+      },
+      { injector }
+    )
 
     // set table options for the first time
     updateOptions()
@@ -64,7 +74,7 @@ export function createAngularTable<TData extends RowData>(
     // convert table instance to signal for proxify to listen to any table state and options changes
     const tableSignal = computed(
       () => {
-        void [state(), resolvedOptionsSignal()]
+        tableChangeNotifier()
         return table
       },
       {


### PR DESCRIPTION
Following are the changes:

- Added optional `injector` parameter for more flexibility. Consumer can `createAngularTable` anywhere.

- Replace runInInjectionContext with an injector in the `effect`.  This has the same behaviour since only `effect` requires to be in the injector context.

- Remove unncessary untracked and signals.

- Remove proxifyTable as I think this is unncessary, since table is not required to be a signal. `laziInit` already proxified the table object. Pls correct me if I'm wrong.

- Refactored grouping example to include pagination  state.