### PR TITLE
docs: Fix `Columns Definitions Guide` example code

### DIFF
--- a/docs/guide/column-defs.md
+++ b/docs/guide/column-defs.md
@@ -167,9 +167,9 @@ type Person = {
 You could extract the `first` value like so:
 
 ```tsx
-columnHelper.accessor('name.first'), {
+columnHelper.accessor('name.first', {
   id: 'firstName',
-}
+})
 
 // OR
 


### PR DESCRIPTION
As the title suggests.