### PR TITLE
fix(angular-table): handle null and number values with flex-render

### DIFF
--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -80,11 +80,16 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
         content,
         this.getTemplateRefContext()
       )
+    } else if (
+      typeof content === 'object' &&
+      content !== null &&
+      content !== undefined
+    ) {
+      return this.renderComponent(content)
     }
-    return this.renderComponent(content)
   }
 
-  private renderStringContent() {
+  private renderStringContent(): EmbeddedViewRef<unknown> {
     const context = () => {
       return typeof this.content === 'string'
         ? this.content
@@ -97,7 +102,9 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
     })
   }
 
-  private renderComponent(flexRenderComponent: FlexRenderComponent<TProps>) {
+  private renderComponent(
+    flexRenderComponent: FlexRenderComponent<TProps>
+  ): ComponentRef<unknown> {
     const { component, inputs, injector } = flexRenderComponent
 
     const getContext = () => this.props

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -18,6 +18,7 @@ type FlexRenderContent<TProps extends NonNullable<unknown>> =
   | string
   | FlexRenderComponent<TProps>
   | TemplateRef<{ $implicit: TProps }>
+  | null
 
 @Directive({
   selector: '[flexRender]',
@@ -80,12 +81,10 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
         content,
         this.getTemplateRefContext()
       )
-    } else if (
-      typeof content === 'object' &&
-      content !== null &&
-      content !== undefined
-    ) {
+    } else if (content instanceof FlexRenderComponent) {
       return this.renderComponent(content)
+    } else {
+      return null
     }
   }
 

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -16,6 +16,7 @@ import {
 
 type FlexRenderContent<TProps extends NonNullable<unknown>> =
   | string
+  | number
   | FlexRenderComponent<TProps>
   | TemplateRef<{ $implicit: TProps }>
   | null
@@ -28,8 +29,11 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   implements OnInit, DoCheck
 {
   @Input({ required: true, alias: 'flexRender' })
-  content: string | ((props: TProps) => FlexRenderContent<TProps>) | undefined =
-    undefined
+  content:
+    | number
+    | string
+    | ((props: TProps) => FlexRenderContent<TProps>)
+    | undefined = undefined
 
   @Input({ required: true, alias: 'flexRenderProps' })
   props: TProps = {} as TProps
@@ -63,7 +67,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
       return null
     }
 
-    if (typeof content === 'string') {
+    if (typeof content === 'string' || typeof content === 'number') {
       return this.renderStringContent()
     }
     if (typeof content === 'function') {
@@ -73,7 +77,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   }
 
   private renderContent(content: FlexRenderContent<TProps>) {
-    if (typeof content === 'string') {
+    if (typeof content === 'string' || typeof content === 'number') {
       return this.renderStringContent()
     }
     if (content instanceof TemplateRef) {
@@ -90,7 +94,8 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
 
   private renderStringContent(): EmbeddedViewRef<unknown> {
     const context = () => {
-      return typeof this.content === 'string'
+      return typeof this.content === 'string' ||
+        typeof this.content === 'number'
         ? this.content
         : this.content?.(this.props)
     }


### PR DESCRIPTION
@KevinVandy grouping example was broken due to flexRenderDirective not handling null content (e.g. when a cell is grouped)

<img width="583" alt="Screenshot 2024-05-13 alle 08 47 41" src="https://github.com/TanStack/table/assets/37072694/a2fd9eea-793b-4da6-9923-a6d923f9b122">

Here a screenshot of the grouping example after the fix