### PR TITLE
Add a missing guard for 'undefined' in the getFilteredRowModel function.

### DIFF
--- a/packages/table-core/src/utils/getFilteredRowModel.ts
+++ b/packages/table-core/src/utils/getFilteredRowModel.ts
@@ -53,7 +53,7 @@ export function getFilteredRowModel<TData extends RowData>(): (
           })
         })
 
-        const filterableIds = columnFilters.map(d => d.id)
+        const filterableIds = (columnFilters ?? []).map(d => d.id)
 
         const globalFilterFn = table.getGlobalFilterFn()
 


### PR DESCRIPTION
Hi,

I had a small issue with GlobalFilter while trying to use filter values with the createTable function.
I encountered a problem related to an undefined value in getFilteredRowModel

I found a missing undefined guard in getFilteredRowModel.ts.
There is another guard in the same function (https://github.com/TanStack/table/blob/047348f2f6ccb180e568f80ce5dd84b3087d630f/packages/table-core/src/utils/getFilteredRowModel.ts#L31), but it was missing in the section I committed.

After committing this change, everything works fine for me now.


P.S. Thanks for the awesome project. I am really enjoying TanStack Table.