### PR TITLE
Small typo in documentation regarding column definitions

### DIFF
--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -22,7 +22,7 @@ Define your data as an array of objects with a stable reference. `data` can come
 
 #### Defining Columns
 
-Column definitions are covered in detail in the previous section in the [Column Def Guide](../column-defs). We'll note here, however, that when you define the type of your columns, you should use the same `TData` type that you used for you data.
+Column definitions are covered in detail in the previous section in the [Column Def Guide](../column-defs). We'll note here, however, that when you define the type of your columns, you should use the same `TData` type that you used for your data.
 
 ```ts
 const columns: ColumnDef<User>[] = [] //Pass User type as the generic TData type


### PR DESCRIPTION
Came across this while reading the docs earlier and thought I'd put up a quick fix. Thanks!