### PR TITLE
docs: minor fix to lit & react `column-sizing` examples

### DIFF
--- a/examples/lit/column-sizing/src/main.ts
+++ b/examples/lit/column-sizing/src/main.ts
@@ -128,7 +128,16 @@ class LitTableExample extends LitElement {
             )}
         </tbody>
       </table>
-      <pre>123</pre>
+      <pre>
+${JSON.stringify(
+          {
+            columnSizing: table.getState().columnSizing,
+            columnSizingInfo: table.getState().columnSizingInfo,
+          },
+          null,
+          2
+        )}</pre
+      >
       <style>
         * {
           font-family: sans-serif;

--- a/examples/react/column-sizing/src/main.tsx
+++ b/examples/react/column-sizing/src/main.tsx
@@ -101,7 +101,7 @@ const defaultColumns: ColumnDef<Person>[] = [
 ]
 
 function App() {
-  const [data, setData] = React.useState(() => [...defaultData])
+  const [data] = React.useState(() => [...defaultData])
   const [columns] = React.useState<typeof defaultColumns>(() => [
     ...defaultColumns,
   ])


### PR DESCRIPTION
For React example - remove unused `setData` (state can be removed entirely if feels like it)

For Lit - print column sizing state instead of weird `123`