### PR TITLE
fix: invalidate cached values after updating accessor functions

### DIFF
--- a/packages/table-core/__tests__/CachedValue.test.ts
+++ b/packages/table-core/__tests__/CachedValue.test.ts
@@ -1,0 +1,56 @@
+import { ColumnDef, getCoreRowModel } from '../src'
+import { createColumnHelper } from '../src/columnHelper'
+import { createTable } from '../src/core/table'
+import { getGroupedRowModel } from '../src/utils/getGroupedRowModel'
+import { makeData, Person } from './makeTestData'
+
+type personKeys = keyof Person
+type PersonColumn = ColumnDef<Person, string | number | Person[] | undefined>
+const columnHelper = createColumnHelper<Person>()
+
+describe('#CachedValue', () => {
+  it('cached value invalidated after changing accessorFn', () => {
+    const data = makeData(1)
+
+    const targetColumnId = 'name'
+
+    const table = createTable<Person>({
+      data,
+      columns: [
+        columnHelper.accessor(() => 'hoge', {
+          id: targetColumnId,
+        }),
+      ],
+      onStateChange() {},
+      renderFallbackValue: '',
+      state: {},
+      getCoreRowModel: getCoreRowModel(),
+      getGroupedRowModel: getGroupedRowModel(),
+    })
+
+    const row = table.getCoreRowModel().rows[0]
+    expect(row.getValue(targetColumnId)).toBe('hoge')
+
+    let execCounter = 0
+    table.setOptions(old => {
+      return {
+        ...old,
+        columns: [
+          columnHelper.accessor(
+            () => {
+              execCounter = execCounter + 1
+              return 'fuga'
+            },
+            {
+              id: targetColumnId,
+            }
+          ),
+        ],
+      }
+    })
+
+    expect(row.getValue(targetColumnId)).toBe('fuga')
+    row.getValue(targetColumnId)
+    expect(execCounter).toBe(1)
+  })
+})


### PR DESCRIPTION
# What's this PR

https://github.com/TanStack/table/issues/5363

The above issue reported that `getValues` returns stale cached values after changing accessor functions.

This PR fixes it.

[8cd8449](https://github.com/TanStack/table/pull/5582/commits/8cd84491002e8033318165779d4abfaa9f2e6b13): add unit tests
[f66f4e6](https://github.com/TanStack/table/pull/5582/commits/f66f4e6ea6096355ddfb45695318840aa01da5c9): accessor functions are also held as cache, and it determines whether the cached data are fresh or stale.