### PR TITLE
fix: add dependency because columnSizeVars does not change

### DIFF
--- a/examples/react/column-resizing-performant/src/main.tsx
+++ b/examples/react/column-resizing-performant/src/main.tsx
@@ -105,7 +105,7 @@ function App() {
       colSizes[`--col-${header.column.id}-size`] = header.column.getSize()
     }
     return colSizes
-  }, [table.getState().columnSizingInfo])
+  }, [table.getState().columnSizingInfo, table.getState().columnSizing])
 
   //demo purposes
   const [enableMemo, setEnableMemo] = React.useState(true)


### PR DESCRIPTION
## SUMMARY

- There is a missing value in useMemo dependency in the example code, so a bug occurs when execute resetSize.

## DIFF

-  AS IS


https://github.com/TanStack/table/assets/57904979/a6899db4-6d54-445d-a9e5-0b0678d13595


- To Be

https://github.com/TanStack/table/assets/57904979/fbed418a-ba0b-4f75-9984-4656092ce1f8

