### PR TITLE
docs(pagination): rephrase autoResetPageIndex behaviour

### DIFF
--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -142,9 +142,7 @@ Besides the `manualPagination`, `pageCount`, and `rowCount` options which are us
 
 #### Auto Reset Page Index
 
-The `autoResetPageIndex` table option is true by default, and it will reset the `pageIndex` to `0` when page-altering state changes occur, such as when the `data` is updated, filters change, grouping changes, etc. This is useful to prevent the table from showing an empty page when the `pageIndex` is out of range.
-
-However, you can opt out of this behavior by setting the `autoResetPageIndex` option to `false`.
+By default, `pageIndex` is reset to `0` when page-altering state changes occur, such as when the `data` is updated, filters change, grouping changes, etc. This behavior is automatically disabled when `manualPagination` is true but it can be overridden by explicitly assigning a value to the `autoResetPageIndex` table option.
 
 ```jsx
 const table = useReactTable({

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -142,7 +142,7 @@ Besides the `manualPagination`, `pageCount`, and `rowCount` options which are us
 
 #### Auto Reset Page Index
 
-By default, `pageIndex` is reset to `0` when page-altering state changes occur, such as when the `data` is updated, filters change, grouping changes, etc. This behavior is automatically disabled when `manualPagination` is true but it can be overridden by explicitly assigning a value to the `autoResetPageIndex` table option.
+By default, `pageIndex` is reset to `0` when page-altering state changes occur, such as when the `data` is updated, filters change, grouping changes, etc. This behavior is automatically disabled when `manualPagination` is true but it can be overridden by explicitly assigning a boolean value to the `autoResetPageIndex` table option.
 
 ```jsx
 const table = useReactTable({


### PR DESCRIPTION
Hey! I was confused by the `autoResetPageIndex` explanation since I noticed it wasn't working on a table with `manualPagination` (which is the expected behavior - all good here).

The docs mention `autoResetPageIndex` is true by default but I had a look at the code and if I'm not mistaken it is undefined by default.

Here is when the magic happens:
https://github.com/TanStack/table/blob/f7e69bc9939d170a1e2fa4112e369814143b8114/packages/table-core/src/features/RowPagination.ts#L226-L230


I rephrased that sentence in the docs removing the mention to "the flag true by default". The _behaviour_ is active by default, but the _flag_ isn't true otherwise `manualPagination` wouldn't override it in the snippet above.