### PR TITLE
docs: fix Header link in Header Group API

### DIFF
--- a/docs/api/core/header-group.md
+++ b/docs/api/core/header-group.md
@@ -30,4 +30,4 @@ The depth of the header group, zero-indexed based.
 type headers = Header<TData>[]
 ```
 
-An array of [Header](../../header) objects that belong to this header group
+An array of [Header](../header) objects that belong to this header group


### PR DESCRIPTION
[In CORE APIS  > Header Group](https://tanstack.com/table/v8/docs/api/core/header-group), the Link to `Header` is broken and rendering a 404 page:

https://github.com/TanStack/table/assets/22207414/93b306fb-aa82-4429-a615-759907a12a9d

