### PR TITLE
Fix `arrIncludes` filterFn

### DIFF
--- a/packages/table-core/src/filterFns.ts
+++ b/packages/table-core/src/filterFns.ts
@@ -50,7 +50,7 @@ const arrIncludes: FilterFn<any> = (
   return row.getValue<unknown[]>(columnId)?.includes(filterValue)
 }
 
-arrIncludes.autoRemove = (val: any) => testFalsey(val) || !val?.length
+arrIncludes.autoRemove = (val: any) => testFalsey(val)
 
 const arrIncludesAll: FilterFn<any> = (
   row,


### PR DESCRIPTION
The `filterValue` for this function is not an array. Therefore, we should not check for its length.