### PR TITLE
docs: table fix editable example link

### DIFF
--- a/docs/api/core/table.md
+++ b/docs/api/core/table.md
@@ -89,7 +89,7 @@ declare module '@tanstack/table-core' {
 }
 ```
 
-> 🧠 Think of this option as an arbitrary "context" for your table. This is a great way to pass arbitrary data or functions to your table without having to pass it to every thing the table touches. A good example is passing a locale object to your table to use for formatting dates, numbers, etc or even a function that can be used to update editable data like in the [editable-data example](../../framework/react/examples/editable-data).
+> 🧠 Think of this option as an arbitrary "context" for your table. This is a great way to pass arbitrary data or functions to your table without having to pass it to every thing the table touches. A good example is passing a locale object to your table to use for formatting dates, numbers, etc or even a function that can be used to update editable data like in the [editable-data example](../../../framework/react/examples/editable-data).
 
 ### `state`
 


### PR DESCRIPTION
Fixed the example link for editable data; it was broken here -  https://tanstack.com/table/latest/docs/api/core/table#meta

Before: 

https://github.com/TanStack/table/assets/33326988/95f85dd4-986c-48f9-999b-355f3af713dd




After: 

https://github.com/TanStack/table/assets/33326988/f4090a36-e571-49ef-9223-51947ff40ebc


