### PR TITLE
Refactored the core headers/table folders to the new format with separated concerns

### DIFF
--- a/packages/table-core/src/core/headers/CreateHeader.ts
+++ b/packages/table-core/src/core/headers/CreateHeader.ts
@@ -1,0 +1,54 @@
+import { Column, Header, RowData, Table } from '../../types'
+import { Header_Core } from './Headers.types'
+
+export function _createHeader<TData extends RowData, TValue>(
+  table: Table<TData>,
+  column: Column<TData, TValue>,
+  options: {
+    id?: string
+    isPlaceholder?: boolean
+    placeholderId?: string
+    index: number
+    depth: number
+  }
+): Header<TData, TValue> {
+  const id = options.id ?? column.id
+
+  let header: Header_Core<TData, TValue> = {
+    id,
+    column,
+    index: options.index,
+    isPlaceholder: !!options.isPlaceholder,
+    placeholderId: options.placeholderId,
+    depth: options.depth,
+    subHeaders: [],
+    colSpan: 0,
+    rowSpan: 0,
+    headerGroup: null!,
+    getLeafHeaders: (): Header<TData, unknown>[] => {
+      const leafHeaders: Header<TData, unknown>[] = []
+
+      const recurseHeader = (h: Header_Core<TData, any>) => {
+        if (h.subHeaders && h.subHeaders.length) {
+          h.subHeaders.map(recurseHeader)
+        }
+        leafHeaders.push(h as Header<TData, unknown>)
+      }
+
+      recurseHeader(header)
+
+      return leafHeaders
+    },
+    getContext: () => ({
+      table,
+      header: header as Header<TData, TValue>,
+      column,
+    }),
+  }
+
+  table._features.forEach(feature => {
+    feature._createHeader?.(header as Header<TData, TValue>, table)
+  })
+
+  return header as Header<TData, TValue>
+}

--- a/packages/table-core/src/core/headers/Headers.ts
+++ b/packages/table-core/src/core/headers/Headers.ts
@@ -1,191 +1,13 @@
-import {
-  RowData,
-  Column,
-  Header,
-  HeaderGroup,
-  Table,
-  TableFeature,
-} from '../../types'
+import { RowData, Table, TableFeature } from '../../types'
 import { getMemoOptions, memo } from '../../utils'
-
-const debug = 'debugHeaders'
-
-export interface HeaderGroup_Core<TData extends RowData> {
-  depth: number
-  headers: Header<TData, unknown>[]
-  id: string
-}
-
-export interface HeaderContext<TData, TValue> {
-  /**
-   * An instance of a column.
-   */
-  column: Column<TData, TValue>
-  /**
-   * An instance of a header.
-   */
-  header: Header<TData, TValue>
-  /**
-   * The table instance.
-   */
-  table: Table<TData>
-}
-
-export interface Header_Core<TData extends RowData, TValue> {
-  /**
-   * The col-span for the header.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#colspan)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  colSpan: number
-  /**
-   * The header's associated column object.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#column)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  column: Column<TData, TValue>
-  /**
-   * The depth of the header, zero-indexed based.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#depth)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  depth: number
-  /**
-   * Returns the rendering context (or props) for column-based components like headers, footers and filters.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#getcontext)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  getContext: () => HeaderContext<TData, TValue>
-  /**
-   * Returns the leaf headers hierarchically nested under this header.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#getleafheaders)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  getLeafHeaders: () => Header<TData, unknown>[]
-  /**
-   * The header's associated header group object.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#headergroup)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  headerGroup: HeaderGroup<TData>
-  /**
-   * The unique identifier for the header.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#id)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  id: string
-  /**
-   * The index for the header within the header group.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#index)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  index: number
-  /**
-   * A boolean denoting if the header is a placeholder header.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#isplaceholder)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  isPlaceholder: boolean
-  /**
-   * If the header is a placeholder header, this will be a unique header ID that does not conflict with any other headers across the table.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#placeholderid)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  placeholderId?: string
-  /**
-   * The row-span for the header.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#rowspan)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  rowSpan: number
-  /**
-   * The header's hierarchical sub/child headers. Will be empty if the header's associated column is a leaf-column.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#subheaders)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  subHeaders: Header<TData, TValue>[]
-}
-
-export interface Table_Headers<TData extends RowData> {
-  /**
-   * Returns all header groups for the table.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getheadergroups)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  getHeaderGroups: () => HeaderGroup<TData>[]
-  /**
-   * Returns the footer groups for the table.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getfootergroups)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  getFooterGroups: () => HeaderGroup<TData>[]
-  /**
-   * Returns headers for all columns in the table, including parent headers.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getflatheaders)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  getFlatHeaders: () => Header<TData, unknown>[]
-  /**
-   * Returns headers for all leaf columns in the table, (not including parent headers).
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getleafheaders)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
-   */
-  getLeafHeaders: () => Header<TData, unknown>[]
-}
-
-//
-
-function _createHeader<TData extends RowData, TValue>(
-  table: Table<TData>,
-  column: Column<TData, TValue>,
-  options: {
-    id?: string
-    isPlaceholder?: boolean
-    placeholderId?: string
-    index: number
-    depth: number
-  }
-): Header<TData, TValue> {
-  const id = options.id ?? column.id
-
-  let header: Header_Core<TData, TValue> = {
-    id,
-    column,
-    index: options.index,
-    isPlaceholder: !!options.isPlaceholder,
-    placeholderId: options.placeholderId,
-    depth: options.depth,
-    subHeaders: [],
-    colSpan: 0,
-    rowSpan: 0,
-    headerGroup: null!,
-    getLeafHeaders: (): Header<TData, unknown>[] => {
-      const leafHeaders: Header<TData, unknown>[] = []
-
-      const recurseHeader = (h: Header_Core<TData, any>) => {
-        if (h.subHeaders && h.subHeaders.length) {
-          h.subHeaders.map(recurseHeader)
-        }
-        leafHeaders.push(h as Header<TData, unknown>)
-      }
-
-      recurseHeader(header)
-
-      return leafHeaders
-    },
-    getContext: () => ({
-      table,
-      header: header as Header<TData, TValue>,
-      column,
-    }),
-  }
-
-  table._features.forEach(feature => {
-    feature._createHeader?.(header as Header<TData, TValue>, table)
-  })
-
-  return header as Header<TData, TValue>
-}
+import { _createHeader } from './CreateHeader'
+import { debugHeaders } from './Headers.types'
+import {
+  table_getFlatHeaders,
+  table_getFooterGroups,
+  table_getHeaderGroups,
+  table_getLeafHeaders,
+} from './Headers.utils'
 
 export const Headers: TableFeature = {
   _createTable: <TData extends RowData>(table: Table<TData>): void => {
@@ -196,50 +18,21 @@ export const Headers: TableFeature = {
         table.getState().columnPinning.left,
         table.getState().columnPinning.right,
       ],
-      (allColumns, leafColumns, left, right) => {
-        const leftColumns =
-          left
-            ?.map(columnId => leafColumns.find(d => d.id === columnId)!)
-            .filter(Boolean) ?? []
-
-        const rightColumns =
-          right
-            ?.map(columnId => leafColumns.find(d => d.id === columnId)!)
-            .filter(Boolean) ?? []
-
-        const centerColumns = leafColumns.filter(
-          column => !left?.includes(column.id) && !right?.includes(column.id)
-        )
-
-        const headerGroups = buildHeaderGroups(
-          allColumns,
-          [...leftColumns, ...centerColumns, ...rightColumns],
-          table
-        )
-
-        return headerGroups
-      },
-      getMemoOptions(table.options, debug, 'getHeaderGroups')
+      (allColumns, leafColumns, left, right) =>
+        table_getHeaderGroups(table, allColumns, leafColumns, left, right),
+      getMemoOptions(table.options, debugHeaders, 'getHeaderGroups')
     )
 
     table.getFooterGroups = memo(
       () => [table.getHeaderGroups()],
-      headerGroups => {
-        return [...headerGroups].reverse()
-      },
-      getMemoOptions(table.options, debug, 'getFooterGroups')
+      headerGroups => table_getFooterGroups(headerGroups),
+      getMemoOptions(table.options, debugHeaders, 'getFooterGroups')
     )
 
     table.getFlatHeaders = memo(
       () => [table.getHeaderGroups()],
-      headerGroups => {
-        return headerGroups
-          .map(headerGroup => {
-            return headerGroup.headers
-          })
-          .flat()
-      },
-      getMemoOptions(table.options, debug, 'getFlatHeaders')
+      headerGroups => table_getFlatHeaders(headerGroups),
+      getMemoOptions(table.options, debugHeaders, 'getFlatHeaders')
     )
 
     table.getLeafHeaders = memo(
@@ -248,175 +41,8 @@ export const Headers: TableFeature = {
         table.getCenterHeaderGroups(),
         table.getRightHeaderGroups(),
       ],
-      (left, center, right) => {
-        return [
-          ...(left[0]?.headers ?? []),
-          ...(center[0]?.headers ?? []),
-          ...(right[0]?.headers ?? []),
-        ]
-          .map(header => {
-            return header.getLeafHeaders()
-          })
-          .flat()
-      },
-      getMemoOptions(table.options, debug, 'getLeafHeaders')
+      (left, center, right) => table_getLeafHeaders(left, center, right),
+      getMemoOptions(table.options, debugHeaders, 'getLeafHeaders')
     )
   },
-}
-
-export function buildHeaderGroups<TData extends RowData>(
-  allColumns: Column<TData, unknown>[],
-  columnsToGroup: Column<TData, unknown>[],
-  table: Table<TData>,
-  headerFamily?: 'center' | 'left' | 'right'
-) {
-  // Find the max depth of the columns:
-  // build the leaf column row
-  // build each buffer row going up
-  //    placeholder for non-existent level
-  //    real column for existing level
-
-  let maxDepth = 0
-
-  const findMaxDepth = (columns: Column<TData, unknown>[], depth = 1) => {
-    maxDepth = Math.max(maxDepth, depth)
-
-    columns
-      .filter(column => column.getIsVisible())
-      .forEach(column => {
-        if (column.columns?.length) {
-          findMaxDepth(column.columns, depth + 1)
-        }
-      }, 0)
-  }
-
-  findMaxDepth(allColumns)
-
-  let headerGroups: HeaderGroup<TData>[] = []
-
-  const createHeaderGroup = (
-    headersToGroup: Header<TData, unknown>[],
-    depth: number
-  ) => {
-    // The header group we are creating
-    const headerGroup: HeaderGroup<TData> = {
-      depth,
-      id: [headerFamily, `${depth}`].filter(Boolean).join('_'),
-      headers: [],
-    }
-
-    // The parent columns we're going to scan next
-    const pendingParentHeaders: Header<TData, unknown>[] = []
-
-    // Scan each column for parents
-    headersToGroup.forEach(headerToGroup => {
-      // What is the latest (last) parent column?
-
-      const latestPendingParentHeader = [...pendingParentHeaders].reverse()[0]
-
-      const isLeafHeader = headerToGroup.column.depth === headerGroup.depth
-
-      let column: Column<TData, unknown>
-      let isPlaceholder = false
-
-      if (isLeafHeader && headerToGroup.column.parent) {
-        // The parent header is new
-        column = headerToGroup.column.parent
-      } else {
-        // The parent header is repeated
-        column = headerToGroup.column
-        isPlaceholder = true
-      }
-
-      if (
-        latestPendingParentHeader &&
-        latestPendingParentHeader?.column === column
-      ) {
-        // This column is repeated. Add it as a sub header to the next batch
-        latestPendingParentHeader.subHeaders.push(headerToGroup)
-      } else {
-        // This is a new header. Let's create it
-        const header = _createHeader(table, column, {
-          id: [headerFamily, depth, column.id, headerToGroup?.id]
-            .filter(Boolean)
-            .join('_'),
-          isPlaceholder,
-          placeholderId: isPlaceholder
-            ? `${pendingParentHeaders.filter(d => d.column === column).length}`
-            : undefined,
-          depth,
-          index: pendingParentHeaders.length,
-        })
-
-        // Add the headerToGroup as a subHeader of the new header
-        header.subHeaders.push(headerToGroup)
-        // Add the new header to the pendingParentHeaders to get grouped
-        // in the next batch
-        pendingParentHeaders.push(header)
-      }
-
-      headerGroup.headers.push(headerToGroup)
-      headerToGroup.headerGroup = headerGroup
-    })
-
-    headerGroups.push(headerGroup)
-
-    if (depth > 0) {
-      createHeaderGroup(pendingParentHeaders, depth - 1)
-    }
-  }
-
-  const bottomHeaders = columnsToGroup.map((column, index) =>
-    _createHeader(table, column, {
-      depth: maxDepth,
-      index,
-    })
-  )
-
-  createHeaderGroup(bottomHeaders, maxDepth - 1)
-
-  headerGroups.reverse()
-
-  // headerGroups = headerGroups.filter(headerGroup => {
-  //   return !headerGroup.headers.every(header => header.isPlaceholder)
-  // })
-
-  const recurseHeadersForSpans = (
-    headers: Header<TData, unknown>[]
-  ): { colSpan: number; rowSpan: number }[] => {
-    const filteredHeaders = headers.filter(header =>
-      header.column.getIsVisible()
-    )
-
-    return filteredHeaders.map(header => {
-      let colSpan = 0
-      let rowSpan = 0
-      let childRowSpans = [0]
-
-      if (header.subHeaders && header.subHeaders.length) {
-        childRowSpans = []
-
-        recurseHeadersForSpans(header.subHeaders).forEach(
-          ({ colSpan: childColSpan, rowSpan: childRowSpan }) => {
-            colSpan += childColSpan
-            childRowSpans.push(childRowSpan)
-          }
-        )
-      } else {
-        colSpan = 1
-      }
-
-      const minChildRowSpan = Math.min(...childRowSpans)
-      rowSpan = rowSpan + minChildRowSpan
-
-      header.colSpan = colSpan
-      header.rowSpan = rowSpan
-
-      return { colSpan, rowSpan }
-    })
-  }
-
-  recurseHeadersForSpans(headerGroups[0]?.headers ?? [])
-
-  return headerGroups
 }

--- a/packages/table-core/src/core/headers/Headers.types.ts
+++ b/packages/table-core/src/core/headers/Headers.types.ts
@@ -1,0 +1,126 @@
+import { Column, Header, HeaderGroup, RowData, Table } from '../../types'
+
+export const debugHeaders = 'debugHeaders'
+
+export interface HeaderGroup_Core<TData extends RowData> {
+  depth: number
+  headers: Header<TData, unknown>[]
+  id: string
+}
+
+export interface HeaderContext<TData, TValue> {
+  /**
+   * An instance of a column.
+   */
+  column: Column<TData, TValue>
+  /**
+   * An instance of a header.
+   */
+  header: Header<TData, TValue>
+  /**
+   * The table instance.
+   */
+  table: Table<TData>
+}
+
+export interface Header_Core<TData extends RowData, TValue> {
+  /**
+   * The col-span for the header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#colspan)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  colSpan: number
+  /**
+   * The header's associated column object.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#column)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  column: Column<TData, TValue>
+  /**
+   * The depth of the header, zero-indexed based.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#depth)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  depth: number
+  /**
+   * Returns the rendering context (or props) for column-based components like headers, footers and filters.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#getcontext)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  getContext: () => HeaderContext<TData, TValue>
+  /**
+   * Returns the leaf headers hierarchically nested under this header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#getleafheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  getLeafHeaders: () => Header<TData, unknown>[]
+  /**
+   * The header's associated header group object.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#headergroup)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  headerGroup: HeaderGroup<TData>
+  /**
+   * The unique identifier for the header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#id)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  id: string
+  /**
+   * The index for the header within the header group.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#index)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  index: number
+  /**
+   * A boolean denoting if the header is a placeholder header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#isplaceholder)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  isPlaceholder: boolean
+  /**
+   * If the header is a placeholder header, this will be a unique header ID that does not conflict with any other headers across the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#placeholderid)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  placeholderId?: string
+  /**
+   * The row-span for the header.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#rowspan)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  rowSpan: number
+  /**
+   * The header's hierarchical sub/child headers. Will be empty if the header's associated column is a leaf-column.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#subheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  subHeaders: Header<TData, TValue>[]
+}
+
+export interface Table_Headers<TData extends RowData> {
+  /**
+   * Returns all header groups for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getheadergroups)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  getHeaderGroups: () => HeaderGroup<TData>[]
+  /**
+   * Returns the footer groups for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getfootergroups)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  getFooterGroups: () => HeaderGroup<TData>[]
+  /**
+   * Returns headers for all columns in the table, including parent headers.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getflatheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  getFlatHeaders: () => Header<TData, unknown>[]
+  /**
+   * Returns headers for all leaf columns in the table, (not including parent headers).
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/headers#getleafheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/headers)
+   */
+  getLeafHeaders: () => Header<TData, unknown>[]
+}

--- a/packages/table-core/src/core/headers/Headers.utils.ts
+++ b/packages/table-core/src/core/headers/Headers.utils.ts
@@ -1,0 +1,64 @@
+import { Column, HeaderGroup, RowData, Table } from '../../types'
+import { buildHeaderGroups } from './buildHeaderGroups'
+
+export function table_getHeaderGroups<TData extends RowData>(
+  table: Table<TData>,
+  allColumns: Column<TData, unknown>[],
+  leafColumns: Column<TData, unknown>[],
+  left?: string[],
+  right?: string[]
+) {
+  const leftColumns =
+    left
+      ?.map(columnId => leafColumns.find(d => d.id === columnId)!)
+      .filter(Boolean) ?? []
+
+  const rightColumns =
+    right
+      ?.map(columnId => leafColumns.find(d => d.id === columnId)!)
+      .filter(Boolean) ?? []
+
+  const centerColumns = leafColumns.filter(
+    column => !left?.includes(column.id) && !right?.includes(column.id)
+  )
+
+  const headerGroups = buildHeaderGroups(
+    allColumns,
+    [...leftColumns, ...centerColumns, ...rightColumns],
+    table
+  )
+
+  return headerGroups
+}
+
+export function table_getFooterGroups<TData extends RowData>(
+  headerGroups: HeaderGroup<TData>[]
+) {
+  return [...headerGroups].reverse()
+}
+
+export function table_getFlatHeaders<TData extends RowData>(
+  headerGroups: HeaderGroup<TData>[]
+) {
+  return headerGroups
+    .map(headerGroup => {
+      return headerGroup.headers
+    })
+    .flat()
+}
+
+export function table_getLeafHeaders<TData extends RowData>(
+  left: HeaderGroup<TData>[],
+  center: HeaderGroup<TData>[],
+  right: HeaderGroup<TData>[]
+) {
+  return [
+    ...(left[0]?.headers ?? []),
+    ...(center[0]?.headers ?? []),
+    ...(right[0]?.headers ?? []),
+  ]
+    .map(header => {
+      return header.getLeafHeaders()
+    })
+    .flat()
+}

--- a/packages/table-core/src/core/headers/buildHeaderGroups.ts
+++ b/packages/table-core/src/core/headers/buildHeaderGroups.ts
@@ -1,0 +1,159 @@
+import { Column, Header, HeaderGroup, RowData, Table } from '../../types'
+import { _createHeader } from './CreateHeader'
+
+export function buildHeaderGroups<TData extends RowData>(
+  allColumns: Column<TData, unknown>[],
+  columnsToGroup: Column<TData, unknown>[],
+  table: Table<TData>,
+  headerFamily?: 'center' | 'left' | 'right'
+) {
+  // Find the max depth of the columns:
+  // build the leaf column row
+  // build each buffer row going up
+  //    placeholder for non-existent level
+  //    real column for existing level
+
+  let maxDepth = 0
+
+  const findMaxDepth = (columns: Column<TData, unknown>[], depth = 1) => {
+    maxDepth = Math.max(maxDepth, depth)
+
+    columns
+      .filter(column => column.getIsVisible())
+      .forEach(column => {
+        if (column.columns?.length) {
+          findMaxDepth(column.columns, depth + 1)
+        }
+      }, 0)
+  }
+
+  findMaxDepth(allColumns)
+
+  let headerGroups: HeaderGroup<TData>[] = []
+
+  const createHeaderGroup = (
+    headersToGroup: Header<TData, unknown>[],
+    depth: number
+  ) => {
+    // The header group we are creating
+    const headerGroup: HeaderGroup<TData> = {
+      depth,
+      id: [headerFamily, `${depth}`].filter(Boolean).join('_'),
+      headers: [],
+    }
+
+    // The parent columns we're going to scan next
+    const pendingParentHeaders: Header<TData, unknown>[] = []
+
+    // Scan each column for parents
+    headersToGroup.forEach(headerToGroup => {
+      // What is the latest (last) parent column?
+
+      const latestPendingParentHeader = [...pendingParentHeaders].reverse()[0]
+
+      const isLeafHeader = headerToGroup.column.depth === headerGroup.depth
+
+      let column: Column<TData, unknown>
+      let isPlaceholder = false
+
+      if (isLeafHeader && headerToGroup.column.parent) {
+        // The parent header is new
+        column = headerToGroup.column.parent
+      } else {
+        // The parent header is repeated
+        column = headerToGroup.column
+        isPlaceholder = true
+      }
+
+      if (
+        latestPendingParentHeader &&
+        latestPendingParentHeader?.column === column
+      ) {
+        // This column is repeated. Add it as a sub header to the next batch
+        latestPendingParentHeader.subHeaders.push(headerToGroup)
+      } else {
+        // This is a new header. Let's create it
+        const header = _createHeader(table, column, {
+          id: [headerFamily, depth, column.id, headerToGroup?.id]
+            .filter(Boolean)
+            .join('_'),
+          isPlaceholder,
+          placeholderId: isPlaceholder
+            ? `${pendingParentHeaders.filter(d => d.column === column).length}`
+            : undefined,
+          depth,
+          index: pendingParentHeaders.length,
+        })
+
+        // Add the headerToGroup as a subHeader of the new header
+        header.subHeaders.push(headerToGroup)
+        // Add the new header to the pendingParentHeaders to get grouped
+        // in the next batch
+        pendingParentHeaders.push(header)
+      }
+
+      headerGroup.headers.push(headerToGroup)
+      headerToGroup.headerGroup = headerGroup
+    })
+
+    headerGroups.push(headerGroup)
+
+    if (depth > 0) {
+      createHeaderGroup(pendingParentHeaders, depth - 1)
+    }
+  }
+
+  const bottomHeaders = columnsToGroup.map((column, index) =>
+    _createHeader(table, column, {
+      depth: maxDepth,
+      index,
+    })
+  )
+
+  createHeaderGroup(bottomHeaders, maxDepth - 1)
+
+  headerGroups.reverse()
+
+  // headerGroups = headerGroups.filter(headerGroup => {
+  //   return !headerGroup.headers.every(header => header.isPlaceholder)
+  // })
+
+  const recurseHeadersForSpans = (
+    headers: Header<TData, unknown>[]
+  ): { colSpan: number; rowSpan: number }[] => {
+    const filteredHeaders = headers.filter(header =>
+      header.column.getIsVisible()
+    )
+
+    return filteredHeaders.map(header => {
+      let colSpan = 0
+      let rowSpan = 0
+      let childRowSpans = [0]
+
+      if (header.subHeaders && header.subHeaders.length) {
+        childRowSpans = []
+
+        recurseHeadersForSpans(header.subHeaders).forEach(
+          ({ colSpan: childColSpan, rowSpan: childRowSpan }) => {
+            colSpan += childColSpan
+            childRowSpans.push(childRowSpan)
+          }
+        )
+      } else {
+        colSpan = 1
+      }
+
+      const minChildRowSpan = Math.min(...childRowSpans)
+      rowSpan = rowSpan + minChildRowSpan
+
+      header.colSpan = colSpan
+      header.rowSpan = rowSpan
+
+      return { colSpan, rowSpan }
+    })
+  }
+
+  recurseHeadersForSpans(headerGroups[0]?.headers ?? [])
+
+  return headerGroups
+}

--- a/packages/table-core/src/core/table/Table.ts
+++ b/packages/table-core/src/core/table/Table.ts
@@ -5,19 +5,13 @@ import {
   TableOptionsResolved,
   TableState,
   Table,
-  RowModel,
-  TableOptions,
   RowData,
-  TableMeta,
-  TableFeature,
 } from '../../types'
 
-//
 import { Headers } from '../headers/Headers'
 import { Rows } from '../rows/Rows'
 import { Cells } from '../cells/Cells'
 import { Columns } from '../columns/Columns'
-//
 
 import { ColumnFaceting } from '../../features/column-faceting/ColumnFaceting'
 import { ColumnFiltering } from '../../features/column-filtering/ColumnFiltering'
@@ -34,6 +28,7 @@ import { RowPagination } from '../../features/row-pagination/RowPagination'
 import { RowPinning } from '../../features/row-pinning/RowPinning'
 import { RowSelection } from '../../features/row-selection/RowSelection'
 import { RowSorting } from '../../features/row-sorting/RowSorting'
+import { Table_Core } from './Table.types'
 
 const coreFeatures = [Cells, Columns, Rows, Headers] as const
 
@@ -54,181 +49,6 @@ const builtInFeatures = [
   ColumnSizing,
   ColumnResizing,
 ] as const
-
-//
-
-export interface TableOptions_Core<TData extends RowData> {
-  /**
-   * An array of extra features that you can add to the table instance.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#_features)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  _features?: TableFeature[]
-  /**
-   * Set this option to override any of the `autoReset...` feature options.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#autoresetall)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  autoResetAll?: boolean
-  /**
-   * The data for the table to display. This array should match the type you provided to `table.setRowType<...>`. Columns can access this data via string/index or a functional accessor. When the `data` option changes reference, the table will reprocess the data.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#data)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  data: TData[]
-  /**
-   * Set this option to `true` to output all debugging information to the console.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugall)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  debugAll?: boolean
-  /**
-   * Set this option to `true` to output header debugging information to the console.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugheaders)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  debugHeaders?: boolean
-  /**
-   * Set this option to `true` to output table debugging information to the console.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugtable)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  debugTable?: boolean
-
-  /**
-   * This required option is a factory for a function that computes and returns the core row model for the table.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getcorerowmodel)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  getCoreRowModel: (table: Table<any>) => () => RowModel<any>
-  /**
-   * Use this option to optionally pass initial state to the table. This state will be used when resetting various table states either automatically by the table (eg. `options.autoResetPageIndex`) or via functions like `table.resetRowSelection()`. Most reset function allow you optionally pass a flag to reset to a blank/default state instead of the initial state.
-   *
-   * Table state will not be reset when this object changes, which also means that the initial state object does not need to be stable.
-   *
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#initialstate)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  initialState?: Partial<TableState>
-  /**
-   * This option is used to optionally implement the merging of table options.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#mergeoptions)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  mergeOptions?: (
-    defaultOptions: TableOptions<TData>,
-    options: Partial<TableOptions<TData>>
-  ) => TableOptions<TData>
-  /**
-   * You can pass any object to `options.meta` and access it anywhere the `table` is available via `table.options.meta`.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#meta)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  meta?: TableMeta<TData>
-  /**
-   * The `onStateChange` option can be used to optionally listen to state changes within the table.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#onstatechange)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  onStateChange: (updater: Updater<TableState>) => void
-  /**
-   * The `state` option can be used to optionally _control_ part or all of the table state. The state you pass here will merge with and overwrite the internal automatically-managed state to produce the final state for the table. You can also listen to state changes via the `onStateChange` option.
-   * > Note: Any state passed in here will override both the internal state and any other `initialState` you provide.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#state)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  state: Partial<TableState>
-}
-
-export function tableOptions<TData extends RowData = any>(
-  options: Omit<TableOptions<TData>, 'columns'>
-): Omit<TableOptions<TData>, 'columns'>
-
-export function tableOptions<TData extends RowData = any>(
-  options: Omit<TableOptions<TData>, 'data'>
-): Omit<TableOptions<TData>, 'data'>
-
-export function tableOptions<TData extends RowData = any>(
-  options: Omit<TableOptions<TData>, 'getCoreRowModel'>
-): Omit<TableOptions<TData>, 'getCoreRowModel'>
-
-export function tableOptions<TData extends RowData = any>(
-  options: Omit<TableOptions<TData>, 'data' | 'columns'>
-): Omit<TableOptions<TData>, 'data' | 'columns'>
-
-export function tableOptions<TData extends RowData = any>(
-  options: Omit<TableOptions<TData>, 'getCoreRowModel' | 'columns'>
-): Omit<TableOptions<TData>, 'getCoreRowModel' | 'columns'>
-
-export function tableOptions<TData extends RowData = any>(
-  options: Omit<TableOptions<TData>, 'data' | 'getCoreRowModel'>
-): Omit<TableOptions<TData>, 'data' | 'getCoreRowModel'>
-
-export function tableOptions<TData extends RowData = any>(
-  options: Omit<TableOptions<TData>, 'data' | 'columns' | 'getCoreRowModel'>
-): Omit<TableOptions<TData>, 'data' | 'columns' | 'getCoreRowModel'>
-
-export function tableOptions<TData extends RowData = any>(
-  options: TableOptions<TData>
-): TableOptions<TData>
-
-export function tableOptions(options: unknown) {
-  return options
-}
-
-export interface Table_Core<TData extends RowData> {
-  _features: readonly TableFeature[]
-  _getCoreRowModel?: () => RowModel<TData>
-  _queue: (cb: () => void) => void
-  /**
-   * Returns the core row model before any processing has been applied.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getcorerowmodel)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  getCoreRowModel: () => RowModel<TData>
-  /**
-   * Returns the final model after all processing from other used features has been applied. This is the row model that is most commonly used for rendering.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getrowmodel)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  getRowModel: () => RowModel<TData>
-  /**
-   * Call this function to get the table's current state. It's recommended to use this function and its state, especially when managing the table state manually. It is the exact same state used internally by the table for every feature and function it provides.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getstate)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  getState: () => TableState
-  /**
-   * This is the resolved initial state of the table.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#initialstate)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  initialState: TableState
-  /**
-   * A read-only reference to the table's current options.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#options)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  options: RequiredKeys<TableOptionsResolved<TData>, 'state'>
-  /**
-   * Call this function to reset the table state to the initial state.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#reset)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  reset: () => void
-  /**
-   * This function can be used to update the table options.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#setoptions)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  setOptions: (newOptions: Updater<TableOptionsResolved<TData>>) => void
-  /**
-   * Call this function to update the table state.
-   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#setstate)
-   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
-   */
-  setState: (updater: Updater<TableState>) => void
-}
 
 export function _createTable<TData extends RowData>(
   options: TableOptionsResolved<TData>

--- a/packages/table-core/src/core/table/Table.types.ts
+++ b/packages/table-core/src/core/table/Table.types.ts
@@ -1,0 +1,185 @@
+import {
+  RowData,
+  RowModel,
+  Table,
+  TableFeature,
+  TableMeta,
+  TableOptions,
+  TableOptionsResolved,
+  TableState,
+  Updater,
+} from '../../types'
+import { RequiredKeys } from '../../utils'
+
+export interface TableOptions_Core<TData extends RowData> {
+  /**
+   * An array of extra features that you can add to the table instance.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#_features)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  _features?: TableFeature[]
+  /**
+   * Set this option to override any of the `autoReset...` feature options.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#autoresetall)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  autoResetAll?: boolean
+  /**
+   * The data for the table to display. This array should match the type you provided to `table.setRowType<...>`. Columns can access this data via string/index or a functional accessor. When the `data` option changes reference, the table will reprocess the data.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#data)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  data: TData[]
+  /**
+   * Set this option to `true` to output all debugging information to the console.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugall)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  debugAll?: boolean
+  /**
+   * Set this option to `true` to output header debugging information to the console.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugheaders)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  debugHeaders?: boolean
+  /**
+   * Set this option to `true` to output table debugging information to the console.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#debugtable)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  debugTable?: boolean
+
+  /**
+   * This required option is a factory for a function that computes and returns the core row model for the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getcorerowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getCoreRowModel: (table: Table<any>) => () => RowModel<any>
+  /**
+   * Use this option to optionally pass initial state to the table. This state will be used when resetting various table states either automatically by the table (eg. `options.autoResetPageIndex`) or via functions like `table.resetRowSelection()`. Most reset function allow you optionally pass a flag to reset to a blank/default state instead of the initial state.
+   *
+   * Table state will not be reset when this object changes, which also means that the initial state object does not need to be stable.
+   *
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#initialstate)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  initialState?: Partial<TableState>
+  /**
+   * This option is used to optionally implement the merging of table options.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#mergeoptions)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  mergeOptions?: (
+    defaultOptions: TableOptions<TData>,
+    options: Partial<TableOptions<TData>>
+  ) => TableOptions<TData>
+  /**
+   * You can pass any object to `options.meta` and access it anywhere the `table` is available via `table.options.meta`.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#meta)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  meta?: TableMeta<TData>
+  /**
+   * The `onStateChange` option can be used to optionally listen to state changes within the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#onstatechange)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  onStateChange: (updater: Updater<TableState>) => void
+  /**
+   * The `state` option can be used to optionally _control_ part or all of the table state. The state you pass here will merge with and overwrite the internal automatically-managed state to produce the final state for the table. You can also listen to state changes via the `onStateChange` option.
+   * > Note: Any state passed in here will override both the internal state and any other `initialState` you provide.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#state)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  state: Partial<TableState>
+}
+
+export function tableOptions<TData extends RowData = any>(
+  options: Omit<TableOptions<TData>, 'columns'>
+): Omit<TableOptions<TData>, 'columns'>
+
+export function tableOptions<TData extends RowData = any>(
+  options: Omit<TableOptions<TData>, 'data'>
+): Omit<TableOptions<TData>, 'data'>
+
+export function tableOptions<TData extends RowData = any>(
+  options: Omit<TableOptions<TData>, 'getCoreRowModel'>
+): Omit<TableOptions<TData>, 'getCoreRowModel'>
+
+export function tableOptions<TData extends RowData = any>(
+  options: Omit<TableOptions<TData>, 'data' | 'columns'>
+): Omit<TableOptions<TData>, 'data' | 'columns'>
+
+export function tableOptions<TData extends RowData = any>(
+  options: Omit<TableOptions<TData>, 'getCoreRowModel' | 'columns'>
+): Omit<TableOptions<TData>, 'getCoreRowModel' | 'columns'>
+
+export function tableOptions<TData extends RowData = any>(
+  options: Omit<TableOptions<TData>, 'data' | 'getCoreRowModel'>
+): Omit<TableOptions<TData>, 'data' | 'getCoreRowModel'>
+
+export function tableOptions<TData extends RowData = any>(
+  options: Omit<TableOptions<TData>, 'data' | 'columns' | 'getCoreRowModel'>
+): Omit<TableOptions<TData>, 'data' | 'columns' | 'getCoreRowModel'>
+
+export function tableOptions<TData extends RowData = any>(
+  options: TableOptions<TData>
+): TableOptions<TData>
+
+export function tableOptions(options: unknown) {
+  return options
+}
+
+export interface Table_Core<TData extends RowData> {
+  _features: readonly TableFeature[]
+  _getCoreRowModel?: () => RowModel<TData>
+  _queue: (cb: () => void) => void
+  /**
+   * Returns the core row model before any processing has been applied.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getcorerowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getCoreRowModel: () => RowModel<TData>
+  /**
+   * Returns the final model after all processing from other used features has been applied. This is the row model that is most commonly used for rendering.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getrowmodel)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getRowModel: () => RowModel<TData>
+  /**
+   * Call this function to get the table's current state. It's recommended to use this function and its state, especially when managing the table state manually. It is the exact same state used internally by the table for every feature and function it provides.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#getstate)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  getState: () => TableState
+  /**
+   * This is the resolved initial state of the table.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#initialstate)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  initialState: TableState
+  /**
+   * A read-only reference to the table's current options.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#options)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  options: RequiredKeys<TableOptionsResolved<TData>, 'state'>
+  /**
+   * Call this function to reset the table state to the initial state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#reset)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  reset: () => void
+  /**
+   * This function can be used to update the table options.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#setoptions)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  setOptions: (newOptions: Updater<TableOptionsResolved<TData>>) => void
+  /**
+   * Call this function to update the table state.
+   * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/table#setstate)
+   * @link [Guide](https://tanstack.com/table/v8/docs/guide/tables)
+   */
+  setState: (updater: Updater<TableState>) => void
+}

--- a/packages/table-core/src/features/column-pinning/ColumnPinning.ts
+++ b/packages/table-core/src/features/column-pinning/ColumnPinning.ts
@@ -1,4 +1,4 @@
-import { buildHeaderGroups } from '../../core/headers/Headers'
+import { buildHeaderGroups } from '../../core/headers/buildHeaderGroups'
 import { Table, Column, Row, RowData, TableFeature } from '../../types'
 import { getMemoOptions, makeStateUpdater, memo } from '../../utils'
 import {

--- a/packages/table-core/src/index.ts
+++ b/packages/table-core/src/index.ts
@@ -17,12 +17,15 @@ export * from './core/cells/Cells.utils'
 
 //Columns
 export * from './core/columns/CreateColumn'
-export * from './core/columns/Columns.utils'
-export * from './core/columns/Columns.types'
 export * from './core/columns/Columns'
+export * from './core/columns/Columns.types'
+export * from './core/columns/Columns.utils'
 
 //Headers
+export * from './core/headers/CreateHeader'
 export * from './core/headers/Headers'
+export * from './core/headers/Headers.types'
+export * from './core/headers/Headers.utils'
 
 //Rows
 export * from './core/rows/CreateRow'
@@ -32,9 +35,11 @@ export * from './core/rows/Rows.utils'
 
 //Table
 export * from './core/table/Table'
+export * from './core/table/Table.types'
 
 //Utils
 export * from './utils'
+export * from './core/headers/buildHeaderGroups'
 export * from './core/table/getCoreRowModel'
 
 /**

--- a/packages/table-core/src/types.ts
+++ b/packages/table-core/src/types.ts
@@ -1,4 +1,4 @@
-import { TableOptions_Core, Table_Core } from './core/table/Table'
+import { TableOptions_Core, Table_Core } from './core/table/Table.types'
 import {
   Table_ColumnVisibility,
   TableState_ColumnVisibility,
@@ -32,7 +32,7 @@ import {
   HeaderGroup_Core,
   HeaderContext,
   Table_Headers,
-} from './core/headers/Headers'
+} from './core/headers/Headers.types'
 import {
   Column_ColumnFaceting,
   TableOptions_ColumnFaceting,


### PR DESCRIPTION
- Refactored the headers folder in core for create, base, types, and utils
- Refactored core table folder to separate types and base
- Match file import ordering in index

Questions: Should the ...core/Table.ts file be called CreateTable.ts to match the other core folders that are creating?