### PR TITLE
ci: Improve Nx inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -15,53 +15,51 @@
       "{projectRoot}/**/*",
       "!{projectRoot}/**/*.md"
     ],
-    "public": [
+    "production": [
       "default",
-      "{projectRoot}/build",
-      "{projectRoot}/dist",
-      "!{projectRoot}/.eslintrc.cjs",
-      "!{projectRoot}/tsconfig.eslint.json"
+      "!{projectRoot}/tests/**/*",
+      "!{projectRoot}/eslint.config.js"
     ]
   },
   "targetDefaults": {
-    "test:lib": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
-      "outputs": ["{projectRoot}/coverage"],
-      "cache": true
-    },
-    "test:eslint": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
-      "cache": true
-    },
-    "test:types": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
-      "cache": true
-    },
-    "test:build": {
-      "dependsOn": ["build"],
-      "inputs": ["default", "^public"],
-      "cache": true
-    },
-    "build": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
-      "outputs": ["{projectRoot}/build", "{projectRoot}/dist"],
-      "cache": true
+    "test:format": {
+      "cache": true,
+      "inputs": ["{workspaceRoot}/**/*"]
     },
     "test:knip": {
       "cache": true,
       "inputs": ["{workspaceRoot}/**/*"]
     },
-    "test:format": {
-      "cache": true,
-      "inputs": ["{workspaceRoot}/**/*"]
-    },
     "test:sherif": {
       "cache": true,
-      "inputs": ["{workspaceRoot}/**/*"]
+      "inputs": ["{workspaceRoot}/**/package.json"]
+    },
+    "test:eslint": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^production", "{workspaceRoot}/eslint.config.js"]
+    },
+    "test:lib": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^production"],
+      "outputs": ["{projectRoot}/coverage"]
+    },
+    "test:types": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^production"]
+    },
+    "build": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"],
+      "outputs": ["{projectRoot}/build", "{projectRoot}/dist"]
+    },
+    "test:build": {
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["production"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
-  "name": "table",
-  "namespace": "@tanstack",
+  "name": "root",
   "private": true,
-  "repository": "https://github.com/tanstack/table.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tanstack/table.git"
+  },
   "packageManager": "pnpm@9.3.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- Renamed `public` to `production` to match [Nx docs](https://nx.dev/reference/inputs)
- `build` will not be invalidated when only tests change
- `test:build` now has the right cache inputs
- `test:sherif` only depends on `package.json` files