### PR TITLE
Update columns.md

### DIFF
--- a/docs/guide/columns.md
+++ b/docs/guide/columns.md
@@ -18,7 +18,7 @@ You can find the `column` objects in many places. They are often attached
 
 #### Header and Cell Objects
 
-Before you reach for one of the `table` instance APIs, consider if you actually need to retrieve either [`headers`](../headers) or [`cells`](../cells) instead of `columns`. If you are rending out the markup for your table, you will most likely want to reach for the APIs that return headers or cells instead of columns. The column objects themselves are not really meant to render out the headers or cells, but the `header` and `cell` objects will contain references to these `column` objects from which they can derive the necessary information to render their UI.
+Before you reach for one of the `table` instance APIs, consider if you actually need to retrieve either [headers](../headers) or [cells](../cells) instead of `columns`. If you are rending out the markup for your table, you will most likely want to reach for the APIs that return headers or cells instead of columns. The column objects themselves are not really meant to render out the headers or cells, but the `header` and `cell` objects will contain references to these `column` objects from which they can derive the necessary information to render their UI.
 
 ```js
 const column = cell.column; // get column from cell


### PR DESCRIPTION
The usage of backticks inside of the header and cell links made it so that the text could not be properly parsed and rendered the links impossible to use. With this change, the links are available again.