### PR TITLE
Fix: allow TValue to be specified in display and group column helpers

### DIFF
--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -66,8 +66,12 @@ export type ColumnHelper<TData extends RowData> = {
   ) => TAccessor extends AccessorFn<TData>
     ? AccessorFnColumnDef<TData, TValue>
     : AccessorKeyColumnDef<TData, TValue>
-  display: (column: DisplayColumnDef<TData>) => DisplayColumnDef<TData, unknown>
-  group: (column: GroupColumnDef<TData>) => GroupColumnDef<TData, unknown>
+  display: <TValue = unknown>(
+    column: DisplayColumnDef<TData, TValue>
+  ) => DisplayColumnDef<TData, TValue>
+  group: <TValue = unknown>(
+    column: GroupColumnDef<TData, TValue>
+  ) => GroupColumnDef<TData, TValue>
 }
 
 export function createColumnHelper<


### PR DESCRIPTION
By default, the return types of `columnHelper.display` and `columnHelper.group` are fine, because `ColumnDef<TData, TValue>` is contravariant with respect to `TValue`. However, the user might extend `ColumnDefBase` (or another type constituent of `ColumnDef`) via declaration merging, such that this no longer holds. At that point, the helper can no longer be used because its return type is no longer assignable to `ColumnDef`. Adding the type argument to `display` and `group` fixes this issue.