### PR TITLE
Fix JSDoc comment for rankItem

### DIFF
--- a/packages/match-sorter-utils/src/index.ts
+++ b/packages/match-sorter-utils/src/index.ts
@@ -70,7 +70,6 @@ export type Ranking = (typeof rankings)[keyof typeof rankings]
 /**
  * Gets the highest ranking for value for the given item based on its values for the given keys
  * @param {*} item - the item to rank
- * @param {Array} keys - the keys to get values from the item for the ranking
  * @param {String} value - the value to rank against
  * @param {Object} options - options to control the ranking
  * @return {{rank: Number, accessorIndex: Number, accessorThreshold: Number}} - the highest ranking


### PR DESCRIPTION
The JSDoc comment for the function `rankItem` currently includes the parameter `keys`, although the function does not have a parameter `keys`.