### PR TITLE
Fix getFacetedMinMaxValues

### DIFF
--- a/packages/table-core/src/utils/getFacetedMinMaxValues.ts
+++ b/packages/table-core/src/utils/getFacetedMinMaxValues.ts
@@ -10,11 +10,11 @@ export function getFacetedMinMaxValues<TData extends RowData>(): (
       () => [table.getColumn(columnId)?.getFacetedRowModel()],
       facetedRowModel => {
         if (!facetedRowModel) return undefined
-        
+
         const uniqueValues = facetedRowModel.flatRows
-          .flatMap((flatRow) => flatRow.getUniqueValues(columnId) ?? [])
+          .flatMap(flatRow => flatRow.getUniqueValues(columnId) ?? [])
           .map(Number)
-          .filter((value) => !Number.isNaN(value))
+          .filter(value => !Number.isNaN(value))
 
         if (!uniqueValues.length) return
 

--- a/packages/table-core/src/utils/getFacetedMinMaxValues.ts
+++ b/packages/table-core/src/utils/getFacetedMinMaxValues.ts
@@ -18,8 +18,8 @@ export function getFacetedMinMaxValues<TData extends RowData>(): (
 
         if (!uniqueValues.length) return
 
-        let facetedMinValue = uniqueValues.at(0)!
-        let facetedMaxValue = uniqueValues.at(-1)!
+        let facetedMinValue = uniqueValues[0]!
+        let facetedMaxValue = uniqueValues[uniqueValues.length - 1]!
 
         for (const value of uniqueValues) {
           if (value < facetedMinValue) facetedMinValue = value

--- a/packages/table-core/src/utils/getFacetedMinMaxValues.ts
+++ b/packages/table-core/src/utils/getFacetedMinMaxValues.ts
@@ -12,7 +12,7 @@ export function getFacetedMinMaxValues<TData extends RowData>(): (
         if (!facetedRowModel) return undefined
 
         const firstValue =
-          facetedRowModel.flatRows[0]?.getUniqueValues(columnId)
+          facetedRowModel.flatRows[0]?.getUniqueValues(columnId)?.[0]
 
         if (typeof firstValue === 'undefined') {
           return undefined

--- a/packages/table-core/src/utils/getFacetedMinMaxValues.ts
+++ b/packages/table-core/src/utils/getFacetedMinMaxValues.ts
@@ -10,32 +10,23 @@ export function getFacetedMinMaxValues<TData extends RowData>(): (
       () => [table.getColumn(columnId)?.getFacetedRowModel()],
       facetedRowModel => {
         if (!facetedRowModel) return undefined
+        
+        const uniqueValues = facetedRowModel.flatRows
+          .flatMap((flatRow) => flatRow.getUniqueValues(columnId) ?? [])
+          .map(Number)
+          .filter((value) => !Number.isNaN(value))
 
-        const firstValue =
-          facetedRowModel.flatRows[0]?.getUniqueValues(columnId)?.[0]
+        if (!uniqueValues.length) return
 
-        if (typeof firstValue === 'undefined') {
-          return undefined
+        let facetedMinValue = uniqueValues.at(0)!
+        let facetedMaxValue = uniqueValues.at(-1)!
+
+        for (const value of uniqueValues) {
+          if (value < facetedMinValue) facetedMinValue = value
+          else if (value > facetedMaxValue) facetedMaxValue = value
         }
 
-        let facetedMinMaxValues: [any, any] = [firstValue, firstValue]
-
-        for (let i = 0; i < facetedRowModel.flatRows.length; i++) {
-          const values =
-            facetedRowModel.flatRows[i]!.getUniqueValues<number>(columnId)
-
-          for (let j = 0; j < values.length; j++) {
-            const value = values[j]!
-
-            if (value < facetedMinMaxValues[0]) {
-              facetedMinMaxValues[0] = value
-            } else if (value > facetedMinMaxValues[1]) {
-              facetedMinMaxValues[1] = value
-            }
-          }
-        }
-
-        return facetedMinMaxValues
+        return [facetedMinValue, facetedMaxValue]
       },
       getMemoOptions(table.options, 'debugTable', 'getFacetedMinMaxValues')
     )


### PR DESCRIPTION
I noticed a bug in getFacetedMinMaxValues that I'm surprised no one else has reported or the type checks haven't flagged. Actually, I'm sure I've run into this issue before, but I guess I never got around to reporting it...

The `getUniqueValues` function says it returns (and in testing, does return) an array of values. Thus, `firstValue` becomes e.g. `[123]`, and  `facetedMinMaxValues` will get initialized to `[[123], [123]]`, which sometimes results in the function returning e.g. `[123, [123]]`, depending on the row values. I'm guessing people don't always notice a bug here because an array is being `<`/`>` compared to a numbe, which I think coerces the array to a string?

My first commit makes the minimal change that I think fixes the issue. The second commit reworks the function to be a bit safer imo.