### PR TITLE
docs: fix incorrect type usage in `@tanstack/angular-table` state documentation

### DIFF
--- a/docs/framework/angular/guide/table-state.md
+++ b/docs/framework/angular/guide/table-state.md
@@ -70,7 +70,7 @@ import {combineLatest, switchMap} from 'rxjs';
 
 class TableComponent {
   readonly columnFilters = signal<ColumnFiltersState>([]) //no default filters
-  readonly sorting = signal<SortingState[]>([
+  readonly sorting = signal<SortingState>([
     {
       id: 'age',
       desc: true, //sort by age in descending order by default


### PR DESCRIPTION
`SortingState` is an array, so use of `SortingState[]` is incorrect in this example.