### PR TITLE
fix typo on tables.md

### DIFF
--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -18,7 +18,7 @@ To create a table instance, 3 `options` are required: `columns`, `data`, and a `
 
 #### Defining Data
 
-Define your data as an array of objects with a stable reference. `data` can come from anywhere like an API response or defined statically in your code, but it must have a stable reference to prevent infinite re-renders. If using TypeScript, the the type that you give your data will be used as a `TData` generic. See the [Data Guide](../data) for more info.
+Define your data as an array of objects with a stable reference. `data` can come from anywhere like an API response or defined statically in your code, but it must have a stable reference to prevent infinite re-renders. If using TypeScript, the type that you give your data will be used as a `TData` generic. See the [Data Guide](../data) for more info.
 
 #### Defining Columns
 


### PR DESCRIPTION
Hello amazing team behind this amazing lib 😄,

A small typo PR change on [docs](https://tanstack.com/table/latest/docs/guide/tables#creating-a-table-instance:~:text=If%20using%20TypeScript%2C%20the%20the%20type%20that%20you%20give%20your%20data%20will%20be%20used%20as%20a%20TData%20generic.%20See%20the%20Data%20Guide%20for%20more%20info.) in the line "If using Typescript..". 

"The" is repeated twice.

![image](https://github.com/user-attachments/assets/1d2e41c6-bf49-4c11-a685-42773b1a37cc)

Again, thank you so much folks for this library which makes working with tables much much simpler. Cheers. 