### PR TITLE
fix: major performance bug in Vue-adapter

### DIFF
--- a/packages/vue-table/src/index.ts
+++ b/packages/vue-table/src/index.ts
@@ -13,7 +13,7 @@ import { mergeProxy } from './merge-proxy'
 
 export * from '@tanstack/table-core'
 
-type TableOptionsWithReactiveData<TData extends RowData> = Omit<
+export type TableOptionsWithReactiveData<TData extends RowData> = Omit<
   TableOptions<TData>,
   'data'
 > & {

--- a/packages/vue-table/src/index.ts
+++ b/packages/vue-table/src/index.ts
@@ -52,12 +52,6 @@ export function useVueTable<TData extends RowData>(
       state: {}, // Dummy state
       onStateChange: () => {}, // noop
       renderFallbackValue: null,
-      mergeOptions(
-        defaultOptions: TableOptions<TData>,
-        options: TableOptions<TData>
-      ) {
-        return mergeProxy(defaultOptions, options)
-      },
     },
     getOptionsWithReactiveData(initialOptions)
   )


### PR DESCRIPTION
The `mergeOptions` causes huge performance issues in the Vue-adapter whenever the state of the table is updated. This is probably because it merges proxies within proxies, within proxies etc.

As far as I know, there is no need for any special handling of option-merging in the Vue-adapter. Removing it fixes the problem, and the library works like it should.