### PR TITLE
fix: correct broken link to row models section in table guide

### DIFF
--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -98,4 +98,4 @@ For example, you can find the core table instance API docs here: [Table API](../
 
 ### Table Row Models
 
-There is a special set of table instance APIs for reading rows out of the table instance called row models. TanStack Table has advanced features where the rows that are generated may be very different than the array of `data` that you originally passed in. To learn more about the different row models that you can pass in as a table option, see the [Row Models Guide](./row-models).
+There is a special set of table instance APIs for reading rows out of the table instance called row models. TanStack Table has advanced features where the rows that are generated may be very different than the array of `data` that you originally passed in. To learn more about the different row models that you can pass in as a table option, see the [Row Models Guide](../row-models).


### PR DESCRIPTION
A simple fix for incorrect link on `https://tanstack.com/table/latest/docs/guide/tables` page.