### PR TITLE
Fix label typo in config.json

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -121,7 +121,7 @@
           "to": "guide/tables"
         },
         {
-          "label": "Rows Models",
+          "label": "Row Models",
           "to": "guide/row-models"
         },
         {


### PR DESCRIPTION
Just a small typo fix for the sidebar in the docs.