### PR TITLE
Change `target` to `currentTarget` in the example

### DIFF
--- a/examples/react/virtualized-infinite-scrolling/src/main.tsx
+++ b/examples/react/virtualized-infinite-scrolling/src/main.tsx
@@ -184,7 +184,7 @@ function App() {
       ({flatData.length} of {totalDBRowCount} rows fetched)
       <div
         className="container"
-        onScroll={e => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
+        onScroll={e => fetchMoreOnBottomReached(e.currentTarget)}
         ref={tableContainerRef}
         style={{
           overflow: 'auto', //our scrollable table container


### PR DESCRIPTION
In this case, it will accomplish the same functionality without the type casting