### PR TITLE
Bug fix - allow searching of numbers in global filters

### DIFF
--- a/packages/table-core/src/filterFns.ts
+++ b/packages/table-core/src/filterFns.ts
@@ -5,7 +5,7 @@ const includesString: FilterFn<any> = (
   columnId: string,
   filterValue: string
 ) => {
-  const search = filterValue.toLowerCase()
+  const search = filterValue?.toString()?.toLowerCase()
   return Boolean(
     row
       .getValue<string | null>(columnId)


### PR DESCRIPTION
Fixes https://github.com/TanStack/table/issues/4280

When searching for a number, seeing a TypeError: filterValue.toLowerCase is not a function.
The
[toLowerCase()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase)
method does not exist on the Number prototype but does on the String prototype.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/14fe9fb9-81b8-4f42-a648-766be71b1f93">

Converting it to a string before calling .toLowerCase method.