### PR TITLE
docs(expansion/table): tip use table option getRowId if data may change

### DIFF
--- a/docs/api/core/table.md
+++ b/docs/api/core/table.md
@@ -227,7 +227,7 @@ getRowId?: (
 ) => string
 ```
 
-This optional function is used to derive a unique ID for any given row. If not provided the rows index is used (nested rows join together with `.` using their grandparents' index eg. `index.index.index`). If you need to identify individual rows that are originating from any server-side operations, it's suggested you use this function to return an ID that makes sense regardless of network IO/ambiguity eg. a userId, taskId, database ID field, etc.
+This optional function is used to derive a unique ID for any given row. If not provided the rows index is used (nested rows join together with `.` using their grandparents' index eg. `index.index.index`). If you need to identify individual rows that are originating from any server-side operations, it's suggested you use this function to return an ID that makes sense regardless of network IO/ambiguity eg. a userId, taskId, database ID field, etc. It also prevents [expansion](../../guide/expanding) glitch if table data changes.
 
 ## Table API
 

--- a/docs/api/features/expanding.md
+++ b/docs/api/features/expanding.md
@@ -15,6 +15,8 @@ export type ExpandedTableState = {
 }
 ```
 
+Tip: if the table data may change, make sure to specify the table option [`getRowId`](../core/table#getrowid) so that the expanded state depends on immutable data ID, instead of default row index.
+
 ## Row API
 
 ### `toggleExpanded`


### PR DESCRIPTION
Fix https://github.com/TanStack/table/issues/2028

Add a tip in https://tanstack.com/table/v8/docs/api/features/expanding to mention using the table option `getRowId` to avoid expansion glitch when table data changes.

Also mentioned in https://tanstack.com/table/v8/docs/api/core/table#getrowid that the option helps expansion.