### PR TITLE
Fix : Corrected typo in example code

### DIFF
--- a/docs/guide/global-filtering.md
+++ b/docs/guide/global-filtering.md
@@ -106,7 +106,7 @@ const table = useReactTable({
   state: {
     globalFilter,
   },
-  onGlobalFilterChange: setGlobalFilte
+  onGlobalFilterChange: setGlobalFilter
 })
 ```
 


### PR DESCRIPTION
In example code, setGlobalFilter function name was missing "r" in the code.