### PR TITLE
Refactor example and fix ESLint error

### DIFF
--- a/examples/react/editable-data/src/main.tsx
+++ b/examples/react/editable-data/src/main.tsx
@@ -26,7 +26,7 @@ declare module '@tanstack/react-table' {
 
 // Give our default column cell renderer editing superpowers!
 const defaultColumn: Partial<ColumnDef<Person>> = {
-  cell: ({ getValue, row: { index }, column: { id }, table }) => {
+  cell: function Cell({ getValue, row: { index }, column: { id }, table }){
     const initialValue = getValue()
     // We need to keep and update the state of the cell normally
     const [value, setValue] = React.useState(initialValue)


### PR DESCRIPTION
Fix ESLint error:

```
"React Hook "React.useState" is called in function "cell" that is neither 
a React function component nor a custom React Hook function. 
React component names must start with an uppercase letter. 
(react-hooks/rules-of-hooks)"
```

Related to: [https://github.com/TanStack/table/discussions/4205#discussioncomment-3206311](https://github.com/TanStack/table/discussions/4205#discussioncomment-3206311)