### PR TITLE
fix: Use correct pagecount accessor (#5732)

### DIFF
--- a/examples/react/kitchen-sink/src/components/ActionButtons.tsx
+++ b/examples/react/kitchen-sink/src/components/ActionButtons.tsx
@@ -76,7 +76,7 @@ export function ActionButtons<T extends RowData>({
           <input
             type="number"
             min="1"
-            max={table.getPageCount()}
+            max={pageCount}
             defaultValue={pageIndex + 1}
             onChange={e => {
               const page = e.target.value ? Number(e.target.value) - 1 : 0


### PR DESCRIPTION
This fixes the issue of the kitchen sink example not loading locally/on Stackblitz/CodeSandbox since table is not defined in that scope anymore.

Related Issue: https://github.com/TanStack/table/issues/5732

