### PR TITLE
Fix solid adapter in alpha version

### DIFF
--- a/packages/solid-table/src/createTable.ts
+++ b/packages/solid-table/src/createTable.ts
@@ -23,17 +23,18 @@ export function createTable<
     getInitialTableState(_features, tableOptions.initialState),
   )
 
-  const statefulOptions = mergeProps(tableOptions, {
+  const statefulOptions: TableOptions<TFeatures, TData> = {
+    ...tableOptions,
     _features,
     state: { ...store, ...tableOptions.state },
-    mergeOptions(defaultOptions, options) {
+    mergeOptions: (defaultOptions, options) => {
       return mergeProps(defaultOptions, options)
     },
     onStateChange: (updater) => {
       setStore(updater)
       tableOptions.onStateChange?.(updater)
     },
-  } as TableOptions<TFeatures, TData>) as TableOptions<TFeatures, TData>
+  }
 
   const table = constructTable<TFeatures, TData>(statefulOptions)
 

--- a/packages/solid-table/src/createTable.ts
+++ b/packages/solid-table/src/createTable.ts
@@ -23,21 +23,24 @@ export function createTable<
     getInitialTableState(_features, tableOptions.initialState),
   )
 
-  const statefulOptions: TableOptions<TFeatures, TData> = {
-    ...tableOptions,
+  const statefulOptions = mergeProps(tableOptions, {
     _features,
     state: { ...store, ...tableOptions.state },
+    mergeOptions(defaultOptions, options) {
+      return mergeProps(defaultOptions, options)
+    },
     onStateChange: (updater) => {
       setStore(updater)
       tableOptions.onStateChange?.(updater)
     },
-  }
+  } as TableOptions<TFeatures, TData>) as TableOptions<TFeatures, TData>
 
   const table = constructTable<TFeatures, TData>(statefulOptions)
 
   createComputed(() => {
     table.setOptions((prev) => {
       return mergeProps(prev, tableOptions, {
+        _features: { ...coreFeatures, ...tableOptions._features },
         state: mergeProps(store, tableOptions.state || {}),
         onStateChange: (updater: Updater<TableState<TFeatures>>) => {
           setStore(updater)


### PR DESCRIPTION
Reintroduce the `mergeOptions` property which is needed to merge props without losing reactivity when calling `setOptions`