### PR TITLE
Global JSX namespace is deprecated

### DIFF
--- a/packages/react-table/src/index.tsx
+++ b/packages/react-table/src/index.tsx
@@ -18,7 +18,7 @@ export type Renderable<TProps> = React.ReactNode | React.ComponentType<TProps>
 export function flexRender<TProps extends object>(
   Comp: Renderable<TProps>,
   props: TProps
-): React.ReactNode | JSX.Element {
+): React.ReactNode | React.JSX.Element {
   return !Comp ? null : isReactComponent<TProps>(Comp) ? (
     <Comp {...props} />
   ) : (


### PR DESCRIPTION
The JSX Global namespace has been deprecated for a while, and removed in React 19: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript