### PR TITLE
Fix missing table variable

### DIFF
--- a/examples/react/kitchen-sink/src/components/ActionButtons.tsx
+++ b/examples/react/kitchen-sink/src/components/ActionButtons.tsx
@@ -76,7 +76,7 @@ export function ActionButtons<T extends RowData>({
           <input
             type="number"
             min="1"
-            max={table.getPageCount()}
+            max={pageCount}
             defaultValue={pageIndex + 1}
             onChange={e => {
               const page = e.target.value ? Number(e.target.value) - 1 : 0


### PR DESCRIPTION
fixes error "Cannot find name 'table'"