### PR TITLE
feat(angular-table): Refactor Flex render implementation - Zoneless, Better type safety, allows reactive values into cell content, re-render when cell context changes, allow to pass signal inputs into custom components

### DIFF
--- a/docs/framework/angular/angular-table.md
+++ b/docs/framework/angular/angular-table.md
@@ -40,39 +40,169 @@ FlexRender supports any type of content supported by Angular:
 - A [TemplateRef](https://angular.dev/api/core/TemplateRef)
 - A [Component](https://angular.dev/api/core/Component) wrapped into `FlexRenderComponent`
 
-Example:
+You can just use the `cell.renderValue` or `cell.getValue` APIs to render the cells of your table. However,
+these APIs will only spit out the raw cell values (from accessor functions).
+If you are using the `cell: () => any` column definition options, you will want to use the `FlexRenderDirective` from the adapter.
+
+Cell column definition is **reactive** and runs into an **injection context**, then you can inject services or make use of signals to automatically modify the rendered content.
+
+#### Example
 
 ```ts
 @Component({
   imports: [FlexRenderDirective],
   //...
 })
+class YourComponent {}
 ```
 
 ```angular-html
 
 <tbody>
 @for (row of table.getRowModel().rows; track row.id) {
-<tr>
-  @for (cell of row.getVisibleCells(); track cell.id) {
-<td>
-  <ng-container
-    *flexRender="
+  <tr>
+    @for (cell of row.getVisibleCells(); track cell.id) {
+      <td>
+        <ng-container
+          *flexRender="
               cell.column.columnDef.cell;
               props: cell.getContext();
               let cell
             "
-  >
-    <!-- if you want to render a simple string -->
-    {{ cell }}
-    <!-- if you want to render an html string -->
-    <div [innerHTML]="cell"></div>
-  </ng-container>
-</td>
-}
-</tr>
+        >
+          <!-- if you want to render a simple string -->
+          {{ cell }}
+          <!-- if you want to render an html string -->
+          <div [innerHTML]="cell"></div>
+        </ng-container>
+      </td>
+    }
+  </tr>
 }
 </tbody>
+```
+
+#### Rendering a Component
+
+To render a Component into a specific column header/cell/footer, you can pass a `FlexRenderComponent` instantiated with
+your `ComponentType, with the ability to include parameters such as inputs and an injector.
+
+```ts
+import {flexRenderComponent} from "./flex-render-component";
+import {ChangeDetectionStrategy} from "@angular/core";
+
+@Component({
+  template: `
+    ...
+  `,
+  standalone: true,
+  changeDetectionStrategy: ChangeDetectionStrategy.OnPush
+})
+class CustomCell {
+  readonly content = input.required<string>();
+
+  readonly type = input<MyType>()
+}
+
+class AppComponent {
+  columns: ColumnDef<unknown>[] = [
+    {
+      id: 'custom-cell',
+      header: () => {
+        const translateService = inject(TranslateService);
+        return translateService.translate('...');
+      },
+      cell: (context) => {
+        return flexRenderComponent(
+          MyCustomComponent,
+          {
+            injector, // Optional injector
+            inputs: {
+              // Mandatory input since we are using `input.required()
+              content: context.row.original.rowProperty,
+              type // Optional input
+            }
+          }
+        )
+      },
+    },
+  ]
+}
+```
+
+Underneath, this utilizes
+the [ViewContainerRef#createComponent](https://angular.dev/api/core/ViewContainerRef#createComponent) api.
+Therefore, you should declare your custom inputs using the @Input decorator or input/model signals.
+
+You can still access the table cell context through the `injectFlexRenderContext` function, which returns the context
+value based on the props you pass to the `FlexRenderDirective`.
+
+```ts
+
+@Component({
+  // ...
+})
+class CustomCellComponent {
+  // context of a cell component
+  readonly context = injectFlexRenderContext<CellContext<TData, TValue>>();
+  // context of a header/footer component
+  readonly context = injectFlexRenderContext<HeaderContext<TData, TValue>>();
+}
+```
+
+Alternatively, you can render a component into a specific column header, cell, or footer by passing the component type
+to the corresponding column definitions. These column definitions will be provided to the `flexRender` directive along
+with the `context`.
+
+```ts
+class AppComponent {
+  columns: ColumnDef<Person>[] = [
+    {
+      id: 'select',
+      header: () => TableHeadSelectionComponent<Person>,
+      cell: () => TableRowSelectionComponent<Person>,
+    },
+  ]
+}
+```
+
+```angular-html
+<ng-container
+  *flexRender="
+    header.column.columnDef.header;
+    props: header.getContext();
+    let headerCell
+  "
+>
+  {{ headerCell }}
+</ng-container>
+```
+
+Properties of `context` provided in the `flexRender` directive will be accessible to your component.
+You can explicitly define the context properties required by your component.
+In this example, the context provided to flexRender is of type HeaderContext.
+Input signal `table`, which is a property of HeaderContext together with `column` and `header` properties,
+is then defined to be used in the component. If any of the context properties are
+needed in your component, feel free to use them. Please take note that only input signal is supported,
+when defining access to context properties, using this approach.
+
+```angular-ts
+@Component({
+  template: `
+    <input
+      type="checkbox"
+      [checked]="table().getIsAllRowsSelected()"
+      [indeterminate]="table().getIsSomeRowsSelected()"
+      (change)="table().toggleAllRowsSelected()"
+    />
+  `,
+  // ...
+})
+export class TableHeadSelectionComponent<T> {
+  //column = input.required<Column<T, unknown>>()
+  //header = input.required<Header<T, unknown>>()
+  table = input.required<Table<T>>()
+}
 ```
 
 #### Rendering a TemplateRef
@@ -169,103 +299,5 @@ class AppComponent {
       cell: () => this.customCell(),
     },
   ]
-}
-```
-
-#### Rendering a Component
-
-To render a Component into a specific column header/cell/footer, you can pass a `FlexRenderComponent instantiated with
-your `ComponentType, with the ability to include optional parameters such as inputs and an injector.
-
-```ts
-import {FlexRenderComponent} from "@tanstack/angular-table";
-
-class AppComponent {
-  columns: ColumnDef<unknown>[] = [
-    {
-      id: 'customCell',
-      header: () => new FlexRenderComponent(
-        CustomCellComponent,
-        {}, // optional inputs
-        injector // optional injector
-      ),
-      cell: () => this.customCell(),
-    },
-  ]
-}
-```
-
-Underneath, this utilizes
-the [ViewContainerRef#createComponent](https://angular.dev/api/core/ViewContainerRef#createComponent) api.
-Therefore, you should declare your custom inputs using the @Input decorator or input/model signals.
-
-You can still access the table cell context through the `injectFlexRenderContext` function, which returns the context
-value based on the props you pass to the `FlexRenderDirective`.
-
-```ts
-@Component({
-  // ...
-})
-class CustomCellComponent {
-  // context of a cell component
-  readonly context = injectFlexRenderContext<CellContext<TData, TValue>>();
-  // context of a header/footer component
-  readonly context = injectFlexRenderContext<HeaderContext<TData, TValue>>();
-}
-```
-
-Alternatively, you can render a component into a specific column header, cell, or footer by passing the component type 
-to the corresponding column definitions. These column definitions will be provided to the `flexRender` directive along with the `context`.
-
-```ts
-import {FlexRenderComponent} from "@tanstack/angular-table";
-
-class AppComponent {
-  columns: ColumnDef<Person>[] = [
-    {
-      id: 'select',
-      header: () => TableHeadSelectionComponent<Person>,
-      cell: () => TableRowSelectionComponent<Person>,
-    },
-  ]
-}
-```
-
-```angular2html
-<ng-container
-  *flexRender="
-    header.column.columnDef.header;
-    props: header.getContext();
-    let headerCell
-  "
->
-  {{ headerCell }}
-</ng-container>
-```
-
-Properties of `context` provided in the `flexRender` directive will be accessible to your component. 
-You can explicitly define the context properties required by your component. 
-In this example, the context provided to flexRender is of type HeaderContext. 
-Input signal `table`, which is a property of HeaderContext together with `column` and `header` properties,
-is then defined to be used in the component. If any of the context properties are 
-needed in your component, feel free to use them. Please take note that only input signal is supported, 
-when defining access to context properties, using this approach.
-
-```angular-ts
-@Component({
-  template: `
-    <input
-      type="checkbox"
-      [checked]="table().getIsAllRowsSelected()"
-      [indeterminate]="table().getIsSomeRowsSelected()"
-      (change)="table().toggleAllRowsSelected()"
-    />
-  `,
-  // ...
-})
-export class TableHeadSelectionComponent<T> {
-  //column = input.required<Column<T, unknown>>()
-  //header = input.required<Header<T, unknown>>()
-  table = input.required<Table<T>>()
 }
 ```

--- a/docs/framework/angular/angular-table.md
+++ b/docs/framework/angular/angular-table.md
@@ -85,23 +85,28 @@ class YourComponent {}
 #### Rendering a Component
 
 To render a Component into a specific column header/cell/footer, you can pass a `FlexRenderComponent` instantiated with
-your `ComponentType, with the ability to include parameters such as inputs and an injector.
+your `ComponentType, with the ability to include parameters such as inputs, outputs and a custom injector.
 
 ```ts
 import {flexRenderComponent} from "./flex-render-component";
-import {ChangeDetectionStrategy} from "@angular/core";
+import {ChangeDetectionStrategy, input, output} from "@angular/core";
 
 @Component({
   template: `
     ...
   `,
   standalone: true,
-  changeDetectionStrategy: ChangeDetectionStrategy.OnPush
+  changeDetectionStrategy: ChangeDetectionStrategy.OnPush,
+  host: {
+    '(click)': 'clickEvent.emit($event)'
+  }
 })
 class CustomCell {
   readonly content = input.required<string>();
+  readonly cellType = input<MyType>();
 
-  readonly type = input<MyType>()
+  // An output that will emit for every cell click
+  readonly clickEvent = output<Event>();
 }
 
 class AppComponent {
@@ -120,7 +125,12 @@ class AppComponent {
             inputs: {
               // Mandatory input since we are using `input.required()
               content: context.row.original.rowProperty,
-              type // Optional input
+              // cellType? - Optional input
+            },
+            outputs: {
+              clickEvent: () => {
+                // Do something
+              }
             }
           }
         )

--- a/examples/angular/row-selection/src/app/app.component.ts
+++ b/examples/angular/row-selection/src/app/app.component.ts
@@ -9,7 +9,7 @@ import {
 import {
   ColumnDef,
   createAngularTable,
-  FlexRenderComponent,
+  flexRenderComponent,
   FlexRenderDirective,
   getCoreRowModel,
   getFilteredRowModel,
@@ -43,10 +43,10 @@ export class AppComponent {
     {
       id: 'select',
       header: () => {
-        return new FlexRenderComponent(TableHeadSelectionComponent)
+        return flexRenderComponent(TableHeadSelectionComponent)
       },
       cell: () => {
-        return new FlexRenderComponent(TableRowSelectionComponent)
+        return flexRenderComponent(TableRowSelectionComponent)
       },
     },
     {

--- a/packages/angular-table/package.json
+++ b/packages/angular-table/package.json
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "clean": "rimraf ./build",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc --noEmit && vitest --typecheck",
     "test:lib": "vitest",
     "test:lib:dev": "vitest --watch",
     "build": "ng-packagr -p ng-package.json -c tsconfig.build.json && rimraf ./build/lib/package.json"

--- a/packages/angular-table/package.json
+++ b/packages/angular-table/package.json
@@ -57,6 +57,7 @@
     "@angular/core": "^17.3.9",
     "@angular/platform-browser": "^17.3.9",
     "@angular/platform-browser-dynamic": "^17.3.9",
+    "typescript": "5.4.5",
     "ng-packagr": "^17.3.0"
   },
   "peerDependencies": {

--- a/packages/angular-table/package.json
+++ b/packages/angular-table/package.json
@@ -59,7 +59,6 @@
     "@angular/platform-browser": "^17.3.9",
     "@angular/platform-browser-dynamic": "^17.3.9",
     "ng-packagr": "^17.3.0",
-    "reflect-metadata": "^0.2.2",
     "typescript": "5.4.5",
     "vitest": "^1.6.0"
   },

--- a/packages/angular-table/package.json
+++ b/packages/angular-table/package.json
@@ -53,12 +53,15 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@analogjs/vite-plugin-angular": "^1.3.1",
+    "@analogjs/vite-plugin-angular": "^1.11.0",
+    "@analogjs/vitest-angular": "^1.11.0",
     "@angular/core": "^17.3.9",
     "@angular/platform-browser": "^17.3.9",
     "@angular/platform-browser-dynamic": "^17.3.9",
+    "ng-packagr": "^17.3.0",
+    "reflect-metadata": "^0.2.2",
     "typescript": "5.4.5",
-    "ng-packagr": "^17.3.0"
+    "vitest": "^1.6.0"
   },
   "peerDependencies": {
     "@angular/core": ">=17"

--- a/packages/angular-table/src/flex-render-component-ref.ts
+++ b/packages/angular-table/src/flex-render-component-ref.ts
@@ -1,0 +1,108 @@
+import {
+  ComponentRef,
+  inject,
+  Injectable,
+  Injector,
+  KeyValueDiffer,
+  KeyValueDiffers,
+  Type,
+  ViewContainerRef,
+} from '@angular/core'
+import { FlexRenderComponent, FlexRenderComponentProps } from './flex-render'
+
+@Injectable()
+export class FlexRenderComponentFactory {
+  #viewContainerRef = inject(ViewContainerRef)
+
+  createComponent<T>(
+    flexRenderComponent: FlexRenderComponent<T>,
+    componentInjector: Injector
+  ): FlexRenderComponentRef<T> {
+    const componentRef = this.#viewContainerRef.createComponent(
+      flexRenderComponent.component,
+      {
+        injector: componentInjector,
+      }
+    )
+
+    return new FlexRenderComponentRef(
+      componentRef,
+      flexRenderComponent,
+      componentInjector
+    )
+  }
+}
+
+/**
+ * @internal
+ */
+export class FlexRenderComponentRef<T> {
+  keyValueDiffers: KeyValueDiffers
+  keyValueDiffer: KeyValueDiffer<any, any>
+
+  constructor(
+    readonly componentRef: ComponentRef<T>,
+    readonly componentData: FlexRenderComponent<T>,
+    readonly componentInjector: Injector
+  ) {
+    this.keyValueDiffers = componentInjector.get(KeyValueDiffers)
+    this.keyValueDiffer = this.keyValueDiffers
+      .find(this.componentData.inputs ?? {})
+      .create()
+    this.keyValueDiffer.diff(this.componentData.inputs ?? {})
+  }
+
+  get component() {
+    return this.componentData.component
+  }
+
+  get inputs() {
+    return this.componentData.inputs ?? {}
+  }
+
+  /**
+   * Get component inputs diff by the given item
+   */
+  diff(item: FlexRenderComponent<T>) {
+    return this.keyValueDiffer.diff(item.inputs ?? {})
+  }
+
+  /**
+   *
+   * @param compare Whether the current ref component instance is the same as the given one
+   */
+  eq(compare: FlexRenderComponent<T>): boolean {
+    return compare.component === this.component
+  }
+
+  /**
+   * Tries to update current component refs input by the new given content component.
+   */
+  update(content: FlexRenderComponent<T>) {
+    const eq = this.eq(content)
+    if (!eq) return
+    const changes = this.diff(content)
+    if (!changes) return
+    changes.forEachAddedItem(item => {
+      this.setInput(item.key, item.currentValue)
+    })
+    changes.forEachChangedItem(item => {
+      this.setInput(item.key, item.currentValue)
+    })
+    changes.forEachRemovedItem(item => {
+      this.setInput(item.key, undefined)
+    })
+  }
+
+  setInputs(inputs: Record<string, unknown>) {
+    for (const prop in inputs) {
+      this.setInput(prop, inputs[prop])
+    }
+  }
+
+  setInput(key: string, value: unknown) {
+    if (this.componentData.allowedInputNames.includes(key)) {
+      this.componentRef.setInput(key, value)
+    }
+  }
+}

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -17,7 +17,10 @@ import {
 } from '@angular/core'
 import { FlexRenderComponentProps } from './flex-render/context'
 import { FlexRenderFlags } from './flex-render/flags'
-import { FlexRenderComponent } from './flex-render/flex-render-component'
+import {
+  flexRenderComponent,
+  FlexRenderComponent,
+} from './flex-render/flex-render-component'
 import { FlexRenderComponentFactory } from './flex-render/flex-render-component-ref'
 import {
   FlexRenderComponentView,
@@ -273,7 +276,10 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
     component: Extract<FlexRenderTypedContent, { kind: 'component' }>
   ): FlexRenderComponentView {
     const view = this.#flexRenderComponentFactory.createComponent(
-      new FlexRenderComponent(component.content, this.props),
+      flexRenderComponent(component.content, {
+        inputs: this.props,
+        injector: this.injector,
+      }),
       this.injector
     )
     view.setInputs({ ...this.props })

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -73,10 +73,11 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   ) {}
 
   ngOnChanges(changes: SimpleChanges) {
+    console.log('changes', changes)
     if (changes['content']) {
       this.renderFlags |= FlexRenderFlags.ContentChanged
     }
-    if (!changes['content'] && changes['props']) {
+    if (changes['props']) {
       this.renderFlags |= FlexRenderFlags.PropsReferenceChanged
     }
     this.checkView()
@@ -98,10 +99,9 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
     }
 
     const contentToRender = this.#getContentValue(this.props)
+
     if (contentToRender.kind === 'null' || !this.renderView) {
-      // Whether the content is null or view has not been rendered, we set contentChanged
-      // flag in order to re-initialize everything via the `render` method;
-      this.renderFlags |= FlexRenderFlags.ContentChanged
+      this.renderFlags = FlexRenderFlags.Creation
     } else {
       this.renderView.setContent(contentToRender.content)
       const previousContentInfo = this.renderView.previousContent
@@ -116,7 +116,10 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   }
 
   checkView() {
-    if (this.renderFlags & FlexRenderFlags.ContentChanged) {
+    if (
+      this.renderFlags &
+      (FlexRenderFlags.ContentChanged | FlexRenderFlags.Creation)
+    ) {
       this.render()
       return
     }

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -73,7 +73,6 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   ) {}
 
   ngOnChanges(changes: SimpleChanges) {
-    console.log('changes', changes)
     if (changes['content']) {
       this.renderFlags |= FlexRenderFlags.ContentChanged
     }
@@ -101,7 +100,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
     const contentToRender = this.#getContentValue(this.props)
 
     if (contentToRender.kind === 'null' || !this.renderView) {
-      this.renderFlags = FlexRenderFlags.Creation
+      this.renderFlags |= FlexRenderFlags.Creation
     } else {
       this.renderView.setContent(contentToRender.content)
       const previousContentInfo = this.renderView.previousContent

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -1,28 +1,29 @@
 import {
-  ComponentMirror,
-  ComponentRef,
   Directive,
   DoCheck,
   EmbeddedViewRef,
   Inject,
-  InjectionToken,
   Injector,
   Input,
-  InputSignal,
   OnChanges,
-  OutputEmitterRef,
   SimpleChanges,
   TemplateRef,
   Type,
   ViewContainerRef,
   inject,
-  reflectComponentType,
   runInInjectionContext,
 } from '@angular/core'
+import { FlexRenderComponentProps } from './flex-render/context'
+import { FlexRenderComponent } from './flex-render/flex-render-component'
 import {
   FlexRenderComponentFactory,
   FlexRenderComponentRef,
-} from './flex-render-component-ref'
+} from './flex-render/flex-render-component-ref'
+
+export {
+  type FlexRenderComponentProps,
+  injectFlexRenderContext,
+} from './flex-render/context'
 
 export type FlexRenderContent<TProps extends NonNullable<unknown>> =
   | string
@@ -55,11 +56,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   @Input({ required: false, alias: 'flexRenderInjector' })
   injector: Injector = inject(Injector)
 
-  ref?:
-    | FlexRenderComponentRef<any>
-    | ComponentRef<unknown>
-    | EmbeddedViewRef<unknown>
-    | null = null
+  ref?: FlexRenderComponentRef<any> | EmbeddedViewRef<unknown> | null = null
 
   #isFirstRender = true
   #lastContentChecked: FlexRenderContent<TProps> | null = null
@@ -271,46 +268,4 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
       return { kind: 'object', content }
     }
   }
-}
-
-type Inputs<T> = {
-  [K in keyof T as T[K] extends InputSignal<infer R>
-    ? K
-    : never]: T[K] extends InputSignal<infer R> ? R : never
-}
-
-type Outputs<T> = {
-  [K in keyof T as T[K] extends OutputEmitterRef<infer R>
-    ? K
-    : never]: T[K] extends OutputEmitterRef<infer R> ? (v: R) => void : never
-}
-
-export class FlexRenderComponent<TComponent = any> {
-  readonly mirror: ComponentMirror<TComponent>
-  readonly allowedInputNames: string[] = []
-
-  constructor(
-    readonly component: Type<TComponent>,
-    readonly inputs?: Inputs<TComponent>,
-    readonly injector?: Injector
-  ) {
-    const mirror = reflectComponentType(component)
-    if (!mirror) {
-      throw new Error(
-        `[@tanstack-table/angular] The provided symbol is not a component`
-      )
-    }
-    this.mirror = mirror
-    for (const input of this.mirror.inputs) {
-      this.allowedInputNames.push(input.propName)
-    }
-  }
-}
-
-export const FlexRenderComponentProps = new InjectionToken<
-  NonNullable<unknown>
->('[@tanstack/angular-table] Flex render component context props')
-
-export function injectFlexRenderContext<T extends NonNullable<unknown>>(): T {
-  return inject<T>(FlexRenderComponentProps)
 }

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -80,17 +80,17 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
 
   #getContentValue = memo(
     () => [this.#latestContent(), this.props, this.content],
-    latestContent => {
+    (latestContent) => {
       return mapToFlexRenderTypedContent(latestContent)
     },
-    { key: 'flexRenderContentValue', debug: () => false }
+    { key: 'flexRenderContentValue', debug: () => false },
   )
 
   constructor(
     @Inject(ViewContainerRef)
     private readonly viewContainerRef: ViewContainerRef,
     @Inject(TemplateRef)
-    private readonly templateRef: TemplateRef<any>
+    private readonly templateRef: TemplateRef<any>,
   ) {}
 
   ngOnChanges(changes: SimpleChanges) {
@@ -111,15 +111,6 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
       this.renderFlags &= ~FlexRenderFlags.ViewFirstRender
       return
     }
-
-    // TODO: Optimization for V9 / future updates?.
-    //  We could check for dirty signal changes when we are able to detect whether the table state changes here
-    //  const isChanged =
-    //   this.renderFlags &
-    //   (FlexRenderFlags.DirtySignal | FlexRenderFlags.PropsReferenceChanged)
-    //  if (!isChanged) {
-    //    return
-    //  }
 
     this.renderFlags |= FlexRenderFlags.DirtyCheck
 
@@ -196,7 +187,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
           // so we'll try to check for updates into ngDoCheck
           this.#changeDetectorRef.markForCheck()
         },
-        { injector: this.viewContainerRef.injector }
+        { injector: this.viewContainerRef.injector },
       )
     }
   }
@@ -210,7 +201,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   }
 
   #renderViewByContent(
-    content: FlexRenderTypedContent
+    content: FlexRenderTypedContent,
   ): FlexRenderView<any> | null {
     if (content.kind === 'primitive') {
       return this.#renderStringContent(content)
@@ -226,7 +217,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   }
 
   #renderStringContent(
-    template: Extract<FlexRenderTypedContent, { kind: 'primitive' }>
+    template: Extract<FlexRenderTypedContent, { kind: 'primitive' }>,
   ): FlexRenderTemplateView {
     const context = () => {
       return typeof this.content === 'string' ||
@@ -243,7 +234,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   }
 
   #renderTemplateRefContent(
-    template: Extract<FlexRenderTypedContent, { kind: 'templateRef' }>
+    template: Extract<FlexRenderTypedContent, { kind: 'templateRef' }>,
   ): FlexRenderTemplateView {
     const latestContext = () => this.props
     const view = this.viewContainerRef.createEmbeddedView(template.content, {
@@ -258,7 +249,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
     flexRenderComponent: Extract<
       FlexRenderTypedContent,
       { kind: 'flexRenderComponent' }
-    >
+    >,
   ): FlexRenderComponentView {
     const { inputs, injector } = flexRenderComponent.content
 
@@ -272,18 +263,18 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
     })
     const view = this.#flexRenderComponentFactory.createComponent(
       flexRenderComponent.content,
-      componentInjector
+      componentInjector,
     )
     if (inputs) view.setInputs(inputs)
     return new FlexRenderComponentView(flexRenderComponent, view)
   }
 
   #renderCustomComponent(
-    component: Extract<FlexRenderTypedContent, { kind: 'component' }>
+    component: Extract<FlexRenderTypedContent, { kind: 'component' }>,
   ): FlexRenderComponentView {
     const view = this.#flexRenderComponentFactory.createComponent(
       new FlexRenderComponent(component.content, this.props),
-      this.injector
+      this.injector,
     )
     view.setInputs({ ...this.props })
     return new FlexRenderComponentView(component, view)

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -134,7 +134,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
         // Here updating the instance input values is a no-op since the instance of the context properties (table, cell, etc...) doesn't change,
         // but marking the view as dirty allows to re-evaluate all invokation in the component template.
         if (this.ref instanceof FlexRenderComponentRef) {
-          this.ref.componentRef.changeDetectorRef.markForCheck()
+          this.ref.markAsDirty()
         }
         break
       }

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -112,26 +112,17 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
       return
     }
 
-    console.log('go into do check')
-
-    // TODO: Optimization for V9 / future updates?. We could check for dirty signal changes when
-    //  we are able to detect whether the table state changes here
-    // const isChanged =
+    // TODO: Optimization for V9 / future updates?.
+    //  We could check for dirty signal changes when we are able to detect whether the table state changes here
+    //  const isChanged =
     //   this.renderFlags &
     //   (FlexRenderFlags.DirtySignal | FlexRenderFlags.PropsReferenceChanged)
-    // if (!isChanged) {
-    //   return
-    // }
-    // if (this.renderFlags & FlexRenderFlags.DirtySignal) {
-    //   this.renderFlags &= ~FlexRenderFlags.DirtySignal
-    //   return
-    // }
+    //  if (!isChanged) {
+    //    return
+    //  }
 
     this.renderFlags |= FlexRenderFlags.DirtyCheck
-    this.checkViewChanges()
-  }
 
-  checkViewChanges(): void {
     const latestContent = this.#getContentValue()
     if (latestContent.kind === 'null' || !this.renderView) {
       this.renderFlags |= FlexRenderFlags.ContentChanged
@@ -297,18 +288,4 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
     view.setInputs({ ...this.props })
     return new FlexRenderComponentView(component, view)
   }
-}
-
-function logFlags(place: string, flags: FlexRenderFlags, val: any) {
-  console.group(`${place}`, val)
-  const result = {} as Record<string, boolean>
-  for (const key in FlexRenderFlags) {
-    // Skip the reverse mapping of numeric values to keys in enums
-    if (isNaN(Number(key))) {
-      const flagValue = FlexRenderFlags[key as keyof typeof FlexRenderFlags]
-      console.log(key, !!(flags & flagValue))
-    }
-  }
-  console.groupEnd()
-  return result
 }

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -254,7 +254,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
       { kind: 'flexRenderComponent' }
     >
   ): FlexRenderComponentView {
-    const { inputs, injector } = flexRenderComponent.content
+    const { inputs, outputs, injector } = flexRenderComponent.content
 
     const getContext = () => this.props
     const proxy = new Proxy(this.props, {
@@ -268,7 +268,6 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
       flexRenderComponent.content,
       componentInjector
     )
-    if (inputs) view.setInputs(inputs)
     return new FlexRenderComponentView(flexRenderComponent, view)
   }
 
@@ -282,7 +281,6 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
       }),
       this.injector
     )
-    view.setInputs({ ...this.props })
     return new FlexRenderComponentView(component, view)
   }
 }

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -80,17 +80,17 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
 
   #getContentValue = memo(
     () => [this.#latestContent(), this.props, this.content],
-    (latestContent) => {
+    latestContent => {
       return mapToFlexRenderTypedContent(latestContent)
     },
-    { key: 'flexRenderContentValue', debug: () => false },
+    { key: 'flexRenderContentValue', debug: () => false }
   )
 
   constructor(
     @Inject(ViewContainerRef)
     private readonly viewContainerRef: ViewContainerRef,
     @Inject(TemplateRef)
-    private readonly templateRef: TemplateRef<any>,
+    private readonly templateRef: TemplateRef<any>
   ) {}
 
   ngOnChanges(changes: SimpleChanges) {
@@ -187,7 +187,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
           // so we'll try to check for updates into ngDoCheck
           this.#changeDetectorRef.markForCheck()
         },
-        { injector: this.viewContainerRef.injector },
+        { injector: this.viewContainerRef.injector }
       )
     }
   }
@@ -201,7 +201,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   }
 
   #renderViewByContent(
-    content: FlexRenderTypedContent,
+    content: FlexRenderTypedContent
   ): FlexRenderView<any> | null {
     if (content.kind === 'primitive') {
       return this.#renderStringContent(content)
@@ -217,7 +217,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   }
 
   #renderStringContent(
-    template: Extract<FlexRenderTypedContent, { kind: 'primitive' }>,
+    template: Extract<FlexRenderTypedContent, { kind: 'primitive' }>
   ): FlexRenderTemplateView {
     const context = () => {
       return typeof this.content === 'string' ||
@@ -234,7 +234,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   }
 
   #renderTemplateRefContent(
-    template: Extract<FlexRenderTypedContent, { kind: 'templateRef' }>,
+    template: Extract<FlexRenderTypedContent, { kind: 'templateRef' }>
   ): FlexRenderTemplateView {
     const latestContext = () => this.props
     const view = this.viewContainerRef.createEmbeddedView(template.content, {
@@ -249,7 +249,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
     flexRenderComponent: Extract<
       FlexRenderTypedContent,
       { kind: 'flexRenderComponent' }
-    >,
+    >
   ): FlexRenderComponentView {
     const { inputs, injector } = flexRenderComponent.content
 
@@ -263,18 +263,18 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
     })
     const view = this.#flexRenderComponentFactory.createComponent(
       flexRenderComponent.content,
-      componentInjector,
+      componentInjector
     )
     if (inputs) view.setInputs(inputs)
     return new FlexRenderComponentView(flexRenderComponent, view)
   }
 
   #renderCustomComponent(
-    component: Extract<FlexRenderTypedContent, { kind: 'component' }>,
+    component: Extract<FlexRenderTypedContent, { kind: 'component' }>
   ): FlexRenderComponentView {
     const view = this.#flexRenderComponentFactory.createComponent(
       new FlexRenderComponent(component.content, this.props),
-      this.injector,
+      this.injector
     )
     view.setInputs({ ...this.props })
     return new FlexRenderComponentView(component, view)

--- a/packages/angular-table/src/flex-render.ts
+++ b/packages/angular-table/src/flex-render.ts
@@ -1,20 +1,29 @@
 import {
-  ChangeDetectorRef,
+  ComponentMirror,
   ComponentRef,
   Directive,
+  DoCheck,
   EmbeddedViewRef,
   Inject,
-  inject,
   InjectionToken,
   Injector,
   Input,
-  isSignal,
-  type OnChanges,
-  type SimpleChanges,
+  InputSignal,
+  OnChanges,
+  OutputEmitterRef,
+  SimpleChanges,
   TemplateRef,
   Type,
   ViewContainerRef,
+  inject,
+  isSignal,
+  reflectComponentType,
+  runInInjectionContext,
 } from '@angular/core'
+import {
+  FlexRenderComponentFactory,
+  FlexRenderComponentRef,
+} from './flex-render-component-ref'
 
 export type FlexRenderContent<TProps extends NonNullable<unknown>> =
   | string
@@ -28,9 +37,10 @@ export type FlexRenderContent<TProps extends NonNullable<unknown>> =
 @Directive({
   selector: '[flexRender]',
   standalone: true,
+  providers: [FlexRenderComponentFactory],
 })
 export class FlexRenderDirective<TProps extends NonNullable<unknown>>
-  implements OnChanges
+  implements OnChanges, DoCheck
 {
   @Input({ required: true, alias: 'flexRender' })
   content:
@@ -46,6 +56,17 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   @Input({ required: false, alias: 'flexRenderInjector' })
   injector: Injector = inject(Injector)
 
+  ref?:
+    | FlexRenderComponentRef<any>
+    | ComponentRef<unknown>
+    | EmbeddedViewRef<unknown>
+    | null = null
+
+  #isFirstRender = true
+  #lastContentChecked: FlexRenderContent<TProps> | null = null
+
+  readonly #flexRenderComponentFactory = inject(FlexRenderComponentFactory)
+
   constructor(
     @Inject(ViewContainerRef)
     private readonly viewContainerRef: ViewContainerRef,
@@ -53,12 +74,15 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
     private readonly templateRef: TemplateRef<any>
   ) {}
 
-  ref?: ComponentRef<unknown> | EmbeddedViewRef<unknown> | null = null
+  ngDoCheck(): void {
+    if (this.#isFirstRender) {
+      this.#isFirstRender = false
+      return
+    }
+    this.rerender()
+  }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.ref instanceof ComponentRef) {
-      this.ref.injector.get(ChangeDetectorRef).markForCheck()
-    }
     if (!changes['content']) {
       return
     }
@@ -66,17 +90,55 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   }
 
   render() {
+    console.log('Trigger render')
     this.viewContainerRef.clear()
     const { content, props } = this
     if (content === null || content === undefined) {
       this.ref = null
+      this.#lastContentChecked = null
       return
     }
-    if (typeof content === 'function') {
-      return this.renderContent(content(props))
-    } else {
-      return this.renderContent(content)
+
+    const resolvedContent = this.#getContentValue(props)
+    this.ref = this.renderContent(resolvedContent)
+    this.#lastContentChecked = resolvedContent
+  }
+
+  rerender(): void {
+    const { props } = this
+    const currentContent = this.#getContentValue(props)
+
+    if (this.#lastContentChecked !== currentContent) {
+      // Every time the component is checked for changes,
+      // we manually have to check if the given cell value differs, as the user passes only a reference to the header/row cell definition.
+      const currentContentType = this.#getContentType(currentContent)
+      const previousContentType = this.#getContentType(this.#lastContentChecked)
+
+      if (
+        currentContentType === 'primitive' &&
+        previousContentType === 'primitive'
+      ) {
+        // Basically a noop. Primitive content doesn't need any manual update since that type of content it's rendered with an EmbebbedViewRef with
+        // a getter as a context, then it will be revaluated during change detection cycle.
+      } else if (
+        currentContentType === 'flexRenderComponent' &&
+        previousContentType === 'flexRenderComponent' &&
+        currentContent instanceof FlexRenderComponent
+      ) {
+        // New FlexRenderComponent will always have a different reference that previous one,
+        // then in that case instead of recreating the entire view, we will only update what changes
+        if (
+          this.ref instanceof FlexRenderComponentRef &&
+          this.ref.eq(currentContent)
+        ) {
+          this.ref.update(currentContent)
+        }
+      } else {
+        this.render()
+      }
     }
+
+    this.#lastContentChecked = currentContent
   }
 
   private renderContent(content: FlexRenderContent<TProps>) {
@@ -112,30 +174,28 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
   }
 
   private renderComponent(
-    flexRenderComponent: FlexRenderComponent<TProps>
-  ): ComponentRef<unknown> {
-    const { component, inputs, injector } = flexRenderComponent
+    flexRenderComponent: FlexRenderComponent
+  ): FlexRenderComponentRef<unknown> {
+    const { inputs, injector } = flexRenderComponent
 
     const getContext = () => this.props
-
     const proxy = new Proxy(this.props, {
-      get: (_, key) => getContext()?.[key as keyof typeof _],
+      get: (_, key) => getContext()[key as keyof typeof _],
     })
-
     const componentInjector = Injector.create({
       parent: injector ?? this.injector,
       providers: [{ provide: FlexRenderComponentProps, useValue: proxy }],
     })
 
-    const componentRef = this.viewContainerRef.createComponent(component, {
-      injector: componentInjector,
-    })
-    for (const prop in inputs) {
-      if (componentRef.instance?.hasOwnProperty(prop)) {
-        componentRef.setInput(prop, inputs[prop])
-      }
+    const ref = this.#flexRenderComponentFactory.createComponent(
+      flexRenderComponent,
+      componentInjector
+    )
+    if (inputs) {
+      ref.setInputs(inputs)
     }
-    return componentRef
+
+    return ref
   }
 
   private renderCustomComponent(
@@ -148,7 +208,7 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
       // Only signal based input can be added here
       if (
         componentRef.instance?.hasOwnProperty(prop) &&
-        // @ts-ignore
+        // @ts-ignore - unknown error
         isSignal(componentRef.instance[prop])
       ) {
         componentRef.setInput(prop, this.props[prop])
@@ -165,19 +225,79 @@ export class FlexRenderDirective<TProps extends NonNullable<unknown>>
       },
     }
   }
+
+  #getContentValue(context: TProps) {
+    const content = this.content
+    return typeof content !== 'function'
+      ? content
+      : runInInjectionContext(this.injector, () => content(context))
+  }
+
+  #getContentType(
+    content: FlexRenderContent<TProps>
+  ): 'primitive' | 'flexRenderComponent' | 'component' | 'object' | null {
+    if (content === null || content === undefined) {
+      return null
+    }
+    const type = typeof content
+    const isPrimitive =
+      type === 'string' ||
+      type === 'number' ||
+      type === 'boolean' ||
+      type === 'bigint' ||
+      type === 'symbol'
+    if (isPrimitive) {
+      return 'primitive'
+    }
+    let currentType: 'object' | 'flexRenderComponent' | 'component' = 'object'
+    if (type === 'object') {
+      if (content instanceof FlexRenderComponent) {
+        currentType = 'flexRenderComponent'
+      } else if (content instanceof TemplateRef || content instanceof Type) {
+        currentType = 'component'
+      }
+    }
+    return currentType
+  }
 }
 
-export class FlexRenderComponent<T extends NonNullable<unknown>> {
+type Inputs<T> = {
+  [K in keyof T as T[K] extends InputSignal<infer R>
+    ? K
+    : never]: T[K] extends InputSignal<infer R> ? R : never
+}
+
+type Outputs<T> = {
+  [K in keyof T as T[K] extends OutputEmitterRef<infer R>
+    ? K
+    : never]: T[K] extends OutputEmitterRef<infer R> ? (v: R) => void : never
+}
+
+export class FlexRenderComponent<TComponent = any> {
+  readonly mirror: ComponentMirror<TComponent>
+  readonly allowedInputNames: string[] = []
+
   constructor(
-    readonly component: Type<unknown>,
-    readonly inputs: T = {} as T,
+    readonly component: Type<TComponent>,
+    readonly inputs?: Inputs<TComponent>,
     readonly injector?: Injector
-  ) {}
+  ) {
+    const mirror = reflectComponentType(component)
+    if (!mirror) {
+      throw new Error(
+        `[@tanstack-table/angular] The provided symbol is not a component`
+      )
+    }
+    this.mirror = mirror
+    for (const input of this.mirror.inputs) {
+      this.allowedInputNames.push(input.propName)
+    }
+  }
 }
 
-const FlexRenderComponentProps = new InjectionToken<NonNullable<unknown>>(
-  '[@tanstack/angular-table] Flex render component context props'
-)
+export const FlexRenderComponentProps = new InjectionToken<
+  NonNullable<unknown>
+>('[@tanstack/angular-table] Flex render component context props')
 
 export function injectFlexRenderContext<T extends NonNullable<unknown>>(): T {
   return inject<T>(FlexRenderComponentProps)

--- a/packages/angular-table/src/flex-render/context.ts
+++ b/packages/angular-table/src/flex-render/context.ts
@@ -1,0 +1,9 @@
+import { inject, InjectionToken } from '@angular/core'
+
+export const FlexRenderComponentProps = new InjectionToken<
+  NonNullable<unknown>
+>('[@tanstack/angular-table] Flex render component context props')
+
+export function injectFlexRenderContext<T extends NonNullable<unknown>>(): T {
+  return inject<T>(FlexRenderComponentProps)
+}

--- a/packages/angular-table/src/flex-render/flags.ts
+++ b/packages/angular-table/src/flex-render/flags.ts
@@ -1,0 +1,23 @@
+export enum FlexRenderFlags {
+  /**
+   * Whether the view has been created.
+   */
+  Creation = 1 << 0,
+  /**
+   * Whether the `content` property has changed.
+   * When this flag is enabled, the view is recreated from scratch after clearing the previous one.
+   */
+  ContentChanged = 1 << 1,
+  /**
+   * Whether the `props` property has changed.
+   * When this flag is enabled, the view context is updated based on the type of the content:
+   * - Component view: inputs will be updated and view will be marked as dirty
+   * - TemplateRef | primitive values: view will be marked as dirty
+   */
+  PropsReferenceChanged = 1 << 2,
+  /**
+   * Whether the current rendered view has to be dirty checked.
+   * When this flag is enabled, the view will be updated based on it's type.
+   */
+  DirtyCheck = 1 << 3,
+}

--- a/packages/angular-table/src/flex-render/flags.ts
+++ b/packages/angular-table/src/flex-render/flags.ts
@@ -7,14 +7,14 @@ export enum FlexRenderFlags {
    * Indicates that the view is being created for the first time or will be cleared during the next update phase.
    * This is the initial state and will transition after the first ngDoCheck.
    */
-  Creation = 1 << 0,
+  ViewFirstRender = 1 << 0,
   /**
    * Represents a state where the view is not dirty, meaning no changes require rendering updates.
    */
   Pristine = 1 << 1,
   /**
-   * Represents a state where the `content` property has been modified or the view requires a complete re-render.
-   * When this flag is enabled, the view is cleared and recreated from scratch.
+   * Indicates the `content` property has been modified or the view requires a complete re-render.
+   * When this flag is enabled, the view will be cleared and recreated from scratch.
    */
   ContentChanged = 1 << 2,
   /**
@@ -33,4 +33,8 @@ export enum FlexRenderFlags {
    * Indicates that a signal within the `content(props)` result has changed
    */
   DirtySignal = 1 << 5,
+  /**
+   * Indicates that the first render effect has been checked at least one time.
+   */
+  RenderEffectChecked = 1 << 6,
 }

--- a/packages/angular-table/src/flex-render/flags.ts
+++ b/packages/angular-table/src/flex-render/flags.ts
@@ -4,10 +4,14 @@ export enum FlexRenderFlags {
    */
   Creation = 1 << 0,
   /**
+   * Whether the view is not dirty.
+   */
+  Pristine = 1 << 1,
+  /**
    * Indicates that the `content` property has changed or the view need a complete re-rendering.
    * When this flag is enabled, the view is recreated from scratch after clearing the previous one.
    */
-  ContentChanged = 1 << 1,
+  ContentChanged = 1 << 2,
   /**
    * Indicates that the `props` property reference has changed.
    * When this flag is enabled, the view context is updated based on the type of the content.
@@ -15,9 +19,9 @@ export enum FlexRenderFlags {
    * For Component view, inputs will be updated and view will be marked as dirty.
    * For TemplateRef and primitive values, view will be marked as dirty
    */
-  PropsReferenceChanged = 1 << 2,
+  PropsReferenceChanged = 1 << 3,
   /**
    * Indicates the current rendered view has to be dirty checked.
    */
-  DirtyCheck = 1 << 3,
+  DirtyCheck = 1 << 4,
 }

--- a/packages/angular-table/src/flex-render/flags.ts
+++ b/packages/angular-table/src/flex-render/flags.ts
@@ -4,12 +4,12 @@ export enum FlexRenderFlags {
    */
   Creation = 1 << 0,
   /**
-   * Whether the `content` property has changed or the view need a complete re-rendering.
+   * Indicates that the `content` property has changed or the view need a complete re-rendering.
    * When this flag is enabled, the view is recreated from scratch after clearing the previous one.
    */
   ContentChanged = 1 << 1,
   /**
-   * Whether the `props` property reference has changed.
+   * Indicates that the `props` property reference has changed.
    * When this flag is enabled, the view context is updated based on the type of the content.
    *
    * For Component view, inputs will be updated and view will be marked as dirty.
@@ -17,7 +17,7 @@ export enum FlexRenderFlags {
    */
   PropsReferenceChanged = 1 << 2,
   /**
-   * Whether the current rendered view has to be dirty checked.
+   * Indicates the current rendered view has to be dirty checked.
    */
   DirtyCheck = 1 << 3,
 }

--- a/packages/angular-table/src/flex-render/flags.ts
+++ b/packages/angular-table/src/flex-render/flags.ts
@@ -24,4 +24,8 @@ export enum FlexRenderFlags {
    * Indicates the current rendered view has to be dirty checked.
    */
   DirtyCheck = 1 << 4,
+  /**
+   * Whether a signal changed into the current content
+   */
+  DirtySignal = 1 << 5,
 }

--- a/packages/angular-table/src/flex-render/flags.ts
+++ b/packages/angular-table/src/flex-render/flags.ts
@@ -1,15 +1,20 @@
+/**
+ * Flags used to manage and optimize the rendering lifecycle of content of the cell,
+ * while using FlexRenderDirective.
+ */
 export enum FlexRenderFlags {
   /**
-   * Whether the view has not been created yet or the current view will be cleared during the update phase.
+   * Indicates that the view is being created for the first time or will be cleared during the next update phase.
+   * This is the initial state and will transition after the first ngDoCheck.
    */
   Creation = 1 << 0,
   /**
-   * Whether the view is not dirty.
+   * Represents a state where the view is not dirty, meaning no changes require rendering updates.
    */
   Pristine = 1 << 1,
   /**
-   * Indicates that the `content` property has changed or the view need a complete re-rendering.
-   * When this flag is enabled, the view is recreated from scratch after clearing the previous one.
+   * Represents a state where the `content` property has been modified or the view requires a complete re-render.
+   * When this flag is enabled, the view is cleared and recreated from scratch.
    */
   ContentChanged = 1 << 2,
   /**
@@ -21,11 +26,11 @@ export enum FlexRenderFlags {
    */
   PropsReferenceChanged = 1 << 3,
   /**
-   * Indicates the current rendered view has to be dirty checked.
+   * Indicates that the current rendered view needs to be checked for changes.
    */
   DirtyCheck = 1 << 4,
   /**
-   * Whether a signal changed into the current content
+   * Indicates that a signal within the `content(props)` result has changed
    */
   DirtySignal = 1 << 5,
 }

--- a/packages/angular-table/src/flex-render/flags.ts
+++ b/packages/angular-table/src/flex-render/flags.ts
@@ -1,23 +1,23 @@
 export enum FlexRenderFlags {
   /**
-   * Whether the view has been created.
+   * Whether the view has not been created yet or the current view will be cleared during the update phase.
    */
   Creation = 1 << 0,
   /**
-   * Whether the `content` property has changed.
+   * Whether the `content` property has changed or the view need a complete re-rendering.
    * When this flag is enabled, the view is recreated from scratch after clearing the previous one.
    */
   ContentChanged = 1 << 1,
   /**
-   * Whether the `props` property has changed.
-   * When this flag is enabled, the view context is updated based on the type of the content:
-   * - Component view: inputs will be updated and view will be marked as dirty
-   * - TemplateRef | primitive values: view will be marked as dirty
+   * Whether the `props` property reference has changed.
+   * When this flag is enabled, the view context is updated based on the type of the content.
+   *
+   * For Component view, inputs will be updated and view will be marked as dirty.
+   * For TemplateRef and primitive values, view will be marked as dirty
    */
   PropsReferenceChanged = 1 << 2,
   /**
    * Whether the current rendered view has to be dirty checked.
-   * When this flag is enabled, the view will be updated based on it's type.
    */
   DirtyCheck = 1 << 3,
 }

--- a/packages/angular-table/src/flex-render/flex-render-component-ref.ts
+++ b/packages/angular-table/src/flex-render/flex-render-component-ref.ts
@@ -8,7 +8,7 @@ import {
   KeyValueDiffers,
   ViewContainerRef,
 } from '@angular/core'
-import { FlexRenderComponent } from './flex-render'
+import { FlexRenderComponent } from './flex-render-component'
 
 @Injectable()
 export class FlexRenderComponentFactory {
@@ -33,9 +33,6 @@ export class FlexRenderComponentFactory {
   }
 }
 
-/**
- * @internal
- */
 export class FlexRenderComponentRef<T> {
   readonly #keyValueDiffersFactory: KeyValueDiffers
   #keyValueDiffer: KeyValueDiffer<any, any>

--- a/packages/angular-table/src/flex-render/flex-render-component-ref.ts
+++ b/packages/angular-table/src/flex-render/flex-render-component-ref.ts
@@ -68,7 +68,7 @@ export class FlexRenderComponentRef<T> {
    *
    * @param compare Whether the current ref component instance is the same as the given one
    */
-  eq(compare: FlexRenderComponent<T>): boolean {
+  eqType(compare: FlexRenderComponent<T>): boolean {
     return compare.component === this.component
   }
 
@@ -76,7 +76,7 @@ export class FlexRenderComponentRef<T> {
    * Tries to update current component refs input by the new given content component.
    */
   update(content: FlexRenderComponent<T>) {
-    const eq = this.eq(content)
+    const eq = this.eqType(content)
     if (!eq) return
     const changes = this.diff(content)
     if (!changes) return

--- a/packages/angular-table/src/flex-render/flex-render-component.ts
+++ b/packages/angular-table/src/flex-render/flex-render-component.ts
@@ -1,0 +1,37 @@
+import {
+  ComponentMirror,
+  inject,
+  InjectionToken,
+  Injector,
+  InputSignal,
+  reflectComponentType,
+  Type,
+} from '@angular/core'
+
+type Inputs<T> = {
+  [K in keyof T as T[K] extends InputSignal<infer R>
+    ? K
+    : never]: T[K] extends InputSignal<infer R> ? R : never
+}
+
+export class FlexRenderComponent<TComponent = any> {
+  readonly mirror: ComponentMirror<TComponent>
+  readonly allowedInputNames: string[] = []
+
+  constructor(
+    readonly component: Type<TComponent>,
+    readonly inputs?: Inputs<TComponent>,
+    readonly injector?: Injector
+  ) {
+    const mirror = reflectComponentType(component)
+    if (!mirror) {
+      throw new Error(
+        `[@tanstack-table/angular] The provided symbol is not a component`
+      )
+    }
+    this.mirror = mirror
+    for (const input of this.mirror.inputs) {
+      this.allowedInputNames.push(input.propName)
+    }
+  }
+}

--- a/packages/angular-table/src/flex-render/flex-render-component.ts
+++ b/packages/angular-table/src/flex-render/flex-render-component.ts
@@ -1,8 +1,7 @@
 import {
   ComponentMirror,
-  inject,
-  InjectionToken,
   Injector,
+  input,
   InputSignal,
   reflectComponentType,
   Type,
@@ -11,9 +10,63 @@ import {
 type Inputs<T> = {
   [K in keyof T as T[K] extends InputSignal<infer R>
     ? K
-    : never]: T[K] extends InputSignal<infer R> ? R : never
+    : never]?: T[K] extends InputSignal<infer R> ? R : never
 }
 
+type OptionalKeys<T, K = keyof T> = K extends keyof T
+  ? T[K] extends Required<T>[K]
+    ? undefined extends T[K]
+      ? K
+      : never
+    : K
+  : never
+
+interface FlexRenderRequiredOptions<TInputs extends Record<string, any>> {
+  /**
+   * Component instance inputs. They will be set via [componentRef.setInput API](https://angular.dev/api/core/ComponentRef#setInput)
+   */
+  inputs: TInputs
+  /**
+   * Optional {@link Injector} that will be used when rendering the component
+   */
+  injector?: Injector
+}
+
+interface FlexRenderOptions<TInputs extends Record<string, any>> {
+  /**
+   * Component instance inputs. They will be set via [componentRef.setInput API](https://angular.dev/api/core/ComponentRef#setInput)
+   */
+  inputs?: TInputs
+  /**
+   * Optional {@link Injector} that will be used when rendering the component
+   */
+  injector?: Injector
+}
+
+/**
+ * Helper function to create a [@link FlexRenderComponent] instance, with better type-safety.
+ *
+ * - options object must be passed when the given component instance contains at least one required signal input.
+ * - options/inputs is typed with the given component inputs
+ */
+export function flexRenderComponent<
+  TComponent = any,
+  TInputs extends Inputs<TComponent> = Inputs<TComponent>,
+>(
+  component: Type<TComponent>,
+  ...options: OptionalKeys<TInputs> extends never
+    ? [FlexRenderOptions<TInputs>?]
+    : [FlexRenderRequiredOptions<TInputs>]
+) {
+  const { inputs, injector } = options?.[0] ?? {}
+  return new FlexRenderComponent(component, inputs, injector)
+}
+
+/**
+ * Wrapper class for a component that will be used as content for {@link FlexRenderDirective}
+ *
+ * Prefer {@link flexRenderComponent} helper for better type-safety
+ */
 export class FlexRenderComponent<TComponent = any> {
   readonly mirror: ComponentMirror<TComponent>
   readonly allowedInputNames: string[] = []

--- a/packages/angular-table/src/flex-render/flex-render-component.ts
+++ b/packages/angular-table/src/flex-render/flex-render-component.ts
@@ -1,8 +1,8 @@
 import {
   ComponentMirror,
   Injector,
-  input,
   InputSignal,
+  OutputEmitterRef,
   reflectComponentType,
   Type,
 } from '@angular/core'
@@ -13,6 +13,14 @@ type Inputs<T> = {
     : never]?: T[K] extends InputSignal<infer R> ? R : never
 }
 
+type Outputs<T> = {
+  [K in keyof T as T[K] extends OutputEmitterRef<infer R>
+    ? K
+    : never]?: T[K] extends OutputEmitterRef<infer R>
+    ? OutputEmitterRef<R>['emit']
+    : never
+}
+
 type OptionalKeys<T, K = keyof T> = K extends keyof T
   ? T[K] extends Required<T>[K]
     ? undefined extends T[K]
@@ -21,22 +29,36 @@ type OptionalKeys<T, K = keyof T> = K extends keyof T
     : K
   : never
 
-interface FlexRenderRequiredOptions<TInputs extends Record<string, any>> {
+interface FlexRenderRequiredOptions<
+  TInputs extends Record<string, any>,
+  TOutputs extends Record<string, any>,
+> {
   /**
    * Component instance inputs. They will be set via [componentRef.setInput API](https://angular.dev/api/core/ComponentRef#setInput)
    */
   inputs: TInputs
+  /**
+   * Component instance outputs.
+   */
+  outputs?: TOutputs
   /**
    * Optional {@link Injector} that will be used when rendering the component
    */
   injector?: Injector
 }
 
-interface FlexRenderOptions<TInputs extends Record<string, any>> {
+interface FlexRenderOptions<
+  TInputs extends Record<string, any>,
+  TOutputs extends Record<string, any>,
+> {
   /**
    * Component instance inputs. They will be set via [componentRef.setInput API](https://angular.dev/api/core/ComponentRef#setInput)
    */
   inputs?: TInputs
+  /**
+   * Component instance outputs.
+   */
+  outputs?: TOutputs
   /**
    * Optional {@link Injector} that will be used when rendering the component
    */
@@ -48,18 +70,20 @@ interface FlexRenderOptions<TInputs extends Record<string, any>> {
  *
  * - options object must be passed when the given component instance contains at least one required signal input.
  * - options/inputs is typed with the given component inputs
+ * - options/outputs is typed with the given component outputs
  */
 export function flexRenderComponent<
   TComponent = any,
   TInputs extends Inputs<TComponent> = Inputs<TComponent>,
+  TOutputs extends Outputs<TComponent> = Outputs<TComponent>,
 >(
   component: Type<TComponent>,
   ...options: OptionalKeys<TInputs> extends never
-    ? [FlexRenderOptions<TInputs>?]
-    : [FlexRenderRequiredOptions<TInputs>]
+    ? [FlexRenderOptions<TInputs, TOutputs>?]
+    : [FlexRenderRequiredOptions<TInputs, TOutputs>]
 ) {
-  const { inputs, injector } = options?.[0] ?? {}
-  return new FlexRenderComponent(component, inputs, injector)
+  const { inputs, injector, outputs } = options?.[0] ?? {}
+  return new FlexRenderComponent(component, inputs, injector, outputs)
 }
 
 /**
@@ -70,11 +94,13 @@ export function flexRenderComponent<
 export class FlexRenderComponent<TComponent = any> {
   readonly mirror: ComponentMirror<TComponent>
   readonly allowedInputNames: string[] = []
+  readonly allowedOutputNames: string[] = []
 
   constructor(
     readonly component: Type<TComponent>,
     readonly inputs?: Inputs<TComponent>,
-    readonly injector?: Injector
+    readonly injector?: Injector,
+    readonly outputs?: Outputs<TComponent>
   ) {
     const mirror = reflectComponentType(component)
     if (!mirror) {
@@ -85,6 +111,9 @@ export class FlexRenderComponent<TComponent = any> {
     this.mirror = mirror
     for (const input of this.mirror.inputs) {
       this.allowedInputNames.push(input.propName)
+    }
+    for (const output of this.mirror.outputs) {
+      this.allowedOutputNames.push(output.propName)
     }
   }
 }

--- a/packages/angular-table/src/flex-render/view.ts
+++ b/packages/angular-table/src/flex-render/view.ts
@@ -113,7 +113,17 @@ export class FlexRenderComponentView extends FlexRenderView<
   }
 
   override updateProps(props: Record<string, any>) {
-    this.view.setInputs(props)
+    switch (this.content.kind) {
+      case 'component': {
+        this.view.setInputs(props)
+        break
+      }
+      case 'flexRenderComponent': {
+        // No-op. When FlexRenderFlags.PropsReferenceChanged is set,
+        // FlexRenderComponent will be updated into `dirtyCheck`.
+        break
+      }
+    }
   }
 
   override dirtyCheck() {

--- a/packages/angular-table/src/flex-render/view.ts
+++ b/packages/angular-table/src/flex-render/view.ts
@@ -87,9 +87,12 @@ export class FlexRenderTemplateView extends FlexRenderView<
   }
 
   override dirtyCheck() {
-    // Basically a no-op. Currently in all of those cases, we don't need to do any manual update
-    // since this type of content is rendered with an EmbeddedViewRef with a proxy as a context,
-    // then every time the root component is checked for changes, the getter will be re-evaluated.
+    // Basically a no-op. When the view is created via EmbeddedViewRef, we don't need to do any manual update
+    // since this type of content has a proxy as a context, then every time the root component is checked for changes,
+    // the property getter will be re-evaluated.
+    //
+    // If in a future we need to manually mark the view as dirty, just uncomment next line
+    // this.view.markForCheck()
   }
 }
 
@@ -110,13 +113,16 @@ export class FlexRenderComponentView extends FlexRenderView<
   override dirtyCheck() {
     switch (this.content.kind) {
       case 'component': {
+        // Component context is currently valuated with the cell context. Since it's reference
+        // shouldn't change, we force mark the component as dirty in order to re-evaluate function invocation in view.
+        // NOTE: this should behave like having a component with ChangeDetectionStrategy.Default
         this.view.markAsDirty()
         break
       }
       case 'flexRenderComponent': {
-        // the given content instance will always have a different reference that previous one,
-        // then in that case instead of recreating the entire view, we will only update what changes
-        if (this.view.eq(this.content.content)) {
+        // Given context instance will always have a different reference than the previous one,
+        // so instead of recreating the entire view, we will only update the current view
+        if (this.view.eqType(this.content.content)) {
           this.view.update(this.content.content)
         }
         break

--- a/packages/angular-table/src/flex-render/view.ts
+++ b/packages/angular-table/src/flex-render/view.ts
@@ -1,0 +1,126 @@
+import { FlexRenderComponentRef } from './flex-render-component-ref'
+import { EmbeddedViewRef, TemplateRef, Type } from '@angular/core'
+import type { FlexRenderContent } from '../flex-render'
+import { FlexRenderComponent } from './flex-render-component'
+
+export type FlexRenderTypedContent =
+  | { kind: 'null' }
+  | {
+      kind: 'primitive'
+      content: string | number | Record<string, any>
+    }
+  | { kind: 'flexRenderComponent'; content: FlexRenderComponent<unknown> }
+  | { kind: 'templateRef'; content: TemplateRef<unknown> }
+  | { kind: 'component'; content: Type<unknown> }
+
+export function mapToFlexRenderTypedContent(
+  content: FlexRenderContent<any>
+): FlexRenderTypedContent {
+  if (content === null || content === undefined) {
+    return { kind: 'null' }
+  }
+  if (typeof content === 'string' || typeof content === 'number') {
+    return { kind: 'primitive', content }
+  }
+  if (content instanceof FlexRenderComponent) {
+    return { kind: 'flexRenderComponent', content }
+  } else if (content instanceof TemplateRef) {
+    return { kind: 'templateRef', content }
+  } else if (content instanceof Type) {
+    return { kind: 'component', content }
+  } else {
+    return { kind: 'primitive', content }
+  }
+}
+
+export abstract class FlexRenderView<
+  TView extends FlexRenderComponentRef<any> | EmbeddedViewRef<unknown> | null,
+  TProps extends Record<string, any> = any,
+> {
+  view: TView
+
+  #rawContent: FlexRenderContent<TProps>
+  #previousContent: FlexRenderTypedContent | undefined
+  #content: FlexRenderTypedContent
+
+  protected constructor(
+    initialContent: FlexRenderContent<TProps> | null,
+    view: TView
+  ) {
+    this.#rawContent = initialContent
+    this.#content = mapToFlexRenderTypedContent(initialContent)
+    this.view = view
+  }
+
+  get previousContent(): FlexRenderTypedContent {
+    return this.#previousContent ?? { kind: 'null' }
+  }
+
+  get content() {
+    return this.#content
+  }
+
+  setContent(content: FlexRenderContent<any>): FlexRenderTypedContent {
+    this.#rawContent = content
+    this.#previousContent = this.#content
+    this.#content = mapToFlexRenderTypedContent(content)
+    return this.#content
+  }
+
+  abstract updateProps(props: Record<string, any>): void
+
+  abstract dirtyCheck(): void
+}
+
+export class FlexRenderTemplateView extends FlexRenderView<
+  EmbeddedViewRef<unknown>
+> {
+  constructor(
+    initialContent: FlexRenderContent<any>,
+    view: EmbeddedViewRef<unknown>
+  ) {
+    super(initialContent, view)
+  }
+
+  override updateProps(props: Record<string, any>) {
+    this.view.markForCheck()
+  }
+
+  override dirtyCheck() {
+    // Basically a no-op. Currently in all of those cases, we don't need to do any manual update
+    // since this type of content is rendered with an EmbeddedViewRef with a proxy as a context,
+    // then every time the root component is checked for changes, the getter will be re-evaluated.
+  }
+}
+
+export class FlexRenderComponentView extends FlexRenderView<
+  FlexRenderComponentRef<unknown>
+> {
+  constructor(
+    initialContent: FlexRenderComponent<unknown> | Type<unknown>,
+    view: FlexRenderComponentRef<unknown>
+  ) {
+    super(initialContent, view)
+  }
+
+  override updateProps(props: Record<string, any>) {
+    this.view.setInputs(props)
+  }
+
+  override dirtyCheck() {
+    switch (this.content.kind) {
+      case 'component': {
+        this.view.markAsDirty()
+        break
+      }
+      case 'flexRenderComponent': {
+        // the given content instance will always have a different reference that previous one,
+        // then in that case instead of recreating the entire view, we will only update what changes
+        if (this.view.eq(this.content.content)) {
+          this.view.update(this.content.content)
+        }
+        break
+      }
+    }
+  }
+}

--- a/packages/angular-table/src/flex-render/view.ts
+++ b/packages/angular-table/src/flex-render/view.ts
@@ -70,6 +70,8 @@ export abstract class FlexRenderView<
   abstract updateProps(props: Record<string, any>): void
 
   abstract dirtyCheck(): void
+
+  abstract onDestroy(callback: Function): void
 }
 
 export class FlexRenderTemplateView extends FlexRenderView<
@@ -93,6 +95,10 @@ export class FlexRenderTemplateView extends FlexRenderView<
     //
     // If in a future we need to manually mark the view as dirty, just uncomment next line
     // this.view.markForCheck()
+  }
+
+  override onDestroy(callback: Function) {
+    this.view.onDestroy(callback)
   }
 }
 
@@ -129,5 +135,9 @@ export class FlexRenderComponentView extends FlexRenderView<
         break
       }
     }
+  }
+
+  override onDestroy(callback: Function) {
+    this.view.componentRef.onDestroy(callback)
   }
 }

--- a/packages/angular-table/src/flex-render/view.ts
+++ b/packages/angular-table/src/flex-render/view.ts
@@ -35,20 +35,16 @@ export function mapToFlexRenderTypedContent(
 
 export abstract class FlexRenderView<
   TView extends FlexRenderComponentRef<any> | EmbeddedViewRef<unknown> | null,
-  TProps extends Record<string, any> = any,
 > {
-  view: TView
-
-  #rawContent: FlexRenderContent<TProps>
+  readonly view: TView
   #previousContent: FlexRenderTypedContent | undefined
   #content: FlexRenderTypedContent
 
   protected constructor(
-    initialContent: FlexRenderContent<TProps> | null,
+    initialContent: Exclude<FlexRenderTypedContent, { kind: 'null' }>,
     view: TView
   ) {
-    this.#rawContent = initialContent
-    this.#content = mapToFlexRenderTypedContent(initialContent)
+    this.#content = initialContent
     this.view = view
   }
 
@@ -60,11 +56,9 @@ export abstract class FlexRenderView<
     return this.#content
   }
 
-  setContent(content: FlexRenderContent<any>): FlexRenderTypedContent {
-    this.#rawContent = content
+  set content(content: FlexRenderTypedContent) {
     this.#previousContent = this.#content
-    this.#content = mapToFlexRenderTypedContent(content)
-    return this.#content
+    this.#content = content
   }
 
   abstract updateProps(props: Record<string, any>): void
@@ -78,7 +72,10 @@ export class FlexRenderTemplateView extends FlexRenderView<
   EmbeddedViewRef<unknown>
 > {
   constructor(
-    initialContent: FlexRenderContent<any>,
+    initialContent: Extract<
+      FlexRenderTypedContent,
+      { kind: 'primitive' | 'templateRef' }
+    >,
     view: EmbeddedViewRef<unknown>
   ) {
     super(initialContent, view)
@@ -106,7 +103,10 @@ export class FlexRenderComponentView extends FlexRenderView<
   FlexRenderComponentRef<unknown>
 > {
   constructor(
-    initialContent: FlexRenderComponent<unknown> | Type<unknown>,
+    initialContent: Extract<
+      FlexRenderTypedContent,
+      { kind: 'component' | 'flexRenderComponent' }
+    >,
     view: FlexRenderComponentRef<unknown>
   ) {
     super(initialContent, view)

--- a/packages/angular-table/src/flex-render/view.ts
+++ b/packages/angular-table/src/flex-render/view.ts
@@ -125,6 +125,7 @@ export class FlexRenderComponentView extends FlexRenderView<
         if (this.view.eqType(this.content.content)) {
           this.view.update(this.content.content)
         }
+        this.view.markAsDirty()
         break
       }
     }

--- a/packages/angular-table/src/index.ts
+++ b/packages/angular-table/src/index.ts
@@ -15,11 +15,15 @@ export * from '@tanstack/table-core'
 export {
   type FlexRenderContent,
   FlexRenderDirective,
+  FlexRenderDirective as FlexRender,
   injectFlexRenderContext,
   type FlexRenderComponentProps,
 } from './flex-render'
 
-export { FlexRenderComponent } from './flex-render/flex-render-component'
+export {
+  FlexRenderComponent,
+  flexRenderComponent,
+} from './flex-render/flex-render-component'
 
 export function createAngularTable<TData extends RowData>(
   options: () => TableOptions<TData>

--- a/packages/angular-table/src/index.ts
+++ b/packages/angular-table/src/index.ts
@@ -14,10 +14,12 @@ export * from '@tanstack/table-core'
 
 export {
   type FlexRenderContent,
-  FlexRenderComponent,
   FlexRenderDirective,
   injectFlexRenderContext,
+  type FlexRenderComponentProps,
 } from './flex-render'
+
+export { FlexRenderComponent } from './flex-render/flex-render-component'
 
 export function createAngularTable<TData extends RowData>(
   options: () => TableOptions<TData>

--- a/packages/angular-table/src/proxy.ts
+++ b/packages/angular-table/src/proxy.ts
@@ -23,8 +23,9 @@ export function proxifyTable<T>(
        */
       if (
         property.startsWith('get') &&
-        !property.endsWith('Handler') &&
-        !property.endsWith('Model')
+        !property.endsWith('Handler')
+        // Non-reactive properties like `getCoreRowModel` prevent to use latest row `getContext` in some cases
+        // && !property.endsWith('Model')
       ) {
         const maybeFn = table[property] as Function | never
         if (typeof maybeFn === 'function') {

--- a/packages/angular-table/src/proxy.ts
+++ b/packages/angular-table/src/proxy.ts
@@ -24,7 +24,9 @@ export function proxifyTable<T>(
       if (
         property.startsWith('get') &&
         !property.endsWith('Handler')
-        // Non-reactive properties like `getCoreRowModel` prevent to use latest row `getContext` in some cases
+        // e.g. getCoreRowModel, getSelectedRowModel etc.
+        // We need that after a signal change even `rowModel` may mark the view as dirty.
+        // This allows to always get the latest `getContext` value while using flexRender
         // && !property.endsWith('Model')
       ) {
         const maybeFn = table[property] as Function | never

--- a/packages/angular-table/tests/createAngularTable.test.ts
+++ b/packages/angular-table/tests/createAngularTable.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../src/index'
 import { Component, input, isSignal, signal, untracked } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
-import { setSignalInputs } from './test-utils'
+import { setFixtureSignalInputs } from './test-utils'
 
 describe('createAngularTable', () => {
   test('should render with required signal inputs', () => {
@@ -27,7 +27,7 @@ describe('createAngularTable', () => {
     }
 
     const fixture = TestBed.createComponent(FakeComponent)
-    setSignalInputs(fixture.componentInstance, {
+    setFixtureSignalInputs(fixture, {
       data: [],
     })
 

--- a/packages/angular-table/tests/flex-render-component.test-d.ts
+++ b/packages/angular-table/tests/flex-render-component.test-d.ts
@@ -1,0 +1,27 @@
+import { input } from '@angular/core'
+import { test } from 'vitest'
+import { flexRenderComponent } from '../src'
+
+test('Infer component inputs', () => {
+  class Test {
+    readonly input1 = input<string>()
+  }
+
+  // @ts-expect-error Must pass right type as a value
+  flexRenderComponent(Test, { inputs: { input1: 1 } })
+
+  // Input is optional so we can skip passing the property
+  flexRenderComponent(Test, { inputs: {} })
+})
+
+test('Options are mandatory when given component has required inputs', () => {
+  class Test {
+    readonly input1 = input<string>()
+    readonly requiredInput1 = input.required<string>()
+  }
+
+  // @ts-expect-error Required input
+  flexRenderComponent(Test)
+
+  flexRenderComponent(Test, { inputs: { requiredInput1: 'My value' } })
+})

--- a/packages/angular-table/tests/flex-render-table.test.ts
+++ b/packages/angular-table/tests/flex-render-table.test.ts
@@ -235,13 +235,12 @@ export function createTestTable(
 }
 
 @Component({
-  template: `<span>{{ status }}</span> `,
+  template: `<span>{{ status() }}</span> `,
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class TestBadgeComponent {
   readonly context = injectFlexRenderContext<CellContext<TestData, any>>()
 
-  @Input({ required: true })
-  readonly status!: string
+  readonly status = input.required<string>()
 }

--- a/packages/angular-table/tests/flex-render-table.test.ts
+++ b/packages/angular-table/tests/flex-render-table.test.ts
@@ -1,0 +1,247 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  input,
+  signal,
+  type TemplateRef,
+  ViewChild,
+} from '@angular/core'
+import {
+  type CellContext,
+  ColumnDef,
+  getCoreRowModel,
+} from '@tanstack/table-core'
+import {
+  createAngularTable,
+  FlexRenderComponent,
+  FlexRenderDirective,
+  injectFlexRenderContext,
+} from '../src'
+import { TestBed } from '@angular/core/testing'
+import { describe, expect, test } from 'vitest'
+import { By } from '@angular/platform-browser'
+
+const defaultData: TestData[] = [{ id: '1', title: 'My title' }] as TestData[]
+
+const defaultColumns: ColumnDef<TestData>[] = [
+  {
+    id: 'title',
+    accessorKey: 'title',
+    header: 'Title',
+    cell: props => props.renderValue(),
+  },
+]
+
+describe('FlexRenderDirective', () => {
+  test.each([null, undefined])('Render %s as empty', value => {
+    const { fixture, dom } = createTestTable(defaultData, [
+      { id: 'first_cell', header: 'header', cell: () => value },
+    ])
+    const row = dom.getBodyRow(0)!
+    const firstCell = row.querySelector('td')
+
+    expect(firstCell!.matches(':empty')).toBe(true)
+  })
+
+  test.each([
+    ['String column via function', () => 'My string'],
+    ['String column', () => 'My string'],
+    ['Number column via function', () => 0],
+    ['Number column', 0],
+  ])('Render primitive (%s)', (columnName, columnValue) => {
+    const { fixture, dom } = createTestTable(defaultData, [
+      { id: 'first_cell', header: columnName, cell: columnValue as any },
+    ])
+    const row = dom.getBodyRow(0)!
+    const firstCell = row.querySelector('td')
+
+    expectPrimitiveValueIs(
+      firstCell,
+      String(typeof columnValue === 'function' ? columnValue() : columnValue)
+    )
+  })
+
+  test('Render TemplateRef', () => {
+    @Component({
+      template: `
+        <ng-template #template let-context
+          >Cell id: {{ context.cell.id }}</ng-template
+        >
+      `,
+      standalone: true,
+    })
+    class FakeTemplateRefComponent {
+      @ViewChild('template', { static: true })
+      templateRef!: TemplateRef<any>
+    }
+
+    const templateRef = TestBed.createComponent(FakeTemplateRefComponent)
+      .componentInstance.templateRef
+
+    const { dom } = createTestTable(defaultData, [
+      { id: 'first_cell', header: 'Header', cell: () => templateRef },
+    ])
+
+    const row = dom.getBodyRow(0)!
+    const firstCell = row.querySelector('td')
+    expect(firstCell!.textContent).toEqual('Cell id: 0_first_cell')
+  })
+
+  test('Render component with FlexRenderComponent', async () => {
+    const status = signal<string>('Initial status')
+
+    const { dom } = createTestTable(defaultData, [
+      {
+        id: 'first_cell',
+        header: 'Status',
+        cell: () => {
+          return new FlexRenderComponent(TestBadgeComponent, {
+            status: status(),
+          })
+        },
+      },
+    ])
+
+    let row = dom.getBodyRow(0)!
+    let firstCell = row.querySelector('td')
+    expect(firstCell!.textContent).toEqual('Initial status')
+
+    status.set('Updated status')
+    dom.clickTriggerCdButton()
+
+    expect(firstCell!.textContent).toEqual('Updated status')
+  })
+})
+
+function expectPrimitiveValueIs(
+  cell: HTMLTableCellElement | null,
+  value: unknown
+) {
+  expect(cell).not.toBeNull()
+  expect(cell!.matches(':empty')).toBe(false)
+  const span = cell!.querySelector('span')!
+  expect(span).toBeDefined()
+  expect(span.innerHTML).toEqual(value)
+}
+
+type TestData = { id: string; title: string }
+
+export function createTestTable(
+  data: TestData[],
+  columns: ColumnDef<TestData, any>[]
+) {
+  @Component({
+    template: `
+      <table>
+        <thead data-testid="thead">
+          @for (headerGroup of table.getHeaderGroups(); track headerGroup.id) {
+            <tr
+              data-testid="thead_row"
+              [attr.data-testid]="'thead_headergroup_' + headerGroup.id"
+            >
+              @for (header of headerGroup.headers; track header.id) {
+                @if (!header.isPlaceholder) {
+                  <th
+                    [attr.data-testid]="
+                      'thead_headergroup_' + headerGroup.id + '_' + header.id
+                    "
+                  >
+                    <ng-container
+                      *flexRender="
+                        header.column.columnDef.header;
+                        props: header.getContext();
+                        let header
+                      "
+                    >
+                      <span [innerHTML]="header"></span>
+                    </ng-container>
+                  </th>
+                }
+              }
+            </tr>
+          }
+        </thead>
+        <tbody>
+          @for (row of table.getRowModel().rows; track row.id) {
+            <tr [attr.data-testid]="'row_' + row.id">
+              @for (cell of row.getVisibleCells(); track cell.id) {
+                <td [attr.data-testid]="'row_' + row.id + '_cell_' + cell.id">
+                  <ng-container
+                    *flexRender="
+                      cell.column.columnDef.cell;
+                      props: cell.getContext();
+                      let cell
+                    "
+                  >
+                    <span [innerHTML]="cell"></span>
+                  </ng-container>
+                </td>
+              }
+            </tr>
+          }
+        </tbody>
+      </table>
+
+      <button (click)="(0)">Trigger CD</button>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    standalone: true,
+    selector: 'app-table-test',
+    imports: [FlexRenderDirective],
+  })
+  class TestComponent {
+    readonly columns = input<ColumnDef<TestData>[]>(columns)
+    readonly data = input<TestData[]>(data)
+
+    readonly table = createAngularTable(() => {
+      return {
+        columns: this.columns(),
+        data: this.data(),
+        getCoreRowModel: getCoreRowModel(),
+      }
+    })
+  }
+
+  const fixture = TestBed.createComponent(TestComponent)
+
+  fixture.detectChanges()
+
+  return {
+    fixture,
+    dom: {
+      clickTriggerCdButton() {
+        const btn = fixture.debugElement.query(By.css('button'))
+        btn.triggerEventHandler('click', null)
+        fixture.detectChanges()
+      },
+      getTable() {
+        return fixture.nativeElement.querySelector('table') as HTMLTableElement
+      },
+      getHeader() {
+        return this.getTable().querySelector('thead') as HTMLTableSectionElement
+      },
+      getHeaderRow() {
+        return this.getHeader().querySelector('tr') as HTMLTableRowElement
+      },
+      getBody() {
+        return this.getTable().querySelector('tbody') as HTMLTableSectionElement
+      },
+      getBodyRow(index: number) {
+        return this.getBody().rows.item(index)
+      },
+    },
+  }
+}
+
+@Component({
+  template: `<span>{{ status }}</span> `,
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestBadgeComponent {
+  readonly context = injectFlexRenderContext<CellContext<TestData, any>>()
+
+  @Input({ required: true })
+  readonly status!: string
+}

--- a/packages/angular-table/tests/flex-render-table.test.ts
+++ b/packages/angular-table/tests/flex-render-table.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@tanstack/table-core'
 import {
   createAngularTable,
+  flexRenderComponent,
   FlexRenderComponent,
   type FlexRenderContent,
   FlexRenderDirective,
@@ -97,8 +98,10 @@ describe('FlexRenderDirective', () => {
         id: 'first_cell',
         header: 'Status',
         cell: () => {
-          return new FlexRenderComponent(TestBadgeComponent, {
-            status: status(),
+          return flexRenderComponent(TestBadgeComponent, {
+            inputs: {
+              status: status(),
+            },
           })
         },
       },
@@ -137,7 +140,9 @@ describe('FlexRenderDirective', () => {
     expect(firstCell!.matches(':empty')).toBe(true)
 
     statusComponent.set(
-      new FlexRenderComponent(TestBadgeComponent, { status: 'Updated status' })
+      flexRenderComponent(TestBadgeComponent, {
+        inputs: { status: 'Updated status' },
+      })
     )
     fixture.detectChanges()
     const el = firstCell!.firstElementChild as HTMLElement

--- a/packages/angular-table/tests/flex-render.test.ts
+++ b/packages/angular-table/tests/flex-render.test.ts
@@ -13,7 +13,10 @@ import {
   injectFlexRenderContext,
 } from '../src/flex-render'
 import { setFixtureSignalInput, setFixtureSignalInputs } from './test-utils'
-import { FlexRenderComponent } from '../src/flex-render/flex-render-component'
+import {
+  flexRenderComponent,
+  FlexRenderComponent,
+} from '../src/flex-render/flex-render-component'
 
 interface Data {
   id: string
@@ -114,7 +117,7 @@ describe('FlexRenderDirective', () => {
 
     const fixture = TestBed.createComponent(TestRenderComponent)
     setFixtureSignalInputs(fixture, {
-      content: () => new FlexRenderComponent(FakeComponent),
+      content: () => flexRenderComponent(FakeComponent),
       context: {
         property: 'Context value',
       },

--- a/packages/angular-table/tests/flex-render.test.ts
+++ b/packages/angular-table/tests/flex-render.test.ts
@@ -138,11 +138,7 @@ describe('FlexRenderDirective', () => {
     class FakeComponent {
       row = input.required<{ property: string }>()
 
-      constructor() {
-        effect(() => {
-          console.log('row', this.row())
-        })
-      }
+      constructor() {}
     }
 
     const fixture = TestBed.createComponent(TestRenderComponent)

--- a/packages/angular-table/tests/flex-render.test.ts
+++ b/packages/angular-table/tests/flex-render.test.ts
@@ -1,4 +1,10 @@
-import { Component, ViewChild, input, type TemplateRef } from '@angular/core'
+import {
+  Component,
+  ViewChild,
+  input,
+  type TemplateRef,
+  effect,
+} from '@angular/core'
 import { TestBed, type ComponentFixture } from '@angular/core/testing'
 import { createColumnHelper } from '@tanstack/table-core'
 import { describe, expect, test } from 'vitest'
@@ -124,13 +130,19 @@ describe('FlexRenderDirective', () => {
 
   // Skip for now, test framework (using ComponentRef.setInput) cannot recognize signal inputs
   // as component inputs
-  test.skip('should render custom components', () => {
+  test('should render custom components', () => {
     @Component({
       template: `{{ row().property }}`,
       standalone: true,
     })
     class FakeComponent {
       row = input.required<{ property: string }>()
+
+      constructor() {
+        effect(() => {
+          console.log('row', this.row())
+        })
+      }
     }
 
     const fixture = TestBed.createComponent(TestRenderComponent)

--- a/packages/angular-table/tests/flex-render.test.ts
+++ b/packages/angular-table/tests/flex-render.test.ts
@@ -3,11 +3,11 @@ import { TestBed, type ComponentFixture } from '@angular/core/testing'
 import { createColumnHelper } from '@tanstack/table-core'
 import { describe, expect, test } from 'vitest'
 import {
-  FlexRenderComponent,
   FlexRenderDirective,
   injectFlexRenderContext,
 } from '../src/flex-render'
 import { setFixtureSignalInput, setFixtureSignalInputs } from './test-utils'
+import { FlexRenderComponent } from '../src/flex-render/flex-render-component'
 
 interface Data {
   id: string

--- a/packages/angular-table/tests/test-setup.ts
+++ b/packages/angular-table/tests/test-setup.ts
@@ -1,4 +1,4 @@
-import '@analogjs/vite-plugin-angular/setup-vitest'
+import '@analogjs/vitest-angular/setup-zone'
 import '@testing-library/jest-dom/vitest'
 
 import {

--- a/packages/angular-table/tests/test-utils.ts
+++ b/packages/angular-table/tests/test-utils.ts
@@ -8,27 +8,14 @@ type ToSignalInputUpdatableMap<T> = {
     : never]: T[K] extends InputSignal<infer Value> ? Value : never
 }
 
-/**
- * Set required signal input value to component fixture
- * @see https://github.com/angular/angular/issues/54013
- */
-export function setSignalInputs<T extends NonNullable<unknown>>(
-  component: T,
-  inputs: ToSignalInputUpdatableMap<T>
-) {
-  for (const inputKey in inputs) {
-    if (componentHasSignalInputProperty(component, inputKey)) {
-      signalSetFn(component[inputKey][SIGNAL], inputs[inputKey])
-    }
-  }
-}
-
 export function setFixtureSignalInputs<T extends NonNullable<unknown>>(
   componentFixture: ComponentFixture<T>,
   inputs: ToSignalInputUpdatableMap<T>,
   options: { detectChanges: boolean } = { detectChanges: true }
 ) {
-  setSignalInputs(componentFixture.componentInstance, inputs)
+  for (const inputKey in inputs) {
+    componentFixture.componentRef.setInput(inputKey, inputs[inputKey])
+  }
   if (options.detectChanges) {
     componentFixture.detectChanges()
   }
@@ -43,7 +30,7 @@ export function setFixtureSignalInput<
   inputName: InputName,
   value: InputMaps[InputName]
 ) {
-  setSignalInputs(componentFixture.componentInstance, {
+  setFixtureSignalInputs(componentFixture, {
     [inputName]: value,
   } as ToSignalInputUpdatableMap<T>)
 }

--- a/packages/angular-table/tsconfig.test.json
+++ b/packages/angular-table/tsconfig.test.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "ES2015",
+    "module": "ES2022",
+    "useDefineForClassFields": false,
+    "lib": ["ES2022", "dom"],
+    "types": ["vitest/globals"]
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/angular-table/vitest.config.ts
+++ b/packages/angular-table/vitest.config.ts
@@ -1,13 +1,25 @@
 import { defineConfig } from 'vitest/config'
 import packageJson from './package.json'
+import angular from '@analogjs/vite-plugin-angular'
+import path from 'node:path'
+
+const tsconfig = path.join(import.meta.dirname, 'tsconfig.test.json')
+
+const angularPlugin = angular({ tsconfig, jit: true })
 
 export default defineConfig({
+  plugins: [
+    // @ts-expect-error Fix types
+    angularPlugin,
+  ],
   test: {
     name: packageJson.name,
-    dir: './tests',
     watch: false,
+    pool: 'threads',
     environment: 'jsdom',
     setupFiles: ['./tests/test-setup.ts'],
     globals: true,
+    reporters: 'default',
+    disableConsoleIntercept: true,
   },
 })

--- a/packages/angular-table/vitest.config.ts
+++ b/packages/angular-table/vitest.config.ts
@@ -3,9 +3,7 @@ import packageJson from './package.json'
 import angular from '@analogjs/vite-plugin-angular'
 import path from 'node:path'
 
-const tsconfig = path.join(import.meta.dirname, 'tsconfig.test.json')
-
-const angularPlugin = angular({ tsconfig, jit: true })
+const angularPlugin = angular({ tsconfig: 'tsconfig.test.json', jit: true })
 
 export default defineConfig({
   plugins: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2989,6 +2989,9 @@ importers:
       ng-packagr:
         specifier: ^17.3.0
         version: 17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(tslib@2.6.3)(typescript@5.6.2)
+      typescript:
+        specifier: 5.4.5
+        version: 5.4.5
 
   packages/lit-table:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2976,7 +2976,7 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^1.3.1
-        version: 1.5.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(tslib@2.6.3)(typescript@5.6.2))(typescript@5.6.2))(@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(typescript@5.6.2)(webpack@5.90.3(esbuild@0.21.5)))
+        version: 1.5.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5))(@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5)))
       '@angular/core':
         specifier: ^17.3.9
         version: 17.3.11(rxjs@7.8.1)(zone.js@0.14.7)
@@ -2988,7 +2988,7 @@ importers:
         version: 17.3.11(@angular/common@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1))(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))(@angular/platform-browser@17.3.11(@angular/animations@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(@angular/common@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1))(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))
       ng-packagr:
         specifier: ^17.3.0
-        version: 17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(tslib@2.6.3)(typescript@5.6.2)
+        version: 17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5)
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -3081,7 +3081,7 @@ importers:
     devDependencies:
       vue:
         specifier: ^3.4.31
-        version: 3.4.31(typescript@5.6.2)
+        version: 3.4.31(typescript@5.4.5)
 
 packages:
 
@@ -9838,11 +9838,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   ua-parser-js@0.7.38:
     resolution: {integrity: sha512-fYmIy7fKTSFAhG3fuPlubeGaMoAd6r0rSnfEsO5nEY55i26KSLt9EH7PLQiiqPUhNqYIJvSkTy1oArIcXAbPbA==}
 
@@ -10404,10 +10399,10 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@analogjs/vite-plugin-angular@1.5.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(tslib@2.6.3)(typescript@5.6.2))(typescript@5.6.2))(@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(typescript@5.6.2)(webpack@5.90.3(esbuild@0.21.5)))':
+  '@analogjs/vite-plugin-angular@1.5.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5))(@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5)))':
     dependencies:
-      '@angular-devkit/build-angular': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(tslib@2.6.3)(typescript@5.6.2))(typescript@5.6.2)
-      '@ngtools/webpack': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(typescript@5.6.2)(webpack@5.90.3(esbuild@0.21.5))
+      '@angular-devkit/build-angular': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5)
+      '@ngtools/webpack': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5))
       ts-morph: 21.0.1
 
   '@angular-devkit/architect@0.1703.8(chokidar@3.6.0)':
@@ -10434,7 +10429,7 @@ snapshots:
       '@babel/preset-env': 7.24.0(@babel/core@7.24.0)
       '@babel/runtime': 7.24.0
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1))
+      '@ngtools/webpack': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5))
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.1.7(@types/node@20.14.9)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.18(postcss@8.4.35)
@@ -10464,7 +10459,7 @@ snapshots:
       picomatch: 4.0.1
       piscina: 4.4.0
       postcss: 8.4.35
-      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1))
+      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.71.1
@@ -10488,96 +10483,6 @@ snapshots:
       esbuild: 0.20.1
       karma: 6.4.3
       ng-packagr: 17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/express'
-      - '@types/node'
-      - bufferutil
-      - chokidar
-      - debug
-      - html-webpack-plugin
-      - lightningcss
-      - node-sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-
-  '@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(tslib@2.6.3)(typescript@5.6.2))(typescript@5.6.2)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1703.8(chokidar@3.6.0)
-      '@angular-devkit/build-webpack': 0.1703.8(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.21.5)))(webpack@5.90.3(esbuild@0.21.5))
-      '@angular-devkit/core': 17.3.8(chokidar@3.6.0)
-      '@angular/compiler-cli': 17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2)
-      '@babel/core': 7.24.0
-      '@babel/generator': 7.23.6
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/plugin-transform-async-generator-functions': 7.23.9(@babel/core@7.24.0)
-      '@babel/plugin-transform-async-to-generator': 7.23.3(@babel/core@7.24.0)
-      '@babel/plugin-transform-runtime': 7.24.0(@babel/core@7.24.0)
-      '@babel/preset-env': 7.24.0(@babel/core@7.24.0)
-      '@babel/runtime': 7.24.0
-      '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(typescript@5.6.2)(webpack@5.90.3(esbuild@0.21.5))
-      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.1.7(@types/node@20.14.9)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))
-      ansi-colors: 4.1.3
-      autoprefixer: 10.4.18(postcss@8.4.35)
-      babel-loader: 9.1.3(@babel/core@7.24.0)(webpack@5.90.3(esbuild@0.21.5))
-      babel-plugin-istanbul: 6.1.1
-      browserslist: 4.23.1
-      copy-webpack-plugin: 11.0.0(webpack@5.90.3(esbuild@0.21.5))
-      critters: 0.0.22
-      css-loader: 6.10.0(webpack@5.90.3(esbuild@0.21.5))
-      esbuild-wasm: 0.20.1
-      fast-glob: 3.3.2
-      http-proxy-middleware: 2.0.6(@types/express@4.17.21)
-      https-proxy-agent: 7.0.4
-      inquirer: 9.2.15
-      jsonc-parser: 3.2.1
-      karma-source-map-support: 1.4.0
-      less: 4.2.0
-      less-loader: 11.1.0(less@4.2.0)(webpack@5.90.3(esbuild@0.21.5))
-      license-webpack-plugin: 4.0.2(webpack@5.90.3(esbuild@0.21.5))
-      loader-utils: 3.2.1
-      magic-string: 0.30.8
-      mini-css-extract-plugin: 2.8.1(webpack@5.90.3(esbuild@0.21.5))
-      mrmime: 2.0.0
-      open: 8.4.2
-      ora: 5.4.1
-      parse5-html-rewriting-stream: 7.0.0
-      picomatch: 4.0.1
-      piscina: 4.4.0
-      postcss: 8.4.35
-      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.6.2)(webpack@5.90.3(esbuild@0.21.5))
-      resolve-url-loader: 5.0.0
-      rxjs: 7.8.1
-      sass: 1.71.1
-      sass-loader: 14.1.1(sass@1.71.1)(webpack@5.90.3(esbuild@0.21.5))
-      semver: 7.6.0
-      source-map-loader: 5.0.0(webpack@5.90.3(esbuild@0.21.5))
-      source-map-support: 0.5.21
-      terser: 5.29.1
-      tree-kill: 1.2.2
-      tslib: 2.6.2
-      typescript: 5.6.2
-      undici: 6.11.1
-      vite: 5.1.7(@types/node@20.14.9)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
-      watchpack: 2.4.0
-      webpack: 5.90.3(esbuild@0.21.5)
-      webpack-dev-middleware: 6.1.2(webpack@5.90.3(esbuild@0.21.5))
-      webpack-dev-server: 4.15.1(webpack@5.90.3(esbuild@0.21.5))
-      webpack-merge: 5.10.0
-      webpack-subresource-integrity: 5.1.0(webpack@5.90.3(esbuild@0.21.5))
-    optionalDependencies:
-      esbuild: 0.20.1
-      karma: 6.4.3
-      ng-packagr: 17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(tslib@2.6.3)(typescript@5.6.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -10674,21 +10579,6 @@ snapshots:
       semver: 7.6.3
       tslib: 2.6.3
       typescript: 5.4.5
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2)':
-    dependencies:
-      '@angular/compiler': 17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
-      '@babel/core': 7.23.9
-      '@jridgewell/sourcemap-codec': 1.5.0
-      chokidar: 3.6.0
-      convert-source-map: 1.9.0
-      reflect-metadata: 0.2.2
-      semver: 7.6.3
-      tslib: 2.6.3
-      typescript: 5.6.2
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
@@ -13009,16 +12899,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
-  '@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1))':
+  '@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5))':
     dependencies:
       '@angular/compiler-cli': 17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5)
       typescript: 5.4.5
-      webpack: 5.90.3(esbuild@0.21.5)
-
-  '@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(typescript@5.6.2)(webpack@5.90.3(esbuild@0.21.5))':
-    dependencies:
-      '@angular/compiler-cli': 17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2)
-      typescript: 5.6.2
       webpack: 5.90.3(esbuild@0.21.5)
 
   '@nodelib/fs.scandir@2.1.5':
@@ -14208,12 +14092,6 @@ snapshots:
       '@vue/shared': 3.4.31
       vue: 3.4.31(typescript@5.4.5)
 
-  '@vue/server-renderer@3.4.31(vue@3.4.31(typescript@5.6.2))':
-    dependencies:
-      '@vue/compiler-ssr': 3.4.31
-      '@vue/shared': 3.4.31
-      vue: 3.4.31(typescript@5.6.2)
-
   '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@5.4.5))':
     dependencies:
       '@vue/compiler-ssr': 3.5.13
@@ -14982,15 +14860,6 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.4.5
-
-  cosmiconfig@9.0.0(typescript@5.6.2):
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-    optionalDependencies:
-      typescript: 5.6.2
 
   critters@0.0.22:
     dependencies:
@@ -16905,38 +16774,6 @@ snapshots:
     optionalDependencies:
       esbuild: 0.20.2
       rollup: 4.18.0
-    optional: true
-
-  ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2))(tslib@2.6.3)(typescript@5.6.2):
-    dependencies:
-      '@angular/compiler-cli': 17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.6.2)
-      '@rollup/plugin-json': 6.1.0(rollup@4.18.0)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.18.0)
-      '@rollup/wasm-node': 4.18.0
-      ajv: 8.16.0
-      ansi-colors: 4.1.3
-      browserslist: 4.23.1
-      cacache: 18.0.3
-      chokidar: 3.6.0
-      commander: 12.1.0
-      convert-source-map: 2.0.0
-      dependency-graph: 1.0.0
-      esbuild-wasm: 0.20.2
-      fast-glob: 3.3.2
-      find-cache-dir: 3.3.2
-      injection-js: 2.4.0
-      jsonc-parser: 3.3.1
-      less: 4.2.0
-      ora: 5.4.1
-      piscina: 4.6.1
-      postcss: 8.4.39
-      rxjs: 7.8.1
-      sass: 1.77.6
-      tslib: 2.6.3
-      typescript: 5.6.2
-    optionalDependencies:
-      esbuild: 0.20.2
-      rollup: 4.18.0
 
   nice-napi@1.0.2:
     dependencies:
@@ -17365,20 +17202,9 @@ snapshots:
       mlly: 1.7.1
       pathe: 1.1.2
 
-  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1)):
+  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.4.5)
-      jiti: 1.21.6
-      postcss: 8.4.35
-      semver: 7.6.3
-    optionalDependencies:
-      webpack: 5.90.3(esbuild@0.21.5)
-    transitivePeerDependencies:
-      - typescript
-
-  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.6.2)(webpack@5.90.3(esbuild@0.21.5)):
-    dependencies:
-      cosmiconfig: 9.0.0(typescript@5.6.2)
       jiti: 1.21.6
       postcss: 8.4.35
       semver: 7.6.3
@@ -18608,8 +18434,6 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  typescript@5.6.2: {}
-
   ua-parser-js@0.7.38: {}
 
   uc.micro@2.1.0: {}
@@ -18888,16 +18712,6 @@ snapshots:
       '@vue/shared': 3.4.31
     optionalDependencies:
       typescript: 5.4.5
-
-  vue@3.4.31(typescript@5.6.2):
-    dependencies:
-      '@vue/compiler-dom': 3.4.31
-      '@vue/compiler-sfc': 3.4.31
-      '@vue/runtime-dom': 3.4.31
-      '@vue/server-renderer': 3.4.31(vue@3.4.31(typescript@5.6.2))
-      '@vue/shared': 3.4.31
-    optionalDependencies:
-      typescript: 5.6.2
 
   vue@3.5.13(typescript@5.4.5):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2992,9 +2992,6 @@ importers:
       ng-packagr:
         specifier: ^17.3.0
         version: 17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5)
-      reflect-metadata:
-        specifier: ^0.2.2
-        version: 0.2.2
       typescript:
         specifier: 5.4.5
         version: 5.4.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2975,8 +2975,11 @@ importers:
         version: 2.6.3
     devDependencies:
       '@analogjs/vite-plugin-angular':
-        specifier: ^1.3.1
-        version: 1.5.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5))(@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5)))
+        specifier: ^1.11.0
+        version: 1.11.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/node@20.14.9)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5))
+      '@analogjs/vitest-angular':
+        specifier: ^1.11.0
+        version: 1.11.0(@analogjs/vite-plugin-angular@1.11.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/node@20.14.9)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5)))(vitest@1.6.0(@types/node@20.14.9)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.6)(terser@5.31.1))
       '@angular/core':
         specifier: ^17.3.9
         version: 17.3.11(rxjs@7.8.1)(zone.js@0.14.7)
@@ -2989,9 +2992,15 @@ importers:
       ng-packagr:
         specifier: ^17.3.0
         version: 17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5)
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
       typescript:
         specifier: 5.4.5
         version: 5.4.5
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.0(@types/node@20.14.9)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.6)(terser@5.31.1)
 
   packages/lit-table:
     dependencies:
@@ -3092,11 +3101,23 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@analogjs/vite-plugin-angular@1.5.0':
-    resolution: {integrity: sha512-e88LyREExpKc6KgpRUcKu8JJO0k6ZVDHYzsKEzRVxbz34e8D3LTGJxYAoiW6ucxW4irKbhHZlySll5+cdtvfXA==}
+  '@analogjs/vite-plugin-angular@1.11.0':
+    resolution: {integrity: sha512-18HSwOAVFQjwwRQPq9+duOoubuiut0INo55h0gV3v2TWS+tAP2wXP8SPyAG99P3ySNQB7zMUYE8mVsqLM+8bDA==}
     peerDependencies:
-      '@angular-devkit/build-angular': ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
-      '@ngtools/webpack': ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      '@angular-devkit/build-angular': ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@angular/build': ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@angular-devkit/build-angular':
+        optional: true
+      '@angular/build':
+        optional: true
+
+  '@analogjs/vitest-angular@1.11.0':
+    resolution: {integrity: sha512-ZY0AOJfTV/eIOkx3QLCF0iOUnGfYNGpf45kVVrOcuam2II6w6YcgsqpRxDIR66wXi3gbvIxJzwB05v0Hc4+Gkw==}
+    peerDependencies:
+      '@analogjs/vite-plugin-angular': '*'
+      '@angular-devkit/architect': ^0.1500.0 || ^0.1600.0 || ^0.1700.0 || ^0.1800.0 || ^0.1900.0 || next
+      vitest: ^1.3.1 || ^2.0.0
 
   '@angular-devkit/architect@0.1703.8':
     resolution: {integrity: sha512-lKxwG4/QABXZvJpqeSIn/kAwnY6MM9HdHZUV+o5o3UiTi+vO8rZApG4CCaITH3Bxebm7Nam7Xbk8RuukC5rq6g==}
@@ -9899,6 +9920,9 @@ packages:
     resolution: {integrity: sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -9967,6 +9991,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.2:
+    resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@1.6.0:
     resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
@@ -10399,11 +10429,17 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@analogjs/vite-plugin-angular@1.5.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5))(@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5)))':
+  '@analogjs/vite-plugin-angular@1.11.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/node@20.14.9)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5))':
     dependencies:
-      '@angular-devkit/build-angular': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5)
-      '@ngtools/webpack': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5))
       ts-morph: 21.0.1
+      vfile: 6.0.3
+    optionalDependencies:
+      '@angular-devkit/build-angular': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/express@4.17.21)(@types/node@20.14.9)(chokidar@3.6.0)(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5)
+
+  '@analogjs/vitest-angular@1.11.0(@analogjs/vite-plugin-angular@1.11.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/node@20.14.9)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5)))(vitest@1.6.0(@types/node@20.14.9)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.6)(terser@5.31.1))':
+    dependencies:
+      '@analogjs/vite-plugin-angular': 1.11.0(@angular-devkit/build-angular@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(@types/node@20.14.9)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(tslib@2.6.3)(typescript@5.4.5))(typescript@5.4.5))
+      vitest: 1.6.0(@types/node@20.14.9)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.6)(terser@5.31.1)
 
   '@angular-devkit/architect@0.1703.8(chokidar@3.6.0)':
     dependencies:
@@ -10416,7 +10452,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1703.8(chokidar@3.6.0)
-      '@angular-devkit/build-webpack': 0.1703.8(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.21.5)))(webpack@5.90.3(esbuild@0.21.5))
+      '@angular-devkit/build-webpack': 0.1703.8(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)))(webpack@5.90.3(esbuild@0.20.1))
       '@angular-devkit/core': 17.3.8(chokidar@3.6.0)
       '@angular/compiler-cli': 17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5)
       '@babel/core': 7.24.0
@@ -10429,16 +10465,16 @@ snapshots:
       '@babel/preset-env': 7.24.0(@babel/core@7.24.0)
       '@babel/runtime': 7.24.0
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5))
+      '@ngtools/webpack': 17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1))
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.1.7(@types/node@20.14.9)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.18(postcss@8.4.35)
-      babel-loader: 9.1.3(@babel/core@7.24.0)(webpack@5.90.3(esbuild@0.21.5))
+      babel-loader: 9.1.3(@babel/core@7.24.0)(webpack@5.90.3(esbuild@0.20.1))
       babel-plugin-istanbul: 6.1.1
       browserslist: 4.23.1
-      copy-webpack-plugin: 11.0.0(webpack@5.90.3(esbuild@0.21.5))
+      copy-webpack-plugin: 11.0.0(webpack@5.90.3(esbuild@0.20.1))
       critters: 0.0.22
-      css-loader: 6.10.0(webpack@5.90.3(esbuild@0.21.5))
+      css-loader: 6.10.0(webpack@5.90.3(esbuild@0.20.1))
       esbuild-wasm: 0.20.1
       fast-glob: 3.3.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)
@@ -10447,11 +10483,11 @@ snapshots:
       jsonc-parser: 3.2.1
       karma-source-map-support: 1.4.0
       less: 4.2.0
-      less-loader: 11.1.0(less@4.2.0)(webpack@5.90.3(esbuild@0.21.5))
-      license-webpack-plugin: 4.0.2(webpack@5.90.3(esbuild@0.21.5))
+      less-loader: 11.1.0(less@4.2.0)(webpack@5.90.3(esbuild@0.20.1))
+      license-webpack-plugin: 4.0.2(webpack@5.90.3(esbuild@0.20.1))
       loader-utils: 3.2.1
       magic-string: 0.30.8
-      mini-css-extract-plugin: 2.8.1(webpack@5.90.3(esbuild@0.21.5))
+      mini-css-extract-plugin: 2.8.1(webpack@5.90.3(esbuild@0.20.1))
       mrmime: 2.0.0
       open: 8.4.2
       ora: 5.4.1
@@ -10459,13 +10495,13 @@ snapshots:
       picomatch: 4.0.1
       piscina: 4.4.0
       postcss: 8.4.35
-      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5))
+      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.71.1
-      sass-loader: 14.1.1(sass@1.71.1)(webpack@5.90.3(esbuild@0.21.5))
+      sass-loader: 14.1.1(sass@1.71.1)(webpack@5.90.3(esbuild@0.20.1))
       semver: 7.6.0
-      source-map-loader: 5.0.0(webpack@5.90.3(esbuild@0.21.5))
+      source-map-loader: 5.0.0(webpack@5.90.3(esbuild@0.20.1))
       source-map-support: 0.5.21
       terser: 5.29.1
       tree-kill: 1.2.2
@@ -10475,10 +10511,10 @@ snapshots:
       vite: 5.1.7(@types/node@20.14.9)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
       watchpack: 2.4.0
       webpack: 5.90.3(esbuild@0.21.5)
-      webpack-dev-middleware: 6.1.2(webpack@5.90.3(esbuild@0.21.5))
-      webpack-dev-server: 4.15.1(webpack@5.90.3(esbuild@0.21.5))
+      webpack-dev-middleware: 6.1.2(webpack@5.90.3(esbuild@0.20.1))
+      webpack-dev-server: 4.15.1(webpack@5.90.3(esbuild@0.20.1))
       webpack-merge: 5.10.0
-      webpack-subresource-integrity: 5.1.0(webpack@5.90.3(esbuild@0.21.5))
+      webpack-subresource-integrity: 5.1.0(webpack@5.90.3(esbuild@0.20.1))
     optionalDependencies:
       esbuild: 0.20.1
       karma: 6.4.3
@@ -10502,12 +10538,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1703.8(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.21.5)))(webpack@5.90.3(esbuild@0.21.5))':
+  '@angular-devkit/build-webpack@0.1703.8(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)))(webpack@5.90.3(esbuild@0.20.1))':
     dependencies:
       '@angular-devkit/architect': 0.1703.8(chokidar@3.6.0)
       rxjs: 7.8.1
       webpack: 5.90.3(esbuild@0.21.5)
-      webpack-dev-server: 4.15.1(webpack@5.90.3(esbuild@0.21.5))
+      webpack-dev-server: 4.15.1(webpack@5.90.3(esbuild@0.20.1))
     transitivePeerDependencies:
       - chokidar
 
@@ -12899,7 +12935,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
-  '@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5))':
+  '@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1))':
     dependencies:
       '@angular/compiler-cli': 17.3.11(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(typescript@5.4.5)
       typescript: 5.4.5
@@ -14388,7 +14424,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.1.3(@babel/core@7.24.0)(webpack@5.90.3(esbuild@0.21.5)):
+  babel-loader@9.1.3(@babel/core@7.24.0)(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       '@babel/core': 7.24.0
       find-cache-dir: 4.0.0
@@ -14823,7 +14859,7 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@11.0.0(webpack@5.90.3(esbuild@0.21.5)):
+  copy-webpack-plugin@11.0.0(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -14883,7 +14919,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@6.10.0(webpack@5.90.3(esbuild@0.21.5)):
+  css-loader@6.10.0(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.39)
       postcss: 8.4.39
@@ -16363,7 +16399,7 @@ snapshots:
       picocolors: 1.0.1
       shell-quote: 1.8.1
 
-  less-loader@11.1.0(less@4.2.0)(webpack@5.90.3(esbuild@0.21.5)):
+  less-loader@11.1.0(less@4.2.0)(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       klona: 2.0.6
       less: 4.2.0
@@ -16388,7 +16424,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.90.3(esbuild@0.21.5)):
+  license-webpack-plugin@4.0.2(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       webpack-sources: 3.2.3
     optionalDependencies:
@@ -16616,7 +16652,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.8.1(webpack@5.90.3(esbuild@0.21.5)):
+  mini-css-extract-plugin@2.8.1(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
@@ -17202,7 +17238,7 @@ snapshots:
       mlly: 1.7.1
       pathe: 1.1.2
 
-  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3(esbuild@0.21.5)):
+  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.4.5)
       jiti: 1.21.6
@@ -17671,7 +17707,7 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.7.1
 
-  sass-loader@14.1.1(sass@1.71.1)(webpack@5.90.3(esbuild@0.21.5)):
+  sass-loader@14.1.1(sass@1.71.1)(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -18022,7 +18058,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.90.3(esbuild@0.21.5)):
+  source-map-loader@5.0.0(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.0
@@ -18483,6 +18519,10 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
 
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.2
+
   universalify@0.1.2: {}
 
   universalify@0.2.0: {}
@@ -18540,6 +18580,16 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.2:
+    dependencies:
+      '@types/unist': 3.0.2
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.2
+      vfile-message: 4.0.2
 
   vite-node@1.6.0(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1):
     dependencies:
@@ -18746,7 +18796,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-dev-middleware@5.3.4(webpack@5.90.3(esbuild@0.21.5)):
+  webpack-dev-middleware@5.3.4(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -18755,7 +18805,7 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.90.3(esbuild@0.21.5)
 
-  webpack-dev-middleware@6.1.2(webpack@5.90.3(esbuild@0.21.5)):
+  webpack-dev-middleware@6.1.2(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -18765,7 +18815,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.90.3(esbuild@0.21.5)
 
-  webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.21.5)):
+  webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -18795,7 +18845,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.90.3(esbuild@0.21.5))
+      webpack-dev-middleware: 5.3.4(webpack@5.90.3(esbuild@0.20.1))
       ws: 8.17.1
     optionalDependencies:
       webpack: 5.90.3(esbuild@0.21.5)
@@ -18813,7 +18863,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.90.3(esbuild@0.21.5)):
+  webpack-subresource-integrity@5.1.0(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.90.3(esbuild@0.21.5)


### PR DESCRIPTION
I refactored how the FlexRender directive applies updates internally during change detection. This will resolve issues like #5767 without necessarily waiting for v9 (so this is not a breaking change for users). It now should also work with zoneless and it's reactive if someone use signals into the cell content. Also there are some dx improvements that helps writing column custom content easily

**tldr**
- [Updated vitest config with new analog version. Resolve some issues we had with tests. Add some "integration" tests. Old tests are all passing with the newest implementation without changes](https://github.com/TanStack/table/pull/5856#update-vitest-configuration:~:text=Update%20vitest%20configuration)
- [Better type safety](https://github.com/TanStack/table/pull/5856#update-vitest-configuration:~:text=Enhanced%20Type%20Safety%20for%20FlexRenderComponent)
- [The cell definition content may update more than before, support zoneless and signals into cell definition](https://github.com/TanStack/table/pull/5856#update-vitest-configuration:~:text=Refactor%20FlexRenderDirective%20rendering%20mechanism) 
- Some code has been moved into separate files

For those who enjoy reading 😅:

## Update vitest configuration 

I've updated vitest test setup with latest version of @analog/vitest-angular and @analog/vite-plugin-angular in order to compile the angular components correctly. 

We are now able to use angular signal inputs during test. I removed all workaround utils we had to use before. Now we could also opt for switching the FlexRenderDirective to signal inputs instead of old-based @Input decorators, even if we cannot rely on effects, we should always use ngOnChanges).

## Enhanced Type Safety for FlexRenderComponent 

The FlexRenderComponent inputs are now typed based on the given component instance
```typescript
@Component()
class MyComp {   
  readonly input1 = input<string>();
  readonly input2 = input.required<number>();
}

new FlexRenderComponent(MyComp, { ... }) // correctly typed as { input1: string | undefined, input2: number }
```

I have also added a `flexRenderComponent` function util that can be used to enhance typesafety and which use an option object instead of multiple arguments to pass data. This allows us to add new arguments in the future without breaking that signature (e.g. in the future we will probably need to bind angular "outputs").

In v9 we may want to have only one of the two available to avoid confusion?

```typescript
@Component()
class Example {   
  readonly input1 = input<string>();
}

//  Example doesn't have required inputs, so 2nd argument is optional. `input1` is typed as `string | undefined`
flexRenderComponent(Example)

@Component()
class ExampleRequired {   
  readonly input1 = input.required<string>();
}

//  Example doesn't have required inputs, so 2nd argument is mandatory. `input1` is typed as `string`
flexRenderComponent(ExampleRequired, { inputs: { input1: "value" } )


```

## Injection context for cell content

Cell content now runs within an injection context. This allows users to inject services and using signals into the cell definition, even outside angular components.

```typescript
// file outside angular
const columns = [ 
  {
      accessorFn: row => row.lastName,
      id: 'lastName',
      header: () => {
        return inject(MyService).returnSomething(...)
      }
  }
]
```

## Refactor FlexRenderDirective rendering mechanism

[tldr](https://github.com/TanStack/table/pull/5856#update-vitest-configuration:~:text=Now%2C%20we%20can%20do%20the%20same%20directly%20into%20the%20column%20definitions)

This is the biggest part. With the previous implementation, we were only relying on `ngOnChanges` hook.

`ngOnChanges` is called by Angular when any data-bound property change, but it's not enough for some reasons:
- `content` property is a reference of the cell/header definition, which could be a function. Doing `content(props)` may return different values, but since we are passing a reference, Angular cannot evaluate it for us automatically.
- `props` most of the time will be `(cell|header).getContext()`, which is memoized for cell (but no headers). Then even in this case the reference may not change

When table data change, we are sure that at least both properties changes. Currently this is the only case were we are re-rendering the cell view.

With this PR, first I am introducing some logic to split some rendering-related code on separate classes (those are not exposed to the library consumers):
- `FlexRenderComponentRef`: a wrapper for Angular ComponentRef, which expose some internal utils to detect changes, set inputs via angular `setInput` api etc.
- `FlexRenderComponentFactory`: an angular service that is responsible to create instances of FlexRenderComponentRef.
- `FlexRenderView`: an abstract class that encapsulate the view state and some information, and defines some logic that we invoke in specific phases of the view checker. It has two implementations:
  - `FlexRenderTemplateView`: a class that define update methods for content rendered via EmbeddedViewRef (which we use to render primitives like string, number or even TemplateRef instances)
  - `FlexRenderComponentView`: a class that define update methods for content rendered via FlexRenderComponentRef (ComponentRef)
 - Code related to FlexRenderComponent injectable context has been moved into a separate file (those declarations are exported for library consumers, but they have not changed)

I've then revisited the rendering business logic via `ngDoCheck` hook and implementing Bit fields to handle the rendering phases.

Link: [angular-table/src/flex-render/flags.ts](https://github.com/riccardoperra/table/blob/feat/angular-flex-render-granular-update/packages/angular-table/src/flex-render/flags.ts)

```ts
/**
 * Flags used to manage and optimize the rendering lifecycle of content of the cell,
 * while using FlexRenderDirective.
 */
export enum FlexRenderFlags {
  /**
   * Indicates that the view is being created for the first time or will be cleared during the next update phase.
   * This is the initial state and will transition after the first ngDoCheck.
   */
  ViewFirstRender = 1 << 0,
  /**
   * Represents a state where the view is not dirty, meaning no changes require rendering updates.
   */
  Pristine = 1 << 1,
  /**
   * Indicates the `content` property has been modified or the view requires a complete re-render.
   * When this flag is enabled, the view will be cleared and recreated from scratch.
   */
  ContentChanged = 1 << 2,
  /**
   * Indicates that the `props` property reference has changed.
   * When this flag is enabled, the view context is updated based on the type of the content.
   *
   * For Component view, inputs will be updated and view will be marked as dirty.
   * For TemplateRef and primitive values, view will be marked as dirty
   */
  PropsReferenceChanged = 1 << 3,
  /**
   * Indicates that the current rendered view needs to be checked for changes.
   */
  DirtyCheck = 1 << 4,
  /**
   * Indicates that a signal within the `content(props)` result has changed
   */
  DirtySignal = 1 << 5,
  /**
   * Indicates that the first render effect has been checked at least one time.
   */
  RenderEffectChecked = 1 << 6,
}
```

Regardless of the implementation, there are two new behaviors:

#### Initializing an effect during the first render 
During the view first render, we initialize an `effect` that set the `DirtySignal` flag every time the `content(props)` changes, if signals are used into the cell definition. This allows to react to changes even without ngZone, and opens up some possibilities in v9 to further improve rendering, for example detecting also when the `table` state signals changes

#### Checking changes in ngDoCheck

During the ngDoCheck lifecycle hook, we determine whether the view needs to be updated by evaluating a set of flags and comparing the result of content(props) with its previous value. At the moment, this check occurs during every doCheck cycle. However, in a future we could use store slices (v10?+) and signals (v9 with the reactivity feature i was working on) to improve this phase updating more efficently.

---

### What changes for users

The new implementation is retrocompatible with previous versions, but improves dx of columns definition while using Angular since this let now to render content conditionally, using signals inside etc.

Most of the time the code I saw to render custom content was something like this, splitting how the table is rendered in both template and typescript

```html
<tbody>
  @for (row of table.getRowModel().rows; track row.id) {
    <tr>
      @for (cell of row.getVisibleCells(); track cell.id) {
        <td>
          @switch (cell.id) {
            <!-- this could have be done also in column def, but what if we want to add some custom logic? -->
            @case ('user') {
              {{ cell.row.original.firstName }}
              {{ cell.row.original.lastName }}
            }
            @case ('status') {
              @if (colors().length) { 
                <app-colored-badge [colors]="colors()" [status]="cell.row.original.status"></app-colored-badge>
              } @else {
                 {{ 'status'. + cell.row.original.status | translate }}
              }
            }
           <!-- This is for columns that can just use the `renderValue` :/ -->
            @default {
              <ng-container
                *flexRender="
                  cell.column.columnDef.cell;
                  props: cell.getContext();
                  let cell
                "
              >
                <div [innerHTML]="cell"></div>
              </ng-container>
            }
          }
        </td>
      }
    </tr>
  }
</tbody>
```

Now, we can do the same directly into the column definitions 😄 

```ts
const helper = createColumnHelper<Person>()
const columns = [
  helper.display({
    id: 'user',
    cell: context => {
      const { firstName, lastName } = context.row.original
      // Just an example of a service that may concat non-empty string
      const stringHelper = inject(StringHelper)
      return stringHelper.joinNonEmpty([firstName, lastName], ' ')

      // or maybe i want to render a component in some specific conditions
      const { firstName, lastName, email } = context.row.original
      if (!email) { 
        return `${firstName} ${lastName}`
      }
      return new FlexRenderComponent(
        CustomCell, 
        { content: `${firstName} ${lastName}`, tooltip: email }
      )
    },
  }),
  helper.accessor('status', {
    id: 'status',
    cell: ({ getValue }) => {
      const status = getValue()
      // this may be a signal, then everything here will be revaluated also when its value change.
      const colors = appColors()
      if (!colors) {
        // just an example
        return translate(`status.${status}`)
      }
      return new FlexRenderComponent(AppColoredBadge, {
        status,
        colors,
      })
    },
  }),
]
```