### PR TITLE
docs: improve vanilla js installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,4 +78,4 @@ The `@tanstack/lit-table` package works with Lit 3.
 npm install @tanstack/table-core
 ```
 
-Don't see your favorite framework (or favorite version of your framework) listed? You can always just use the `@tanstack/table-core` package and build your own adapter in your own codebase. Usually, only a thin wrapper is needed to manage state and rendering for your specific framework. Browse the [source code](https://github.com/TanStack/table/tree/main/packages) of all of the other adapters to see how they work.
+Don't see your favorite framework (or favorite version of your framework) listed? You can always just use the `@tanstack/table-core` package and build your own adapter in your own codebase. Usually, only a thin wrapper is needed to manage state and rendering for your specific framework. Browse the [source code](https://github.com/TanStack/table/tree/main/packages) of all of the other adapters to see how they work. `@tanstack/table-core` is currently only working in vanilla JavaScript with ES6 or above. This means using static HTML and <script> tags without ES6 is not a viable option


### PR DESCRIPTION
Dear TanStack Team Table,

I have updated the documentation to include a note about TanStack/table's compatibility requirements. Specifically, I added clarification that it currently works only with vanilla JavaScript using ES6 or above, and that using static HTML with <script> tags without ES6 support is not viable.

This update aims to assist developers in understanding the compatibility requirements and ensure a smoother integration experience.

Looking forward to your feedback!

Best Regards,