### PR TITLE
Check whether filter value is an array

### DIFF
--- a/packages/table-core/src/filterFns.ts
+++ b/packages/table-core/src/filterFns.ts
@@ -125,7 +125,7 @@ inNumberRange.resolveFilterValue = (val: [any, any]) => {
 }
 
 inNumberRange.autoRemove = (val: any) =>
-  testFalsey(val) || (testFalsey(val[0]) && testFalsey(val[1]))
+  testFalsey(val) || (Array.isArray(val) && testFalsey(val[0]) && testFalsey(val[1]))
 
 // Export
 


### PR DESCRIPTION
 before declaring it as falsy for `inNumberRange` filter
fixes #5901