### PR TITLE
fix: spread table options in lit adapter

### DIFF
--- a/packages/lit-table/src/index.ts
+++ b/packages/lit-table/src/index.ts
@@ -54,9 +54,8 @@ export class TableController<TData extends RowData>
 
     this.tableInstance.setOptions(prev => ({
       ...prev,
+      ...options,
       state: { ...this._tableState, ...options.state },
-      data: options.data,
-      columns: options.columns,
       onStateChange: (updater: any) => {
         this._tableState = updater(this._tableState)
         this.host.requestUpdate()


### PR DESCRIPTION
Currently the Lit adapter takes only `columns`, `data` and `state` into account when updating the table options.
This PR spreads the options, as suggested in this [issue](https://github.com/TanStack/table/issues/5831).