### PR TITLE
fix: broken hyperlink in row-selection.md for getRowId

### DIFF
--- a/docs/api/features/row-selection.md
+++ b/docs/api/features/row-selection.md
@@ -15,7 +15,7 @@ export type RowSelectionTableState = {
 }
 ```
 
-By default, the row selection state uses the index of each row as the row identifiers. Row selection state can instead be tracked with a custom unique row id by passing in a custom [getRowId](../../../api/core/table.md#getrowid) function to the the table.
+By default, the row selection state uses the index of each row as the row identifiers. Row selection state can instead be tracked with a custom unique row id by passing in a custom [getRowId](../../../docs/api/core/table.md#getrowid) function to the the table.
 
 ## Table Options
 


### PR DESCRIPTION
Fixed broken hyperlink for getRowId link, which previously led to a 404 page.