### PR TITLE
chore(svelte-table): cleanup package.json

### DIFF
--- a/packages/svelte-table/package.json
+++ b/packages/svelte-table/package.json
@@ -20,15 +20,13 @@
     "svelte-table",
     "datagrid"
   ],
-  "type": "commonjs",
-  "module": "build/lib/index.esm.js",
-  "main": "build/lib/index.js",
+  "type": "module",
+  "main": "build/lib/index.esm.js",
   "types": "build/lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",
-      "import": "./build/lib/index.mjs",
-      "default": "./build/lib/index.js"
+      "default": "./build/lib/index.esm.js"
     },
     "./package.json": "./package.json"
   },
@@ -37,7 +35,6 @@
   },
   "files": [
     "build/lib/*",
-    "build/umd/*",
     "src"
   ],
   "scripts": {


### PR DESCRIPTION
Svelte only supports ESM, so there's no reason to list CJS or UMD files in the `package.json`