### PR TITLE
chore(svelte-table): cleanup package.json

### DIFF
--- a/packages/svelte-table/package.json
+++ b/packages/svelte-table/package.json
@@ -22,15 +22,11 @@
   ],
   "type": "module",
   "types": "dist/index.d.ts",
-  "module": "dist/index.js",
-  "svelte": "./dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js",
-      "import": "./dist/index.js"
-    },
-    "./package.json": "./package.json"
+      "default": "./dist/index.js"
+    }
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
The `module` and `svelte` field will both be ignored since `exports` is present, so there's no reason to have either of them.

Within `exports`, the `svelte` and `import` statements can be replaced with a single `default` statement. It's also nicer to use `default` since it produces better error messages when imported in an unsupported environment - e.g. if you were to import it in a CJS project (though in this case that'd be near impossible since Svelte 4+ is ESM-only)

Exporting `package.json` is also unnecessary. There was an old version of `rollup-plugin-svelte` that required it, but that's been fixed there and so is no longer needed