### PR TITLE
Fix Table API doc link

### DIFF
--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -4,7 +4,7 @@ title: Table Instance Guide
 
 ## API
 
-[Table API](../../api/core/table)
+[Table API](../api/core/table.md)
 
 ## Table Instance Guide
 


### PR DESCRIPTION
Current API doc link sends to a 404. Updated link to direct to core api docs for the table.