### PR TITLE
docs: make global filter work in row selection example

### DIFF
--- a/examples/react/row-selection/src/main.tsx
+++ b/examples/react/row-selection/src/main.tsx
@@ -108,6 +108,7 @@ function App() {
     data,
     columns,
     state: {
+      globalFilter,
       rowSelection,
     },
     enableRowSelection: true, //enable row selection for all rows


### PR DESCRIPTION
until now the globalFilter was just set into a useState but it was never used to filter