### PR TITLE
Don't try to @render svelte components in FlexRender

### DIFF
--- a/packages/svelte-table/src/FlexRender.svelte
+++ b/packages/svelte-table/src/FlexRender.svelte
@@ -35,7 +35,6 @@
 {:else if isFunction(content)}
   {@const result = content(context as any)}
   {#if result instanceof RenderComponentConfig}
-    {@render result.component(result.props)}
     {@const { component: Component, props } = result}
     <Component {...props} />
   {:else if result instanceof RenderSnippetConfig}


### PR DESCRIPTION
Svelte Components should not be @render'd, only snippets get @render'd, per the docs.

Unlike Svelte 4, the Component in FlexRender will already be dynamically evaluated.

This fixes examples/svelte/sorting for Svelte 5.

The failure around undefined headers there was because trying to @render a component like this code did does not do anything sane to it.