### PR TITLE
Don't directly reference local state

### DIFF
--- a/packages/svelte-table/src/createTable.svelte.ts
+++ b/packages/svelte-table/src/createTable.svelte.ts
@@ -25,7 +25,9 @@ export function createTable<
     tableOptions,
     {
       _features,
-      state: { ...state, ...tableOptions.state },
+      get state() {
+        return { ...state, ...tableOptions.state }
+      },
       mergeOptions: (
         defaultOptions: TableOptions<TFeatures, TData>,
         newOptions: Partial<TableOptions<TFeatures, TData>>,
@@ -40,7 +42,9 @@ export function createTable<
   function updateOptions() {
     table.setOptions((prev) => {
       return mergeObjects(prev, tableOptions, {
-        state: mergeObjects(state, tableOptions.state || {}),
+        get state() {
+          return mergeObjects(state, tableOptions.state || {})
+        },
         onStateChange: (updater: any) => {
           if (isFunction(updater)) state = updater(state)
           else state = mergeObjects(state, updater)


### PR DESCRIPTION
In svelte 5, $state (here, the variable named 'state')  referenced locally is not reactive, because of how evaluation occurs[1].
This means in the listed code, ...state will only ever refer to the original value of state, even if it is later updated or re-evaluated (by updateOptions, for example)

To make it reactive locally, the docs recommend using a closure (you can use getter functions and properties too if you want), which is what we do here.

This makes it so ...state always refers to the current value of state, even after updateOptions changes it..

This in turn, fixes the browser warning issued by svelte on all usage of createTable.

See https://svelte.dev/docs/svelte/compiler-warnings#state_referenced_locally for more details.

Svelte (currently) only warns if you do this and *also* reassign the variable, under the assumption that doing this means you want the local reference to see the new value.  A cursory read of the code suggests we *do* want to see the new value post-updateOptions call, which means we need to lazily evaluate (or use a data class)

[1] The short, mostly correct version: The code is evaluated once, and $state/etc get transformed into function calls and proxies so that it dynamically re-evaluated when dependencies change.  As a result, referencing state directly in the local scope (like this code does) only ever refers to the original value, even when you reassign it (as updateOptions does)

This is one of the more confusing foibles of svelte5, and has led to lots of complaining  :)
