### PR TITLE
docs: issues with the pagination-controlled url href

### DIFF
--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -7,7 +7,7 @@ title: Pagination Guide
 Want to skip to the implementation? Check out these examples:
 
 - [pagination](../../framework/react/examples/pagination)
-- [pagination-controlled (React Query)](../../framework/react/examples/pagination-controlled)
+- [pagination-controlled (React Query)](../../docs/framework/react/examples/pagination-controlled)
 - [editable-data](../../framework/react/examples/editable-data)
 - [expanding](../../framework/react/examples/expanding)
 - [filters](../../framework/react/examples/filters)


### PR DESCRIPTION
The href url was pointing to a not found page, I updated it to the one I believe is the new proper one