### PR TITLE
Improve type for 'Editable Data' React example

### DIFF
--- a/examples/react/editable-data/src/main.tsx
+++ b/examples/react/editable-data/src/main.tsx
@@ -20,7 +20,7 @@ import { makeData, Person } from './makeData'
 
 declare module '@tanstack/react-table' {
   interface TableMeta<TData extends RowData> {
-    updateData: (rowIndex: number, columnId: string, value: unknown) => void
+    updateData: (rowIndex: number, columnId: keyof TData, value: unknown) => void
   }
 }
 
@@ -33,7 +33,8 @@ const defaultColumn: Partial<ColumnDef<Person>> = {
 
     // When the input is blurred, we'll call our table meta's updateData function
     const onBlur = () => {
-      table.options.meta?.updateData(index, id, value)
+      const columnId = id as keyof Person;
+      table.options.meta?.updateData(index, columnId, value)
     }
 
     // If the initialValue is changed external, sync it up with our state


### PR DESCRIPTION
Edits [this example](https://tanstack.com/table/latest/docs/framework/react/examples/editable-data).

This change improves the `columnId` type to assert the possible row keys.

#### Before

<img width="447" alt="Screenshot 2025-03-16 at 18 45 03" src="https://github.com/user-attachments/assets/6d404c21-b123-4c1f-afdf-52e522db520e" />

#### After

<img width="924" alt="Screenshot 2025-03-16 at 18 45 15" src="https://github.com/user-attachments/assets/bef1e6e5-a055-405b-90d6-6afcb7eeb89a" />
