### PR TITLE
fix: support unsetting getPaginationRowModel

### DIFF
--- a/packages/table-core/src/features/RowPagination.ts
+++ b/packages/table-core/src/features/RowPagination.ts
@@ -373,7 +373,11 @@ export const RowPagination: TableFeature = {
           table.options.getPaginationRowModel(table)
       }
 
-      if (table.options.manualPagination || !table._getPaginationRowModel) {
+      if (
+        table.options.manualPagination ||
+        !table._getPaginationRowModel ||
+        !table.options.getPaginationRowModel
+      ) {
         return table.getPrePaginationRowModel()
       }
 


### PR DESCRIPTION
Previously, it was not possible to unset the table.options.getPaginationRowModel option, because the result of that function is cached in table._getPaginationRowModel, and therefore the `!table._getPaginationRowModel` check will always evaluate to false.

Use case: Based on a UI switch, we want to enable or disable the pagination of the React table.