### PR TITLE
fix: Duplicate sub-rows in pagination row model.

### DIFF
--- a/packages/table-core/src/utils/getPaginationRowModel.ts
+++ b/packages/table-core/src/utils/getPaginationRowModel.ts
@@ -44,13 +44,22 @@ export function getPaginationRowModel<TData extends RowData>(opts?: {
 
         paginatedRowModel.flatRows = []
 
+        // keep track of the already added flatRows, to avoid duplication of already expanded sub-rows
+        const addedFlatRowsSet = new Set()
+
         const handleRow = (row: Row<TData>) => {
+          if (addedFlatRowsSet.has(row.id)) {
+            return
+          }
+
           paginatedRowModel.flatRows.push(row)
+          addedFlatRowsSet.add(row.id)
+
           if (row.subRows.length) {
             row.subRows.forEach(handleRow)
           }
         }
-
+        
         paginatedRowModel.rows.forEach(handleRow)
 
         return paginatedRowModel


### PR DESCRIPTION
When sub-rows were already expanded on the page, they were added more than once to the pagination row model's flatRows.
This was previously reported [here](https://github.com/TanStack/table/issues/5833)