### PR TITLE
fix(solid-table): converge on use for hooks

### DIFF
--- a/docs/api/core/table.md
+++ b/docs/api/core/table.md
@@ -2,7 +2,7 @@
 title: Table APIs
 ---
 
-## `createAngularTable` / `useReactTable` / `createSolidTable` / `useQwikTable` / `useVueTable` / `createSvelteTable`
+## `createAngularTable` / `useReactTable` / `useSolidTable` / `useQwikTable` / `useVueTable` / `createSvelteTable`
 
 ```tsx
 type useReactTable = <TData extends AnyData>(

--- a/docs/framework/solid/guide/table-state.md
+++ b/docs/framework/solid/guide/table-state.md
@@ -11,7 +11,7 @@ TanStack Table has a simple underlying internal state management system to store
 You do not need to set up anything special in order for the table state to work. If you pass nothing into either `state`, `initialState`, or any of the `on[State]Change` table options, the table will manage its own state internally. You can access any part of this internal state by using the `table.getState()` table instance API.
 
 ```jsx
-const table = createSolidTable({
+const table = useSolidTable({
   columns,
   get data() {
     return data()
@@ -28,7 +28,7 @@ console.log(table.getState().rowSelection) //access just the row selection state
 If all you need to do for certain states is customize their initial default values, you still do not need to manage any of the state yourself. You can simply set values in the `initialState` option of the table instance.
 
 ```jsx
-const table = createSolidTable({
+const table = useSolidTable({
   columns,
   data,
   initialState: {
@@ -67,7 +67,7 @@ const [columnFilters, setColumnFilters] = createSignal([]) //no default filters
 const [sorting, setSorting] = createSignal([{
   id: 'age',
   desc: true, //sort by age in descending order by default
-}]) 
+}])
 const [pagination, setPagination] = createSignal({ pageIndex: 0, pageSize: 15 })
 
 //Use our controlled state values to fetch data
@@ -77,7 +77,7 @@ const tableQuery = createQuery({
   //...
 })
 
-const table = createSolidTable({
+const table = useSolidTable({
   columns,
   get data() {
     return tableQuery.data()
@@ -109,7 +109,7 @@ A couple of more tricks may be needed to make this work. If you use the `onState
 
 ```jsx
 //create a table instance with default state values
-const table = createSolidTable({
+const table = useSolidTable({
   columns,
   get data() {
     return data()
@@ -147,7 +147,7 @@ Specifying an `on[State]Change` callback tells the table instance that this will
 ```jsx
 const [sorting, setSorting] = createSignal([])
 //...
-const table = createSolidTable({
+const table = useSolidTable({
   columns,
   data,
   //...
@@ -170,7 +170,7 @@ What implications does this have? It means that if you want to add in some extra
 const [sorting, setSorting] = createSignal([])
 const [pagination, setPagination] = createSignal({ pageIndex: 0, pageSize: 10 })
 
-const table = createSolidTable({
+const table = useSolidTable({
   get columns() {
     return columns()
   },
@@ -210,7 +210,7 @@ const table = createSolidTable({
 All complex states in TanStack Table have their own TypeScript types that you can import and use. This can be handy for ensuring that you are using the correct data structures and properties for the state values that you are controlling.
 
 ```tsx
-import { createSolidTable, type SortingState } from '@tanstack/solid-table'
+import { useSolidTable, type SortingState } from '@tanstack/solid-table'
 //...
 const [sorting, setSorting] = createSignal<SortingState[]>([
   {

--- a/docs/framework/solid/solid-table.md
+++ b/docs/framework/solid/solid-table.md
@@ -4,15 +4,15 @@ title: Solid Table
 
 The `@tanstack/solid-table` adapter is a wrapper around the core table logic. Most of it's job is related to managing state the "solid" way, providing types and the rendering implementation of cell/header/footer templates.
 
-## `createSolidTable`
+## `useSolidTable`
 
 Takes an `options` object and returns a table.
 
 ```tsx
-import { createSolidTable } from '@tanstack/solid-table'
+import { useSolidTable } from '@tanstack/solid-table'
 
 function App() {
-  const table = createSolidTable(options)
+  const table = useSolidTable(options)
 
   // ...render your table
 }

--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -8,7 +8,7 @@ title: Table Instance Guide
 
 ## Table Instance Guide
 
-TanStack Table is a headless UI library. When we talk about the `table` or "table instance", we're not talking about a literal `<table>` element. Instead, we're referring to the core table object that contains the table state and APIs. The `table` instance is created by calling your adapter's `createTable` function (e.g. `useReactTable`, `useVueTable`, `createSolidTable`, `createSvelteTable`, `createAngularTable`, `useQwikTable`).
+TanStack Table is a headless UI library. When we talk about the `table` or "table instance", we're not talking about a literal `<table>` element. Instead, we're referring to the core table object that contains the table state and APIs. The `table` instance is created by calling your adapter's `createTable` function (e.g. `useReactTable`, `useVueTable`, `useSolidTable`, `createSvelteTable`, `createAngularTable`, `useQwikTable`).
 
 The `table` instance that is returned from the `createTable` function (from the framework adapter) is the main object that you will interact with to read and mutate the table state. It is the one place where everything happens in TanStack Table. When you get to the point where you are rendering your UI, you will use APIs from this `table` instance.
 
@@ -63,7 +63,7 @@ const table = useQwikTable({ columns, data, getCoreRowModel: getCoreRowModel() }
 const table = useReactTable({ columns, data, getCoreRowModel: getCoreRowModel() })
 
 //solid
-const table = createSolidTable({ columns, get data() { return data() }, getCoreRowModel: getCoreRowModel() })
+const table = useSolidTable({ columns, get data() { return data() }, getCoreRowModel: getCoreRowModel() })
 
 //svelte
 const table = createSvelteTable({ columns, data, getCoreRowModel: getCoreRowModel() })

--- a/examples/solid/basic/src/App.tsx
+++ b/examples/solid/basic/src/App.tsx
@@ -2,7 +2,7 @@ import {
   flexRender,
   getCoreRowModel,
   ColumnDef,
-  createSolidTable,
+  useSolidTable,
 } from '@tanstack/solid-table'
 import { createSignal, For } from 'solid-js'
 
@@ -81,7 +81,7 @@ function App() {
   const [data, setData] = createSignal(defaultData)
   const rerender = () => setData(defaultData)
 
-  const table = createSolidTable({
+  const table = useSolidTable({
     get data() {
       return data()
     },

--- a/examples/solid/bootstrap/src/App.tsx
+++ b/examples/solid/bootstrap/src/App.tsx
@@ -2,7 +2,7 @@ import {
   flexRender,
   getCoreRowModel,
   ColumnDef,
-  createSolidTable,
+  useSolidTable,
 } from '@tanstack/solid-table'
 import { createSignal, For } from 'solid-js'
 import { makeData, Person } from './makeData'
@@ -66,7 +66,7 @@ function App() {
   const [data, setData] = createSignal(makeData(10))
   const rerender = () => setData(makeData(10))
 
-  const table = createSolidTable({
+  const table = useSolidTable({
     get data() {
       return data()
     },

--- a/examples/solid/column-groups/src/App.tsx
+++ b/examples/solid/column-groups/src/App.tsx
@@ -2,7 +2,7 @@ import {
   flexRender,
   getCoreRowModel,
   ColumnDef,
-  createSolidTable,
+  useSolidTable,
 } from '@tanstack/solid-table'
 import { createSignal, For } from 'solid-js'
 
@@ -98,7 +98,7 @@ function App() {
   const [data, setData] = createSignal(defaultData)
   const rerender = () => setData(defaultData)
 
-  const table = createSolidTable({
+  const table = useSolidTable({
     get data() {
       return data()
     },

--- a/examples/solid/column-ordering/src/App.tsx
+++ b/examples/solid/column-ordering/src/App.tsx
@@ -7,7 +7,7 @@ import {
   ColumnOrderState,
   VisibilityState,
   ColumnDef,
-  createSolidTable,
+  useSolidTable,
 } from '@tanstack/solid-table'
 
 const defaultColumns: ColumnDef<Person>[] = [
@@ -70,7 +70,7 @@ function App() {
   )
   const rerender = () => setData(() => makeData(20))
 
-  const table = createSolidTable({
+  const table = useSolidTable({
     get data() {
       return data()
     },

--- a/examples/solid/column-visibility/src/App.tsx
+++ b/examples/solid/column-visibility/src/App.tsx
@@ -3,7 +3,7 @@ import {
   getCoreRowModel,
   VisibilityState,
   ColumnDef,
-  createSolidTable,
+  useSolidTable,
 } from '@tanstack/solid-table'
 import { createSignal, For, Show } from 'solid-js'
 
@@ -102,7 +102,7 @@ function App() {
   )
   const rerender = () => setData(defaultData)
 
-  const table = createSolidTable({
+  const table = useSolidTable({
     get data() {
       return data()
     },

--- a/examples/solid/filters/src/App.tsx
+++ b/examples/solid/filters/src/App.tsx
@@ -7,7 +7,7 @@ import {
   getFacetedMinMaxValues,
   ColumnDef,
   ColumnFiltersState,
-  createSolidTable,
+  useSolidTable,
 } from '@tanstack/solid-table'
 import { debounce } from '@solid-primitives/scheduled'
 import { makeData, Person } from './makeData'
@@ -76,7 +76,7 @@ function App() {
   )
   const refreshData = () => setData(makeData(50000))
 
-  const table = createSolidTable({
+  const table = useSolidTable({
     get data() {
       return data()
     },

--- a/examples/solid/sorting/src/App.tsx
+++ b/examples/solid/sorting/src/App.tsx
@@ -4,7 +4,7 @@ import {
   getSortedRowModel,
   SortingState,
   ColumnDef,
-  createSolidTable,
+  useSolidTable,
 } from '@tanstack/solid-table'
 import { makeData, Person } from './makeData'
 import { createSignal, For, Show } from 'solid-js'
@@ -66,7 +66,7 @@ function App() {
     },
   ]
 
-  const table = createSolidTable({
+  const table = useSolidTable({
     get data() {
       return data()
     },

--- a/packages/solid-table/src/index.tsx
+++ b/packages/solid-table/src/index.tsx
@@ -24,7 +24,7 @@ export function flexRender<TProps>(
   return Comp
 }
 
-export function createSolidTable<TData extends RowData>(
+export function useSolidTable<TData extends RowData>(
   options: TableOptions<TData>
 ) {
   const resolvedOptions: TableOptionsResolved<TData> = mergeProps(
@@ -62,4 +62,13 @@ export function createSolidTable<TData extends RowData>(
   })
 
   return table
+}
+
+/**
+ * @deprecated Use useSolidTable instead
+ */
+export function useSolidTable<TData extends RowData>(
+  options: TableOptions<TData>
+) {
+  return useSolidTable(options)
 }


### PR DESCRIPTION
Adopt `useSolidTable` syntax for solid, so it's like vue/react/svelte5. This is aligned with how we do for tanstack [router](https://tanstack.com/router/latest/docs/framework/solid/guide/path-params#path-params-in-components) (useParams, useSearch, useRouter ..) and [query](https://tanstack.com/query/latest/docs/framework/solid/reference/useQuery) (useQuery, useMutation ..), [store](https://tanstack.com/store/latest/docs/framework/solid/reference/functions/usestore) (useStore) and the "official" [solid router](https://docs.solidjs.com/solid-router/reference/primitives/use-match) (useNavigate, useMatch ..), so it's nice to have syntax convergence for hooks.