### PR TITLE
fix(table-core): use right Document instance on getResizeHandler (column-sizing feature)

### DIFF
--- a/packages/table-core/src/features/ColumnSizing.ts
+++ b/packages/table-core/src/features/ColumnSizing.ts
@@ -10,6 +10,7 @@ import {
 } from '../types'
 import { getMemoOptions, makeStateUpdater, memo } from '../utils'
 import { ColumnPinningPosition } from './ColumnPinning'
+import { safelyAccessDocument } from '../utils/document'
 
 //
 
@@ -428,8 +429,7 @@ export const ColumnSizing: TableFeature = {
           }))
         }
 
-        const contextDocument =
-          _contextDocument || typeof document !== 'undefined' ? document : null
+        const contextDocument = safelyAccessDocument(_contextDocument)
 
         const mouseEvents = {
           moveHandler: (e: MouseEvent) => onMove(e.clientX),

--- a/packages/table-core/src/utils/document.ts
+++ b/packages/table-core/src/utils/document.ts
@@ -7,6 +7,6 @@ export function safelyAccessDocumentEvent(event: Event): Document | null {
     !!event.target &&
     typeof event.target === 'object' &&
     'ownerDocument' in event.target
-    ? event.target.ownerDocument
+    ? (event.target.ownerDocument as Document | null)
     : null
 }

--- a/packages/table-core/src/utils/document.ts
+++ b/packages/table-core/src/utils/document.ts
@@ -1,0 +1,12 @@
+export function safelyAccessDocument(_document?: Document): Document | null {
+  return _document || (typeof document !== 'undefined' ? document : null)
+}
+
+export function safelyAccessDocumentEvent(event: Event): Document | null {
+  return !!event &&
+    !!event.target &&
+    typeof event.target === 'object' &&
+    'ownerDocument' in event.target
+    ? event.target.ownerDocument
+    : null
+}

--- a/packages/table-core/tests/test-setup.ts
+++ b/packages/table-core/tests/test-setup.ts
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom/vitest'

--- a/packages/table-core/tests/utils/document.test.ts
+++ b/packages/table-core/tests/utils/document.test.ts
@@ -2,14 +2,17 @@ import {
   safelyAccessDocument,
   safelyAccessDocumentEvent,
 } from '../../src/utils/document'
-import { expect, vi, beforeEach, afterEach } from 'vitest'
-import { before } from 'node:test'
+import { afterEach, beforeEach, expect, describe, test } from 'vitest'
 
 const originalDocument = globalThis.document
 
+export function getDocumentMock(): Document {
+  return {} as Document
+}
+
 describe('safelyAccessDocument', () => {
   describe('global document', () => {
-    const mockedDocument = {}
+    const mockedDocument = getDocumentMock()
     const originalDocument = globalThis.document
     beforeEach(() => {
       if (typeof globalThis.document === 'undefined') {
@@ -18,6 +21,7 @@ describe('safelyAccessDocument', () => {
     })
     afterEach(() => {
       if (typeof originalDocument === 'undefined') {
+        // @ts-expect-error Just Typings
         delete globalThis.document
       }
     })
@@ -40,9 +44,11 @@ describe('safelyAccessDocumentEvent', () => {
   test('get document by given event', () => {
     const fakeDocument = {}
     const event = new Event('mousedown')
+
     class FakeElement extends EventTarget {
       ownerDocument = fakeDocument
     }
+
     Object.defineProperty(event, 'target', { value: new FakeElement() })
 
     const document = safelyAccessDocumentEvent(event)

--- a/packages/table-core/tests/utils/document.test.ts
+++ b/packages/table-core/tests/utils/document.test.ts
@@ -1,0 +1,51 @@
+import {
+  safelyAccessDocument,
+  safelyAccessDocumentEvent,
+} from '../../src/utils/document'
+import { expect, vi, beforeEach, afterEach } from 'vitest'
+import { before } from 'node:test'
+
+const originalDocument = globalThis.document
+
+describe('safelyAccessDocument', () => {
+  describe('global document', () => {
+    const mockedDocument = {}
+    const originalDocument = globalThis.document
+    beforeEach(() => {
+      if (typeof globalThis.document === 'undefined') {
+        globalThis.document = mockedDocument
+      }
+    })
+    afterEach(() => {
+      if (typeof originalDocument === 'undefined') {
+        delete globalThis.document
+      }
+    })
+
+    test('get global document when no args are passed', () => {
+      const contextDocument = safelyAccessDocument()
+      expect(contextDocument).toEqual(mockedDocument)
+    })
+  })
+
+  test('get document', () => {
+    let givenDocument = {} as Document
+    const contextDocument = safelyAccessDocument(givenDocument)
+
+    expect(contextDocument).toEqual(givenDocument)
+  })
+})
+
+describe('safelyAccessDocumentEvent', () => {
+  test('get document by given event', () => {
+    const fakeDocument = {}
+    const event = new Event('mousedown')
+    class FakeElement extends EventTarget {
+      ownerDocument = fakeDocument
+    }
+    Object.defineProperty(event, 'target', { value: new FakeElement() })
+
+    const document = safelyAccessDocumentEvent(event)
+    expect(fakeDocument).toEqual(document)
+  })
+})

--- a/packages/table-core/vitest.config.ts
+++ b/packages/table-core/vitest.config.ts
@@ -6,8 +6,9 @@ export default defineConfig({
     name: packageJson.name,
     dir: './tests',
     watch: false,
-    environment: 'jsdom',
-    setupFiles: ['./tests/test-setup.ts'],
+    environment: 'node',
+    // environment: 'jsdom',
+    // setupFiles: ['./tests/test-setup.ts'],
     globals: true,
   },
 })

--- a/packages/table-core/vitest.config.ts
+++ b/packages/table-core/vitest.config.ts
@@ -7,8 +7,6 @@ export default defineConfig({
     dir: './tests',
     watch: false,
     environment: 'node',
-    // environment: 'jsdom',
-    // setupFiles: ['./tests/test-setup.ts'],
     globals: true,
   },
 })


### PR DESCRIPTION
Related to my comment https://github.com/TanStack/table/pull/5747#issuecomment-2799893027

I'd consider to remove jsdom env in table-core test since since this package should be framework agnostic. It could ensure us that things doesn't break while running the code in a non browser env. wdyt?

I've added two new utils safelyAccessDocument and safelyAccessDocumentEvent just for testing purposes (actually using only `safelyAccessDocument`) as it can be useful to reuse that portion of code also in other files. Those utils are not currently present in public api, is it ok?