### PR TITLE
fix(examples): add `to` to navigate to fix typescript

### DIFF
--- a/examples/react/query-router-search-params/src/hooks/useFilters.ts
+++ b/examples/react/query-router-search-params/src/hooks/useFilters.ts
@@ -15,9 +15,10 @@ export function useFilters<T extends RouteIds<RegisteredRouter['routeTree']>>(
 
   const setFilters = (partialFilters: Partial<typeof filters>) =>
     navigate({
+      to: ".",
       search: prev => cleanEmptyParams({ ...prev, ...partialFilters }),
     })
-  const resetFilters = () => navigate({ search: {} })
+  const resetFilters = () => navigate({ to: ".", search: {} })
 
   return { filters, setFilters, resetFilters }
 }


### PR DESCRIPTION
This PR fixes a Typescript problem with the `navigate` function in the `useFilters` hook.

Fixes #5812 