### PR TITLE
fix ColumnHelper['accessor'] TValue type

### DIFF
--- a/packages/table-core/src/columnHelper.ts
+++ b/packages/table-core/src/columnHelper.ts
@@ -50,22 +50,25 @@ import { DeepKeys, DeepValue } from './utils'
 //   cell: info => info.getValue(),
 // })
 
+type AccessorValue<
+  TData,
+  TAccessor extends AccessorFn<TData> | DeepKeys<TData>,
+> =
+  TAccessor extends AccessorFn<TData, infer TReturn>
+    ? TReturn
+    : TAccessor extends DeepKeys<TData>
+      ? DeepValue<TData, TAccessor>
+      : never
+
 export type ColumnHelper<TData extends RowData> = {
-  accessor: <
-    TAccessor extends AccessorFn<TData> | DeepKeys<TData>,
-    TValue extends TAccessor extends AccessorFn<TData, infer TReturn>
-      ? TReturn
-      : TAccessor extends DeepKeys<TData>
-        ? DeepValue<TData, TAccessor>
-        : never,
-  >(
+  accessor: <TAccessor extends AccessorFn<TData> | DeepKeys<TData>>(
     accessor: TAccessor,
     column: TAccessor extends AccessorFn<TData>
-      ? DisplayColumnDef<TData, TValue>
-      : IdentifiedColumnDef<TData, TValue>
+      ? DisplayColumnDef<TData, AccessorValue<TData, TAccessor>>
+      : IdentifiedColumnDef<TData, AccessorValue<TData, TAccessor>>
   ) => TAccessor extends AccessorFn<TData>
-    ? AccessorFnColumnDef<TData, TValue>
-    : AccessorKeyColumnDef<TData, TValue>
+    ? AccessorFnColumnDef<TData, AccessorValue<TData, TAccessor>>
+    : AccessorKeyColumnDef<TData, AccessorValue<TData, TAccessor>>
   display: (column: DisplayColumnDef<TData>) => DisplayColumnDef<TData, unknown>
   group: (column: GroupColumnDef<TData>) => GroupColumnDef<TData, unknown>
 }


### PR DESCRIPTION
Fixes #4382

I ran into #4382 trying to write a generic, reusable wrapper around react-table. Looking into the issue brought me to the `ColumnHelper` type. I've had issues in the past when trying to transform one generic type parameter into a second, inferred generic parameter, and often it can be fixed using a distributive helper type instead. So I tried pulling out the `TValue` generic parameter into one, and then using that in `ColumnHelper` instead.

This seems to work! I'm able to create a properly typed, generic reusable wrapper component by defining the props like this:

```ts
type Columns<T> = {
    [K in keyof Required<T>]: ColumnDef<T, T[K]>;
}[keyof Required<T>][];
type ColumnsBuilder<T> = (helper: ColumnHelper<T>) => Columns<T>;

interface Props<T> {
  data: T[] | null;
  columns: ColumnsBuilder<T>;
};
```

And the types are compatible, with no types lost:

```ts
type Person = {
    id: number;
    firstName: string;
    lastName: string;
    age?: number;
    visits: number;
    status: string;
};

// (ColumnDef<Person, number> | ColumnDef<Person, string> | ColumnDef<Person, number | undefined>)[]
type ColumnsType = Columns<Person>;

const columns: ColumnsBuilder<Person> = (columnHelper) => [
    // Inferred as: <(p: Person) => string>(accessor: (p: Person) => string, column: DisplayColumnDef<Person, string>) => AccessorFnColumnDef<Person, string>
    columnHelper.accessor((p) => p.firstName, {
        header: 'First Name',
        cell: (info) => <strong>{info.getValue()}</strong>,
    }),
    // inferred as: <"age">(accessor: "age", column: IdentifiedColumnDef<Person, number | undefined>) => AccessorKeyColumnDef<Person, number | undefined>
    columnHelper.accessor('age', {
        header: 'Last Name',
        cell: (info) => <em>{info.getValue()}</em>,
    }),
    // inferred as: <"status">(accessor: "status", column: IdentifiedColumnDef<Person, string>) => AccessorKeyColumnDef<Person, string>
    columnHelper.accessor('status', {
        header: 'Status',
        cell: (info) => (
            <span
                style={{
                    color: info.getValue() === 'Active' ? 'green' : 'red',
                    fontWeight: 'bold',
                }}
            >
                {info.getValue()}
            </span>
        ),
    }),
],
```