### PR TITLE
Update column-sizing.md

### DIFF
--- a/docs/guide/column-sizing.md
+++ b/docs/guide/column-sizing.md
@@ -11,7 +11,7 @@ Want to skip to the implementation? Check out these examples:
 
 ## API
 
-[Column Sizing API](../api/features/column-sizing)
+[Column Sizing API](/table/latest/docs/api/features/column-sizing)
 
 ## Column Sizing Guide
 


### PR DESCRIPTION
The relative path (starting with ../) does not resolve correctly to the  right path. This is a bug in GitHub?

Using an absolute path will fix this.

Details:
The page is at
/table/latest/docs/guide/column-sizing
The relative path is:
../api/features/column-sizing

This should lead to the correct path:
/table/latest/docs/api/features/column-sizing
In reality, this leads to the wrong page:
/table/latest/api/features/column-sizing

Here, ../  skips two directories (guide and docs) instead of one, which is a bug.