### PR TITLE
fix: Avoid duplicate call to autoreset by removing the wrap in `_queue`

### DIFF
--- a/packages/table-core/src/utils/getGroupedRowModel.ts
+++ b/packages/table-core/src/utils/getGroupedRowModel.ts
@@ -166,10 +166,8 @@ export function getGroupedRowModel<TData extends RowData>(): (
         }
       },
       getMemoOptions(table.options, 'debugTable', 'getGroupedRowModel', () => {
-        table._queue(() => {
-          table._autoResetExpanded()
-          table._autoResetPageIndex()
-        })
+        table._autoResetExpanded()
+        table._autoResetPageIndex()
       })
     )
 }


### PR DESCRIPTION
Fix https://github.com/TanStack/table/issues/6025

the `onChange` in the memo options is always called once on initialization, for each model.

Several models enqueue a call to `_autoResetPageIndex` (core model, sorted model, grouped model), which are all resolved together in a Promise. They should all evaluate `registered === false`.

However, because the call in `getGroupedRowModel` is wrapped in another layer of `_queue`: https://github.com/TanStack/table/blob/0cc6992c7836489661a0954a2b56e620850ad4da/packages/table-core/src/utils/getGroupedRowModel.ts#L168-L173
 the call to `_autoResetPageIndex` actually resolves later, once `registered` is `true`, and it calls `table.resetPageIndex()`.

The wrap in `_queue` is also not present in https://github.com/TanStack/table/blob/0cc6992c7836489661a0954a2b56e620850ad4da/packages/table-core/src/utils/getCoreRowModel.ts#L78-L80 or in https://github.com/TanStack/table/blob/0cc6992c7836489661a0954a2b56e620850ad4da/packages/table-core/src/utils/getSortedRowModel.ts#L117-L119

As far as I can tell it should not be there.