### PR TITLE
Fix DeepKeys to handle arrays properly

### DIFF
--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -50,7 +50,7 @@ export type DeepKeys<T, TDepth extends any[] = []> = TDepth['length'] extends 5
     : T extends readonly any[] & IsTuple<T>
       ? AllowedIndexes<T> | DeepKeysPrefix<T, AllowedIndexes<T>, TDepth>
       : T extends any[]
-        ? DeepKeys<T[number], [...TDepth, any]>
+        ? `${number}` | ObjectPathPrefix<T, number, TDepth>
         : T extends Date
           ? never
           : T extends object


### PR DESCRIPTION
The types for nested arrays in the `DeepKeys` type seem definitely wrong to me. The type properly handles tuples, but not arrays of arbitrary length. For example, given this type:

```ts
DeepKeys<{
  foo: { bar: string }[];
}>
```

This currently resolves to `"foo" | "foo.bar"`, which is unexpected. If we change the type to be a tuple (i.e. `{ bar: string }[]` --> `[{ bar: string }]`), then we correctly get `"foo" | "foo.0.bar"`.

This change updates the handling for arbitrary length arrays so that the above type will resolve to:
```ts
"foo" | `foo.${number}` | `foo.${number}.bar`
```

This puts the onus on the user to make sure the number is not out of range, but that seems reasonable to me.