### PR TITLE
docs: remove unused footer colum def

### DIFF
--- a/examples/react/expanding/src/main.tsx
+++ b/examples/react/expanding/src/main.tsx
@@ -77,34 +77,28 @@ function App() {
             </div>
           </div>
         ),
-        footer: props => props.column.id,
       },
       {
         accessorFn: row => row.lastName,
         id: 'lastName',
         cell: info => info.getValue(),
         header: () => <span>Last Name</span>,
-        footer: props => props.column.id,
       },
       {
         accessorKey: 'age',
         header: () => 'Age',
-        footer: props => props.column.id,
       },
       {
         accessorKey: 'visits',
         header: () => <span>Visits</span>,
-        footer: props => props.column.id,
       },
       {
         accessorKey: 'status',
         header: 'Status',
-        footer: props => props.column.id,
       },
       {
         accessorKey: 'progress',
         header: 'Profile Progress',
-        footer: props => props.column.id,
       },
     ],
     []


### PR DESCRIPTION
This came up [on Discord](https://discord.com/channels/719702312431386674/1003326939899113492/1384416391104299108).

Values for `footer` are set but never used.