### PR TITLE
Add missing equalsStringSenstivie

### DIFF
--- a/packages/table-core/src/filterFns.ts
+++ b/packages/table-core/src/filterFns.ts
@@ -42,6 +42,19 @@ const equalsString: FilterFn<any> = (
 
 equalsString.autoRemove = (val: any) => testFalsey(val)
 
+const equalsStringSensitive: FilterFn<any> = (
+  row,
+  columnId: string,
+  filterValue: string
+) => {
+  return (
+    row.getValue<string | null>(columnId)?.toString() ===
+    filterValue?.toLowerCase()
+  )
+}
+
+equalsStringSensitive.autoRemove = (val: any) => testFalsey(val)
+
 const arrIncludes: FilterFn<any> = (
   row,
   columnId: string,
@@ -133,6 +146,7 @@ export const filterFns = {
   includesString,
   includesStringSensitive,
   equalsString,
+  equalsStringSensitive,
   arrIncludes,
   arrIncludesAll,
   arrIncludesSome,


### PR DESCRIPTION
The docs reference a equalsStringSensitive filter function that seems to be entirely missing. Figured simple enough to include rather than remove from the docs. (Unless there's historical reasons for it being removed? I'm unable to find when that happened.)

https://github.com/TanStack/table/blame/v8.21.3/docs/guide/column-filtering.md#L160

Edit: This summarizes the issue for me that I discovered. Was filtering for `Active` vs `Inactive`. 
https://github.com/TanStack/table/issues/4951