### PR TITLE
fix(table-core): Correct `getAutoSortingFn` logic when row count is less then `10`

### DIFF
--- a/packages/table-core/src/features/RowSorting.ts
+++ b/packages/table-core/src/features/RowSorting.ts
@@ -306,7 +306,7 @@ export const RowSorting: TableFeature = {
     table: Table<TData>
   ): void => {
     column.getAutoSortingFn = () => {
-      const firstRows = table.getFilteredRowModel().flatRows.slice(10)
+      const firstRows = table.getFilteredRowModel().flatRows.slice(0, 10)
 
       let isString = false
 


### PR DESCRIPTION
Fixes [slice array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) logic in `getAutoSortingFn` to properly sample first 10 rows for default auto row sorting.

Fixes https://github.com/TanStack/table/issues/4908