### PR TITLE
Update React peer dependency to support React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-table",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Hooks for building lightweight, fast and extendable datagrids for React",
   "license": "MIT",
   "homepage": "https://react-table.tanstack.com",
@@ -52,7 +52,7 @@
   ],
   "browserslist": "> 0.25%, not dead",
   "peerDependencies": {
-    "react": "^16.8.3 || ^17.0.0-0 || ^18.0.0"
+    "react": "^16.8.3 || ^17.0.0-0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",


### PR DESCRIPTION
This PR updates the `react-table` package to officially support React 19 by modifying the peer dependency range in `package.json`:

- Updated `react` peer dependency to include: `^19.0.0`
- Bumped package version from `7.8.0` to `7.9.0`

## Reason

React 19 introduces several updates that improve rendering and developer experience. This change ensures `react-table` remains compatible with projects upgrading to React 19.

## Checklist

- [x] Peer dependency updated
- [x] Version bumped

