### PR TITLE
fix(doc): column filtering typo

### DIFF
--- a/docs/guide/column-filtering.md
+++ b/docs/guide/column-filtering.md
@@ -27,9 +27,9 @@ TanStack table supports both both client-side and manual server-side filtering. 
 
 ### Client-Side vs Server-Side Filtering
 
-If you have a large dataset, you may not want to load all of that data into the client's browser in order to filter it. In this case, you will most likely want to implement server-side filtering, sorting, pagination, etc. 
+If you have a large dataset, you may not want to load all of that data into the client's browser in order to filter it. In this case, you will most likely want to implement server-side filtering, sorting, pagination, etc.
 
-However, as also discussed in the [Pagination Guide](../pagination.md#should-you-use-client-side-pagination), a lot of developers underestimate how many rows can be loaded client-side without a performance hit. The TanStack table examples are often tested to handle up to 100,000 rows or more with decent performance for client-side filtering, sorting, pagination, and grouping. This doesn't necessarily that your app will be able to handle that many rows, but if your table is only going to have a few thousand rows at most, you might be able to take advantage of the client-side filtering, sorting, pagination, and grouping that TanStack table provides.
+However, as also discussed in the [Pagination Guide](../pagination.md#should-you-use-client-side-pagination), a lot of developers underestimate how many rows can be loaded client-side without a performance hit. The TanStack table examples are often tested to handle up to 100,000 rows or more with decent performance for client-side filtering, sorting, pagination, and grouping. This doesn't necessarily mean that your app will be able to handle that many rows, but if your table is only going to have a few thousand rows at most, you might be able to take advantage of the client-side filtering, sorting, pagination, and grouping that TanStack table provides.
 
 > TanStack Table can handle thousands of client-side rows with good performance. Don't rule out client-side filtering, pagination, sorting, etc. without some thought first.
 
@@ -246,10 +246,10 @@ const startsWithFilterFn = <TData extends MRT_RowData>(
     .startsWith(filterValue); // toString, toLowerCase, and trim the filter value in `resolveFilterValue`
 
 // remove the filter value from filter state if it is falsy (empty string in this case)
-startsWithFilterFn.autoRemove = (val: any) => !val; 
+startsWithFilterFn.autoRemove = (val: any) => !val;
 
 // transform/sanitize/format the filter value before it is passed to the filter function
-startsWithFilterFn.resolveFilterValue = (val: any) => val.toString().toLowerCase().trim(); 
+startsWithFilterFn.resolveFilterValue = (val: any) => val.toString().toLowerCase().trim();
 ```
 
 ### Customize Column Filtering
@@ -331,5 +331,5 @@ There are a lot of Column and Table APIs that you can use to interact with the c
 - `column.getIsFiltered` - Useful for displaying a visual indicator that a column is currently being filtered
 - `column.getFilterIndex` - Useful for displaying in what order the current filter is being applied
 
-- `column.getAutoFilterFn` - 
+- `column.getAutoFilterFn` -
 - `column.getFilterFn` - Useful for displaying which filter mode or function is currently being used


### PR DESCRIPTION
Fixes a typo in the "Column Filtering Guide" doc.

Fixes https://github.com/TanStack/table/issues/6064