### PR TITLE
fix: retain columnFiltersMeta when leaf row filtering

### DIFF
--- a/packages/table-core/src/utils/filterRowsUtils.ts
+++ b/packages/table-core/src/utils/filterRowsUtils.ts
@@ -39,6 +39,7 @@ function filterRowModelFromLeafs<TData extends RowData>(
         row.parentId
       )
       newRow.columnFilters = row.columnFilters
+      newRow.columnFiltersMeta = row.columnFiltersMeta
 
       if (row.subRows?.length && depth < maxDepth) {
         newRow.subRows = recurseFilterRows(row.subRows, depth + 1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures column filter metadata is correctly propagated to leaf rows during leaf-based filtering, resolving inconsistent results and missing/incorrect filter states in grouped or nested tables. Users should now see consistent filter behavior and indicators across all hierarchy levels.
* **Tests**
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->