### PR TITLE
docs: add missing import type for TableMeta module declaration

### DIFF
--- a/docs/api/core/table.md
+++ b/docs/api/core/table.md
@@ -82,6 +82,8 @@ meta?: TableMeta // This interface is extensible via declaration merging. See be
 You can pass any object to `options.meta` and access it anywhere the `table` is available via `table.options.meta` This type is global to all tables and can be extended like so:
 
 ```tsx
+import '@tanstack/table-core';
+
 declare module '@tanstack/table-core' {
   interface TableMeta<TData extends RowData> {
     foo: string


### PR DESCRIPTION
Update [TableMeta module declaration](https://tanstack.com/table/v8/docs/api/core/table#meta) with the import statement to match [ColumnMeta module declaration](https://tanstack.com/table/v8/docs/api/core/column-def#meta).

For reference, see [#4157](https://github.com/TanStack/table/discussions/4157#discussioncomment-3208313) and [#4104](https://github.com/TanStack/table/discussions/4104#discussioncomment-3208323).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added a TypeScript example showing how to extend table metadata via declaration merging, helping developers add custom properties in strongly typed projects.
  * Clarified usage notes and the import pattern to ensure type augmentation is recognized by TypeScript.
  * No behavioral or API changes to the library; this update only improves developer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->