### PR TITLE
fix(ColumnFiltering.ts): check Array.includes before generic object comparison

### DIFF
--- a/packages/table-core/src/features/ColumnFiltering.ts
+++ b/packages/table-core/src/features/ColumnFiltering.ts
@@ -287,12 +287,12 @@ export const ColumnFiltering: TableFeature = {
         return filterFns.equals
       }
 
-      if (value !== null && typeof value === 'object') {
-        return filterFns.equals
-      }
-
       if (Array.isArray(value)) {
         return filterFns.arrIncludes
+      }
+
+      if (value !== null && typeof value === 'object') {
+        return filterFns.equals
       }
 
       return filterFns.weakEquals


### PR DESCRIPTION
Reorders the conditional logic in ColumnFiltering.ts so that Array.includes checks are evaluated before falling back to generic object checks. This prevents incorrect matches when filtering columns against arrays.