### PR TITLE
Fix calculation of leafRows in getGroupedRowModel

### DIFF
--- a/packages/table-core/src/utils/getGroupedRowModel.ts
+++ b/packages/table-core/src/utils/getGroupedRowModel.ts
@@ -72,7 +72,7 @@ export function getGroupedRowModel<TData extends RowData>(): (
               })
 
               // Flatten the leaf rows of the rows in this group
-              const leafRows = depth
+              const leafRows = groupedRows.some((row) => row.subRows.length > 0)
                 ? flattenBy(groupedRows, row => row.subRows)
                 : groupedRows
 


### PR DESCRIPTION
Fixes #6093 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with grouped tables where leaf rows were not correctly identified, leading to incorrect or missing aggregated values.
  - Ensures summary rows (totals, averages, custom aggregations) display accurate data when groups are expanded or collapsed.
  - Improves stability when working with deeply nested groups, preventing occasional errors and inconsistent displays.
  - Enhances reliability of downstream features that depend on leaf rows in grouped views, resulting in more predictable and correct table behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->