### PR TITLE
fix: next section is actually previous section

### DIFF
--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -71,7 +71,7 @@ const data = ref<User[]>([])
 
 #### Defining Columns
 
-Column definitions are covered in detail in the next section in the [Column Def Guide](../column-defs.md). We'll note here, however, that when you define the type of your columns, you should use the same `TData` type that you used for you data.
+Column definitions are covered in detail in the previous section in the [Column Def Guide](../column-defs.md). We'll note here, however, that when you define the type of your columns, you should use the same `TData` type that you used for you data.
 
 ```ts
 const columns: ColumnDef<User>[] = [] //Pass User type as the generic TData type


### PR DESCRIPTION
Little confusion in the docs 

**next section**

should be

**previous section**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a cross-reference in the Defining Columns section to point to the previous section, improving navigation accuracy.
  * Clarified guidance around using the same data type across examples, reinforcing consistency without changing meaning.
  * No functional changes; this update improves clarity and reduces potential confusion in the tables guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->