### PR TITLE
docs(expanding): clarify description of autoResetExpanded setting

### DIFF
--- a/docs/api/features/expanding.md
+++ b/docs/api/features/expanding.md
@@ -81,7 +81,7 @@ This function is called when the `expanded` table state changes. If a function i
 autoResetExpanded?: boolean
 ```
 
-Enable this setting to automatically reset the expanded state of the table when expanding state changes.
+Enable this setting to automatically reset the expanded state of the table when table state changes.
 
 ### `enableExpanding`
 


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the behavior of autoResetExpanded: the reset is described as occurring when the overall table state changes, rather than when only the expanding state changes.
  * Improved wording to reduce confusion and align the description with actual behavior.
  * No functional changes; this is a documentation-only update to enhance accuracy and user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->