### PR TITLE
feat: add existingTable param to useReactTable

### DIFF
--- a/.changeset/beige-singers-admire.md
+++ b/.changeset/beige-singers-admire.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-table': patch
+---
+
+feat: add existingTable param to useReactTable

--- a/packages/angular-table/src/index.ts
+++ b/packages/angular-table/src/index.ts
@@ -26,7 +26,8 @@ export {
 } from './flex-render/flex-render-component'
 
 export function createAngularTable<TData extends RowData>(
-  options: () => TableOptions<TData>
+  options: () => TableOptions<TData>,
+  existingTable?: Table<TData>
 ): Table<TData> & Signal<Table<TData>> {
   return lazyInit(() => {
     const resolvedOptions = {
@@ -36,7 +37,7 @@ export function createAngularTable<TData extends RowData>(
       ...options(),
     }
 
-    const table = createTable(resolvedOptions)
+    const table = existingTable ?? createTable(resolvedOptions)
 
     // By default, manage table state here using the table's initial state
     const state = signal<TableState>(table.initialState)

--- a/packages/lit-table/src/index.ts
+++ b/packages/lit-table/src/index.ts
@@ -36,7 +36,7 @@ export class TableController<TData extends RowData>
     ;(this.host = host).addController(this)
   }
 
-  public table(options: TableOptions<TData>) {
+  public table(options: TableOptions<TData>, existingTable?: Table<TData>) {
     if (!this.tableInstance) {
       const resolvedOptions: TableOptionsResolved<TData> = {
         state: {},
@@ -45,7 +45,7 @@ export class TableController<TData extends RowData>
         ...options,
       }
 
-      this.tableInstance = createTable(resolvedOptions)
+      this.tableInstance = existingTable ?? createTable(resolvedOptions)
       this._tableState = {
         ...this.tableInstance.initialState,
         ...options.state,

--- a/packages/react-table/src/index.tsx
+++ b/packages/react-table/src/index.tsx
@@ -6,6 +6,7 @@ import {
   TableOptionsResolved,
   RowData,
   createTable,
+  Table,
 } from '@tanstack/table-core'
 
 export type Renderable<TProps> = React.ReactNode | React.ComponentType<TProps>
@@ -55,7 +56,8 @@ function isExoticComponent(component: any) {
 }
 
 export function useReactTable<TData extends RowData>(
-  options: TableOptions<TData>
+  options: TableOptions<TData>,
+  existingTable?: Table<TData>
 ) {
   // Compose in the generic options to the user options
   const resolvedOptions: TableOptionsResolved<TData> = {
@@ -65,9 +67,9 @@ export function useReactTable<TData extends RowData>(
     ...options,
   }
 
-  // Create a new table and store it in state
+  // Create or use the provided table instance and store it in state
   const [tableRef] = React.useState(() => ({
-    current: createTable<TData>(resolvedOptions),
+    current: existingTable ?? createTable<TData>(resolvedOptions),
   }))
 
   // By default, manage table state here using the table's initial state

--- a/packages/solid-table/src/index.tsx
+++ b/packages/solid-table/src/index.tsx
@@ -25,7 +25,8 @@ export function flexRender<TProps>(
 }
 
 export function createSolidTable<TData extends RowData>(
-  options: TableOptions<TData>
+  options: TableOptions<TData>,
+  existingTable?: import('@tanstack/table-core').Table<TData>
 ) {
   const resolvedOptions: TableOptionsResolved<TData> = mergeProps(
     {
@@ -42,7 +43,7 @@ export function createSolidTable<TData extends RowData>(
     options
   )
 
-  const table = createTable<TData>(resolvedOptions)
+  const table = existingTable ?? createTable<TData>(resolvedOptions)
   const [state, setState] = createStore(table.initialState)
 
   createComputed(() => {

--- a/packages/svelte-table/src/index.ts
+++ b/packages/svelte-table/src/index.ts
@@ -69,7 +69,8 @@ export function flexRender(component: any, props: any): ComponentType | null {
 type ReadableOrVal<T> = T | Readable<T>
 
 export function createSvelteTable<TData extends RowData>(
-  options: ReadableOrVal<TableOptions<TData>>
+  options: ReadableOrVal<TableOptions<TData>>,
+  existingTable?: import('@tanstack/table-core').Table<TData>
 ) {
   let optionsStore: Readable<TableOptions<TData>>
 
@@ -86,7 +87,7 @@ export function createSvelteTable<TData extends RowData>(
     ...get(optionsStore),
   }
 
-  let table = createTable(resolvedOptions)
+  let table = existingTable ?? createTable(resolvedOptions)
 
   let stateStore = writable(/** @type {number} */ table.initialState)
   // combine stores

--- a/packages/vue-table/src/index.ts
+++ b/packages/vue-table/src/index.ts
@@ -51,7 +51,8 @@ function getOptionsWithReactiveData<TData extends RowData>(
 }
 
 export function useVueTable<TData extends RowData>(
-  initialOptions: TableOptionsWithReactiveData<TData>
+  initialOptions: TableOptionsWithReactiveData<TData>,
+  existingTable?: import('@tanstack/table-core').Table<TData>
 ) {
   const IS_REACTIVE = isRef(initialOptions.data)
 
@@ -75,9 +76,9 @@ export function useVueTable<TData extends RowData>(
     IS_REACTIVE ? getOptionsWithReactiveData(initialOptions) : initialOptions
   )
 
-  const table = createTable<TData>(
-    resolvedOptions as TableOptionsResolved<TData>
-  )
+  const table =
+    existingTable ??
+    createTable<TData>(resolvedOptions as TableOptionsResolved<TData>)
 
   // Add reactivity support
   if (IS_REACTIVE) {


### PR DESCRIPTION
## 🎯 Changes

This enables framework agnostic table adapters to create a table outside of the react context, but then use the existing react package to interact with it as a regular table.

The second commit is AI matching the changes to `useReactTable` across all the other frameworks. I don't have the framework experience to know if it did a great job or not, but the changes should be pretty simple to review.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `useReactTable` hook with an optional `existingTable` parameter. Developers can now optionally provide an externally-created Table instance for reuse instead of having the hook automatically create a new one, providing greater flexibility and control over table instance lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->