### PR TITLE
Fix syntax error in pagination example

### DIFF
--- a/docs/framework/vue/guide/table-state.md
+++ b/docs/framework/vue/guide/table-state.md
@@ -114,7 +114,7 @@ const sorting = ref([{
   id: 'age',
   desc: true, //sort by age in descending order by default
 }])
-const pagination = ref({ pageIndex: 0, pageSize: 15 }
+const pagination = ref({ pageIndex: 0, pageSize: 15 })
 
 //Use our controlled state values to fetch data
 const tableQuery = useQuery({


### PR DESCRIPTION
Adding missing `)` character.

## 🎯 Changes

Add missing `)` character on example while define pagination state in vue

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a syntax error in the Vue table state guide, fixing a code example in the Controlled State section to ensure accuracy and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->