### PR TITLE
docs(example/column-resize-performant): optimize memoization during column resizing

### DIFF
--- a/examples/react/column-resizing-performant/src/main.tsx
+++ b/examples/react/column-resizing-performant/src/main.tsx
@@ -190,7 +190,7 @@ function App() {
             ))}
           </div>
           {/* When resizing any column we will render this special memoized version of our table body */}
-          {table.getState().columnSizingInfo.isResizingColumn && enableMemo ? (
+          {enableMemo ? (
             <MemoizedTableBody table={table} />
           ) : (
             <TableBody table={table} />
@@ -243,9 +243,10 @@ function TableBody({ table }: { table: Table<Person> }) {
 }
 
 //special memoized wrapper for our table body that we will use during column resizing
-export const MemoizedTableBody = React.memo(
-  TableBody,
-  (prev, next) => prev.table.options.data === next.table.options.data
+export const MemoizedTableBody = React.memo(TableBody, (prev, next) =>
+  next.table.getState().columnSizingInfo.isResizingColumn
+    ? prev.table.options.data === next.table.options.data
+    : false
 ) as typeof TableBody
 
 const rootElement = document.getElementById('root')


### PR DESCRIPTION
## 🎯 Changes

Unneccessary component remounts fixed by checking resize inside UseMemo.
Refer to issue and original solution #6121 by @ItaiYospehi

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized column-resizing performance in the example application. The rendering efficiency during resize operations has been enhanced through improved memoization logic that intelligently adapts based on resizing state. This results in fewer unnecessary component re-renders during resize sessions and smoother, more responsive user interactions overall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->