### PR TITLE
fix(table-core): Pass column to resolveFilterValue

### DIFF
--- a/.changeset/flat-regions-buy.md
+++ b/.changeset/flat-regions-buy.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+fix(table-core): Pass column to resolveFilterValue

--- a/packages/table-core/src/utils/getFilteredRowModel.ts
+++ b/packages/table-core/src/utils/getFilteredRowModel.ts
@@ -49,7 +49,7 @@ export function getFilteredRowModel<TData extends RowData>(): (
           resolvedColumnFilters.push({
             id: d.id,
             filterFn,
-            resolvedValue: filterFn.resolveFilterValue?.(d.value) ?? d.value,
+            resolvedValue: filterFn.resolveFilterValue?.(d.value, column) ?? d.value,
           })
         })
 
@@ -73,7 +73,7 @@ export function getFilteredRowModel<TData extends RowData>(): (
               id: column.id,
               filterFn: globalFilterFn,
               resolvedValue:
-                globalFilterFn.resolveFilterValue?.(globalFilter) ??
+                globalFilterFn.resolveFilterValue?.(globalFilter, column) ??
                 globalFilter,
             })
           })


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Pass column object as the second argument to `filterFn` `resolveFilterValue` as described by its type `ColumnFilterAutoRemoveTestFn`.

Ref: https://github.com/TanStack/table/discussions/4834

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed filter resolution to properly include column context information in all filtering operations. Column-specific and global filters now receive the complete column data required, improving overall filtering accuracy and consistency. This enhancement enables more precise filter behavior across the table.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->