### PR TITLE
docs(v7): use github source link instead of broken v7 doc site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > [Looking for the latest version?](https://github.com/tanstack/react-table)
 
-## Visit [react-table-v7.tanstack.com](https://react-table-v7.tanstack.com) for docs, guides, API and more!
+## Visit the [v7 Documentation Source](https://github.com/TanStack/table/blob/v7/docs/src/pages/docs/overview.md) for docs, guides, API and more!
 
 ## Quick Features
 


### PR DESCRIPTION
## Description
The link to the v7 documentation website (`react-table-v7.tanstack.com`) in the README is broken/redirecting incorrect page.

Since the v7 website seems unsupported, this PR updates the link to point directly to the v7 documentation source files hosted on GitHub, ensuring users can still access the guides.

##  🎯 Changes
- Updated documentation link in [README.md](cci:7://file:///Users/changjun/Desktop/table/README.md:0:0-0:0) to point to `docs/src/pages/docs/overview.md` on the v7 branch.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).