### PR TITLE
fix(core): getIsSomePageRowsSelected - do not return false when all page rows selected

### DIFF
--- a/.changeset/late-radios-decide.md
+++ b/.changeset/late-radios-decide.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+getIsSomePageRowsSelected no longer returns false when all rows of a page are selected

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -445,10 +445,7 @@ export const RowSelection: TableFeature = {
     }
 
     table.getIsSomePageRowsSelected = () => {
-      const paginationFlatRows = table.getPaginationRowModel().flatRows
-      return table.getIsAllPageRowsSelected()
-        ? false
-        : paginationFlatRows
+      return table.getPaginationRowModel().flatRows
             .filter((row) => row.getCanSelect())
             .some((d) => d.getIsSelected() || d.getIsSomeSelected())
     }


### PR DESCRIPTION
## 🎯 Changes

getIsSomePageRowsSelected no longer returns false when all rows of a page are selected

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `getIsSomePageRowsSelected` to correctly return true when all rows on a page are selected. Previously, this function would incorrectly return false when all selectable rows on the current page were selected, making it difficult to accurately track and determine row selection state. The fix ensures reliable and consistent selection detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->