### PR TITLE
docs: fix a few small typos

### DIFF
--- a/docs/guide/expanding.md
+++ b/docs/guide/expanding.md
@@ -40,7 +40,7 @@ Expanded data can either contain table rows or any other data you want to displa
 
 ### Table rows as expanded data
 
-Expanded rows are essentially child rows that inherit the same column structure as their parent rows. If your data object already includes these expanded rows data, you can utilize the `getSubRows` function to specify these child rows. However, if your data object does not contain the expanded rows data, they can be treated as custom expanded data, which is discussed in next section.
+Expanded rows are essentially child rows that inherit the same column structure as their parent rows. If your data object already includes these expanded rows data, you can utilize the `getSubRows` function to specify these child rows. However, if your data object does not contain the expanded rows data, they can be treated as custom expanded data, which is discussed in the next section.
 
 For example, if you have a data object like this:
 

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -30,7 +30,7 @@ Using client-side pagination means that the `data` that you fetch will contain *
 
 Client-side pagination is usually the simplest way to implement pagination when using TanStack Table, but it might not be practical for very large datasets.
 
-However, a lot of people underestimate just how much data can be handled client-side. If your table will only ever have a few thousand rows or less, client-side pagination can still be a viable option. TanStack Table is designed to scale up to 10s of thousands of rows with decent performance for pagination, filtering, sorting, and grouping. The [official pagination example](../framework/react/examples/pagination) loads 100,000 rows and still performs well, albeit with only handful of columns.
+However, a lot of people underestimate just how much data can be handled client-side. If your table will only ever have a few thousand rows or less, client-side pagination can still be a viable option. TanStack Table is designed to scale up to 10s of thousands of rows with decent performance for pagination, filtering, sorting, and grouping. The [official pagination example](../framework/react/examples/pagination) loads 100,000 rows and still performs well, albeit with only a handful of columns.
 
 Every use-case is different and will depend on the complexity of the table, how many columns you have, how large every piece of data is, etc. The main bottlenecks to pay attention to are:
 

--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -71,7 +71,7 @@ const data = ref<User[]>([])
 
 #### Defining Columns
 
-Column definitions are covered in detail in the next section in the [Column Def Guide](./column-defs.md). We'll note here, however, that when you define the type of your columns, you should use the same `TData` type that you used for you data.
+Column definitions are covered in detail in the next section in the [Column Def Guide](./column-defs.md). We'll note here, however, that when you define the type of your columns, you should use the same `TData` type that you used for your data.
 
 ```ts
 const columns: ColumnDef<User>[] = [] //Pass User type as the generic TData type


### PR DESCRIPTION
## 🎯 Changes

**docs/guide/expanding.md**
- Fixed grammar: “discussed in next section” → “discussed in the next section”

**docs/guide/tables.md**
- Fixed typo: “used for you data” → “used for your data”

**docs/guide/pagination.md**
- Fixed wording: “only handful of columns” → “only a handful of columns”


<!-- What changes are made in this PR? Describe the change and its motivation. -->
This PR fixes a few small wording/grammar issues in the Table docs guides to improve readability. No behavior or API changes.


## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [X] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Improved clarity and readability across documentation guides with minor grammar and spelling corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->