### PR TITLE
fix(table-core): clear stale columnFiltersMeta in getFilteredRowModel

### DIFF
--- a/packages/table-core/src/utils/getFilteredRowModel.ts
+++ b/packages/table-core/src/utils/getFilteredRowModel.ts
@@ -87,6 +87,7 @@ export function getFilteredRowModel<TData extends RowData>(): (
           const row = rowModel.flatRows[j]!
 
           row.columnFilters = {}
+          row.columnFiltersMeta = {}
 
           if (resolvedColumnFilters.length) {
             for (let i = 0; i < resolvedColumnFilters.length; i++) {

--- a/packages/table-core/tests/getFilteredRowModel.test.ts
+++ b/packages/table-core/tests/getFilteredRowModel.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createColumnHelper,
+  createTable,
+  functionalUpdate,
+  getCoreRowModel,
+  getFilteredRowModel,
+} from '../src'
+
+type TestRow = {
+  a: string
+  b: string
+}
+
+describe('#getFilteredRowModel', () => {
+  it('clears columnFiltersMeta between filter runs so removed filter meta does not persist', () => {
+    const data: TestRow[] = [
+      { a: 'x', b: 'y' },
+      { a: 'x', b: 'z' },
+    ]
+
+    const columnHelper = createColumnHelper<TestRow>()
+    const columns = [
+      columnHelper.accessor('a', {
+        id: 'a',
+        filterFn: (row, columnId, filterValue, addMeta) => {
+          addMeta?.({ from: 'a' })
+          return row.getValue<string>(columnId) === filterValue
+        },
+      }),
+      columnHelper.accessor('b', {
+        id: 'b',
+        filterFn: (row, columnId, filterValue) => {
+          return row.getValue<string>(columnId) === filterValue
+        },
+      }),
+    ]
+
+    let state: any = {
+      columnFilters: [],
+      globalFilter: undefined,
+    }
+
+    // Create a tiny state container so `table.setColumnFilters` updates `table.options.state`
+    let table: ReturnType<typeof createTable<TestRow>>
+    table = createTable<TestRow>({
+      data,
+      columns,
+      renderFallbackValue: '',
+      getCoreRowModel: getCoreRowModel(),
+      getFilteredRowModel: getFilteredRowModel(),
+      state,
+      onStateChange: (updater) => {
+        state = functionalUpdate(updater, state)
+        table.setOptions((prev) => ({ ...prev, state }))
+      },
+    })
+
+    table.setColumnFilters([{ id: 'a', value: 'x' }])
+    const first = table.getFilteredRowModel().flatRows[0]!
+    expect(first.columnFiltersMeta.a).toEqual({ from: 'a' })
+
+    // Switch to a different filter that does not write meta
+    table.setColumnFilters([{ id: 'b', value: 'y' }])
+    const second = table.getFilteredRowModel().flatRows[0]!
+    expect(second.columnFiltersMeta.a).toBeUndefined()
+  })
+})
+


### PR DESCRIPTION
## 🎯 Changes

This PR fixes a small issue in `getFilteredRowModel` where `row.columnFiltersMeta` could retain stale entries across filter updates.

### What changed
Reset `row.columnFiltersMeta = {}` whenever `row.columnFilters` is reset during filtered row model recomputation.

### Why
When switching/removing column filters, filter functions that previously wrote meta could leave old meta behind. Clearing `columnFiltersMeta` ensures meta always reflects the current filter run.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table filtering reliability by ensuring column filter metadata is properly initialized and cleared between consecutive filter operations.

* **Tests**
  * Added test coverage validating correct filter metadata behavior during filter state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->