### PR TITLE
docs: fix TanStack Start link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ We're looking for TanStack Table Partners to join our mission! Partner with us t
 - <a href="https://github.com/tanstack/query"><b>TanStack Query</b></a> – Async state & caching
 - <a href="https://github.com/tanstack/ranger"><b>TanStack Ranger</b></a> – Range & slider primitives
 - <a href="https://github.com/tanstack/router"><b>TanStack Router</b></a> – Type‑safe routing, caching & URL state
-- <a href="https://github.com/tanstack/router"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
+- <a href="https://github.com/tanstack/start"><b>TanStack Start</b></a> – Full‑stack SSR & streaming
 - <a href="https://github.com/tanstack/store"><b>TanStack Store</b></a> – Reactive data store
 - <a href="https://github.com/tanstack/virtual"><b>TanStack Virtual</b></a> – Virtualized rendering
 


### PR DESCRIPTION
## 🎯 Changes
Fix incorrect ecosystem link in README where “TanStack Start” mistakenly pointed to the Router repo; now points to the correct tanstack/start repo.

How to verify -
Open README → “Explore the TanStack Ecosystem” → click “TanStack Start” link → confirm it goes to https://github.com/tanstack/start.

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected an ecosystem documentation link to direct users to the correct repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->