### PR TITLE
fix: add variance annotations to fix file-order-dependent type errors

### DIFF
--- a/packages/table-core/src/core/cell.ts
+++ b/packages/table-core/src/core/cell.ts
@@ -1,7 +1,7 @@
 import { RowData, Cell, Column, Row, Table } from '../types'
 import { Getter, getMemoOptions, memo } from '../utils'
 
-export interface CellContext<TData extends RowData, TValue> {
+export interface CellContext<in out TData extends RowData, in out TValue> {
   cell: Cell<TData, TValue>
   column: Column<TData, TValue>
   getValue: Getter<TValue>
@@ -10,7 +10,7 @@ export interface CellContext<TData extends RowData, TValue> {
   table: Table<TData>
 }
 
-export interface CoreCell<TData extends RowData, TValue> {
+export interface CoreCell<in out TData extends RowData, in out TValue> {
   /**
    * The associated Column object for the cell.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/cell#column)

--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -8,7 +8,7 @@ import {
 } from '../types'
 import { getMemoOptions, memo } from '../utils'
 
-export interface CoreColumn<TData extends RowData, TValue> {
+export interface CoreColumn<in out TData extends RowData, in out TValue> {
   /**
    * The resolved accessor function to use when extracting the value for the column from each row. Will only be defined if the column def has a valid accessor key or function defined.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/column#accessorfn)

--- a/packages/table-core/src/core/headers.ts
+++ b/packages/table-core/src/core/headers.ts
@@ -16,7 +16,7 @@ export interface CoreHeaderGroup<TData extends RowData> {
   id: string
 }
 
-export interface HeaderContext<TData, TValue> {
+export interface HeaderContext<in out TData, in out TValue> {
   /**
    * An instance of a column.
    */
@@ -31,7 +31,7 @@ export interface HeaderContext<TData, TValue> {
   table: Table<TData>
 }
 
-export interface CoreHeader<TData extends RowData, TValue> {
+export interface CoreHeader<in out TData extends RowData, in out TValue> {
   /**
    * The col-span for the header.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/core/header#colspan)

--- a/packages/table-core/src/features/ColumnFaceting.ts
+++ b/packages/table-core/src/features/ColumnFaceting.ts
@@ -46,8 +46,8 @@ export interface FacetedOptions<TData extends RowData> {
 //
 
 export const ColumnFaceting: TableFeature = {
-  createColumn: <TData extends RowData>(
-    column: Column<TData, unknown>,
+  createColumn: <TData extends RowData, TValue>(
+    column: Column<TData, TValue>,
     table: Table<TData>,
   ): void => {
     column._getFacetedRowModel =

--- a/packages/table-core/src/features/ColumnFiltering.ts
+++ b/packages/table-core/src/features/ColumnFiltering.ts
@@ -265,8 +265,8 @@ export const ColumnFiltering: TableFeature = {
     } as ColumnFiltersOptions<TData>
   },
 
-  createColumn: <TData extends RowData>(
-    column: Column<TData, unknown>,
+  createColumn: <TData extends RowData, TValue>(
+    column: Column<TData, TValue>,
     table: Table<TData>,
   ): void => {
     column.getAutoFilterFn = () => {
@@ -334,7 +334,7 @@ export const ColumnFiltering: TableFeature = {
 
         //
         if (
-          shouldAutoRemoveFilter(filterFn as FilterFn<TData>, newFilter, column)
+          shouldAutoRemoveFilter(filterFn as FilterFn<TData>, newFilter, column as Column<TData, unknown>)
         ) {
           return old?.filter((d) => d.id !== column.id) ?? []
         }

--- a/packages/table-core/src/features/ColumnGrouping.ts
+++ b/packages/table-core/src/features/ColumnGrouping.ts
@@ -34,7 +34,7 @@ export type AggregationFnOption<TData extends RowData> =
   | BuiltInAggregationFn
   | AggregationFn<TData>
 
-export interface GroupingColumnDef<TData extends RowData, TValue> {
+export interface GroupingColumnDef<in out TData extends RowData, in out TValue> {
   /**
    * The cell to display each row for the column if the cell is an aggregate. If a function is passed, it will be passed a props object with the context of the cell and should return the property type for your adapter (the exact type depends on the adapter being used).
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/grouping#aggregatedcell)

--- a/packages/table-core/src/features/ColumnOrdering.ts
+++ b/packages/table-core/src/features/ColumnOrdering.ts
@@ -88,8 +88,8 @@ export const ColumnOrdering: TableFeature = {
     }
   },
 
-  createColumn: <TData extends RowData>(
-    column: Column<TData, unknown>,
+  createColumn: <TData extends RowData, TValue>(
+    column: Column<TData, TValue>,
     table: Table<TData>,
   ): void => {
     column.getIndex = memo(

--- a/packages/table-core/src/features/GlobalFiltering.ts
+++ b/packages/table-core/src/features/GlobalFiltering.ts
@@ -118,8 +118,8 @@ export const GlobalFiltering: TableFeature = {
     } as GlobalFilterOptions<TData>
   },
 
-  createColumn: <TData extends RowData>(
-    column: Column<TData, unknown>,
+  createColumn: <TData extends RowData, TValue>(
+    column: Column<TData, TValue>,
     table: Table<TData>,
   ): void => {
     column.getCanGlobalFilter = () => {
@@ -127,7 +127,7 @@ export const GlobalFiltering: TableFeature = {
         (column.columnDef.enableGlobalFilter ?? true) &&
         (table.options.enableGlobalFilter ?? true) &&
         (table.options.enableFilters ?? true) &&
-        (table.options.getColumnCanGlobalFilter?.(column) ?? true) &&
+        (table.options.getColumnCanGlobalFilter?.(column as Column<TData, unknown>) ?? true) &&
         !!column.accessorFn
       )
     }

--- a/packages/table-core/src/types.ts
+++ b/packages/table-core/src/types.ts
@@ -98,14 +98,20 @@ import { CellContext, CoreCell } from './core/cell'
 import { CoreColumn } from './core/column'
 
 export interface TableFeature<TData extends RowData = any> {
-  createCell?: (
-    cell: Cell<TData, unknown>,
-    column: Column<TData>,
+  createCell?: <TValue>(
+    cell: Cell<TData, TValue>,
+    column: Column<TData, TValue>,
     row: Row<TData>,
     table: Table<TData>,
   ) => void
-  createColumn?: (column: Column<TData, unknown>, table: Table<TData>) => void
-  createHeader?: (header: Header<TData, unknown>, table: Table<TData>) => void
+  createColumn?: <TValue>(
+    column: Column<TData, TValue>,
+    table: Table<TData>
+  ) => void
+  createHeader?: <TValue>(
+    header: Header<TData, TValue>,
+    table: Table<TData>
+  ) => void
   createRow?: (row: Row<TData>, table: Table<TData>) => void
   createTable?: (table: Table<TData>) => void
   getDefaultColumnDef?: () => Partial<ColumnDef<TData, unknown>>
@@ -227,7 +233,7 @@ export interface RowModel<TData extends RowData> {
   rowsById: Record<string, Row<TData>>
 }
 
-export type AccessorFn<TData extends RowData, TValue = unknown> = (
+export type AccessorFn<in TData extends RowData, out TValue = unknown> = (
   originalRow: TData,
   index: number,
 ) => TValue
@@ -256,7 +262,7 @@ type ColumnIdentifiers<TData extends RowData, TValue> =
 
 //
 
-interface ColumnDefExtensions<TData extends RowData, TValue = unknown>
+interface ColumnDefExtensions<in out TData extends RowData, in out TValue = unknown>
   extends
     VisibilityColumnDef,
     ColumnPinningColumnDef,
@@ -267,8 +273,8 @@ interface ColumnDefExtensions<TData extends RowData, TValue = unknown>
     ColumnSizingColumnDef {}
 
 export interface ColumnDefBase<
-  TData extends RowData,
-  TValue = unknown,
+  in out TData extends RowData,
+  in out TValue = unknown,
 > extends ColumnDefExtensions<TData, TValue> {
   getUniqueValues?: AccessorFn<TData, unknown[]>
   footer?: ColumnDefTemplate<HeaderContext<TData, TValue>>
@@ -279,8 +285,8 @@ export interface ColumnDefBase<
 //
 
 export interface IdentifiedColumnDef<
-  TData extends RowData,
-  TValue = unknown,
+  in out TData extends RowData,
+  in out TValue = unknown,
 > extends ColumnDefBase<TData, TValue> {
   id?: string
   header?: StringOrTemplateHeader<TData, TValue>
@@ -292,8 +298,8 @@ export type DisplayColumnDef<
 > = ColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
 
 interface GroupColumnDefBase<
-  TData extends RowData,
-  TValue = unknown,
+  in out TData extends RowData,
+  in out TValue = unknown,
 > extends ColumnDefBase<TData, TValue> {
   columns?: ColumnDef<TData, any>[]
 }
@@ -304,8 +310,8 @@ export type GroupColumnDef<
 > = GroupColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
 
 export interface AccessorFnColumnDefBase<
-  TData extends RowData,
-  TValue = unknown,
+  in out TData extends RowData,
+  in out TValue = unknown,
 > extends ColumnDefBase<TData, TValue> {
   accessorFn: AccessorFn<TData, TValue>
 }
@@ -316,8 +322,8 @@ export type AccessorFnColumnDef<
 > = AccessorFnColumnDefBase<TData, TValue> & ColumnIdentifiers<TData, TValue>
 
 export interface AccessorKeyColumnDefBase<
-  TData extends RowData,
-  TValue = unknown,
+  in out TData extends RowData,
+  in out TValue = unknown,
 > extends ColumnDefBase<TData, TValue> {
   id?: string
   accessorKey: (string & {}) | keyof TData
@@ -347,7 +353,7 @@ export type ColumnDefResolved<
   accessorKey?: string
 }
 
-export interface Column<TData extends RowData, TValue = unknown>
+export interface Column<in out TData extends RowData, in out TValue = unknown>
   extends
     CoreColumn<TData, TValue>,
     ColumnVisibilityColumn,
@@ -360,11 +366,13 @@ export interface Column<TData extends RowData, TValue = unknown>
     ColumnSizingColumn,
     ColumnOrderColumn {}
 
-export interface Cell<TData extends RowData, TValue>
-  extends CoreCell<TData, TValue>, GroupingCell {}
+export interface Cell<in out TData extends RowData, in out TValue>
+  extends CoreCell<TData, TValue>,
+    GroupingCell {}
 
-export interface Header<TData extends RowData, TValue>
-  extends CoreHeader<TData, TValue>, ColumnSizingHeader {}
+export interface Header<in out TData extends RowData, in out TValue>
+  extends CoreHeader<TData, TValue>,
+    ColumnSizingHeader {}
 
 export interface HeaderGroup<
   TData extends RowData,


### PR DESCRIPTION
## Summary

- Adds `in out` (invariant) variance annotations to `TData` and `TValue` type parameters on all mutually recursive types in the `ColumnDef`/`Column` cycle (`ColumnDefBase`, `Column`, `Cell`, `Header`, `CoreColumn`, `CoreCell`, `CoreHeader`, `HeaderContext`, `CellContext`, `GroupingColumnDef`, and related `ColumnDef` variants)
- Makes `TableFeature`'s `createCell`/`createColumn`/`createHeader` methods generic over `TValue` so the invariant type parameter flows through correctly in implementation code
- Propagates `TValue` to feature `createColumn` implementations and internal helpers (`shouldAutoRemoveFilter`) that were previously hardcoding `Column<TData, unknown>`
- Fixes a bug where `tsc` silently drops type errors depending on file processing order, while the IDE (language server) correctly reports them

### Root cause

TypeScript has a known variance computation bug with mutually recursive generic types ([microsoft/TypeScript#44572](https://github.com/microsoft/TypeScript/issues/44572), closed as Design Limitation). When `tsc` processes files in a certain order, the variance computation cycle causes it to bail out and cache `TValue` as `[independent]`, making `ColumnDef<Row, string>` incorrectly assignable to `ColumnDef<Row, unknown>`. The official workaround is explicit variance annotations, introduced in TS 4.7 ([microsoft/TypeScript#48240](https://github.com/microsoft/TypeScript/pull/48240)).

### Reproduction

https://github.com/Faithfinder/ts-ide-cli-repro (`main` branch)

Fixes #6167
Related: #4241, #4382

## Test plan

- [x] `table-core` type-checks cleanly (`tsc --noEmit`)
- [x] `table-core` unit tests pass (21/21)
- [x] `react-table` unit tests pass (8/8)
- [x] Verified against the [repro](https://github.com/Faithfinder/ts-ide-cli-repro) — all 3 type errors are now correctly reported by `tsc` regardless of file order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript typing across the table core module by applying variance annotations to generic types, enhancing type safety and inference for consumers and tooling without changing runtime behavior or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->