### PR TITLE
Fix broken documentation link for global filters example

### DIFF
--- a/docs/guide/global-filtering.md
+++ b/docs/guide/global-filtering.md
@@ -6,7 +6,7 @@ title: Global Filtering Guide
 
 Want to skip to the implementation? Check out these examples:
 
-- [Global Filters](https://github.com/TanStack/table/tree/main/examples/react/filters-global)
+- [Global Filters](https://github.com/TanStack/table/tree/main/examples/react/filters-fuzzy)
 
 ## API
 


### PR DESCRIPTION
## 🎯 Changes

Updated a broken documentation link in `docs/guide/global-filtering.md` — the existing link pointed to `examples/react/filters-global` which doesn't exist and returned a 404. Changed it to point to `examples/react/filters-fuzzy` which is the actual example that demonstrates global filtering functionality.

Fixes #6141

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).