### PR TITLE
Add preact integration for tanstack-table

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 > - [Angular Table](https://tanstack.com/table/v8/docs/framework/angular/angular-table)
 > - [Lit Table](https://tanstack.com/table/v8/docs/framework/lit/lit-table)
 > - [Qwik Table](https://tanstack.com/table/v8/docs/framework/qwik/qwik-table)
+> - [Preact Table](https://tanstack.com/table/v8/docs/framework/preact/preact-table)
 > - [React Table](https://tanstack.com/table/v8/docs/framework/react/react-table)
 > - [Solid Table](https://tanstack.com/table/v8/docs/framework/solid/solid-table)
 > - [Svelte Table](https://tanstack.com/table/v8/docs/framework/svelte/svelte-table)
@@ -43,7 +44,7 @@
 
 A headless table library for building powerful datagrids with full control over markup, styles, and behavior.
 
-- Framework‑agnostic core with bindings for React, Vue & Solid
+- Framework‑agnostic core with bindings for React, Preact, Vue, Solid, and more
 - 100% customizable — bring your own UI, components, and styles
 - Sorting, filtering, grouping, aggregation & row selection
 - Lightweight, virtualizable & server‑side friendly

--- a/docs/config.json
+++ b/docs/config.json
@@ -59,6 +59,15 @@
           ]
         },
         {
+          "label": "preact",
+          "children": [
+            {
+              "label": "Preact Table Adapter",
+              "to": "framework/preact/preact-table"
+            }
+          ]
+        },
+        {
           "label": "react",
           "children": [
             {
@@ -170,6 +179,15 @@
             {
               "label": "Table State",
               "to": "framework/qwik/guide/table-state"
+            }
+          ]
+        },
+        {
+          "label": "preact",
+          "children": [
+            {
+              "label": "Table State",
+              "to": "framework/preact/guide/table-state"
             }
           ]
         },

--- a/docs/framework/preact/guide/table-state.md
+++ b/docs/framework/preact/guide/table-state.md
@@ -1,0 +1,196 @@
+---
+title: Table State (Preact) Guide
+---
+
+## Table State (Preact) Guide
+
+TanStack Table has a simple underlying internal state management system to store and manage the state of the table. It also lets you selectively pull out any state that you need to manage in your own state management. This guide will walk you through the different ways in which you can interact with and manage the state of the table.
+
+### Accessing Table State
+
+You do not need to set up anything special in order for the table state to work. If you pass nothing into either `state`, `initialState`, or any of the `on[State]Change` table options, the table will manage its own state internally. You can access any part of this internal state by using the `table.getState()` table instance API.
+
+```jsx
+const table = usePreactTable({
+  columns,
+  data,
+  //...
+})
+
+console.log(table.getState()) //access the entire internal state
+console.log(table.getState().rowSelection) //access just the row selection state
+```
+
+### Custom Initial State
+
+If all you need to do for certain states is customize their initial default values, you still do not need to manage any of the state yourself. You can simply set values in the `initialState` option of the table instance.
+
+```jsx
+const table = usePreactTable({
+  columns,
+  data,
+  initialState: {
+    columnOrder: ['age', 'firstName', 'lastName'], //customize the initial column order
+    columnVisibility: {
+      id: false //hide the id column by default
+    },
+    expanded: true, //expand all rows by default
+    sorting: [
+      {
+        id: 'age',
+        desc: true //sort by age in descending order by default
+      }
+    ]
+  },
+  //...
+})
+```
+
+> **Note**: Only specify each particular state in either `initialState` or `state`, but not both. If you pass in a particular state value to both `initialState` and `state`, the initialized state in `state` will overwrite any corresponding value in `initialState`.
+
+### Controlled State
+
+If you need easy access to the table state in other areas of your application, TanStack Table makes it easy to control and manage any or all of the table state in your own state management system. You can do this by passing in your own state and state management functions to the `state` and `on[State]Change` table options.
+
+#### Individual Controlled State
+
+You can control just the state that you need easy access to. You do NOT have to control all of the table state if you do not need to. It is recommended to only control the state that you need on a case-by-case basis.
+
+In order to control a particular state, you need to both pass in the corresponding `state` value and the `on[State]Change` function to the table instance.
+
+Let's take filtering, sorting, and pagination as an example in a "manual" server-side data fetching scenario. You can store the filtering, sorting, and pagination state in your own state management, but leave out any other state like column order, column visibility, etc. if your API does not care about those values.
+
+```jsx
+const [columnFilters, setColumnFilters] = useState([]) //no default filters
+const [sorting, setSorting] = useState([{
+  id: 'age',
+  desc: true, //sort by age in descending order by default
+}]) 
+const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 15 })
+
+//Use our controlled state values to fetch data
+const tableQuery = useQuery({
+  queryKey: ['users', columnFilters, sorting, pagination],
+  queryFn: () => fetchUsers(columnFilters, sorting, pagination),
+  //...
+})
+
+const table = usePreactTable({
+  columns,
+  data: tableQuery.data,
+  //...
+  state: {
+    columnFilters, //pass controlled state back to the table (overrides internal state)
+    sorting,
+    pagination
+  },
+  onColumnFiltersChange: setColumnFilters, //hoist columnFilters state into our own state management
+  onSortingChange: setSorting,
+  onPaginationChange: setPagination,
+})
+//...
+```
+
+#### Fully Controlled State
+
+Alternatively, you can control the entire table state with the `onStateChange` table option. It will hoist out the entire table state into your own state management system. Be careful with this approach, as you might find that raising some frequently changing state values up a preact tree, like `columnSizingInfo` state`, might cause bad performance issues.
+
+A couple of more tricks may be needed to make this work. If you use the `onStateChange` table option, the initial values of the `state` must be populated with all of the relevant state values for all of the features that you want to use. You can either manually type out all of the initial state values, or use the `table.setOptions` API in a special way as shown below.
+
+```jsx
+//create a table instance with default state values
+const table = usePreactTable({
+  columns,
+  data,
+  //... Note: `state` values are NOT passed in yet
+})
+
+const [state, setState] = useState({
+  ...table.initialState, //populate the initial state with all of the default state values from the table instance
+  pagination: {
+    pageIndex: 0,
+    pageSize: 15 //optionally customize the initial pagination state.
+  }
+})
+
+//Use the table.setOptions API to merge our fully controlled state onto the table instance
+table.setOptions(prev => ({
+  ...prev, //preserve any other options that we have set up above
+  state, //our fully controlled state overrides the internal state
+  onStateChange: setState //any state changes will be pushed up to our own state management
+}))
+```
+
+### On State Change Callbacks
+
+So far, we have seen the `on[State]Change` and `onStateChange` table options work to "hoist" the table state changes into our own state management. However, there are a few things about using these options that you should be aware of.
+
+#### 1. **State Change Callbacks MUST have their corresponding state value in the `state` option**.
+
+Specifying an `on[State]Change` callback tells the table instance that this will be a controlled state. If you do not specify the corresponding `state` value, that state will be "frozen" with its initial value.
+
+```jsx
+const [sorting, setSorting] = useState([])
+//...
+const table = usePreactTable({
+  columns,
+  data,
+  //...
+  state: {
+    sorting, //required because we are using `onSortingChange`
+  },
+  onSortingChange: setSorting, //makes the `state.sorting` controlled
+})
+```
+
+#### 2. **Updaters can either be raw values or callback functions**.
+
+The `on[State]Change` and `onStateChange` callbacks work exactly like the `setState` functions in React/Preact. The updater values can either be a new state value or a callback function that takes the previous state value and returns the new state value.
+
+What implications does this have? It means that if you want to add in some extra logic in any of the `on[State]Change` callbacks, you can do so, but you need to check whether or not the new incoming updater value is a function or value.
+
+```jsx
+const [sorting, setSorting] = useState([])
+const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 })
+
+const table = usePreactTable({
+  columns,
+  data,
+  //...
+  state: {
+    pagination,
+    sorting,
+  }
+  //syntax 1
+  onPaginationChange: (updater) => {
+    setPagination(old => {
+      const newPaginationValue = updater instanceof Function ? updater(old) : updater
+      //do something with the new pagination value
+      //...
+      return newPaginationValue
+    })
+  },
+  //syntax 2
+  onSortingChange: (updater) => {
+    const newSortingValue = updater instanceof Function ? updater(sorting) : updater
+    //do something with the new sorting value
+    //...
+    setSorting(updater) //normal state update
+  }
+})
+```
+
+### State Types
+
+All complex states in TanStack Table have their own TypeScript types that you can import and use. This can be handy for ensuring that you are using the correct data structures and properties for the state values that you are controlling.
+
+```tsx
+import { usePreactTable, type SortingState } from '@tanstack/preact-table'
+//...
+const [sorting, setSorting] = useState<SortingState[]>([
+  {
+    id: 'age', //you should get autocomplete for the `id` and `desc` properties
+    desc: true,
+  }
+])
+```

--- a/docs/framework/preact/preact-table.md
+++ b/docs/framework/preact/preact-table.md
@@ -1,0 +1,19 @@
+---
+title: Preact Table
+---
+
+The `@tanstack/preact-table` adapter is a wrapper around the core table logic. Most of its job is related to managing state the "preact" way, providing types and the rendering implementation of cell/header/footer templates.
+
+## `usePreactTable`
+
+Takes an `options` object and returns a table.
+
+```tsx
+import { usePreactTable } from '@tanstack/preact-table'
+
+function App() {
+  const table = usePreactTable(options)
+
+  // ...render your table
+}
+```

--- a/docs/guide/tables.md
+++ b/docs/guide/tables.md
@@ -8,7 +8,7 @@ title: Table Instance Guide
 
 ## Table Instance Guide
 
-TanStack Table is a headless UI library. When we talk about the `table` or "table instance", we're not talking about a literal `<table>` element. Instead, we're referring to the core table object that contains the table state and APIs. The `table` instance is created by calling your adapter's `createTable` function (e.g. `useReactTable`, `createSolidTable`, `createSvelteTable`, `useQwikTable`, `useVueTable`).
+TanStack Table is a headless UI library. When we talk about the `table` or "table instance", we're not talking about a literal `<table>` element. Instead, we're referring to the core table object that contains the table state and APIs. The `table` instance is created by calling your adapter's `createTable` function (e.g. `useReactTable`, `usePreactTable`, `createSolidTable`, `createSvelteTable`, `useQwikTable`, `useVueTable`).
 
 ### Creating a Table Instance
 
@@ -91,6 +91,9 @@ const table = createTable({ columns, data })
 
 //react
 const table = useReactTable({ columns, data })
+
+//preact
+const table = usePreactTable({ columns, data })
 
 //solid
 const table = createSolidTable({ columns, data })

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,14 @@ The `@tanstack/react-table` package works with React 16.8, React 17, React 18, a
 
 > NOTE: Even though the react adapter works with React 19, it may not work with the new React Compiler that's coming out along-side React 19. This may be fixed in future TanStack Table updates.
 
+## Preact Table
+
+```bash
+npm install @tanstack/preact-table
+```
+
+The `@tanstack/preact-table` package works with Preact 10.
+
 ## Vue Table
 
 ```bash

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -2,7 +2,7 @@
 title: Introduction
 ---
 
-TanStack Table is a **Headless UI** library for building powerful tables & datagrids for TS/JS, React, Vue, Solid, Qwik, and Svelte.
+TanStack Table is a **Headless UI** library for building powerful tables & datagrids for TS/JS, React, Preact, Vue, Solid, Qwik, and Svelte.
 
 ## What is "headless" UI?
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,7 +10,7 @@ While TanStack Table is written in [TypeScript](https://www.typescriptlang.org/)
 
 ## Headless
 
-As it was mentioned extensively in the [Intro](./introduction.md) section, TanStack Table is **headless**. This means that it doesn't render any DOM elements, and instead relies on you, the UI/UX developer to provide the table's markup and styles. This is a great way to build a table that can be used in any UI framework, including React, Vue, Solid, Svelte, Qwik, and even JS-to-native platforms like React Native!
+As it was mentioned extensively in the [Intro](./introduction.md) section, TanStack Table is **headless**. This means that it doesn't render any DOM elements, and instead relies on you, the UI/UX developer to provide the table's markup and styles. This is a great way to build a table that can be used in any UI framework, including React, Preact, Vue, Solid, Svelte, Qwik, and even JS-to-native platforms like React Native!
 
 ## Core Objects and Types
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "pnpm run test:ci",
     "test:pr": "nx affected --targets=test:sherif,test:knip,test:docs,test:lib,test:types,build",
     "test:ci": "nx run-many --targets=test:sherif,test:knip,test:docs,test:lib,test:types,build",
-    "test:sherif": "sherif -i react -i react-dom -i vue -i solid-js -i svelte -i @builder.io/qwik",
+    "test:sherif": "sherif -i preact -i react -i react-dom -i vue -i solid-js -i svelte -i @builder.io/qwik",
     "test:lib": "nx affected --targets=test:lib --exclude=examples/**",
     "test:lib:dev": "pnpm test:lib && nx watch --all -- pnpm test:lib",
     "test:types": "nx affected --targets=test:types --exclude=examples/**",

--- a/packages/preact-table/package.json
+++ b/packages/preact-table/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@tanstack/preact-table",
+  "version": "8.21.3",
+  "description": "Headless UI for building powerful tables & datagrids for Preact.",
+  "author": "Tanner Linsley",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TanStack/table.git",
+    "directory": "packages/preact-table"
+  },
+  "homepage": "https://tanstack.com/table",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
+  "keywords": [
+    "preact",
+    "table",
+    "preact-table",
+    "datagrid"
+  ],
+  "type": "commonjs",
+  "module": "build/lib/index.esm.js",
+  "main": "build/lib/index.js",
+  "types": "build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.mjs",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "engines": {
+    "node": ">=12"
+  },
+  "files": [
+    "build/lib/*",
+    "build/umd/*",
+    "src"
+  ],
+  "scripts": {
+    "clean": "rimraf ./build",
+    "test:lib": "vitest",
+    "test:lib:dev": "pnpm test:lib --watch",
+    "test:types": "tsc --noEmit",
+    "build": "pnpm build:rollup && pnpm build:types",
+    "build:rollup": "rollup --config rollup.config.mjs",
+    "build:types": "tsc --emitDeclarationOnly"
+  },
+  "dependencies": {
+    "@tanstack/table-core": "workspace:*"
+  },
+  "devDependencies": {
+    "preact": "^10.23.2"
+  },
+  "peerDependencies": {
+    "preact": ">=10"
+  }
+}

--- a/packages/preact-table/rollup.config.mjs
+++ b/packages/preact-table/rollup.config.mjs
@@ -1,0 +1,18 @@
+// @ts-check
+
+import { defineConfig } from 'rollup'
+import { buildConfigs } from '../../scripts/getRollupConfig.js'
+
+export default defineConfig(
+  buildConfigs({
+    name: 'preact-table',
+    jsName: 'PreactTable',
+    outputFile: 'index',
+    entryFile: 'src/index.ts',
+    external: ['preact', 'preact/hooks', '@tanstack/table-core'],
+    globals: {
+      preact: 'preact',
+      'preact/hooks': 'preactHooks',
+    },
+  }),
+)

--- a/packages/preact-table/src/index.ts
+++ b/packages/preact-table/src/index.ts
@@ -1,0 +1,68 @@
+import type { ComponentChildren, ComponentType, VNode } from 'preact'
+import { h } from 'preact'
+import { useState } from 'preact/hooks'
+export * from '@tanstack/table-core'
+
+import {
+  TableOptions,
+  TableOptionsResolved,
+  RowData,
+  createTable,
+} from '@tanstack/table-core'
+
+export type Renderable<TProps> = ComponentChildren | ComponentType<TProps>
+
+/**
+ * If rendering headers, cells, or footers with custom markup, use flexRender instead of `cell.getValue()` or `cell.renderValue()`.
+ */
+export function flexRender<TProps extends object>(
+  Comp: Renderable<TProps>,
+  props: TProps,
+): ComponentChildren | VNode<TProps> {
+  return !Comp ? null : isComponent<TProps>(Comp) ? h(Comp, props) : Comp
+}
+
+function isComponent<TProps>(
+  component: unknown,
+): component is ComponentType<TProps> {
+  return typeof component === 'function'
+}
+
+export function usePreactTable<TData extends RowData>(
+  options: TableOptions<TData>,
+) {
+  // Compose in the generic options to the user options
+  const resolvedOptions: TableOptionsResolved<TData> = {
+    state: {}, // Dummy state
+    onStateChange: () => {}, // noop
+    renderFallbackValue: null,
+    ...options,
+  }
+
+  // Create a new table and store it in state
+  const [tableRef] = useState(() => ({
+    current: createTable<TData>(resolvedOptions),
+  }))
+
+  // By default, manage table state here using the table's initial state
+  const [state, setState] = useState(() => tableRef.current.initialState)
+
+  // Compose the default state above with any user state. This will allow the user
+  // to only control a subset of the state if desired.
+  tableRef.current.setOptions((prev) => ({
+    ...prev,
+    ...options,
+    state: {
+      ...state,
+      ...options.state,
+    },
+    // Similarly, we'll maintain both our internal state and any user-provided
+    // state.
+    onStateChange: (updater) => {
+      setState(updater)
+      options.onStateChange?.(updater)
+    },
+  }))
+
+  return tableRef.current
+}

--- a/packages/preact-table/tests/core/core.test.tsx
+++ b/packages/preact-table/tests/core/core.test.tsx
@@ -1,0 +1,142 @@
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from 'vitest'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { useReducer } from 'preact/hooks'
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  usePreactTable,
+} from '../../src'
+
+type Person = {
+  firstName: string
+  lastName: string
+  age: number
+}
+
+const defaultData: Person[] = [
+  { firstName: 'tanner', lastName: 'linsley', age: 29 },
+  { firstName: 'joe', lastName: 'bergevin', age: 45 },
+]
+
+const defaultColumns: ColumnDef<Person>[] = [
+  {
+    accessorKey: 'firstName',
+    header: 'First Name',
+    cell: (info) => info.getValue(),
+  },
+  {
+    accessorKey: 'age',
+    header: 'Age',
+    cell: (info) => info.getValue(),
+  },
+]
+
+function makeContainer() {
+  const container = document.createElement('div')
+  document.body.append(container)
+  return container
+}
+
+describe('preact-table core', () => {
+  it('flexRender handles null, primitives, and component renderables', () => {
+    const container = makeContainer()
+
+    expect(flexRender<{}>(null as any, {})).toBeNull()
+    expect(flexRender<any>('static', {} as any)).toEqual('static')
+
+    const Greeting = ({ name }: { name: string }) => <span>Hello {name}</span>
+    const node = flexRender(Greeting, { name: 'Preact' })
+
+    act(() => {
+      render(<div>{node}</div>, container)
+    })
+
+    expect(container.textContent).toContain('Hello Preact')
+
+    act(() => {
+      render(null, container)
+    })
+    container.remove()
+  })
+
+  it('keeps a stable table instance across re-renders', () => {
+    const container = makeContainer()
+    let tableRef: ReturnType<typeof usePreactTable<Person>> | undefined
+    let triggerRerender: (() => void) | undefined
+
+    function App() {
+      const [, rerender] = useReducer((x: number) => x + 1, 0)
+      const table = usePreactTable({
+        data: defaultData,
+        columns: defaultColumns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      tableRef = table
+      triggerRerender = () => rerender(Math.random())
+
+      return null
+    }
+
+    act(() => {
+      render(<App />, container)
+    })
+
+    const prev = tableRef
+
+    act(() => {
+      triggerRerender?.()
+    })
+
+    const next = tableRef
+
+    expect(prev).toBeDefined()
+    expect(next).toBeDefined()
+    expect(prev).toStrictEqual(next)
+
+    act(() => {
+      render(null, container)
+    })
+    container.remove()
+  })
+
+  it('updates internal state and calls onStateChange', () => {
+    const container = makeContainer()
+    let tableRef: ReturnType<typeof usePreactTable<Person>> | undefined
+    let onStateChangeCount = 0
+
+    function App() {
+      const table = usePreactTable({
+        data: defaultData,
+        columns: defaultColumns,
+        getCoreRowModel: getCoreRowModel(),
+        onStateChange: () => {
+          onStateChangeCount++
+        },
+      })
+
+      tableRef = table
+      return null
+    }
+
+    act(() => {
+      render(<App />, container)
+    })
+
+    act(() => {
+      tableRef?.setColumnVisibility({ firstName: false })
+    })
+
+    expect(tableRef?.getState().columnVisibility).toEqual({ firstName: false })
+    expect(onStateChangeCount).toBeGreaterThan(0)
+
+    act(() => {
+      render(null, container)
+    })
+    container.remove()
+  })
+})

--- a/packages/preact-table/tests/test-setup.ts
+++ b/packages/preact-table/tests/test-setup.ts
@@ -1,0 +1,1 @@
+// Intentionally empty for now; reserved for shared preact-table test setup.

--- a/packages/preact-table/tsconfig.json
+++ b/packages/preact-table/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./build/lib"
+  },
+  "include": ["src"]
+}

--- a/packages/preact-table/vitest.config.ts
+++ b/packages/preact-table/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+import packageJson from './package.json'
+
+export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'preact',
+  },
+  test: {
+    name: packageJson.name,
+    dir: './tests',
+    watch: false,
+    environment: 'jsdom',
+    setupFiles: ['./tests/test-setup.ts'],
+    globals: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,7 +136,7 @@ importers:
         version: 17.3.11(@angular/common@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1))(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))(@angular/platform-browser@17.3.11(@angular/animations@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(@angular/common@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1))(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(rxjs@7.8.1)
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -209,7 +209,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -282,7 +282,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -355,7 +355,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -431,7 +431,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -501,7 +501,7 @@ importers:
         version: 17.3.11(@angular/common@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1))(@angular/compiler@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))(@angular/platform-browser@17.3.11(@angular/animations@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))(@angular/common@17.3.11(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1))(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7)))
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -577,7 +577,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -653,7 +653,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -705,7 +705,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -778,7 +778,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -857,7 +857,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -930,7 +930,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -1003,7 +1003,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -1073,7 +1073,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -1149,7 +1149,7 @@ importers:
         version: 8.4.1
       '@tanstack/angular-table':
         specifier: ^8.21.3
-        version: link:../../../packages/angular-table
+        version: 8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -1177,7 +1177,7 @@ importers:
     dependencies:
       '@tanstack/lit-table':
         specifier: ^8.21.3
-        version: link:../../../packages/lit-table
+        version: 8.21.3(lit@3.1.4)
       '@twind/core':
         specifier: ^1.1.3
         version: 1.1.3(typescript@5.4.5)
@@ -1211,7 +1211,7 @@ importers:
         version: 8.4.1
       '@tanstack/lit-table':
         specifier: ^8.21.3
-        version: link:../../../packages/lit-table
+        version: 8.21.3(lit@3.1.4)
       lit:
         specifier: ^3.1.4
         version: 3.1.4
@@ -1233,7 +1233,7 @@ importers:
         version: 8.4.1
       '@tanstack/lit-table':
         specifier: ^8.21.3
-        version: link:../../../packages/lit-table
+        version: 8.21.3(lit@3.1.4)
       lit:
         specifier: ^3.1.4
         version: 3.1.4
@@ -1255,7 +1255,7 @@ importers:
         version: 8.4.1
       '@tanstack/lit-table':
         specifier: ^8.21.3
-        version: link:../../../packages/lit-table
+        version: 8.21.3(lit@3.1.4)
       lit:
         specifier: ^3.1.4
         version: 3.1.4
@@ -1277,7 +1277,7 @@ importers:
         version: 8.4.1
       '@tanstack/lit-table':
         specifier: ^8.21.3
-        version: link:../../../packages/lit-table
+        version: 8.21.3(lit@3.1.4)
       lit:
         specifier: ^3.1.4
         version: 3.1.4
@@ -1299,7 +1299,7 @@ importers:
         version: 8.4.1
       '@tanstack/lit-table':
         specifier: ^8.21.3
-        version: link:../../../packages/lit-table
+        version: 8.21.3(lit@3.1.4)
       lit:
         specifier: ^3.1.4
         version: 3.1.4
@@ -1321,7 +1321,7 @@ importers:
         version: 8.4.1
       '@tanstack/lit-table':
         specifier: ^8.21.3
-        version: link:../../../packages/lit-table
+        version: 8.21.3(lit@3.1.4)
       '@tanstack/lit-virtual':
         specifier: ^3.8.3
         version: 3.8.3(lit@3.1.4)
@@ -1343,7 +1343,7 @@ importers:
     dependencies:
       '@tanstack/qwik-table':
         specifier: ^8.21.3
-        version: link:../../../packages/qwik-table
+        version: 8.21.3(@builder.io/qwik@1.6.0(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1)(undici@7.16.0))
     devDependencies:
       '@builder.io/qwik':
         specifier: ^1.6.0
@@ -1362,10 +1362,10 @@ importers:
     dependencies:
       '@tanstack/match-sorter-utils':
         specifier: ^8.19.4
-        version: link:../../../packages/match-sorter-utils
+        version: 8.19.4
       '@tanstack/qwik-table':
         specifier: ^8.21.3
-        version: link:../../../packages/qwik-table
+        version: 8.21.3(@builder.io/qwik@1.6.0(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1)(undici@7.16.0))
     devDependencies:
       '@builder.io/qwik':
         specifier: ^1.6.0
@@ -1387,7 +1387,7 @@ importers:
     dependencies:
       '@tanstack/qwik-table':
         specifier: ^8.21.3
-        version: link:../../../packages/qwik-table
+        version: 8.21.3(@builder.io/qwik@1.6.0(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1)(undici@7.16.0))
     devDependencies:
       '@builder.io/qwik':
         specifier: ^1.6.0
@@ -1409,7 +1409,7 @@ importers:
     dependencies:
       '@tanstack/qwik-table':
         specifier: ^8.21.3
-        version: link:../../../packages/qwik-table
+        version: 8.21.3(@builder.io/qwik@1.6.0(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1)(undici@7.16.0))
     devDependencies:
       '@builder.io/qwik':
         specifier: ^1.6.0
@@ -1431,7 +1431,7 @@ importers:
     dependencies:
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1462,7 +1462,7 @@ importers:
     dependencies:
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       bootstrap:
         specifier: ^5.3.3
         version: 5.3.3(@popperjs/core@2.11.8)
@@ -1523,7 +1523,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1554,7 +1554,7 @@ importers:
     dependencies:
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1588,7 +1588,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1622,7 +1622,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1656,7 +1656,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1690,7 +1690,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1721,7 +1721,7 @@ importers:
     dependencies:
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1752,7 +1752,7 @@ importers:
     dependencies:
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1786,7 +1786,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1820,7 +1820,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1854,7 +1854,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1888,10 +1888,10 @@ importers:
         version: 8.4.1
       '@tanstack/match-sorter-utils':
         specifier: ^8.19.4
-        version: link:../../../packages/match-sorter-utils
+        version: 8.19.4
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1925,10 +1925,10 @@ importers:
         version: 8.4.1
       '@tanstack/match-sorter-utils':
         specifier: ^8.19.4
-        version: link:../../../packages/match-sorter-utils
+        version: 8.19.4
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1962,10 +1962,10 @@ importers:
         version: 8.4.1
       '@tanstack/match-sorter-utils':
         specifier: ^8.19.4
-        version: link:../../../packages/match-sorter-utils
+        version: 8.19.4
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1999,7 +1999,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2033,7 +2033,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2067,7 +2067,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2101,7 +2101,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2138,10 +2138,10 @@ importers:
         version: 11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1)
       '@tanstack/match-sorter-utils':
         specifier: ^8.19.4
-        version: link:../../../packages/match-sorter-utils
+        version: 8.19.4
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2193,7 +2193,7 @@ importers:
         version: 5.15.21(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2230,7 +2230,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2267,7 +2267,7 @@ importers:
         version: 5.49.0(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2304,7 +2304,7 @@ importers:
         version: 1.43.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2356,7 +2356,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2390,7 +2390,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2424,7 +2424,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2458,7 +2458,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2492,7 +2492,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2526,7 +2526,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-virtual':
         specifier: ^3.12.0
         version: 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2563,7 +2563,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-virtual':
         specifier: ^3.12.0
         version: 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2603,7 +2603,7 @@ importers:
         version: 5.49.0(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-virtual':
         specifier: ^3.12.0
         version: 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2640,7 +2640,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-virtual':
         specifier: ^3.12.0
         version: 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2677,7 +2677,7 @@ importers:
         version: 8.4.1
       '@tanstack/react-table':
         specifier: ^8.21.3
-        version: link:../../../packages/react-table
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-virtual':
         specifier: ^3.12.0
         version: 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2711,7 +2711,7 @@ importers:
     dependencies:
       '@tanstack/solid-table':
         specifier: ^8.21.3
-        version: link:../../../packages/solid-table
+        version: 8.21.3(solid-js@1.8.18)
       solid-js:
         specifier: ^1.8.18
         version: 1.8.18
@@ -2730,7 +2730,7 @@ importers:
     dependencies:
       '@tanstack/solid-table':
         specifier: ^8.21.3
-        version: link:../../../packages/solid-table
+        version: 8.21.3(solid-js@1.8.18)
       bootstrap:
         specifier: ^5.3.3
         version: 5.3.3(@popperjs/core@2.11.8)
@@ -2758,7 +2758,7 @@ importers:
     dependencies:
       '@tanstack/solid-table':
         specifier: ^8.21.3
-        version: link:../../../packages/solid-table
+        version: 8.21.3(solid-js@1.8.18)
       solid-js:
         specifier: ^1.8.18
         version: 1.8.18
@@ -2777,7 +2777,7 @@ importers:
     dependencies:
       '@tanstack/solid-table':
         specifier: ^8.21.3
-        version: link:../../../packages/solid-table
+        version: 8.21.3(solid-js@1.8.18)
       solid-js:
         specifier: ^1.8.18
         version: 1.8.18
@@ -2799,7 +2799,7 @@ importers:
     dependencies:
       '@tanstack/solid-table':
         specifier: ^8.21.3
-        version: link:../../../packages/solid-table
+        version: 8.21.3(solid-js@1.8.18)
       solid-js:
         specifier: ^1.8.18
         version: 1.8.18
@@ -2821,7 +2821,7 @@ importers:
         version: 1.4.3(solid-js@1.8.18)
       '@tanstack/solid-table':
         specifier: ^8.21.3
-        version: link:../../../packages/solid-table
+        version: 8.21.3(solid-js@1.8.18)
       solid-js:
         specifier: ^1.8.18
         version: 1.8.18
@@ -2843,7 +2843,7 @@ importers:
     dependencies:
       '@tanstack/solid-table':
         specifier: ^8.21.3
-        version: link:../../../packages/solid-table
+        version: 8.21.3(solid-js@1.8.18)
       solid-js:
         specifier: ^1.8.18
         version: 1.8.18
@@ -2871,7 +2871,7 @@ importers:
         version: 3.1.1(svelte@4.2.18)(vite@5.3.2(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1))
       '@tanstack/svelte-table':
         specifier: ^8.21.3
-        version: link:../../../packages/svelte-table
+        version: 8.21.3(svelte@4.2.18)
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -2898,7 +2898,7 @@ importers:
         version: 3.1.1(svelte@4.2.18)(vite@5.3.2(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1))
       '@tanstack/svelte-table':
         specifier: ^8.21.3
-        version: link:../../../packages/svelte-table
+        version: 8.21.3(svelte@4.2.18)
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -2928,7 +2928,7 @@ importers:
         version: 3.1.1(svelte@4.2.18)(vite@5.3.2(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1))
       '@tanstack/svelte-table':
         specifier: ^8.21.3
-        version: link:../../../packages/svelte-table
+        version: 8.21.3(svelte@4.2.18)
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -2958,7 +2958,7 @@ importers:
         version: 3.1.1(svelte@4.2.18)(vite@5.3.2(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1))
       '@tanstack/svelte-table':
         specifier: ^8.21.3
-        version: link:../../../packages/svelte-table
+        version: 8.21.3(svelte@4.2.18)
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -2985,7 +2985,7 @@ importers:
         version: 3.1.1(svelte@4.2.18)(vite@5.3.2(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1))
       '@tanstack/svelte-table':
         specifier: ^8.21.3
-        version: link:../../../packages/svelte-table
+        version: 8.21.3(svelte@4.2.18)
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -3015,10 +3015,10 @@ importers:
         version: 3.1.1(svelte@4.2.18)(vite@5.3.2(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1))
       '@tanstack/match-sorter-utils':
         specifier: ^8.19.4
-        version: link:../../../packages/match-sorter-utils
+        version: 8.19.4
       '@tanstack/svelte-table':
         specifier: ^8.21.3
-        version: link:../../../packages/svelte-table
+        version: 8.21.3(svelte@4.2.18)
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -3048,7 +3048,7 @@ importers:
         version: 3.1.1(svelte@4.2.18)(vite@5.3.2(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1))
       '@tanstack/svelte-table':
         specifier: ^8.21.3
-        version: link:../../../packages/svelte-table
+        version: 8.21.3(svelte@4.2.18)
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -3069,7 +3069,7 @@ importers:
     dependencies:
       '@tanstack/table-core':
         specifier: ^8.21.3
-        version: link:../../../packages/table-core
+        version: 8.21.3
       nanostores:
         specifier: ^0.11.3
         version: 0.11.3
@@ -3088,7 +3088,7 @@ importers:
     dependencies:
       '@tanstack/table-core':
         specifier: ^8.21.3
-        version: link:../../../packages/table-core
+        version: 8.21.3
       nanostores:
         specifier: ^0.11.3
         version: 0.11.3
@@ -3110,7 +3110,7 @@ importers:
     dependencies:
       '@tanstack/table-core':
         specifier: ^8.21.3
-        version: link:../../../packages/table-core
+        version: 8.21.3
       nanostores:
         specifier: ^0.11.3
         version: 0.11.3
@@ -3132,7 +3132,7 @@ importers:
     dependencies:
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.4.31(typescript@5.4.5))
       vue:
         specifier: ^3.4.31
         version: 3.4.31(typescript@5.4.5)
@@ -3160,7 +3160,7 @@ importers:
         version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.4.31(typescript@5.4.5))
       vue:
         specifier: ^3.4.31
         version: 3.4.31(typescript@5.4.5)
@@ -3188,7 +3188,7 @@ importers:
         version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.4.31(typescript@5.4.5))
       vue:
         specifier: ^3.4.31
         version: 3.4.31(typescript@5.4.5)
@@ -3216,7 +3216,7 @@ importers:
         version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.4.31(typescript@5.4.5))
       vue:
         specifier: ^3.4.31
         version: 3.4.31(typescript@5.4.5)
@@ -3241,7 +3241,7 @@ importers:
     dependencies:
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.5.13(typescript@5.4.5))
       vue:
         specifier: ^3.4.31
         version: 3.5.13(typescript@5.4.5)
@@ -3269,7 +3269,7 @@ importers:
         version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.4.31(typescript@5.4.5))
       vue:
         specifier: ^3.4.31
         version: 3.4.31(typescript@5.4.5)
@@ -3297,7 +3297,7 @@ importers:
         version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.4.31(typescript@5.4.5))
       vue:
         specifier: ^3.4.31
         version: 3.4.31(typescript@5.4.5)
@@ -3325,7 +3325,7 @@ importers:
         version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.4.31(typescript@5.4.5))
       vue:
         specifier: ^3.4.31
         version: 3.4.31(typescript@5.4.5)
@@ -3356,7 +3356,7 @@ importers:
         version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.4.31(typescript@5.4.5))
       vue:
         specifier: ^3.4.31
         version: 3.4.31(typescript@5.4.5)
@@ -3384,7 +3384,7 @@ importers:
         version: 8.4.1
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.4.31(typescript@5.4.5))
       vue:
         specifier: ^3.4.31
         version: 3.4.31(typescript@5.4.5)
@@ -3409,7 +3409,7 @@ importers:
     dependencies:
       '@tanstack/vue-table':
         specifier: ^8.21.3
-        version: link:../../../packages/vue-table
+        version: 8.21.3(vue@3.5.13(typescript@5.4.5))
       '@tanstack/vue-virtual':
         specifier: ^3.10.8
         version: 3.11.2(vue@3.5.13(typescript@5.4.5))
@@ -3485,6 +3485,16 @@ importers:
       remove-accents:
         specifier: 0.5.0
         version: 0.5.0
+
+  packages/preact-table:
+    dependencies:
+      '@tanstack/table-core':
+        specifier: workspace:*
+        version: link:../table-core
+    devDependencies:
+      preact:
+        specifier: ^10.23.2
+        version: 10.28.3
 
   packages/qwik-table:
     dependencies:
@@ -5866,17 +5876,39 @@ packages:
   '@swc/helpers@0.5.11':
     resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
 
+  '@tanstack/angular-table@8.21.3':
+    resolution: {integrity: sha512-8VqEGObnTBNJm3qQSPy+WEGqjXDLesEPSnBTEHdbHFh1rMP1pQsgI85Dwy8OX4kB82wIDvJuw4LceGIXZEbotA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@angular/core': '>=17'
+
   '@tanstack/history@1.41.0':
     resolution: {integrity: sha512-euTyZoHidW1+NeAW9V7SSPNjD6c54TBqKBO8HypA880HWlTXLW6V8rcBnfi1LY1W706dGCvDmZDTg6fsl/jJUw==}
     engines: {node: '>=12'}
+
+  '@tanstack/lit-table@8.21.3':
+    resolution: {integrity: sha512-NXe/No6HRGN+OZMJ1pKmoejiFS1QfjirWYOiahBWMojSsLIB5SqYb45L/jlswpKhEAaMWCdps8c93z8HfMG9Kg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      lit: ^3.1.3
 
   '@tanstack/lit-virtual@3.8.3':
     resolution: {integrity: sha512-SONYxXVjK8G0ZL3XF1Byc/U0c3ZNKyzYzSr2y4IW58X55K7OrQrLvAjJb/p1ZVLcX1T6GVMoFA3zeFss1fRwXg==}
     peerDependencies:
       lit: ^3.1.0
 
+  '@tanstack/match-sorter-utils@8.19.4':
+    resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
+    engines: {node: '>=12'}
+
   '@tanstack/query-core@5.49.0':
     resolution: {integrity: sha512-xUTjCPHC8G+ZvIUzjoMOLnMpNXYPQI4HjhlizTVVBwtSp24iWo4/kaBzHAzsrCVyfbiaPIFFkUvicsY4r8kF8A==}
+
+  '@tanstack/qwik-table@8.21.3':
+    resolution: {integrity: sha512-XcKytZ0PVrBYiuzBxxUDqiEzX1IP+r9flaZBOcPZpT2mo2+IND8cSh4+48mma9MNwldTLcfHWWe1QwGP4xAidQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@builder.io/qwik': '>=1.5'
 
   '@tanstack/react-query@5.49.0':
     resolution: {integrity: sha512-3A0BDwGVk6UzWFdz+WTC9HHts9kI42XYLK78/DGmoj9fd6W/NsjEjI5S4lPPebgq9cWWPo9QNciaSWfH71RgNg==}
@@ -5895,6 +5927,13 @@ packages:
     peerDependencies:
       react: '>=16'
       react-dom: '>=16'
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
 
   '@tanstack/react-virtual@3.12.0':
     resolution: {integrity: sha512-6krceiPN07kpxXmU6m8AY7EL0X1gHLu8m3nJdh4phvktzVNxkQfBmSwnRUpoUjGQO1PAn8wSAhYaL8hY1cS1vw==}
@@ -5922,8 +5961,24 @@ packages:
     resolution: {integrity: sha512-yEQV2KQJVolqzWYUpma4uYnOK0hYhXY8GVCWD5UFf3QtDMU2KbsXnBrToZQ1c/m9XrgyD3bWfvVvk/UwT8FVYQ==}
     engines: {node: '>=12'}
 
+  '@tanstack/solid-table@8.21.3':
+    resolution: {integrity: sha512-PmhfSLBxVKiFs01LtYOYrCRhCyTUjxmb4KlxRQiqcALtip8+DOJeeezQM4RSX/GUS0SMVHyH/dNboCpcO++k2A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      solid-js: '>=1.3'
+
   '@tanstack/store@0.1.3':
     resolution: {integrity: sha512-GnolmC8Fr4mvsHE1fGQmR3Nm0eBO3KnZjDU0a+P3TeQNM/dDscFGxtA7p31NplQNW3KwBw4t1RVFmz0VeKLxcw==}
+
+  '@tanstack/svelte-table@8.21.3':
+    resolution: {integrity: sha512-VwLt2xfsYHdchdYdFfcl9bxlJts1I6JK50xqhH+KMB9co98rnIyL4pRhTMSDfuB448yQR9E7d6oBLjx8r69cVg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      svelte: ^4.0.0 || ^3.49.0
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.11.2':
     resolution: {integrity: sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==}
@@ -5933,6 +5988,12 @@ packages:
 
   '@tanstack/virtual-core@3.8.3':
     resolution: {integrity: sha512-vd2A2TnM5lbnWZnHi9B+L2gPtkSeOtJOAw358JqokIH1+v2J7vUAzFVPwB/wrye12RFOurffXu33plm4uQ+JBQ==}
+
+  '@tanstack/vue-table@8.21.3':
+    resolution: {integrity: sha512-rusRyd77c5tDPloPskctMyPLFEQUeBzxdQ+2Eow4F7gDPlPOB1UnnhzfpdvqZ8ZyX2rRNGmqNnQWm87OI2OQPw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      vue: '>=3.2'
 
   '@tanstack/vue-virtual@3.11.2':
     resolution: {integrity: sha512-y0b1p1FTlzxcSt/ZdGWY1AZ52ddwSU69pvFRYAELUSdLLxV8QOPe9dyT/KATO43UCb3DAwiyzi96h2IoYstBOQ==}
@@ -8955,6 +9016,9 @@ packages:
   postcss@8.4.49:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact@10.28.3:
+    resolution: {integrity: sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==}
 
   prettier-plugin-svelte@3.2.5:
     resolution: {integrity: sha512-vP/M/Goc8z4iVIvrwXwbrYVjJgA0Hf8PO1G4LBh/ocSt6vUP6sLvyu9F3ABEGr+dbKyxZjEKLkeFsWy/yYl0HQ==}
@@ -13591,14 +13655,34 @@ snapshots:
     dependencies:
       tslib: 2.6.3
 
+  '@tanstack/angular-table@8.21.3(@angular/core@17.3.11(rxjs@7.8.1)(zone.js@0.14.7))':
+    dependencies:
+      '@angular/core': 17.3.11(rxjs@7.8.1)(zone.js@0.14.7)
+      '@tanstack/table-core': 8.21.3
+      tslib: 2.6.3
+
   '@tanstack/history@1.41.0': {}
+
+  '@tanstack/lit-table@8.21.3(lit@3.1.4)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      lit: 3.1.4
 
   '@tanstack/lit-virtual@3.8.3(lit@3.1.4)':
     dependencies:
       '@tanstack/virtual-core': 3.8.3
       lit: 3.1.4
 
+  '@tanstack/match-sorter-utils@8.19.4':
+    dependencies:
+      remove-accents: 0.5.0
+
   '@tanstack/query-core@5.49.0': {}
+
+  '@tanstack/qwik-table@8.21.3(@builder.io/qwik@1.6.0(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1)(undici@7.16.0))':
+    dependencies:
+      '@builder.io/qwik': 1.6.0(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(terser@5.31.1)(undici@7.16.0)
+      '@tanstack/table-core': 8.21.3
 
   '@tanstack/react-query@5.49.0(react@18.3.1)':
     dependencies:
@@ -13620,6 +13704,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.2.2(react@18.3.1)
+
+  '@tanstack/react-table@8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@tanstack/react-virtual@3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -13663,13 +13753,35 @@ snapshots:
       - supports-color
       - vite
 
+  '@tanstack/solid-table@8.21.3(solid-js@1.8.18)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      solid-js: 1.8.18
+
   '@tanstack/store@0.1.3': {}
+
+  '@tanstack/svelte-table@8.21.3(svelte@4.2.18)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      svelte: 4.2.18
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.11.2': {}
 
   '@tanstack/virtual-core@3.12.0': {}
 
   '@tanstack/virtual-core@3.8.3': {}
+
+  '@tanstack/vue-table@8.21.3(vue@3.4.31(typescript@5.4.5))':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      vue: 3.4.31(typescript@5.4.5)
+
+  '@tanstack/vue-table@8.21.3(vue@3.5.13(typescript@5.4.5))':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      vue: 3.5.13(typescript@5.4.5)
 
   '@tanstack/vue-virtual@3.11.2(vue@3.5.13(typescript@5.4.5))':
     dependencies:
@@ -17111,6 +17223,8 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact@10.28.3: {}
 
   prettier-plugin-svelte@3.2.5(prettier@3.7.4)(svelte@4.2.18):
     dependencies:


### PR DESCRIPTION
## 🎯 Changes

- Added a new `@tanstack/preact-table` adapter package aligned with existing framework integrations.
- Implemented `usePreactTable` and `flexRender` with `@tanstack/table-core` re-exports.
- Wired docs/navigation for Preact (`README`, install docs, framework pages, and docs config).
- Added a `preact` ignore in `test:sherif` and updated lockfile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added official Preact framework support to TanStack Table
  * Introduced usePreactTable hook for seamless Preact integration
  * New flexRender utility for rendering Preact components and values

* **Documentation**
  * Added comprehensive Preact integration guides covering table state management and setup
  * Updated framework overview and installation documentation to include Preact

<!-- end of auto-generated comment: release notes by coderabbit.ai -->