### PR TITLE
fix: table-core's getIsAllSubRowsSelected returns false when subrows are unselectable

### DIFF
--- a/.changeset/cute-walls-judge.md
+++ b/.changeset/cute-walls-judge.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Fixed table-core `row.getIsAllSubRowsSelected` now returns false when subrows are unselectable ()

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -503,15 +503,14 @@ export const RowSelection: TableFeature = {
     }
 
     row.getIsSomeSelected = () => {
-      const selectable = getSelectableSubRowCount(row)
-      const selected = getSelectedSubRowCount(row)
-      return selected > 0 && selected < selectable;
+      const { selectableCount, selectedCount } = getSubRowSelectionsCount(row);
+      return selectedCount > 0 && selectedCount < selectableCount;
     }
 
     row.getIsAllSubRowsSelected = () => {
-      const selectable = getSelectableSubRowCount(row)
-      const selected = getSelectedSubRowCount(row)
-      return selected > 0 && selected === selectable;
+      const { selectableCount, selectedCount } = getSubRowSelectionsCount(row);
+
+      return selectedCount > 0 && selectedCount === selectableCount;
     }
 
     row.getCanSelect = () => {
@@ -639,42 +638,40 @@ export function isRowSelected<TData extends RowData>(
 }
 
 /**
- * Determines the number of selectable sub-rows and nested sub-rows using BFS traversal
- *
- * @param {Row<TData>} row - The table row to evaluate.
- * @returns {number} The number of selectable sub rows.
- */
-export function getSelectableSubRowCount<TData extends RowData>(row: Row<TData>): number {
-  return countSubRows(row, (node) => node.getCanSelect());
-};
-
-/**
- * Determines the number of selectable and selected sub-rows and nested sub-rows using BFS traversal
- *
- * @param {Row<TData>} row - The table row to evaluate.
- * @returns {number} The number of selected sub rows.
- */
-export function getSelectedSubRowCount<TData extends RowData>(row: Row<TData>): number {
-  return countSubRows(row, (node) => node.getCanSelect() && node.getIsSelected());
-};
-
-/**
- * Count the number of sub-rows that satisfy a given condition (checked via BFS across all nested sub-rows).
+ * Determines the number of selectable sub-rows and selected sub-rows (checked via BFS across all nested sub-rows).
  *
  * @param row The table row to evaluate.
- * @param eligibility A function that takes a row and returns a boolean indicating whether the row should be counted.
  * @returns The number of sub-rows that satisfy the condition.
  */
-function countSubRows<TData extends RowData>(row: Row<TData>, eligibility: (row: Row<TData>) => boolean): number {
+export function getSubRowSelectionsCount<TData extends RowData>(row: Row<TData>): { selectableCount: number, selectedCount: number } {
   const q = [...row.subRows];
-  let count = 0;
-  while (q.length) {
-    const node = q.shift()!;
-    if (eligibility(node)) {
-      count += 1;
+  let selectableCount = 0;
+  let selectedCount = 0;
+  let index = 0;
+  while (index < q.length) {
+    const node = q[index]!;
+    if (node.getCanSelect()) {
+      selectableCount += 1;
+      if (node.getIsSelected()) {
+        selectedCount += 1;
+      }
     }
     q.push(...node.subRows);
+    index += 1;
   }
 
-  return count;
+  return { selectableCount, selectedCount };
+}
+
+export function isSubRowSelected<TData extends RowData>(
+  row: Row<TData>,
+  _selection: Record<string, boolean>,
+  _table: Table<TData>,
+): boolean | 'some' | 'all' {
+  if (row.getIsSomeSelected()) {
+    return 'some';
+  } else if (row.getIsAllSubRowsSelected()) {
+    return 'all';
+  }
+  return false;
 }

--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -76,7 +76,7 @@ export interface RowSelectionRow {
    */
   getCanSelectSubRows: () => boolean
   /**
-   * Returns whether or not all of the row's sub rows are selected.
+   * Returns whether or not all of the row's selectable sub rows are selected.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getisallsubrowsselected)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
    */
@@ -88,7 +88,7 @@ export interface RowSelectionRow {
    */
   getIsSelected: () => boolean
   /**
-   * Returns whether or not some of the row's sub rows are selected.
+   * Returns whether or not some of the row's selectable sub rows are selected.
    * @link [API Docs](https://tanstack.com/table/v8/docs/api/features/row-selection#getissomeselected)
    * @link [Guide](https://tanstack.com/table/v8/docs/guide/row-selection)
    */
@@ -503,13 +503,15 @@ export const RowSelection: TableFeature = {
     }
 
     row.getIsSomeSelected = () => {
-      const { rowSelection } = table.getState()
-      return isSubRowSelected(row, rowSelection, table) === 'some'
+      const selectable = getSelectableSubRowCount(row)
+      const selected = getSelectedSubRowCount(row)
+      return selected > 0 && selected < selectable;
     }
 
     row.getIsAllSubRowsSelected = () => {
-      const { rowSelection } = table.getState()
-      return isSubRowSelected(row, rowSelection, table) === 'all'
+      const selectable = getSelectableSubRowCount(row)
+      const selected = getSelectedSubRowCount(row)
+      return selected > 0 && selected === selectable;
     }
 
     row.getCanSelect = () => {
@@ -636,43 +638,43 @@ export function isRowSelected<TData extends RowData>(
   return selection[row.id] ?? false
 }
 
-export function isSubRowSelected<TData extends RowData>(
-  row: Row<TData>,
-  selection: Record<string, boolean>,
-  table: Table<TData>,
-): boolean | 'some' | 'all' {
-  if (!row.subRows?.length) return false
+/**
+ * Determines the number of selectable sub-rows and nested sub-rows using BFS traversal
+ *
+ * @param {Row<TData>} row - The table row to evaluate.
+ * @returns {number} The number of selectable sub rows.
+ */
+export function getSelectableSubRowCount<TData extends RowData>(row: Row<TData>): number {
+  return countSubRows(row, (node) => node.getCanSelect());
+};
 
-  let allChildrenSelected = true
-  let someSelected = false
+/**
+ * Determines the number of selectable and selected sub-rows and nested sub-rows using BFS traversal
+ *
+ * @param {Row<TData>} row - The table row to evaluate.
+ * @returns {number} The number of selected sub rows.
+ */
+export function getSelectedSubRowCount<TData extends RowData>(row: Row<TData>): number {
+  return countSubRows(row, (node) => node.getCanSelect() && node.getIsSelected());
+};
 
-  row.subRows.forEach((subRow) => {
-    // Bail out early if we know both of these
-    if (someSelected && !allChildrenSelected) {
-      return
+/**
+ * Count the number of sub-rows that satisfy a given condition (checked via BFS across all nested sub-rows).
+ *
+ * @param row The table row to evaluate.
+ * @param eligibility A function that takes a row and returns a boolean indicating whether the row should be counted.
+ * @returns The number of sub-rows that satisfy the condition.
+ */
+function countSubRows<TData extends RowData>(row: Row<TData>, eligibility: (row: Row<TData>) => boolean): number {
+  const q = [...row.subRows];
+  let count = 0;
+  while (q.length) {
+    const node = q.shift()!;
+    if (eligibility(node)) {
+      count += 1;
     }
+    q.push(...node.subRows);
+  }
 
-    if (subRow.getCanSelect()) {
-      if (isRowSelected(subRow, selection)) {
-        someSelected = true
-      } else {
-        allChildrenSelected = false
-      }
-    }
-
-    // Check row selection of nested subrows
-    if (subRow.subRows && subRow.subRows.length) {
-      const subRowChildrenSelected = isSubRowSelected(subRow, selection, table)
-      if (subRowChildrenSelected === 'all') {
-        someSelected = true
-      } else if (subRowChildrenSelected === 'some') {
-        someSelected = true
-        allChildrenSelected = false
-      } else {
-        allChildrenSelected = false
-      }
-    }
-  })
-
-  return allChildrenSelected ? 'all' : someSelected ? 'some' : false
+  return count;
 }

--- a/packages/table-core/tests/RowSelection.test.ts
+++ b/packages/table-core/tests/RowSelection.test.ts
@@ -147,92 +147,8 @@ describe('RowSelection', () => {
       expect(result).toEqual(false)
     })
   })
-
-  // IMO the following 2 tests suites are not useful as they are not exposed to the public interface
-  // Instead the 2 RowSelectionRow.* test suites are more useful.
-  describe('getSelectableSubRowCount', () => {
-    it('should return 0 when there are no sub-rows', () => {
-      const data = makeData(1)
-      const columns = generateColumns(data)
-
-      const table = createTable<Person>({
-        enableRowSelection: true,
-        onStateChange() {},
-        renderFallbackValue: '',
-        data,
-        state: { rowSelection: {} },
-        columns,
-        getCoreRowModel: getCoreRowModel(),
-      })
-
-      const firstRow = table.getCoreRowModel().rows[0]
-      const result = RowSelection.getSelectableSubRowCount(firstRow)
-      expect(result).toBe(0)
-    })
-
-    it('should return 0 when all sub-rows are not selectable', () => {
-      const data = makeData(1, 2)
-      const columns = generateColumns(data)
-
-      const table = createTable<Person>({
-        enableRowSelection: (row) => row.depth === 0, // only root rows are selectable
-        onStateChange() {},
-        renderFallbackValue: '',
-        data,
-        getSubRows: (row) => row.subRows,
-        state: { rowSelection: {} },
-        columns,
-        getCoreRowModel: getCoreRowModel(),
-      })
-
-      const firstRow = table.getCoreRowModel().rows[0]
-      const result = RowSelection.getSelectableSubRowCount(firstRow)
-      expect(result).toBe(0)
-    })
-
-    it('should return number of selectable sub-rows', () => {
-      const data = makeData(1, 2)
-      const columns = generateColumns(data)
-
-      const table = createTable<Person>({
-        enableRowSelection: true,
-        onStateChange() {},
-        renderFallbackValue: '',
-        data,
-        getSubRows: (row) => row.subRows,
-        state: { rowSelection: {} },
-        columns,
-        getCoreRowModel: getCoreRowModel(),
-      })
-
-      const firstRow = table.getCoreRowModel().rows[0]
-      const result = RowSelection.getSelectableSubRowCount(firstRow)
-      expect(result).toBe(2)
-    })
-
-    it('should count all nested selectable sub-rows', () => {
-      const data = makeData(1, 2, 2)
-      const columns = generateColumns(data)
-
-      const table = createTable<Person>({
-        enableRowSelection: (row) => row.id !== '0.0.1', // make one of the sub-rows non-selectable
-        onStateChange() {},
-        renderFallbackValue: '',
-        data,
-        getSubRows: (row) => row.subRows,
-        state: { rowSelection: {} },
-        columns,
-        getCoreRowModel: getCoreRowModel(),
-      })
-
-      const firstRow = table.getCoreRowModel().rows[0]
-      const result = RowSelection.getSelectableSubRowCount(firstRow)
-      expect(result).toBe(5) // 2 direct sub-rows + 3 nested sub-rows
-    })
-  })
-
-  describe('getSelectedSubRowCount', () => {
-    it('should return 0 when there are no sub-rows', () => {
+  describe('isSubRowSelected', () => {
+    it('should return false if there are no sub-rows', () => {
       const data = makeData(3)
       const columns = generateColumns(data)
 
@@ -241,38 +157,24 @@ describe('RowSelection', () => {
         onStateChange() {},
         renderFallbackValue: '',
         data,
-        state: { rowSelection: {} },
+        state: {},
         columns,
         getCoreRowModel: getCoreRowModel(),
       })
 
       const firstRow = table.getCoreRowModel().rows[0]
-      const result = RowSelection.getSelectedSubRowCount(firstRow)
-      expect(result).toBe(0)
+
+      const result = RowSelection.isSubRowSelected(
+        firstRow,
+        table.getState().rowSelection,
+        table,
+      )
+
+      expect(result).toEqual(false)
     })
 
-    it('should return 0 when all sub-rows are not selectable', () => {
-      const data = makeData(1, 2)
-      const columns = generateColumns(data)
-
-      const table = createTable<Person>({
-        enableRowSelection: (row) => row.depth === 0, // only root rows are selectable
-        onStateChange() {},
-        renderFallbackValue: '',
-        data,
-        getSubRows: (row) => row.subRows,
-        state: { rowSelection: {} },
-        columns,
-        getCoreRowModel: getCoreRowModel(),
-      })
-
-      const firstRow = table.getCoreRowModel().rows[0]
-      const result = RowSelection.getSelectedSubRowCount(firstRow)
-      expect(result).toBe(0)
-    })
-
-    it('should return 0 when no sub-rows are selected', () => {
-      const data = makeData(1, 2)
+    it('should return false if no sub-rows are selected', () => {
+      const data = makeData(3, 2)
       const columns = generateColumns(data)
 
       const table = createTable<Person>({
@@ -281,22 +183,60 @@ describe('RowSelection', () => {
         renderFallbackValue: '',
         data,
         getSubRows: (row) => row.subRows,
-        state: { rowSelection: {} },
+        state: {
+          rowSelection: {},
+        },
         columns,
         getCoreRowModel: getCoreRowModel(),
       })
 
       const firstRow = table.getCoreRowModel().rows[0]
-      const result = RowSelection.getSelectedSubRowCount(firstRow)
-      expect(result).toBe(0)
+
+      const result = RowSelection.isSubRowSelected(
+        firstRow,
+        table.getState().rowSelection,
+        table,
+      )
+
+      expect(result).toEqual(false)
     })
 
-    it('should return number of selectable and selected sub-rows', () => {
-      const data = makeData(1, 2)
+    it('should return some if some sub-rows are selected', () => {
+      const data = makeData(3, 2)
       const columns = generateColumns(data)
 
       const table = createTable<Person>({
-        enableRowSelection: (row) => row.id !== '0.1', // second sub-row is selectable
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: {
+          rowSelection: {
+            '0.0': true,
+          },
+        },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+
+      const result = RowSelection.isSubRowSelected(
+        firstRow,
+        table.getState().rowSelection,
+        table,
+      )
+
+      expect(result).toEqual('some')
+    })
+
+    it('should return all if all sub-rows are selected', () => {
+      const data = makeData(3, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
         onStateChange() {},
         renderFallbackValue: '',
         data,
@@ -312,26 +252,28 @@ describe('RowSelection', () => {
       })
 
       const firstRow = table.getCoreRowModel().rows[0]
-      const result = RowSelection.getSelectedSubRowCount(firstRow)
-      expect(result).toBe(1)
-    })
 
-    it('should count all nested selectable and selected sub-rows', () => {
-      const data = makeData(1, 2, 2)
+      const result = RowSelection.isSubRowSelected(
+        firstRow,
+        table.getState().rowSelection,
+        table,
+      )
+
+      expect(result).toEqual('all')
+    })
+    it('should return all if all selectable sub-rows are selected', () => {
+      const data = makeData(3, 2)
       const columns = generateColumns(data)
 
       const table = createTable<Person>({
-        enableRowSelection: (row) => row.id !== '0.0.1', // make one of the sub-rows non-selectable
+        enableRowSelection: (row) => row.index === 0, // only first row is selectable (of 2 sub-rows)
         onStateChange() {},
         renderFallbackValue: '',
         data,
         getSubRows: (row) => row.subRows,
         state: {
           rowSelection: {
-            '0.0': true,
-            '0.0.0': true,
-            '0.0.1': true,
-            '0.1.1': true,
+            '0.0': true, // first sub-row
           },
         },
         columns,
@@ -339,9 +281,240 @@ describe('RowSelection', () => {
       })
 
       const firstRow = table.getCoreRowModel().rows[0]
-      const result = RowSelection.getSelectedSubRowCount(firstRow)
-      expect(result).toBe(3)
+
+      const result = RowSelection.isSubRowSelected(
+        firstRow,
+        table.getState().rowSelection,
+        table,
+      )
+
+      expect(result).toEqual('all')
     })
+    it('should return some when some nested sub-rows are selected', () => {
+      const data = makeData(3, 2, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: {
+          rowSelection: {
+            '0.0.0': true, // first nested sub-row
+          },
+        },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+
+      const result = RowSelection.isSubRowSelected(
+        firstRow,
+        table.getState().rowSelection,
+        table,
+      )
+
+      expect(result).toEqual('some')
+    })
+  })
+
+  describe('getSubRowSelectionsCount', () => {
+    describe('selectableCount', () => {
+      it('should be 0 when there are no sub-rows', () => {
+        const data = makeData(1)
+        const columns = generateColumns(data)
+
+        const table = createTable<Person>({
+          enableRowSelection: true,
+          onStateChange() {},
+          renderFallbackValue: '',
+          data,
+          state: { rowSelection: {} },
+          columns,
+          getCoreRowModel: getCoreRowModel(),
+        })
+
+        const firstRow = table.getCoreRowModel().rows[0]
+        const { selectableCount } = RowSelection.getSubRowSelectionsCount(firstRow)
+        expect(selectableCount).toBe(0)
+      })
+
+      it('should be 0 when all sub-rows are not selectable', () => {
+        const data = makeData(1, 2)
+        const columns = generateColumns(data)
+
+        const table = createTable<Person>({
+          enableRowSelection: (row) => row.depth === 0, // only root rows are selectable
+          onStateChange() {},
+          renderFallbackValue: '',
+          data,
+          getSubRows: (row) => row.subRows,
+          state: { rowSelection: {} },
+          columns,
+          getCoreRowModel: getCoreRowModel(),
+        })
+
+        const firstRow = table.getCoreRowModel().rows[0]
+        const { selectableCount } = RowSelection.getSubRowSelectionsCount(firstRow)
+        expect(selectableCount).toBe(0)
+      })
+
+      it('should be number of selectable sub-rows', () => {
+        const data = makeData(1, 2)
+        const columns = generateColumns(data)
+
+        const table = createTable<Person>({
+          enableRowSelection: true,
+          onStateChange() {},
+          renderFallbackValue: '',
+          data,
+          getSubRows: (row) => row.subRows,
+          state: { rowSelection: {} },
+          columns,
+          getCoreRowModel: getCoreRowModel(),
+        })
+
+        const firstRow = table.getCoreRowModel().rows[0]
+        const { selectableCount } = RowSelection.getSubRowSelectionsCount(firstRow)
+        expect(selectableCount).toBe(2)
+      })
+
+      it('should include all nested selectable sub-rows', () => {
+        const data = makeData(1, 2, 2)
+        const columns = generateColumns(data)
+
+        const table = createTable<Person>({
+          enableRowSelection: (row) => row.id !== '0.0.1', // make one of the sub-rows non-selectable
+          onStateChange() {},
+          renderFallbackValue: '',
+          data,
+          getSubRows: (row) => row.subRows,
+          state: { rowSelection: {} },
+          columns,
+          getCoreRowModel: getCoreRowModel(),
+        })
+
+        const firstRow = table.getCoreRowModel().rows[0]
+        const { selectableCount } = RowSelection.getSubRowSelectionsCount(firstRow)
+        expect(selectableCount).toBe(5) // 2 direct sub-rows + 3 nested sub-rows
+      })
+    })
+
+    describe('selectedCount', () => {
+      it('should be 0 when there are no sub-rows', () => {
+        const data = makeData(3)
+        const columns = generateColumns(data)
+
+        const table = createTable<Person>({
+          enableRowSelection: true,
+          onStateChange() {},
+          renderFallbackValue: '',
+          data,
+          state: { rowSelection: {} },
+          columns,
+          getCoreRowModel: getCoreRowModel(),
+        })
+
+        const firstRow = table.getCoreRowModel().rows[0]
+        const { selectedCount } = RowSelection.getSubRowSelectionsCount(firstRow)
+        expect(selectedCount).toBe(0)
+      })
+
+      it('should be 0 when all sub-rows are not selectable', () => {
+        const data = makeData(1, 2)
+        const columns = generateColumns(data)
+
+        const table = createTable<Person>({
+          enableRowSelection: (row) => row.depth === 0, // only root rows are selectable
+          onStateChange() {},
+          renderFallbackValue: '',
+          data,
+          getSubRows: (row) => row.subRows,
+          state: { rowSelection: {} },
+          columns,
+          getCoreRowModel: getCoreRowModel(),
+        })
+
+        const firstRow = table.getCoreRowModel().rows[0]
+        const { selectedCount } = RowSelection.getSubRowSelectionsCount(firstRow)
+        expect(selectedCount).toBe(0)
+      })
+
+      it('should be 0 when no sub-rows are selected', () => {
+        const data = makeData(1, 2)
+        const columns = generateColumns(data)
+
+        const table = createTable<Person>({
+          enableRowSelection: true,
+          onStateChange() {},
+          renderFallbackValue: '',
+          data,
+          getSubRows: (row) => row.subRows,
+          state: { rowSelection: {} },
+          columns,
+          getCoreRowModel: getCoreRowModel(),
+        })
+
+        const firstRow = table.getCoreRowModel().rows[0]
+        const { selectedCount } = RowSelection.getSubRowSelectionsCount(firstRow)
+        expect(selectedCount).toBe(0)
+      })
+
+      it('should be number of selectable and selected sub-rows', () => {
+        const data = makeData(1, 2)
+        const columns = generateColumns(data)
+
+        const table = createTable<Person>({
+          enableRowSelection: (row) => row.id !== '0.1', // second sub-row is not selectable
+          onStateChange() {},
+          renderFallbackValue: '',
+          data,
+          getSubRows: (row) => row.subRows,
+          state: {
+            rowSelection: {
+              '0.0': true,
+              '0.1': true,
+            },
+          },
+          columns,
+          getCoreRowModel: getCoreRowModel(),
+        })
+
+        const firstRow = table.getCoreRowModel().rows[0]
+        const { selectedCount } = RowSelection.getSubRowSelectionsCount(firstRow)
+        expect(selectedCount).toBe(1)
+      })
+
+      it('should include all nested selectable and selected sub-rows', () => {
+        const data = makeData(1, 2, 2)
+        const columns = generateColumns(data)
+
+        const table = createTable<Person>({
+          enableRowSelection: (row) => row.id !== '0.0.1', // make one of the sub-rows non-selectable
+          onStateChange() {},
+          renderFallbackValue: '',
+          data,
+          getSubRows: (row) => row.subRows,
+          state: {
+            rowSelection: {
+              '0.0': true,
+              '0.0.0': true,
+              '0.0.1': true,
+              '0.1.1': true,
+            },
+          },
+          columns,
+          getCoreRowModel: getCoreRowModel(),
+        })
+
+        const firstRow = table.getCoreRowModel().rows[0]
+        const { selectedCount } = RowSelection.getSubRowSelectionsCount(firstRow)
+        expect(selectedCount).toBe(3)
+      })
+    });
   });
 
   describe('RowSelectionRow.getIsSomeSelected', () => {

--- a/packages/table-core/tests/RowSelection.test.ts
+++ b/packages/table-core/tests/RowSelection.test.ts
@@ -147,8 +147,92 @@ describe('RowSelection', () => {
       expect(result).toEqual(false)
     })
   })
-  describe('isSubRowSelected', () => {
-    it('should return false if there are no sub-rows', () => {
+
+  // IMO the following 2 tests suites are not useful as they are not exposed to the public interface
+  // Instead the 2 RowSelectionRow.* test suites are more useful.
+  describe('getSelectableSubRowCount', () => {
+    it('should return 0 when there are no sub-rows', () => {
+      const data = makeData(1)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        state: { rowSelection: {} },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      const result = RowSelection.getSelectableSubRowCount(firstRow)
+      expect(result).toBe(0)
+    })
+
+    it('should return 0 when all sub-rows are not selectable', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: (row) => row.depth === 0, // only root rows are selectable
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: {} },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      const result = RowSelection.getSelectableSubRowCount(firstRow)
+      expect(result).toBe(0)
+    })
+
+    it('should return number of selectable sub-rows', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: {} },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      const result = RowSelection.getSelectableSubRowCount(firstRow)
+      expect(result).toBe(2)
+    })
+
+    it('should count all nested selectable sub-rows', () => {
+      const data = makeData(1, 2, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: (row) => row.id !== '0.0.1', // make one of the sub-rows non-selectable
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: {} },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      const result = RowSelection.getSelectableSubRowCount(firstRow)
+      expect(result).toBe(5) // 2 direct sub-rows + 3 nested sub-rows
+    })
+  })
+
+  describe('getSelectedSubRowCount', () => {
+    it('should return 0 when there are no sub-rows', () => {
       const data = makeData(3)
       const columns = generateColumns(data)
 
@@ -157,24 +241,38 @@ describe('RowSelection', () => {
         onStateChange() {},
         renderFallbackValue: '',
         data,
-        state: {},
+        state: { rowSelection: {} },
         columns,
         getCoreRowModel: getCoreRowModel(),
       })
 
       const firstRow = table.getCoreRowModel().rows[0]
-
-      const result = RowSelection.isSubRowSelected(
-        firstRow,
-        table.getState().rowSelection,
-        table,
-      )
-
-      expect(result).toEqual(false)
+      const result = RowSelection.getSelectedSubRowCount(firstRow)
+      expect(result).toBe(0)
     })
 
-    it('should return false if no sub-rows are selected', () => {
-      const data = makeData(3, 2)
+    it('should return 0 when all sub-rows are not selectable', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: (row) => row.depth === 0, // only root rows are selectable
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: {} },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      const result = RowSelection.getSelectedSubRowCount(firstRow)
+      expect(result).toBe(0)
+    })
+
+    it('should return 0 when no sub-rows are selected', () => {
+      const data = makeData(1, 2)
       const columns = generateColumns(data)
 
       const table = createTable<Person>({
@@ -183,60 +281,22 @@ describe('RowSelection', () => {
         renderFallbackValue: '',
         data,
         getSubRows: (row) => row.subRows,
-        state: {
-          rowSelection: {},
-        },
+        state: { rowSelection: {} },
         columns,
         getCoreRowModel: getCoreRowModel(),
       })
 
       const firstRow = table.getCoreRowModel().rows[0]
-
-      const result = RowSelection.isSubRowSelected(
-        firstRow,
-        table.getState().rowSelection,
-        table,
-      )
-
-      expect(result).toEqual(false)
+      const result = RowSelection.getSelectedSubRowCount(firstRow)
+      expect(result).toBe(0)
     })
 
-    it('should return some if some sub-rows are selected', () => {
-      const data = makeData(3, 2)
+    it('should return number of selectable and selected sub-rows', () => {
+      const data = makeData(1, 2)
       const columns = generateColumns(data)
 
       const table = createTable<Person>({
-        enableRowSelection: true,
-        onStateChange() {},
-        renderFallbackValue: '',
-        data,
-        getSubRows: (row) => row.subRows,
-        state: {
-          rowSelection: {
-            '0.0': true,
-          },
-        },
-        columns,
-        getCoreRowModel: getCoreRowModel(),
-      })
-
-      const firstRow = table.getCoreRowModel().rows[0]
-
-      const result = RowSelection.isSubRowSelected(
-        firstRow,
-        table.getState().rowSelection,
-        table,
-      )
-
-      expect(result).toEqual('some')
-    })
-
-    it('should return all if all sub-rows are selected', () => {
-      const data = makeData(3, 2)
-      const columns = generateColumns(data)
-
-      const table = createTable<Person>({
-        enableRowSelection: true,
+        enableRowSelection: (row) => row.id !== '0.1', // second sub-row is selectable
         onStateChange() {},
         renderFallbackValue: '',
         data,
@@ -252,28 +312,26 @@ describe('RowSelection', () => {
       })
 
       const firstRow = table.getCoreRowModel().rows[0]
-
-      const result = RowSelection.isSubRowSelected(
-        firstRow,
-        table.getState().rowSelection,
-        table,
-      )
-
-      expect(result).toEqual('all')
+      const result = RowSelection.getSelectedSubRowCount(firstRow)
+      expect(result).toBe(1)
     })
-    it('should return all if all selectable sub-rows are selected', () => {
-      const data = makeData(3, 2)
+
+    it('should count all nested selectable and selected sub-rows', () => {
+      const data = makeData(1, 2, 2)
       const columns = generateColumns(data)
 
       const table = createTable<Person>({
-        enableRowSelection: (row) => row.index === 0, // only first row is selectable (of 2 sub-rows)
+        enableRowSelection: (row) => row.id !== '0.0.1', // make one of the sub-rows non-selectable
         onStateChange() {},
         renderFallbackValue: '',
         data,
         getSubRows: (row) => row.subRows,
         state: {
           rowSelection: {
-            '0.0': true, // first sub-row
+            '0.0': true,
+            '0.0.0': true,
+            '0.0.1': true,
+            '0.1.1': true,
           },
         },
         columns,
@@ -281,17 +339,189 @@ describe('RowSelection', () => {
       })
 
       const firstRow = table.getCoreRowModel().rows[0]
-
-      const result = RowSelection.isSubRowSelected(
-        firstRow,
-        table.getState().rowSelection,
-        table,
-      )
-
-      expect(result).toEqual('all')
+      const result = RowSelection.getSelectedSubRowCount(firstRow)
+      expect(result).toBe(3)
     })
-    it('should return some when some nested sub-rows are selected', () => {
-      const data = makeData(3, 2, 2)
+  });
+
+  describe('RowSelectionRow.getIsSomeSelected', () => {
+    it('should return false if there are no sub-rows', () => {
+      const data = makeData(2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        state: { rowSelection: {} },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const { rows } = table.getCoreRowModel();
+      rows.forEach(row => {
+        expect(row.getIsSomeSelected()).toBe(false)
+      });
+    })
+
+    it('should return false if all sub-rows are not selectable', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: (row) => row.depth === 0, // only root rows selectable
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: { '0.0': true, '0.1': true } }, // even if all sub-rows are selected, they are not selectable
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      expect(firstRow.getIsSomeSelected()).toBe(false)
+    })
+
+    it('should return false if all selectable sub-rows are not selected', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: { '0': true } },  // parent row's own selection does not impact outcome
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      expect(firstRow.getIsSomeSelected()).toBe(false)
+    })
+
+    it('should return false if all selectable sub-rows are selected', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: { '0.0': true, '0.1': true } },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      expect(firstRow.getIsSomeSelected()).toBe(false)
+    })
+
+    it('should return true if some selectable sub-rows are selected', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: { '0.0': true } },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      expect(firstRow.getIsSomeSelected()).toBe(true)
+    })
+
+    it('should return true if one nested selectable sub-row is selected', () => {
+      const data = makeData(1, 2, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: { '0.0.0': true } },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      expect(firstRow.getIsSomeSelected()).toBe(true)
+    })
+  });
+
+  describe('RowSelectionRow.getIsAllSubRowsSelected', () => {
+    it('should return false if there are no sub-rows', () => {
+      const data = makeData(2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        state: { rowSelection: {} },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const { rows } = table.getCoreRowModel();
+      rows.forEach(row => {
+        expect(row.getIsAllSubRowsSelected()).toBe(false)
+      });
+    })
+
+    it('should return false if all sub-rows are not selectable', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: (row) => row.depth === 0, // only root rows selectable
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: {} },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      expect(firstRow.getIsAllSubRowsSelected()).toBe(false)
+    })
+
+    it('should return false if any selectable sub-row is not selected', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: { '0.0': true } }, // only one of two selected
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      expect(firstRow.getIsAllSubRowsSelected()).toBe(false)
+    })
+
+    it('should return false if any nested selectable sub-row is not selected', () => {
+      const data = makeData(1, 2, 2)
       const columns = generateColumns(data)
 
       const table = createTable<Person>({
@@ -302,7 +532,12 @@ describe('RowSelection', () => {
         getSubRows: (row) => row.subRows,
         state: {
           rowSelection: {
-            '0.0.0': true, // first nested sub-row
+            '0.0': true,
+            '0.0.0': true,
+            '0.0.1': true,
+            '0.1': true,
+            '0.1.0': true,
+            // '0.1.1' not selected
           },
         },
         columns,
@@ -310,14 +545,54 @@ describe('RowSelection', () => {
       })
 
       const firstRow = table.getCoreRowModel().rows[0]
-
-      const result = RowSelection.isSubRowSelected(
-        firstRow,
-        table.getState().rowSelection,
-        table,
-      )
-
-      expect(result).toEqual('some')
+      expect(firstRow.getIsAllSubRowsSelected()).toBe(false)
     })
-  })
+
+    it('should return true if all selectable sub-rows are selected', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: { '0.0': true, '0.1': true } },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      expect(firstRow.getIsAllSubRowsSelected()).toBe(true)
+    })
+
+    it('should return true if all selectable sub-rows including nested ones are selected', () => {
+      const data = makeData(1, 2, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: true,
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: {
+          rowSelection: {
+            '0.0': true,
+            '0.0.0': true,
+            '0.0.1': true,
+            '0.1': true,
+            '0.1.0': true,
+            '0.1.1': true,
+          },
+        },
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      expect(firstRow.getIsAllSubRowsSelected()).toBe(true)
+    })
+  });
 })

--- a/packages/table-core/tests/RowSelection.test.ts
+++ b/packages/table-core/tests/RowSelection.test.ts
@@ -767,5 +767,24 @@ describe('RowSelection', () => {
       const firstRow = table.getCoreRowModel().rows[0]
       expect(firstRow.getIsAllSubRowsSelected()).toBe(true)
     })
+
+    it('should return true when all selectable sub-rows are selected and some are non-selectable', () => {
+      const data = makeData(1, 2)
+      const columns = generateColumns(data)
+
+      const table = createTable<Person>({
+        enableRowSelection: (row) => row.id !== '0.1', // second sub-row is NOT selectable
+        onStateChange() {},
+        renderFallbackValue: '',
+        data,
+        getSubRows: (row) => row.subRows,
+        state: { rowSelection: { '0.0': true } }, // only selectable sub-row selected
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]
+      expect(firstRow.getIsAllSubRowsSelected()).toBe(true)
+    })
   });
 })


### PR DESCRIPTION
## 🎯 Changes

This PR fixes the root cause for https://github.com/TanStack/table/issues/5173.

The bug was in table-core's `getIsAllSubRowsSelected` which returned true when all sub-rows are unselectable.
This PR fixes the bug by re-implementing the method using counts: `selectedCount == selectableCount && selectedCount > 0`
The count is computed with a breadth-first-search traversal rather than the existing recursive approach.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.
  - ` NX   Successfully ran targets test:sherif, test:knip, test:docs, test:lib, test:types, build for 99 projects and 1 task they depend on (2m)`

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Row selection now correctly ignores unselectable sub-rows when reporting whether all or some sub-rows are selected.

* **New Features**
  * Added a counting helper to accurately report selectable and selected sub-rows across nested hierarchies.

* **Tests**
  * Expanded test coverage for selection counting and all/some selection behaviors, including nested scenarios and non-selectable sub-rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->