### PR TITLE
fix(table-core): respect custom filterFn.autoRemove in shouldAutoRemoveFilter

### DIFF
--- a/.changeset/fix-should-auto-remove-filter.md
+++ b/.changeset/fix-should-auto-remove-filter.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+fix(table-core): respect custom `autoRemove` in `shouldAutoRemoveFilter`

--- a/packages/table-core/src/features/ColumnFiltering.ts
+++ b/packages/table-core/src/features/ColumnFiltering.ts
@@ -418,11 +418,9 @@ export function shouldAutoRemoveFilter<TData extends RowData>(
   value?: any,
   column?: Column<TData, unknown>,
 ) {
-  return (
-    (filterFn && filterFn.autoRemove
-      ? filterFn.autoRemove(value, column)
-      : false) ||
-    typeof value === 'undefined' ||
-    (typeof value === 'string' && !value)
-  )
+  if (filterFn?.autoRemove) {
+    return filterFn.autoRemove(value, column)
+  }
+
+  return typeof value === 'undefined' || (typeof value === 'string' && !value)
 }

--- a/packages/table-core/tests/shouldAutoRemoveFilter.test.ts
+++ b/packages/table-core/tests/shouldAutoRemoveFilter.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { FilterFn } from '../src'
+import { shouldAutoRemoveFilter } from '../src/features/ColumnFiltering'
+
+const customAutoRemove: FilterFn<any> = (row, columnId, filterValue) => {
+  return filterValue === row.getValue(columnId)
+}
+customAutoRemove.autoRemove = (val) => val === undefined
+
+const neverAutoRemove: FilterFn<any> = (row, columnId, filterValue) => {
+  return filterValue === row.getValue(columnId)
+}
+neverAutoRemove.autoRemove = () => false
+
+const noAutoRemove: FilterFn<any> = (row, columnId, filterValue) => {
+  return filterValue === row.getValue(columnId)
+}
+
+describe('shouldAutoRemoveFilter', () => {
+  describe('with custom autoRemove defined', () => {
+    it('should use custom autoRemove result for empty string', () => {
+      expect(shouldAutoRemoveFilter(customAutoRemove, '')).toBe(false)
+    })
+
+    it('should use custom autoRemove result for undefined', () => {
+      expect(shouldAutoRemoveFilter(customAutoRemove, undefined)).toBe(true)
+    })
+
+    it('should use custom autoRemove result for null', () => {
+      expect(shouldAutoRemoveFilter(customAutoRemove, null)).toBe(false)
+    })
+
+    it('should use custom autoRemove result for zero', () => {
+      expect(shouldAutoRemoveFilter(customAutoRemove, 0)).toBe(false)
+    })
+
+    it('should use custom autoRemove result for false', () => {
+      expect(shouldAutoRemoveFilter(customAutoRemove, false)).toBe(false)
+    })
+
+    it('should keep undefined filter when custom autoRemove returns false for it', () => {
+      expect(shouldAutoRemoveFilter(neverAutoRemove, undefined)).toBe(false)
+    })
+  })
+
+  describe('without autoRemove defined', () => {
+    it('should remove undefined filter', () => {
+      expect(shouldAutoRemoveFilter(noAutoRemove, undefined)).toBe(true)
+    })
+
+    it('should remove empty string filter', () => {
+      expect(shouldAutoRemoveFilter(noAutoRemove, '')).toBe(true)
+    })
+
+    it('should keep null filter', () => {
+      expect(shouldAutoRemoveFilter(noAutoRemove, null)).toBe(false)
+    })
+  })
+
+  describe('without filterFn', () => {
+    it('should remove undefined filter', () => {
+      expect(shouldAutoRemoveFilter(undefined, undefined)).toBe(true)
+    })
+
+    it('should remove empty string filter', () => {
+      expect(shouldAutoRemoveFilter(undefined, '')).toBe(true)
+    })
+
+    it('should keep null filter', () => {
+      expect(shouldAutoRemoveFilter(undefined, null)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

Fixes #6101

### Problem

In `shouldAutoRemoveFilter`, the hardcoded `(typeof value ==='string' && !value)` check runs after `filterFn.autoRemove` via `||`, so it can override a custom `autoRemove` that returns `false` for empty strings.

This makes it impossible to use `''` as a valid filter value with custom filter functions:

```ts
// User defines: "only remove when undefined"
filterFn.autoRemove = (val) => val === undefined

// But shouldAutoRemoveFilter ignores this and removes '' anyway
column.setFilterValue('') // → filter silently removed
```
### Before

https://github.com/user-attachments/assets/9021d1d5-e8d4-49df-bdf0-d9acea60b306


### After

https://github.com/user-attachments/assets/d9806611-1289-45b4-863c-2fcdb22bc86c


### What changed

When `filterFn.autoRemove` is defined, only its result is used, without additional hardcoded checks overriding it.
Built-in filter functions are unaffected since they all define `autoRemove` via `testFalsey`.

### Notes
Same issue exists in v9 alpha branch: `packages/table-core/src/features/column-filtering/columnFilteringFeature.utils.ts`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filter auto-removal now correctly respects custom autoRemove logic, preventing unintended removal of valid filter values.

* **Tests**
  * Added comprehensive tests covering custom autoRemove hooks and default behavior across empty, undefined, null, zero, and false values to ensure consistent filter retention/removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->