### PR TITLE
fix(table-core): skip state update in toggleExpanded when state is unchanged

### DIFF
--- a/.changeset/fix-toggle-expanded-noop.md
+++ b/.changeset/fix-toggle-expanded-noop.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Skip state update in toggleExpanded when the desired state matches the current state, avoiding unnecessary re-renders

--- a/packages/table-core/src/features/RowExpanding.ts
+++ b/packages/table-core/src/features/RowExpanding.ts
@@ -290,9 +290,16 @@ export const RowExpanding: TableFeature = {
     table: Table<TData>,
   ): void => {
     row.toggleExpanded = (expanded) => {
-      table.setExpanded((old) => {
-        const exists = old === true ? true : !!old?.[row.id]
+      const isCurrentlyExpanded = row.getIsExpanded()
+      const newExpanded = expanded ?? !isCurrentlyExpanded
 
+      // If the desired state matches the current state, skip the update
+      // to avoid unnecessary re-renders
+      if (newExpanded === isCurrentlyExpanded) {
+        return
+      }
+
+      table.setExpanded((old) => {
         let oldExpanded: ExpandedStateList = {}
 
         if (old === true) {
@@ -303,21 +310,15 @@ export const RowExpanding: TableFeature = {
           oldExpanded = old
         }
 
-        expanded = expanded ?? !exists
-
-        if (!exists && expanded) {
+        if (newExpanded) {
           return {
             ...oldExpanded,
             [row.id]: true,
           }
         }
 
-        if (exists && !expanded) {
-          const { [row.id]: _, ...rest } = oldExpanded
-          return rest
-        }
-
-        return old
+        const { [row.id]: _, ...rest } = oldExpanded
+        return rest
       })
     }
     row.getIsExpanded = () => {


### PR DESCRIPTION
## Problem

Calling `row.toggleExpanded(false)` when the row is already collapsed (or `row.toggleExpanded(true)` when already expanded) triggers `onExpandedChange` and causes an unnecessary re-render of the entire table.

As reported in #6136, this causes noticeable UI freezes when `toggleExpanded` is called in high-frequency event handlers like `onBlur`.

## Root Cause

The `toggleExpanded` function passes an updater to `table.setExpanded()` unconditionally, even when the desired state matches the current state. While the updater returns `old` (same reference) when no change is needed, `onExpandedChange` is still invoked with the updater function, triggering React's state update flow.

## Fix

Added an early return that checks the current expanded state via `row.getIsExpanded()` before calling `table.setExpanded()`. If the desired state matches the current state, the function returns immediately, avoiding the unnecessary state update entirely.

## Before (workaround required)
```tsx
// User had to manually check state before calling toggleExpanded
if (newValue === '') row.getIsExpanded() && row.toggleExpanded(false)
else !row.getIsExpanded() && row.toggleExpanded(true)
```

## After
```tsx
// toggleExpanded now handles this internally
if (newValue === '') row.toggleExpanded(false)
else row.toggleExpanded(true)
```

Closes #6136