### PR TITLE
fix(table-core): guard process.env checks for non-bundled environments

### DIFF
--- a/.changeset/fix-process-not-defined.md
+++ b/.changeset/fix-process-not-defined.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Guard process.env.NODE_ENV checks with typeof to prevent ReferenceError in non-bundled environments

--- a/packages/table-core/src/core/column.ts
+++ b/packages/table-core/src/core/column.ts
@@ -6,7 +6,7 @@ import {
   RowData,
   ColumnDefResolved,
 } from '../types'
-import { getMemoOptions, memo } from '../utils'
+import { getMemoOptions, isDev, memo } from '../utils'
 
 export interface CoreColumn<TData extends RowData, TValue> {
   /**
@@ -100,7 +100,7 @@ export function createColumn<TData extends RowData, TValue>(
 
         for (const key of accessorKey.split('.')) {
           result = result?.[key]
-          if (process.env.NODE_ENV !== 'production' && result === undefined) {
+          if (isDev() && result === undefined) {
             console.warn(
               `"${key}" in deeply nested key "${accessorKey}" returned undefined.`,
             )
@@ -116,7 +116,7 @@ export function createColumn<TData extends RowData, TValue>(
   }
 
   if (!id) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDev()) {
       throw new Error(
         resolvedColumnDef.accessorFn
           ? `Columns require an id when using an accessorFn`

--- a/packages/table-core/src/core/table.ts
+++ b/packages/table-core/src/core/table.ts
@@ -1,4 +1,4 @@
-import { functionalUpdate, getMemoOptions, memo, RequiredKeys } from '../utils'
+import { functionalUpdate, getMemoOptions, isDev, memo, RequiredKeys } from '../utils'
 
 import {
   Updater,
@@ -284,7 +284,7 @@ export function createTable<TData extends RowData>(
   options: TableOptionsResolved<TData>,
 ): Table<TData> {
   if (
-    process.env.NODE_ENV !== 'production' &&
+    isDev() &&
     (options.debugAll || options.debugTable)
   ) {
     console.info('Creating Table Instance...')
@@ -399,7 +399,7 @@ export function createTable<TData extends RowData>(
       if (!row) {
         row = table.getCoreRowModel().rowsById[id]
         if (!row) {
-          if (process.env.NODE_ENV !== 'production') {
+          if (isDev()) {
             throw new Error(`getRow could not find row with ID: ${id}`)
           }
           throw new Error()
@@ -510,7 +510,7 @@ export function createTable<TData extends RowData>(
     getColumn: (columnId) => {
       const column = table._getAllFlatColumnsById()[columnId]
 
-      if (process.env.NODE_ENV !== 'production' && !column) {
+      if (isDev() && !column) {
         console.error(`[Table] Column with id '${columnId}' does not exist.`)
       }
 

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -1,5 +1,17 @@
 import { TableOptionsResolved, TableState, Updater } from './types'
 
+/**
+ * Safely checks if we are in a non-production (development) environment.
+ * Guards against `process` not being defined in environments like
+ * vanilla JS loaded via importmaps without a bundler (e.g. Rails, browser ESM).
+ */
+export function isDev(): boolean {
+  return (
+    typeof process !== 'undefined' &&
+    process.env?.NODE_ENV !== 'production'
+  )
+}
+
 export type PartialKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 export type RequiredKeys<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>
@@ -213,7 +225,7 @@ export function getMemoOptions(
 ) {
   return {
     debug: () => tableOptions?.debugAll ?? tableOptions[debugLevel],
-    key: process.env.NODE_ENV === 'development' && key,
+    key: isDev() && key,
     onChange,
   }
 }

--- a/packages/table-core/src/utils/getFilteredRowModel.ts
+++ b/packages/table-core/src/utils/getFilteredRowModel.ts
@@ -1,6 +1,6 @@
 import { ResolvedColumnFilter } from '../features/ColumnFiltering'
 import { Table, RowModel, Row, RowData } from '../types'
-import { getMemoOptions, memo } from '../utils'
+import { getMemoOptions, isDev, memo } from '../utils'
 import { filterRows } from './filterRowsUtils'
 
 export function getFilteredRowModel<TData extends RowData>(): (
@@ -38,7 +38,7 @@ export function getFilteredRowModel<TData extends RowData>(): (
           const filterFn = column.getFilterFn()
 
           if (!filterFn) {
-            if (process.env.NODE_ENV !== 'production') {
+            if (isDev()) {
               console.warn(
                 `Could not find a valid 'column.filterFn' for column with the ID: ${column.id}.`,
               )


### PR DESCRIPTION
## Problem

When using `@tanstack/table-core` in vanilla JS without a bundler (e.g., via ES module importmaps in Rails), a `ReferenceError: process is not defined` is thrown because the source code contains raw `process.env.NODE_ENV` references.

As reported in #6078, the ESM build output preserves these references without any transformation, and environments without Node.js globals (browser ESM via importmaps, Deno, etc.) crash on them.

## Root Cause

The source code directly accesses `process.env.NODE_ENV` for development-only warnings and debug logging. While bundlers like Vite/Webpack replace these at build time, the published ESM output retains them as-is, causing errors in unbundled environments.

## Fix

Introduced a `isDev()` utility function that safely checks for the existence of `process` before accessing `process.env.NODE_ENV`:

```ts
export function isDev(): boolean {
  return (
    typeof process !== 'undefined' &&
    process.env?.NODE_ENV !== 'production'
  )
}
```

Replaced all direct `process.env.NODE_ENV` checks across `table-core` with calls to `isDev()`.

### Files changed:
- `packages/table-core/src/utils.ts` — Added `isDev()` utility
- `packages/table-core/src/core/column.ts` — 2 occurrences
- `packages/table-core/src/core/table.ts` — 3 occurrences
- `packages/table-core/src/utils/getFilteredRowModel.ts` — 1 occurrence

Closes #6078