### PR TITLE
fix(vue-table): return null for empty string in FlexRender to prevent hydration mismatch

### DIFF
--- a/.changeset/fix-vue-flexrender-hydration.md
+++ b/.changeset/fix-vue-flexrender-hydration.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/vue-table': patch
+---
+
+Return null instead of empty string in FlexRender to prevent Vue SSR hydration mismatch

--- a/packages/vue-table/src/index.ts
+++ b/packages/vue-table/src/index.ts
@@ -37,6 +37,13 @@ export const FlexRender = defineComponent({
         return h(props.render, props.props)
       }
 
+      // Return null for empty/nullish values to avoid Vue SSR hydration
+      // mismatches (e.g. empty string renders a text node on the client
+      // but nothing on the server)
+      if (props.render == null || props.render === '') {
+        return null
+      }
+
       return props.render
     }
   },


### PR DESCRIPTION
## Problem

When using `@tanstack/vue-table` with SSR (e.g., Nuxt), a hydration error occurs inside `<td>` elements when a column value is an empty string `""`.

As reported in #6077, Vue's server-side renderer produces no content for an empty string, while the client-side renderer creates an empty text node, causing a hydration mismatch.

## Root Cause

In the `FlexRender` component, when `props.render` is an empty string:
1. It's not a function or object, so the `h()` branch is skipped
2. It falls through to `return props.render` which returns `""`
3. Vue SSR renders nothing for empty strings, but the client creates a text node
4. This inconsistency triggers a hydration mismatch error

## Fix

Added an explicit check for nullish and empty string values before the fallthrough return, returning `null` instead. This ensures consistent rendering between server and client:

```ts
// Return null for empty/nullish values to avoid Vue SSR hydration
// mismatches
if (props.render == null || props.render === '') {
  return null
}
```

## Reproduction

See the [StackBlitz reproduction](https://stackblitz.com/edit/nuxt-starter-geluyeas?file=app.vue) from the original issue.

Closes #6077