### PR TITLE
fix(table-core): consistent alphanumeric sorting for mixed letter/digit strings

### DIFF
--- a/.changeset/fix-alphanumeric-sorting.md
+++ b/.changeset/fix-alphanumeric-sorting.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Fix inconsistent alphanumeric sorting where letters and digits were ordered differently depending on position in the string

--- a/packages/table-core/src/sortingFns.ts
+++ b/packages/table-core/src/sortingFns.ts
@@ -1,5 +1,8 @@
 import { SortingFn } from './features/RowSorting'
 
+/**
+ * @deprecated No longer used internally. Kept for backwards compatibility.
+ */
 export const reSplitAlphaNumeric = /([0-9]+)/gm
 
 const alphanumeric: SortingFn<any> = (rowA, rowB, columnId) => {
@@ -67,51 +70,58 @@ function toString(a: any) {
   return ''
 }
 
+function isDigitChar(ch: string): boolean {
+  return ch >= '0' && ch <= '9'
+}
+
 // Mixed sorting is slow, but very inclusive of many edge cases.
 // It handles numbers, mixed alphanumeric combinations, and even
 // null, undefined, and Infinity
+//
+// Uses a character-by-character approach to ensure consistent ordering
+// between letters and digits regardless of their position in the string.
+// Letters always sort before digits (e.g. "appleA" < "apple1").
 function compareAlphanumeric(aStr: string, bStr: string) {
-  // Split on number groups, but keep the delimiter
-  // Then remove falsey split values
-  const a = aStr.split(reSplitAlphaNumeric).filter(Boolean)
-  const b = bStr.split(reSplitAlphaNumeric).filter(Boolean)
+  let ai = 0
+  let bi = 0
 
-  // While
-  while (a.length && b.length) {
-    const aa = a.shift()!
-    const bb = b.shift()!
+  while (ai < aStr.length && bi < bStr.length) {
+    const aIsDigit = isDigitChar(aStr[ai]!)
+    const bIsDigit = isDigitChar(bStr[bi]!)
 
-    const an = parseInt(aa, 10)
-    const bn = parseInt(bb, 10)
-
-    const combo = [an, bn].sort()
-
-    // Both are string
-    if (isNaN(combo[0]!)) {
-      if (aa > bb) {
+    if (aIsDigit && bIsDigit) {
+      // Both are digits - extract full numeric sequences and compare as numbers
+      let aNumStr = ''
+      let bNumStr = ''
+      while (ai < aStr.length && isDigitChar(aStr[ai]!)) {
+        aNumStr += aStr[ai]
+        ai++
+      }
+      while (bi < bStr.length && isDigitChar(bStr[bi]!)) {
+        bNumStr += bStr[bi]
+        bi++
+      }
+      const diff = parseInt(aNumStr, 10) - parseInt(bNumStr, 10)
+      if (diff !== 0) {
+        return diff
+      }
+    } else if (aIsDigit !== bIsDigit) {
+      // One is a digit, one is a letter - letters sort before digits
+      return aIsDigit ? 1 : -1
+    } else {
+      // Both are non-digit characters - compare lexicographically
+      if (aStr[ai]! > bStr[bi]!) {
         return 1
       }
-      if (bb > aa) {
+      if (aStr[ai]! < bStr[bi]!) {
         return -1
       }
-      continue
-    }
-
-    // One is a string, one is a number
-    if (isNaN(combo[1]!)) {
-      return isNaN(an) ? -1 : 1
-    }
-
-    // Both are numbers
-    if (an > bn) {
-      return 1
-    }
-    if (bn > an) {
-      return -1
+      ai++
+      bi++
     }
   }
 
-  return a.length - b.length
+  return aStr.length - bStr.length
 }
 
 // Exports


### PR DESCRIPTION
## Problem

The alphanumeric sorting function produces inconsistent ordering for mixed letter/digit strings depending on where digits appear in the string.

As reported in #6174:
- At the start of a string: letters sort before digits (`Aapple` < `1apple`) ✓
- In the middle of a string: digits sort before letters (`apple1` < `appleA`) ✗

Expected consistent behavior: letters should always sort before digits regardless of position.

## Root Cause

The previous implementation used regex-based chunk splitting (`/([0-9]+)/gm`), which produced misaligned chunks when comparing strings with different digit/letter boundaries:

- `"apple1"` splits to `["apple", "1"]`
- `"appleA"` splits to `["appleA"]` (no digit groups)

This caused the comparison to be between `"apple"` and `"appleA"` (string comparison), rather than correctly comparing character-by-character at the divergence point.

## Fix

Replaced the chunk-based approach with a character-by-character comparison that:

1. **Compares non-digit characters lexicographically** — standard string ordering
2. **Extracts and compares full digit sequences as numbers** — natural numeric ordering (e.g., `2` < `10`)
3. **Consistently sorts letters before digits at any position** — the key fix

### Example sort results (ascending):

| Before (inconsistent) | After (consistent) |
|---|---|
| apple1 | appleA |
| apple2 | appleB |
| appleA | apple1 |
| appleB | apple2 |

The exported `reSplitAlphaNumeric` regex is preserved (marked as deprecated) for backwards compatibility.

Closes #6174