### PR TITLE
docs: fix broken filters-global example link in global filtering guide

### DIFF
--- a/docs/guide/global-filtering.md
+++ b/docs/guide/global-filtering.md
@@ -6,7 +6,8 @@ title: Global Filtering Guide
 
 Want to skip to the implementation? Check out these examples:
 
-- [Global Filters](https://github.com/TanStack/table/tree/main/examples/react/filters-global)
+- [Filters](https://github.com/TanStack/table/tree/main/examples/react/filters)
+- [Fuzzy Filters (with Global Filter)](https://github.com/TanStack/table/tree/main/examples/react/filters-fuzzy)
 
 ## API
 


### PR DESCRIPTION
The `filters-global` React example link in the global filtering guide returns a 404 since that example directory does not exist on the main branch.

This replaces the dead link with links to the `filters` and `filters-fuzzy` examples, which both demonstrate global filtering functionality.

Fixes #6141