### PR TITLE
fix: skip toggleExpanded when state already matches desired value

### DIFF
--- a/packages/table-core/src/features/RowExpanding.ts
+++ b/packages/table-core/src/features/RowExpanding.ts
@@ -290,9 +290,13 @@ export const RowExpanding: TableFeature = {
     table: Table<TData>,
   ): void => {
     row.toggleExpanded = (expanded) => {
-      table.setExpanded((old) => {
-        const exists = old === true ? true : !!old?.[row.id]
+      const isCurrentlyExpanded = row.getIsExpanded()
+      const newExpanded = expanded ?? !isCurrentlyExpanded
 
+      // Bail out early if the state won't change to avoid unnecessary re-renders
+      if (!!newExpanded === isCurrentlyExpanded) return
+
+      table.setExpanded((old) => {
         let oldExpanded: ExpandedStateList = {}
 
         if (old === true) {
@@ -303,21 +307,15 @@ export const RowExpanding: TableFeature = {
           oldExpanded = old
         }
 
-        expanded = expanded ?? !exists
-
-        if (!exists && expanded) {
+        if (newExpanded) {
           return {
             ...oldExpanded,
             [row.id]: true,
           }
         }
 
-        if (exists && !expanded) {
-          const { [row.id]: _, ...rest } = oldExpanded
-          return rest
-        }
-
-        return old
+        const { [row.id]: _, ...rest } = oldExpanded
+        return rest
       })
     }
     row.getIsExpanded = () => {


### PR DESCRIPTION
When calling `row.toggleExpanded(bool)` with a value that matches the current expanded state, the function now returns early without calling `setExpanded`. This prevents unnecessary re-renders when the expanded state is not actually changing.

Previously, even no-op calls to `toggleExpanded` would invoke the state updater, which could trigger re-renders in React and cause noticeable UI freezes during rapid interactions like tab-navigating between inputs.

The fix checks `row.getIsExpanded()` before invoking the state setter. If the desired value matches the current state, it bails out immediately. The internal updater logic is also simplified since after the early return, we know the state IS changing, so the exists/expanded conditionals collapse.

Fixes #6136