### PR TITLE
fix: respect custom filterFn.autoRemove over default empty string check

### DIFF
--- a/packages/table-core/src/features/ColumnFiltering.ts
+++ b/packages/table-core/src/features/ColumnFiltering.ts
@@ -418,10 +418,11 @@ export function shouldAutoRemoveFilter<TData extends RowData>(
   value?: any,
   column?: Column<TData, unknown>,
 ) {
+  if (filterFn && filterFn.autoRemove) {
+    return filterFn.autoRemove(value, column)
+  }
+
   return (
-    (filterFn && filterFn.autoRemove
-      ? filterFn.autoRemove(value, column)
-      : false) ||
     typeof value === 'undefined' ||
     (typeof value === 'string' && !value)
   )


### PR DESCRIPTION
When a custom `filterFn` provides an `autoRemove` function, its return value should be the sole authority on whether to remove the filter. Previously, the default checks (`undefined` value, empty string) were OR'd with the custom `autoRemove` result, making it impossible to filter for empty strings even when `autoRemove` explicitly returned `false`.

**Before:**
```ts
return (
  (filterFn && filterFn.autoRemove ? filterFn.autoRemove(value, column) : false) ||
  typeof value === 'undefined' ||
  (typeof value === 'string' && !value)
)
```

**After:**
```ts
if (filterFn && filterFn.autoRemove) {
  return filterFn.autoRemove(value, column)
}

return typeof value === 'undefined' || (typeof value === 'string' && !value)
```

This is a non-breaking change for built-in filter functions since they already handle empty values via `testFalsey` in their own `autoRemove` implementations.

Fixes #6101