### PR TITLE
fix: replace Date.now() with performance.now() in memo debug timing

### DIFF
--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -147,7 +147,7 @@ export function memo<TDeps extends readonly any[], TDepArgs, TResult>(
 
   return (depArgs) => {
     let depTime: number
-    if (opts.key && opts.debug) depTime = Date.now()
+    if (opts.key && opts.debug) depTime = performance.now()
 
     const newDeps = getDeps(depArgs)
 
@@ -162,15 +162,15 @@ export function memo<TDeps extends readonly any[], TDepArgs, TResult>(
     deps = newDeps
 
     let resultTime: number
-    if (opts.key && opts.debug) resultTime = Date.now()
+    if (opts.key && opts.debug) resultTime = performance.now()
 
     result = fn(...newDeps)
     opts?.onChange?.(result)
 
     if (opts.key && opts.debug) {
       if (opts?.debug()) {
-        const depEndTime = Math.round((Date.now() - depTime!) * 100) / 100
-        const resultEndTime = Math.round((Date.now() - resultTime!) * 100) / 100
+        const depEndTime = Math.round((performance.now() - depTime!) * 100) / 100
+        const resultEndTime = Math.round((performance.now() - resultTime!) * 100) / 100
         const resultFpsPercentage = resultEndTime / 16
 
         const pad = (str: number | string, num: number) => {


### PR DESCRIPTION
Next.js warns about `Date.now()` usage in client components because it can cause hydration mismatches between server and client renders. While the `Date.now()` calls in `memo()` are only used for debug timing and guarded behind `opts.debug`, Next.js statically detects `Date.now()` usage and shows the warning regardless.

Switching to `performance.now()` resolves the Next.js warning and also provides more precise sub-millisecond timing measurements for debug output. The `performance.now()` API is available in all modern browsers and Node.js 12+, which aligns with the project's engine requirements.

This is a debug-only change with no impact on runtime behavior.

Fixes #6127