### PR TITLE
fix(vue-table): prevent unnecessary DOM mutations in `FlexRender` for function renderer

### DIFF
--- a/packages/vue-table/src/index.ts
+++ b/packages/vue-table/src/index.ts
@@ -30,10 +30,11 @@ export const FlexRender = defineComponent({
   props: ['render', 'props'],
   setup: (props: { render: any; props: any }) => {
     return () => {
-      if (
-        typeof props.render === 'function' ||
-        typeof props.render === 'object'
-      ) {
+      if (typeof props.render === 'function') {
+        return props.render(props.props)
+      }
+
+      if (typeof props.render === 'object') {
         return h(props.render, props.props)
       }
 


### PR DESCRIPTION
## 🎯 Changes

This PR fixes an issue in Vue `FlexRender` where function renderers can cause unnecessary DOM mutations.

### Problem
When `columns` are created with `computed(() => [...])`, every dependency change recreates the whole column definitions, including new `cell` function references.

At the same time, `FlexRender` handles function renderers with `h(props.render, props.props)`. When `props.render` is a function, Vue treats it as a component type. Because the function reference changes after each re-evaluation, Vue sees it as a different component and triggers an unnecessary unmount/remount. As a result, the DOM can still be mutated even when the cell content has not changed.

This can be observed in the Chrome DevTools Elements panel: after typing in the search input, the `<td>` for Alice's Phone cell is still marked as updated even though its content remains the same.

Mini reproduction: https://stackblitz.com/edit/vitejs-vite-xxp2iyaa?file=src%2FApp.vue&terminal=dev

### Cause
- `columns` is created with `computed(() => [...])`, so each re-evaluation creates new column and renderer references
- `FlexRender` passes function renderers to `h()`, so Vue treats them as component types
- Because the function reference is not stable, Vue sees it as a different component and performs an unnecessary DOM patch / remount

### Solution
This change handles function renderers and component renderers differently:

- If `props.render` is a function, it calls `props.render(props.props)` directly
- If `props.render` is an object, it uses `h(props.render, props.props)`

This avoids treating a plain function renderer as a component type, which helps prevent unnecessary DOM mutations.

### Additional note
This issue can also be easier to trigger depending on how the user defines `columns`.

If `columns` is placed inside `computed(() => [...])`, every dependency change recreates all column definitions, including new `header` / `cell` function references:

```ts
const columns = computed(() => [
  columnHelper.accessor('name', {
    header: `Name (${filteredData.value.length})`,
  }),
  columnHelper.accessor('phone', {
    header: 'Phone',
    cell: ({ getValue }) => getValue(),
  }),
])
````

If it is changed to a stable constant array, and the dynamic part is moved into `header: () => ...`, it can avoid recreating renderer references on every re-evaluation. This can be used as a temporary workaround on the user side:

```ts
const columns = [
  columnHelper.accessor('name', {
    header: () => `Name (${filteredData.value.length})`,
  }),
  columnHelper.accessor('phone', {
    header: 'Phone',
    cell: ({ getValue }) => getValue(),
  }),
]
```

However, this is only a user-side workaround. It does not fix the root cause, which is that `FlexRender` treats a function renderer as a component type.
## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.
