### PR TITLE
Docs: fix what seems to be a copy-paste error

### DIFF
--- a/docs/guide/cells.md
+++ b/docs/guide/cells.md
@@ -42,8 +42,8 @@ The recommended way to access data values from a cell is to use either the `cell
 
 ```js
 // Access data from any of the columns
-const firstName = cell.getValue('firstName') // read the cell value from the firstName column
-const renderedLastName = cell.renderValue('lastName') // render the value from the lastName column
+const value = cell.getValue() // read the cell value
+const rendered = cell.renderValue() // render the value
 ```
 
 #### Access Other Row Data from Any Cell


### PR DESCRIPTION
The cell value access API doesn't accept column name like row API does. The example seems to be copied from the row guide.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.
