### PR TITLE
fix(pagination): autoResetPageIndex should reset to 0, not initialState pageIndex

### DIFF
--- a/.changeset/fix-autoResetPageIndex.md
+++ b/.changeset/fix-autoResetPageIndex.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/table-core": patch
+---
+
+fix(pagination): autoResetPageIndex now resets to 0 instead of initialState pageIndex

--- a/packages/table-core/src/features/RowPagination.ts
+++ b/packages/table-core/src/features/RowPagination.ts
@@ -231,7 +231,7 @@ export const RowPagination: TableFeature = {
         if (queued) return
         queued = true
         table._queue(() => {
-          table.resetPageIndex()
+          table.resetPageIndex(true)
           queued = false
         })
       }


### PR DESCRIPTION
## Summary

Fixes #6207

When `autoResetPageIndex` fires (e.g. after data/filter changes), it now calls `table.resetPageIndex(true)` to reset to `0` (the default page) instead of `table.resetPageIndex()` which resets to `initialState.pagination.pageIndex`.

## Root cause

In `RowPagination.ts`, `_autoResetPageIndex` called `table.resetPageIndex()` without `defaultState = true`:

```ts
// Before
table.resetPageIndex()   // resets to initialState.pageIndex (e.g. 5 from URL restoration)
// After
table.resetPageIndex(true)  // always resets to 0
```

This caused issues when `initialState.pagination.pageIndex` was set to a non-zero value (e.g. restored from URL params). After a filter change that reduced total pages, the table would reset to the initial page (e.g. page 5) rather than page 0, leaving users on an empty/invalid page.

## Changes

- `packages/table-core/src/features/RowPagination.ts`: pass `true` to `resetPageIndex()` in `_autoResetPageIndex`
- Added changeset for patch bump of `@tanstack/table-core`