### PR TITLE
fix(table-core): use autoRemove instead of resolveFilterValue on comparison filter fns

### DIFF
--- a/packages/table-core/src/fns/filterFns.ts
+++ b/packages/table-core/src/fns/filterFns.ts
@@ -141,7 +141,7 @@ export const filterFn_greaterThan: FilterFn<any, any> = <
   return stringValue > stringFilterValue
 }
 
-filterFn_greaterThan.resolveFilterValue = (val: any) => testFalsy(val)
+filterFn_greaterThan.autoRemove = (val: any) => testFalsy(val)
 
 /**
  * Filter function for checking if a number is greater than or equal to a given number.
@@ -160,7 +160,7 @@ export const filterFn_greaterThanOrEqualTo: FilterFn<any, any> = <
   )
 }
 
-filterFn_greaterThanOrEqualTo.resolveFilterValue = (val: any) => testFalsy(val)
+filterFn_greaterThanOrEqualTo.autoRemove = (val: any) => testFalsy(val)
 
 /**
  * Filter function for checking if a number is less than a given number.
@@ -176,7 +176,7 @@ export const filterFn_lessThan: FilterFn<any, any> = <
   return !filterFn_greaterThanOrEqualTo(row as any, columnId, filterValue)
 }
 
-filterFn_lessThan.resolveFilterValue = (val: any) => testFalsy(val)
+filterFn_lessThan.autoRemove = (val: any) => testFalsy(val)
 
 /**
  * Filter function for checking if a number is less than or equal to a given number.
@@ -192,7 +192,7 @@ export const filterFn_lessThanOrEqualTo: FilterFn<any, any> = <
   return !filterFn_greaterThan(row as any, columnId, filterValue)
 }
 
-filterFn_lessThanOrEqualTo.resolveFilterValue = (val: any) => testFalsy(val)
+filterFn_lessThanOrEqualTo.autoRemove = (val: any) => testFalsy(val)
 
 // Range filters
 


### PR DESCRIPTION
## Changes

  - `filterFn_greaterThan`, `filterFn_greaterThanOrEqualTo`, `filterFn_lessThan`, and
    `filterFn_lessThanOrEqualTo` incorrectly used `.resolveFilterValue` instead of `.autoRemove`
  - `resolveFilterValue` transforms the filter value before comparison, so `testFalsy(50)` returns
    `false`, and `false ?? 50` evaluates to `false` (not nullish), making the comparison
    `rowValue > 0` instead of `rowValue > 50`
  - Every other simple filter function in the file correctly uses `.autoRemove`

  Fixes #6212

  ## Checklist

  - [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
  - [x] I have tested this code locally with `pnpm test:pr`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison filter operations to properly manage filter removal when handling empty or invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->