### PR TITLE
fix(pagination): prevent onPaginationChange from firing when state is unchanged

### DIFF
--- a/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
+++ b/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
@@ -1,4 +1,4 @@
-import { functionalUpdate } from '../../utils'
+import { functionalUpdate, shallowEqual } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { Table_Internal } from '../../types/Table'
@@ -35,6 +35,14 @@ export function table_setPagination<
     const newState = functionalUpdate(updater, old)
 
     return newState
+  }
+
+  const currentPagination = table.store.state.pagination
+  if (currentPagination) {
+    const newPagination = functionalUpdate(safeUpdater, currentPagination)
+    if (shallowEqual(currentPagination, newPagination)) {
+      return
+    }
   }
 
   return table.options.onPaginationChange?.(safeUpdater)

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -9,6 +9,25 @@ export function functionalUpdate<T>(updater: Updater<T>, input: T): T {
     : updater
 }
 
+export function shallowEqual<T>(a: T, b: T): boolean {
+  if (Object.is(a, b)) return true
+  if (
+    typeof a !== 'object' ||
+    typeof b !== 'object' ||
+    a === null ||
+    b === null
+  ) {
+    return false
+  }
+  const keysA = Object.keys(a)
+  const keysB = Object.keys(b)
+  if (keysA.length !== keysB.length) return false
+  for (const key of keysA) {
+    if (!Object.is((a as any)[key], (b as any)[key])) return false
+  }
+  return true
+}
+
 export function noop() {}
 
 export function makeStateUpdater<

--- a/packages/table-core/tests/unit/features/row-pagination/rowPaginationFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/row-pagination/rowPaginationFeature.utils.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  getDefaultPaginationState,
+  rowPaginationFeature,
+  table_autoResetPageIndex,
+  table_resetPageIndex,
+  table_setPageIndex,
+  table_setPagination,
+} from '../../../../src'
+import { generateTestTableWithData } from '../../../helpers/generateTestTable'
+
+type TestFeatures = {
+  rowPaginationFeature: {}
+}
+
+function createPaginationTable(onPaginationChange?: (...args: any[]) => void) {
+  const table = generateTestTableWithData<TestFeatures>(10, {
+    _features: {
+      rowPaginationFeature,
+    },
+    ...(onPaginationChange && { onPaginationChange }),
+  } as any)
+  return table
+}
+
+describe('rowPaginationFeature.utils', () => {
+  describe('getDefaultPaginationState', () => {
+    it('should return default pagination state', () => {
+      const state = getDefaultPaginationState()
+      expect(state).toEqual({ pageIndex: 0, pageSize: 10 })
+    })
+  })
+
+  describe('table_setPagination', () => {
+    it('should call onPaginationChange when state actually changes', () => {
+      const onPaginationChange = vi.fn()
+      const table = createPaginationTable(onPaginationChange)
+
+      table_setPagination(table as any, { pageIndex: 2, pageSize: 10 })
+
+      expect(onPaginationChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('should NOT call onPaginationChange when state is unchanged (object updater)', () => {
+      const onPaginationChange = vi.fn()
+      const table = createPaginationTable(onPaginationChange)
+
+      // Set same values as default (pageIndex: 0, pageSize: 10)
+      table_setPagination(table as any, { pageIndex: 0, pageSize: 10 })
+
+      expect(onPaginationChange).not.toHaveBeenCalled()
+    })
+
+    it('should NOT call onPaginationChange when function updater returns same state', () => {
+      const onPaginationChange = vi.fn()
+      const table = createPaginationTable(onPaginationChange)
+
+      table_setPagination(table as any, (old) => ({ ...old }))
+
+      expect(onPaginationChange).not.toHaveBeenCalled()
+    })
+
+    it('should call onPaginationChange when function updater changes pageIndex', () => {
+      const onPaginationChange = vi.fn()
+      const table = createPaginationTable(onPaginationChange)
+
+      table_setPagination(table as any, (old) => ({
+        ...old,
+        pageIndex: old.pageIndex + 1,
+      }))
+
+      expect(onPaginationChange).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('table_setPageIndex', () => {
+    it('should NOT trigger onPaginationChange when pageIndex is already at target', () => {
+      const onPaginationChange = vi.fn()
+      const table = createPaginationTable(onPaginationChange)
+
+      // Default pageIndex is 0, setting to 0 should be a no-op
+      table_setPageIndex(table as any, 0)
+
+      expect(onPaginationChange).not.toHaveBeenCalled()
+    })
+
+    it('should trigger onPaginationChange when pageIndex changes', () => {
+      const onPaginationChange = vi.fn()
+      const table = createPaginationTable(onPaginationChange)
+
+      table_setPageIndex(table as any, 1)
+
+      expect(onPaginationChange).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('table_resetPageIndex', () => {
+    it('should NOT trigger onPaginationChange when already at default', () => {
+      const onPaginationChange = vi.fn()
+      const table = createPaginationTable(onPaginationChange)
+
+      // Already at default pageIndex (0), reset should be a no-op
+      table_resetPageIndex(table as any, true)
+
+      expect(onPaginationChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('table_autoResetPageIndex', () => {
+    it('should NOT trigger onPaginationChange when page index is already at default', () => {
+      const onPaginationChange = vi.fn()
+      const table = createPaginationTable(onPaginationChange)
+
+      // autoResetPageIndex resets to initial/default, which is already 0
+      table_autoResetPageIndex(table as any)
+
+      expect(onPaginationChange).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #6158

- **Problem**: `onPaginationChange` fires on every URL navigation in React Server Components, even when pagination state hasn't changed. When a parent RSC re-renders (e.g., due to `router.push` or `Link` navigation), the `data` prop gets a new reference. This triggers `_autoResetPageIndex` → `resetPageIndex` → `setPagination` → `onPaginationChange`, even though `pageIndex` and `pageSize` are identical. When pagination is persisted to URL params, this creates an infinite loop.

- **Fix**: Add a shallow equality check in `setPagination` before invoking `onPaginationChange`. If the resolved new pagination state is identical to the current state, the callback is skipped entirely.

## Changes

- `packages/table-core/src/utils.ts` — Added `shallowEqual` utility function
- `packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts` — `table_setPagination` now checks if state actually changed before calling `onPaginationChange`
- `packages/table-core/tests/unit/features/row-pagination/rowPaginationFeature.utils.test.ts` — Added 9 tests covering no-op updates for `table_setPagination`, `table_setPageIndex`, `table_resetPageIndex`, and `table_autoResetPageIndex`

## Verification

- All 239 table-core tests pass (including 9 new ones)
- TypeScript type check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized pagination state management to prevent redundant callback invocations when pagination values remain unchanged, reducing unnecessary updates and improving application performance with shallow equality checks.

* **Tests**
  * Added comprehensive unit tests for row pagination utilities, including validation of pagination state updates, callback triggers, page index management, reset behavior, and default state expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->