### PR TITLE
docs: migrate guide example links to relative paths

### DIFF
--- a/docs/guide/column-filtering.md
+++ b/docs/guide/column-filtering.md
@@ -6,12 +6,12 @@ title: Column Filtering Guide
 
 Want to skip to the implementation? Check out these examples:
 
-- [filters](https://github.com/TanStack/table/tree/main/examples/react/filters) (includes faceting)
-- [editable-data](https://github.com/TanStack/table/tree/main/examples/react/editable-data)
-- [expanding](https://github.com/TanStack/table/tree/main/examples/react/expanding)
-- [grouping](https://github.com/TanStack/table/tree/main/examples/react/grouping)
-- [pagination](https://github.com/TanStack/table/tree/main/examples/react/pagination)
-- [row-selection](https://github.com/TanStack/table/tree/main/examples/react/row-selection)
+- [filters](../framework/react/examples/filters) (includes faceting)
+- [editable-data](../framework/react/examples/editable-data)
+- [expanding](../framework/react/examples/expanding)
+- [grouping](../framework/react/examples/grouping)
+- [pagination](../framework/react/examples/pagination)
+- [row-selection](../framework/react/examples/row-selection)
 
 ## API
 

--- a/docs/guide/global-filtering.md
+++ b/docs/guide/global-filtering.md
@@ -6,7 +6,8 @@ title: Global Filtering Guide
 
 Want to skip to the implementation? Check out these examples:
 
-- [Global Filters](https://github.com/TanStack/table/tree/main/examples/react/filters-global)
+- [filters](../framework/react/examples/filters)
+- [filters-fuzzy](../framework/react/examples/filters-fuzzy)
 
 ## API
 

--- a/docs/guide/grouping.md
+++ b/docs/guide/grouping.md
@@ -6,7 +6,7 @@ title: Grouping Guide
 
 Want to skip to the implementation? Check out these examples:
 
-- [grouping](https://github.com/TanStack/table/tree/main/examples/react/grouping)
+- [grouping](../framework/react/examples/grouping)
 
 ## API
 

--- a/docs/guide/row-selection.md
+++ b/docs/guide/row-selection.md
@@ -6,9 +6,9 @@ title: Row Selection Guide
 
 Want to skip to the implementation? Check out these examples:
 
-- [React row-selection](https://github.com/TanStack/table/tree/main/examples/react/row-selection)
-- [Vue row-selection](https://github.com/TanStack/table/tree/main/examples/vue/row-selection)
-- [React expanding](https://github.com/TanStack/table/tree/main/examples/react/expanding)
+- [React row-selection](../framework/react/examples/row-selection)
+- [Vue row-selection](../framework/vue/examples/row-selection)
+- [React expanding](../framework/react/examples/expanding)
 
 ## API
 

--- a/docs/guide/virtualization.md
+++ b/docs/guide/virtualization.md
@@ -6,10 +6,10 @@ title: Virtualization Guide
 
 Want to skip to the implementation? Check out these examples:
 
-- [virtualized-columns](https://github.com/TanStack/table/tree/main/examples/react/virtualized-columns)
-- [virtualized-rows (dynamic row height)](https://github.com/TanStack/table/tree/main/examples/react/virtualized-rows)
-- [virtualized-rows (fixed row height)](https://github.com/TanStack/table/tree/main/examples/react/virtualized-rows)
-- [virtualized-infinite-scrolling](https://github.com/TanStack/table/tree/main/examples/react/virtualized-infinite-scrolling)
+- [virtualized-columns](../framework/react/examples/virtualized-columns)
+- [virtualized-rows (dynamic row height)](../framework/react/examples/virtualized-rows)
+- [virtualized-rows (fixed row height)](../framework/react/examples/virtualized-rows)
+- [virtualized-infinite-scrolling](../framework/react/examples/virtualized-infinite-scrolling)
 
 ## Virtualization Guide
 


### PR DESCRIPTION
## 🎯 Changes

Fixes #6141. Supersedes #6154, #6171, #6193 

`scripts/verify-links.ts` skips anything starting with `https://`, so the 14 absolute `github.com/.../examples/...` URLs across `docs/guide/*` have been outside its coverage. This migrates them to the relative-path form already used by sibling guides (same direction as #6132), bringing them under the link checker.

For `docs/guide/global-filtering.md`, the broken `filters-global` link is replaced with both `filters` and `filters-fuzzy` (following the suggestion on #6171 and the approach in #6193)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:docs`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
