### PR TITLE
fix: preserve undefined in deep accessor types

### DIFF
--- a/.changeset/quiet-bears-protect.md
+++ b/.changeset/quiet-bears-protect.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Preserve `undefined` in deep accessor value types when an optional parent key is used.

--- a/packages/table-core/package.json
+++ b/packages/table-core/package.json
@@ -47,7 +47,7 @@
     "clean": "rimraf ./build",
     "test:lib": "vitest",
     "test:lib:dev": "pnpm test:lib --watch",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc --noEmit && tsc --noEmit -p tsconfig.test-d.json",
     "build": "pnpm build:rollup && pnpm build:types",
     "build:rollup": "rollup --config rollup.config.mjs",
     "build:types": "tsc --emitDeclarationOnly"

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -65,8 +65,9 @@ type DeepKeysPrefix<
   ? `${TPrefix}.${DeepKeys<T[TPrefix], [...TDepth, any]> & string}`
   : never
 
-export type DeepValue<T, TProp> =
-  T extends Record<string | number, any>
+export type DeepValue<T, TProp> = T extends null | undefined
+  ? undefined
+  : T extends Record<string | number, any>
     ? TProp extends `${infer TBranch}.${infer TDeepProp}`
       ? DeepValue<T[TBranch], TDeepProp>
       : T[TProp & string]

--- a/packages/table-core/tests/columnHelper.test-d.ts
+++ b/packages/table-core/tests/columnHelper.test-d.ts
@@ -1,0 +1,27 @@
+import { createColumnHelper } from '../src'
+
+type Expect<T extends true> = T
+type Equal<T, U> =
+  (<G>() => G extends T ? 1 : 2) extends <G>() => G extends U ? 1 : 2
+    ? true
+    : false
+
+type Row = {
+  user: {
+    salary?: {
+      amount: number
+    }
+  }
+}
+
+const columnHelper = createColumnHelper<Row>()
+
+columnHelper.accessor('user.salary.amount', {
+  cell: (info) => {
+    const amount = info.getValue()
+
+    type _ = Expect<Equal<typeof amount, number | undefined>>
+
+    return amount
+  },
+})

--- a/packages/table-core/tsconfig.test-d.json
+++ b/packages/table-core/tsconfig.test-d.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/**/*.test-d.ts"]
+}


### PR DESCRIPTION
## 🎯 Changes

Fixes #6238 by preserving `undefined` in `DeepValue` when a deep string accessor traverses an optional parent key. This keeps `row.getValue()` typed as `number | undefined` for paths like `user.salary.amount` when `salary` is optional.

Added a table-core type regression test for the optional deep accessor case.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

Targeted checks run locally:

- `pnpm --filter @tanstack/table-core test:types`
- `pnpm --filter @tanstack/table-core build`
- `pnpm --filter @tanstack/table-core test:lib`
- `pnpm exec prettier --check packages/table-core/src/utils.ts packages/table-core/tests/columnHelper.test-d.ts packages/table-core/tsconfig.test-d.json packages/table-core/package.json .changeset/quiet-bears-protect.md`
- `git diff --check`

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
