### PR TITLE
fix(react-table): type column contexts with React table

### DIFF
--- a/packages/react-table/src/index.ts
+++ b/packages/react-table/src/index.ts
@@ -3,4 +3,16 @@ export * from '@tanstack/table-core'
 export * from './FlexRender'
 export * from './Subscribe'
 export * from './createTableHook'
-export * from './useTable'
+export { useTable } from './useTable'
+export type {
+  AccessorColumnDef,
+  AccessorFnColumnDef,
+  AccessorKeyColumnDef,
+  CellContext,
+  ColumnDef,
+  DisplayColumnDef,
+  GroupColumnDef,
+  HeaderContext,
+  ReactTable,
+  TableOptions,
+} from './useTable'

--- a/packages/react-table/src/useTable.ts
+++ b/packages/react-table/src/useTable.ts
@@ -7,10 +7,18 @@ import { FlexRender } from './FlexRender'
 import { Subscribe } from './Subscribe'
 import type {
   CellData,
+  ColumnDefTemplate,
+  AccessorColumnDef as CoreAccessorColumnDef,
+  AccessorFnColumnDef as CoreAccessorFnColumnDef,
+  AccessorKeyColumnDef as CoreAccessorKeyColumnDef,
+  CellContext as CoreCellContext,
+  DisplayColumnDef as CoreDisplayColumnDef,
+  GroupColumnDef as CoreGroupColumnDef,
+  HeaderContext as CoreHeaderContext,
+  TableOptions as CoreTableOptions,
   RowData,
   Table,
   TableFeatures,
-  TableOptions,
   TableState,
 } from '@tanstack/table-core'
 import type { Atom, ReadonlyAtom } from '@tanstack/react-store'
@@ -106,9 +114,123 @@ export type ReactTable<
    * console.log(table.state.globalFilter)
    */
   readonly state: Readonly<TSelected> & {
-    columns: TableOptions<TFeatures, TData>['columns']
-    data: TableOptions<TFeatures, TData>['data']
+    columns: TableOptions<TFeatures, TData, TSelected>['columns']
+    data: TableOptions<TFeatures, TData, TSelected>['data']
   }
+}
+
+export type CellContext<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData = CellData,
+  TSelected = {},
+> = Omit<CoreCellContext<TFeatures, TData, TValue>, 'table'> & {
+  table: ReactTable<TFeatures, TData, TSelected>
+}
+
+export type HeaderContext<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData = CellData,
+  TSelected = {},
+> = Omit<CoreHeaderContext<TFeatures, TData, TValue>, 'table'> & {
+  table: ReactTable<TFeatures, TData, TSelected>
+}
+
+type ColumnDefWithReactContext<
+  TColumnDef extends object,
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData,
+  TSelected,
+> = Omit<TColumnDef, 'cell' | 'footer' | 'header'> & {
+  cell?: ColumnDefTemplate<CellContext<TFeatures, TData, TValue, TSelected>>
+  footer?: ColumnDefTemplate<HeaderContext<TFeatures, TData, TValue, TSelected>>
+  header?:
+    | string
+    | ColumnDefTemplate<HeaderContext<TFeatures, TData, TValue, TSelected>>
+}
+
+export type DisplayColumnDef<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData = CellData,
+  TSelected = {},
+> = ColumnDefWithReactContext<
+  CoreDisplayColumnDef<TFeatures, TData, TValue>,
+  TFeatures,
+  TData,
+  TValue,
+  TSelected
+>
+
+export type GroupColumnDef<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData = CellData,
+  TSelected = {},
+> = ColumnDefWithReactContext<
+  Omit<CoreGroupColumnDef<TFeatures, TData, TValue>, 'columns'>,
+  TFeatures,
+  TData,
+  TValue,
+  TSelected
+> & {
+  columns?: ReadonlyArray<ColumnDef<TFeatures, TData, unknown, TSelected>>
+}
+
+export type AccessorFnColumnDef<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData = CellData,
+  TSelected = {},
+> = ColumnDefWithReactContext<
+  CoreAccessorFnColumnDef<TFeatures, TData, TValue>,
+  TFeatures,
+  TData,
+  TValue,
+  TSelected
+>
+
+export type AccessorKeyColumnDef<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData = CellData,
+  TSelected = {},
+> = ColumnDefWithReactContext<
+  CoreAccessorKeyColumnDef<TFeatures, TData, TValue>,
+  TFeatures,
+  TData,
+  TValue,
+  TSelected
+>
+
+export type AccessorColumnDef<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData = CellData,
+  TSelected = {},
+> =
+  | AccessorKeyColumnDef<TFeatures, TData, TValue, TSelected>
+  | AccessorFnColumnDef<TFeatures, TData, TValue, TSelected>
+
+export type ColumnDef<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData = CellData,
+  TSelected = {},
+> =
+  | DisplayColumnDef<TFeatures, TData, TValue, TSelected>
+  | GroupColumnDef<TFeatures, TData, TValue, TSelected>
+  | AccessorColumnDef<TFeatures, TData, TValue, TSelected>
+
+export type TableOptions<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TSelected = {},
+> = Omit<CoreTableOptions<TFeatures, TData>, 'columns' | 'defaultColumn'> & {
+  columns: ReadonlyArray<ColumnDef<TFeatures, TData, any, TSelected>>
+  defaultColumn?: Partial<ColumnDef<TFeatures, TData, any, TSelected>>
 }
 
 export function useTable<
@@ -116,16 +238,14 @@ export function useTable<
   TData extends RowData,
   TSelected = {},
 >(
-  tableOptions: TableOptions<TFeatures, TData>,
+  tableOptions: TableOptions<TFeatures, TData, TSelected>,
   selector: (state: TableState<TFeatures>) => TSelected = () =>
     ({}) as TSelected,
 ): ReactTable<TFeatures, TData, TSelected> {
   const [table] = useState(() => {
-    const tableInstance = constructTable(tableOptions) as ReactTable<
-      TFeatures,
-      TData,
-      TSelected
-    >
+    const tableInstance = constructTable(
+      tableOptions as CoreTableOptions<TFeatures, TData>,
+    ) as ReactTable<TFeatures, TData, TSelected>
 
     tableInstance.Subscribe = ((props: any) => {
       return Subscribe({

--- a/packages/react-table/tests/column-context.test-d.ts
+++ b/packages/react-table/tests/column-context.test-d.ts
@@ -1,0 +1,43 @@
+import { globalFilteringFeature, tableFeatures, useTable } from '../src'
+import type { ColumnDef } from '../src'
+
+const _features = tableFeatures({ globalFilteringFeature })
+
+type Person = {
+  id: string
+  name: string
+}
+
+const data: Person[] = [{ id: '1', name: 'Ada' }]
+
+const columns: Array<ColumnDef<typeof _features, Person>> = [
+  {
+    accessorKey: 'name',
+    header: ({ table }) =>
+      table.Subscribe({
+        selector: (state) => ({ globalFilter: state.globalFilter }),
+        children: null,
+      }),
+    cell: ({ table }) =>
+      table.Subscribe({
+        selector: (state) => ({ globalFilter: state.globalFilter }),
+        children: null,
+      }),
+  },
+]
+
+function TestTable() {
+  const table = useTable({
+    _features,
+    data,
+    columns,
+    state: { globalFilter: '' },
+  })
+
+  return table.Subscribe({
+    selector: (state) => ({ globalFilter: state.globalFilter }),
+    children: null,
+  })
+}
+
+void TestTable


### PR DESCRIPTION
## 🎯 Changes

Fixes #6230.

- Type React column `cell`, `header`, and `footer` contexts so their `table` prop is the React table instance and exposes helpers like `table.Subscribe`.
- Re-export the React adapter's context, column definition, and table option types so `ColumnDef` from `@tanstack/react-table` uses those React-specific contexts.
- Add a type regression test covering `table.Subscribe` usage from both header and cell render callbacks.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.

Targeted checks run instead:

- `pnpm exec prettier --check packages/react-table/src/useTable.ts packages/react-table/src/index.ts packages/react-table/tests/column-context.test-d.ts`
- `pnpm --filter @tanstack/react-table test:eslint`
- `pnpm --filter @tanstack/react-table test:types`
- `pnpm --filter @tanstack/react-table test:lib`
- `pnpm --filter @tanstack/react-table build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New TypeScript types for column definitions and table contexts with enhanced type inference capabilities
  * Explicit type exports improve developer experience and IDE autocompletion support

* **Refactor**
  * Updated public API export structure to explicitly define the package surface, replacing wildcard exports with named type exports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->