### PR TITLE
added *IgnoreDiacritics sort functions

### DIFF
--- a/docs/guide/sorting.md
+++ b/docs/guide/sorting.md
@@ -156,8 +156,12 @@ By default, there are 6 built-in sorting functions to choose from:
 
 - `alphanumeric` - Sorts by mixed alphanumeric values without case-sensitivity. Slower, but more accurate if your strings contain numbers that need to be naturally sorted.
 - `alphanumericCaseSensitive` - Sorts by mixed alphanumeric values with case-sensitivity. Slower, but more accurate if your strings contain numbers that need to be naturally sorted.
+- `alphanumericIgnoreDiacritics` - Sorts by mixed alphanumeric values without case-sensitivity and ignoring diacritics/accent marks. Slower, but more accurate if your strings contain numbers that need to be naturally sorted.
+- `alphanumericIgnoreDiacriticsCaseSensitive` - Sorts by mixed alphanumeric values with case-sensitivity and ignoring diacritics/accent marks. Slower, but more accurate if your strings contain numbers that need to be naturally sorted.
 - `text` - Sorts by text/string values without case-sensitivity. Faster, but less accurate if your strings contain numbers that need to be naturally sorted.
 - `textCaseSensitive` - Sorts by text/string values with case-sensitivity. Faster, but less accurate if your strings contain numbers that need to be naturally sorted.
+- `textIgnoreDiacritics` - Sorts by text/string values without case-sensitivity and ignoring diacritics/accent marks. Faster, but less accurate if your strings contain numbers that need to be naturally sorted.
+- `textCaseIgnoreDiacriticsSensitive` - Sorts by text/string values with case-sensitivity and ignoring diacritics/accent marks. Faster, but less accurate if your strings contain numbers that need to be naturally sorted.
 - `datetime` - Sorts by time, use this if your values are `Date` objects.
 - `basic` - Sorts using a basic/standard `a > b ? 1 : a < b ? -1 : 0` comparison. This is the fastest sorting function, but may not be the most accurate.
 

--- a/docs/guide/sorting.md
+++ b/docs/guide/sorting.md
@@ -161,7 +161,7 @@ By default, there are 6 built-in sorting functions to choose from:
 - `text` - Sorts by text/string values without case-sensitivity. Faster, but less accurate if your strings contain numbers that need to be naturally sorted.
 - `textCaseSensitive` - Sorts by text/string values with case-sensitivity. Faster, but less accurate if your strings contain numbers that need to be naturally sorted.
 - `textIgnoreDiacritics` - Sorts by text/string values without case-sensitivity and ignoring diacritics/accent marks. Faster, but less accurate if your strings contain numbers that need to be naturally sorted.
-- `textCaseIgnoreDiacriticsSensitive` - Sorts by text/string values with case-sensitivity and ignoring diacritics/accent marks. Faster, but less accurate if your strings contain numbers that need to be naturally sorted.
+- `textIgnoreDiacriticsCaseSensitive` - Sorts by text/string values with case-sensitivity and ignoring diacritics/accent marks. Faster, but less accurate if your strings contain numbers that need to be naturally sorted.
 - `datetime` - Sorts by time, use this if your values are `Date` objects.
 - `basic` - Sorts using a basic/standard `a > b ? 1 : a < b ? -1 : 0` comparison. This is the fastest sorting function, but may not be the most accurate.
 

--- a/packages/table-core/src/fns/sortFns.ts
+++ b/packages/table-core/src/fns/sortFns.ts
@@ -33,6 +33,34 @@ export const sortFn_alphanumericCaseSensitive: SortFn<any, any> = <
   )
 }
 
+export const sortFn_alphanumericIgnoreDiacritics: SortFn<any, any> = <
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>(
+  rowA: Row<any, any>,
+  rowB: Row<any, any>,
+  columnId: string,
+) => {
+  return compareAlphanumeric(
+    normalizeText(toString(rowA.getValue(columnId)).toLowerCase()),
+    normalizeText(toString(rowB.getValue(columnId)).toLowerCase()),
+  )
+}
+
+export const sortFn_alphanumericIgnoreDiacriticsCaseSensitive: SortFn<any, any> = <
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>(
+  rowA: Row<any, any>,
+  rowB: Row<any, any>,
+  columnId: string,
+) => {
+  return compareAlphanumeric(
+    normalizeText(toString(rowA.getValue(columnId))),
+    normalizeText(toString(rowB.getValue(columnId))),
+  )
+}
+
 // The text filter is more basic (less numeric support)
 // but is much faster
 export const sortFn_text: SortFn<any, any> = <
@@ -62,6 +90,38 @@ export const sortFn_textCaseSensitive: SortFn<any, any> = <
   return compareBasic(
     toString(rowA.getValue(columnId)),
     toString(rowB.getValue(columnId)),
+  )
+}
+
+// The text filter is more basic (less numeric support)
+// but is much faster
+export const sortFn_textIgnoreDiacritics: SortFn<any, any> = <
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>(
+  rowA: Row<any, any>,
+  rowB: Row<any, any>,
+  columnId: string,
+) => {
+  return compareBasic(
+    normalizeText(toString(rowA.getValue(columnId)).toLowerCase()),
+    normalizeText(toString(rowB.getValue(columnId)).toLowerCase()),
+  )
+}
+
+// The text filter is more basic (less numeric support)
+// but is much faster
+export const sortFn_textIgnoreDiacriticsCaseSensitive: SortFn<any, any> = <
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>(
+  rowA: Row<any, any>,
+  rowB: Row<any, any>,
+  columnId: string,
+) => {
+  return compareBasic(
+    normalizeText(toString(rowA.getValue(columnId))),
+    normalizeText(toString(rowB.getValue(columnId))),
   )
 }
 
@@ -110,6 +170,10 @@ function toString(a: any) {
     return a
   }
   return ''
+}
+
+function normalizeText(str: string): string {
+  return str.normalize('NFD').replace(/\p{Diacritic}/gu, '')
 }
 
 // Mixed sorting is slow, but very inclusive of many edge cases.
@@ -164,10 +228,14 @@ function compareAlphanumeric(aStr: string, bStr: string) {
 export const sortFns = {
   alphanumeric: sortFn_alphanumeric,
   alphanumericCaseSensitive: sortFn_alphanumericCaseSensitive,
+  alphanumericIgnoreDiacritics: sortFn_alphanumericIgnoreDiacritics,
+  alphanumericIgnoreDiacriticsCaseSensitive: sortFn_alphanumericIgnoreDiacriticsCaseSensitive,
   basic: sortFn_basic,
   datetime: sortFn_datetime,
   text: sortFn_text,
   textCaseSensitive: sortFn_textCaseSensitive,
+  textIgnoreDiacritics: sortFn_textIgnoreDiacritics,
+  textIgnoreDiacriticsCaseSensitive: sortFn_textIgnoreDiacriticsCaseSensitive,
 }
 
 export type BuiltInSortFn = keyof typeof sortFns

--- a/packages/table-core/src/fns/sortFns.ts
+++ b/packages/table-core/src/fns/sortFns.ts
@@ -47,10 +47,10 @@ export const sortFn_alphanumericIgnoreDiacritics: SortFn<any, any> = <
   )
 }
 
-export const sortFn_alphanumericIgnoreDiacriticsCaseSensitive: SortFn<any, any> = <
-  TFeatures extends TableFeatures,
-  TData extends RowData,
->(
+export const sortFn_alphanumericIgnoreDiacriticsCaseSensitive: SortFn<
+  any,
+  any
+> = <TFeatures extends TableFeatures, TData extends RowData>(
   rowA: Row<any, any>,
   rowB: Row<any, any>,
   columnId: string,
@@ -229,7 +229,8 @@ export const sortFns = {
   alphanumeric: sortFn_alphanumeric,
   alphanumericCaseSensitive: sortFn_alphanumericCaseSensitive,
   alphanumericIgnoreDiacritics: sortFn_alphanumericIgnoreDiacritics,
-  alphanumericIgnoreDiacriticsCaseSensitive: sortFn_alphanumericIgnoreDiacriticsCaseSensitive,
+  alphanumericIgnoreDiacriticsCaseSensitive:
+    sortFn_alphanumericIgnoreDiacriticsCaseSensitive,
   basic: sortFn_basic,
   datetime: sortFn_datetime,
   text: sortFn_text,


### PR DESCRIPTION
## 🎯 Changes

Added *IgnoreDiacritics sort functions:

- alphanumericIgnoreDiacritics
- alphanumericIgnoreDiacriticsCaseSensitive
- textIgnoreDiacritics
- textIgnoreDiacriticsCaseSensitive

Ignoring diacritics gives a much more natural sorting behaviour.

E.g. having:

- Enrico Toccacelo
- Éric Bernard
- Eric Brandon
- Fred Wacker
- <many more rows>
- Zak O'Sullivan

above is the sorting ignoring diacritics which is what most users would expect when soring on name.

However, when not ignoring diacritics the sorting will be:

- Enrico Toccacelo
- Eric Brandon
- Fred Wacker
- <many more rows>
- Zak O'Sullivan
- Éric Bernard

Éric Bernard will be at the bottom of the table.


## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four new built-in sorting options that ignore diacritics/accent marks: alphanumeric and text sorting in both case-sensitive and case-insensitive variants.

* **Documentation**
  * Updated sorting guide to list the new diacritics-ignoring sort options alongside existing text sort variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->