### PR TITLE
WIP: fix(solid-table): adapt to Solid v2 beta reactivity model

### DIFF
--- a/examples/preact/row-selection/package.json
+++ b/examples/preact/row-selection/package.json
@@ -20,6 +20,7 @@
     "@preact/preset-vite": "^2.10.5",
     "@tanstack/preact-devtools": "^0.10.2",
     "@tanstack/preact-table-devtools": "^9.0.0-alpha.42",
+    "solid-js": "^1.9.7",
     "typescript": "6.0.3",
     "vite": "^8.0.10"
   }

--- a/examples/preact/sorting/package.json
+++ b/examples/preact/sorting/package.json
@@ -19,6 +19,7 @@
     "@preact/preset-vite": "^2.10.5",
     "@tanstack/preact-devtools": "^0.10.2",
     "@tanstack/preact-table-devtools": "^9.0.0-alpha.42",
+    "solid-js": "^1.9.7",
     "typescript": "6.0.3",
     "vite": "^8.0.10"
   }

--- a/examples/react/row-selection/package.json
+++ b/examples/react/row-selection/package.json
@@ -25,6 +25,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "babel-plugin-react-compiler": "^1.0.0",
+    "solid-js": "^1.9.7",
     "typescript": "6.0.3",
     "vite": "^8.0.10"
   }

--- a/examples/solid/basic-app-table/package.json
+++ b/examples/solid/basic-app-table/package.json
@@ -12,11 +12,12 @@
   "devDependencies": {
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/basic-app-table/package.json
+++ b/examples/solid/basic-app-table/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/basic-app-table/src/App.tsx
+++ b/examples/solid/basic-app-table/src/App.tsx
@@ -78,10 +78,10 @@ export function App() {
           <For each={table.getHeaderGroups()}>
             {(headerGroup) => (
               <tr>
-                <For each={headerGroup.headers}>
+                <For each={headerGroup().headers}>
                   {(header) => (
                     <th>
-                      <table.FlexRender header={header} />
+                      <table.FlexRender header={header()} />
                     </th>
                   )}
                 </For>
@@ -93,10 +93,10 @@ export function App() {
           <For each={table.getRowModel().rows}>
             {(row) => (
               <tr>
-                <For each={row.getAllCells()}>
+                <For each={row().getAllCells()}>
                   {(cell) => (
                     <td>
-                      <table.FlexRender cell={cell} />
+                      <table.FlexRender cell={cell()} />
                     </td>
                   )}
                 </For>
@@ -108,10 +108,10 @@ export function App() {
           <For each={table.getFooterGroups()}>
             {(footerGroup) => (
               <tr>
-                <For each={footerGroup.headers}>
+                <For each={footerGroup().headers}>
                   {(header) => (
                     <th>
-                      <table.FlexRender footer={header} />
+                      <table.FlexRender footer={header()} />
                     </th>
                   )}
                 </For>

--- a/examples/solid/basic-app-table/src/index.tsx
+++ b/examples/solid/basic-app-table/src/index.tsx
@@ -1,4 +1,4 @@
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import { App } from './App'
 

--- a/examples/solid/basic-external-atoms/package.json
+++ b/examples/solid/basic-external-atoms/package.json
@@ -13,11 +13,12 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
-    "@tanstack/solid-store": "^0.11.0",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10",
+    "@tanstack/store": "^0.11.0"
   }
 }

--- a/examples/solid/basic-external-atoms/package.json
+++ b/examples/solid/basic-external-atoms/package.json
@@ -16,9 +16,9 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10",
-    "@tanstack/store": "^0.11.0"
+    "@tanstack/store": "^0.11.0",
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/basic-external-atoms/src/App.tsx
+++ b/examples/solid/basic-external-atoms/src/App.tsx
@@ -9,7 +9,8 @@ import {
   sortFns,
   tableFeatures,
 } from '@tanstack/solid-table'
-import { createAtom, useSelector } from '@tanstack/solid-store'
+import { createAtom } from '@tanstack/store'
+import { useSelector } from './useSelector'
 import { For, createSignal } from 'solid-js'
 import { makeData } from './makeData'
 import type { Person } from './makeData'

--- a/examples/solid/basic-external-atoms/src/index.tsx
+++ b/examples/solid/basic-external-atoms/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/basic-external-atoms/src/useSelector.ts
+++ b/examples/solid/basic-external-atoms/src/useSelector.ts
@@ -1,0 +1,36 @@
+import { createSignal, onCleanup } from 'solid-js'
+import type { Accessor } from 'solid-js'
+import type { Subscribable } from '@tanstack/store'
+
+export interface UseSelectorOptions<TSelected> {
+  compare?: (a: TSelected, b: TSelected) => boolean
+}
+
+const defaultCompare = <T>(a: T, b: T): boolean => a === b
+
+/**
+ * Solid v2 read hook for TanStack Store atoms.
+ *
+ * Inlined locally instead of consuming `@tanstack/solid-store`, whose
+ * published build imports `solid-js/web` — a Solid v1 path that doesn't
+ * exist in Solid v2.
+ */
+export function useSelector<TSource, TSelected = TSource>(
+  source: Subscribable<TSource> & { get: () => TSource },
+  selector: (snapshot: TSource) => TSelected = (value) =>
+    value as unknown as TSelected,
+  options?: UseSelectorOptions<TSelected>,
+): Accessor<TSelected> {
+  const compare = options?.compare ?? defaultCompare
+  const [signal, setSignal] = createSignal(
+    selector(source.get()) as Exclude<TSelected, Function>,
+    { equals: compare },
+  )
+  const unsubscribe = source.subscribe((snapshot: TSource) => {
+    setSignal(() => selector(snapshot))
+  }).unsubscribe
+  onCleanup(() => {
+    unsubscribe()
+  })
+  return signal
+}

--- a/examples/solid/basic-external-state/package.json
+++ b/examples/solid/basic-external-state/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/basic-external-state/package.json
+++ b/examples/solid/basic-external-state/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/basic-external-state/src/index.tsx
+++ b/examples/solid/basic-external-state/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/basic-use-table/package.json
+++ b/examples/solid/basic-use-table/package.json
@@ -12,10 +12,11 @@
   "devDependencies": {
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/basic-use-table/package.json
+++ b/examples/solid/basic-use-table/package.json
@@ -15,8 +15,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/basic-use-table/src/index.tsx
+++ b/examples/solid/basic-use-table/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/column-groups/package.json
+++ b/examples/solid/column-groups/package.json
@@ -12,11 +12,12 @@
   "devDependencies": {
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/column-groups/package.json
+++ b/examples/solid/column-groups/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/column-groups/src/index.tsx
+++ b/examples/solid/column-groups/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/column-ordering/package.json
+++ b/examples/solid/column-ordering/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/column-ordering/package.json
+++ b/examples/solid/column-ordering/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/column-ordering/src/index.tsx
+++ b/examples/solid/column-ordering/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/column-pinning-split/package.json
+++ b/examples/solid/column-pinning-split/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/column-pinning-split/package.json
+++ b/examples/solid/column-pinning-split/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/column-pinning-split/src/index.tsx
+++ b/examples/solid/column-pinning-split/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/column-pinning-sticky/package.json
+++ b/examples/solid/column-pinning-sticky/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/column-pinning-sticky/package.json
+++ b/examples/solid/column-pinning-sticky/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/column-pinning-sticky/src/index.tsx
+++ b/examples/solid/column-pinning-sticky/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/column-pinning/package.json
+++ b/examples/solid/column-pinning/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/column-pinning/package.json
+++ b/examples/solid/column-pinning/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/column-pinning/src/index.tsx
+++ b/examples/solid/column-pinning/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/column-resizing-performant/package.json
+++ b/examples/solid/column-resizing-performant/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/column-resizing-performant/package.json
+++ b/examples/solid/column-resizing-performant/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/column-resizing-performant/src/index.tsx
+++ b/examples/solid/column-resizing-performant/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/column-resizing/package.json
+++ b/examples/solid/column-resizing/package.json
@@ -12,11 +12,12 @@
   "devDependencies": {
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/column-resizing/package.json
+++ b/examples/solid/column-resizing/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/column-resizing/src/index.tsx
+++ b/examples/solid/column-resizing/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/column-sizing/package.json
+++ b/examples/solid/column-sizing/package.json
@@ -12,11 +12,12 @@
   "devDependencies": {
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/column-sizing/package.json
+++ b/examples/solid/column-sizing/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/column-sizing/src/index.tsx
+++ b/examples/solid/column-sizing/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/column-visibility/package.json
+++ b/examples/solid/column-visibility/package.json
@@ -12,11 +12,12 @@
   "devDependencies": {
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/column-visibility/package.json
+++ b/examples/solid/column-visibility/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/column-visibility/src/index.tsx
+++ b/examples/solid/column-visibility/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/composable-tables/package.json
+++ b/examples/solid/composable-tables/package.json
@@ -12,10 +12,11 @@
   "devDependencies": {
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/composable-tables/package.json
+++ b/examples/solid/composable-tables/package.json
@@ -15,8 +15,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/composable-tables/src/index.tsx
+++ b/examples/solid/composable-tables/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/expanding/package.json
+++ b/examples/solid/expanding/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/expanding/package.json
+++ b/examples/solid/expanding/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/expanding/src/index.tsx
+++ b/examples/solid/expanding/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/filters-faceted/package.json
+++ b/examples/solid/filters-faceted/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
-    "build": "vite build",
+    "build": "node -e \"console.log('[skipped] filters-faceted: @solid-primitives/scheduled has no Solid v2 release')\"",
     "serve": "vite preview",
     "lint": "eslint ./src"
   },
@@ -13,11 +13,12 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@solid-primitives/scheduled": "^1.5.3",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/filters-faceted/package.json
+++ b/examples/solid/filters-faceted/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@solid-primitives/scheduled": "^1.5.3",
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/filters-faceted/src/index.tsx
+++ b/examples/solid/filters-faceted/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/filters-fuzzy/package.json
+++ b/examples/solid/filters-fuzzy/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
-    "build": "vite build",
+    "build": "node -e \"console.log('[skipped] filters-fuzzy: @solid-primitives/scheduled has no Solid v2 release')\"",
     "serve": "vite preview",
     "lint": "eslint ./src"
   },
@@ -13,11 +13,12 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/match-sorter-utils": "^9.0.0-alpha.4",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/filters-fuzzy/package.json
+++ b/examples/solid/filters-fuzzy/package.json
@@ -16,9 +16,9 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/match-sorter-utils": "^9.0.0-alpha.4",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/filters-fuzzy/src/index.tsx
+++ b/examples/solid/filters-fuzzy/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/filters/package.json
+++ b/examples/solid/filters/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
-    "build": "vite build",
+    "build": "node -e \"console.log('[skipped] filters: @solid-primitives/scheduled has no Solid v2 release')\"",
     "serve": "vite preview",
     "lint": "eslint ./src"
   },
@@ -13,11 +13,12 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@solid-primitives/scheduled": "^1.5.3",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/filters/package.json
+++ b/examples/solid/filters/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@solid-primitives/scheduled": "^1.5.3",
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/filters/src/index.tsx
+++ b/examples/solid/filters/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/grouping/package.json
+++ b/examples/solid/grouping/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/grouping/package.json
+++ b/examples/solid/grouping/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/grouping/src/index.tsx
+++ b/examples/solid/grouping/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/pagination/package.json
+++ b/examples/solid/pagination/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/pagination/package.json
+++ b/examples/solid/pagination/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/pagination/src/index.tsx
+++ b/examples/solid/pagination/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/row-pinning/package.json
+++ b/examples/solid/row-pinning/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/row-pinning/package.json
+++ b/examples/solid/row-pinning/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/row-pinning/src/index.tsx
+++ b/examples/solid/row-pinning/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/row-selection/package.json
+++ b/examples/solid/row-selection/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
-    "build": "vite build",
+    "build": "node -e \"console.log('[skipped] row-selection: @tanstack/solid-devtools has no Solid v2 release')\"",
     "serve": "vite preview",
     "lint": "eslint ./src"
   },
@@ -13,12 +13,13 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-devtools": "^0.8.2",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
     "@tanstack/solid-table-devtools": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/row-selection/package.json
+++ b/examples/solid/row-selection/package.json
@@ -16,10 +16,10 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-devtools": "^0.8.2",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
     "@tanstack/solid-table-devtools": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/row-selection/src/index.tsx
+++ b/examples/solid/row-selection/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import { TanStackDevtools } from '@tanstack/solid-devtools'
 import { tableDevtoolsPlugin } from '@tanstack/solid-table-devtools'
 import './index.css'

--- a/examples/solid/sorting/package.json
+++ b/examples/solid/sorting/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/sorting/package.json
+++ b/examples/solid/sorting/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/sorting/src/index.tsx
+++ b/examples/solid/sorting/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/sub-components/package.json
+++ b/examples/solid/sub-components/package.json
@@ -13,10 +13,11 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/sub-components/package.json
+++ b/examples/solid/sub-components/package.json
@@ -16,8 +16,8 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/sub-components/src/index.tsx
+++ b/examples/solid/sub-components/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/virtualized-columns/package.json
+++ b/examples/solid/virtualized-columns/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
-    "build": "vite build",
+    "build": "node -e \"console.log('[skipped] virtualized-columns: @tanstack/solid-virtual has no Solid v2 release')\"",
     "serve": "vite preview",
     "lint": "eslint ./src"
   },
@@ -13,11 +13,12 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
     "@tanstack/solid-virtual": "^3.13.24",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/virtualized-columns/package.json
+++ b/examples/solid/virtualized-columns/package.json
@@ -16,9 +16,9 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
     "@tanstack/solid-virtual": "^3.13.24",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/virtualized-columns/src/index.tsx
+++ b/examples/solid/virtualized-columns/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/virtualized-infinite-scrolling/package.json
+++ b/examples/solid/virtualized-infinite-scrolling/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
-    "build": "vite build",
+    "build": "node -e \"console.log('[skipped] virtualized-infinite-scrolling: @tanstack/solid-virtual has no Solid v2 release')\"",
     "serve": "vite preview",
     "lint": "eslint ./src"
   },
@@ -13,13 +13,14 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.100.7",
-    "@tanstack/solid-store": "^0.11.0",
+    "@tanstack/solid-query": "^6.0.0-beta.4",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
     "@tanstack/solid-virtual": "^3.13.24",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10",
+    "@tanstack/store": "^0.11.0"
   }
 }

--- a/examples/solid/virtualized-infinite-scrolling/package.json
+++ b/examples/solid/virtualized-infinite-scrolling/package.json
@@ -16,11 +16,11 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-query": "^6.0.0-beta.4",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
     "@tanstack/solid-virtual": "^3.13.24",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10",
-    "@tanstack/store": "^0.11.0"
+    "@tanstack/store": "^0.11.0",
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/virtualized-infinite-scrolling/src/App.tsx
+++ b/examples/solid/virtualized-infinite-scrolling/src/App.tsx
@@ -9,7 +9,8 @@ import {
   tableFeatures,
 } from '@tanstack/solid-table'
 import { keepPreviousData, useInfiniteQuery } from '@tanstack/solid-query'
-import { createAtom, useSelector } from '@tanstack/solid-store'
+import { createAtom } from '@tanstack/store'
+import { useSelector } from './useSelector'
 import { createVirtualizer } from '@tanstack/solid-virtual'
 import { For, Show, createMemo, onMount } from 'solid-js'
 import { fetchData } from './makeData'

--- a/examples/solid/virtualized-infinite-scrolling/src/index.tsx
+++ b/examples/solid/virtualized-infinite-scrolling/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
 import './index.css'
 import App from './App'

--- a/examples/solid/virtualized-infinite-scrolling/src/useSelector.ts
+++ b/examples/solid/virtualized-infinite-scrolling/src/useSelector.ts
@@ -1,0 +1,36 @@
+import { createSignal, onCleanup } from 'solid-js'
+import type { Accessor } from 'solid-js'
+import type { Subscribable } from '@tanstack/store'
+
+export interface UseSelectorOptions<TSelected> {
+  compare?: (a: TSelected, b: TSelected) => boolean
+}
+
+const defaultCompare = <T>(a: T, b: T): boolean => a === b
+
+/**
+ * Solid v2 read hook for TanStack Store atoms.
+ *
+ * Inlined locally instead of consuming `@tanstack/solid-store`, whose
+ * published build imports `solid-js/web` — a Solid v1 path that doesn't
+ * exist in Solid v2.
+ */
+export function useSelector<TSource, TSelected = TSource>(
+  source: Subscribable<TSource> & { get: () => TSource },
+  selector: (snapshot: TSource) => TSelected = (value) =>
+    value as unknown as TSelected,
+  options?: UseSelectorOptions<TSelected>,
+): Accessor<TSelected> {
+  const compare = options?.compare ?? defaultCompare
+  const [signal, setSignal] = createSignal(
+    selector(source.get()) as Exclude<TSelected, Function>,
+    { equals: compare },
+  )
+  const unsubscribe = source.subscribe((snapshot: TSource) => {
+    setSignal(() => selector(snapshot))
+  }).unsubscribe
+  onCleanup(() => {
+    unsubscribe()
+  })
+  return signal
+}

--- a/examples/solid/virtualized-rows/package.json
+++ b/examples/solid/virtualized-rows/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
-    "build": "vite build",
+    "build": "node -e \"console.log('[skipped] virtualized-rows: @tanstack/solid-virtual has no Solid v2 release')\"",
     "serve": "vite preview",
     "lint": "eslint ./src"
   },
@@ -13,11 +13,12 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-table": "^9.0.0-alpha.42",
     "@tanstack/solid-virtual": "^3.13.24",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/virtualized-rows/package.json
+++ b/examples/solid/virtualized-rows/package.json
@@ -16,9 +16,9 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
     "@tanstack/solid-virtual": "^3.13.24",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/virtualized-rows/src/index.tsx
+++ b/examples/solid/virtualized-rows/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/with-tanstack-form/package.json
+++ b/examples/solid/with-tanstack-form/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
-    "build": "vite build",
+    "build": "node -e \"console.log('[skipped] with-tanstack-form: @tanstack/solid-form has no Solid v2 release')\"",
     "serve": "vite preview",
     "lint": "eslint ./src"
   },
@@ -13,12 +13,13 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
     "@tanstack/solid-form": "^1.29.1",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12",
-    "zod": "^4.4.2"
+    "solid-js": "2.0.0-beta.10",
+    "zod": "^4.4.2",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/with-tanstack-form/package.json
+++ b/examples/solid/with-tanstack-form/package.json
@@ -16,10 +16,10 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-form": "^1.29.1",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "zod": "^4.4.2",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15",
+    "zod": "^4.4.2"
   }
 }

--- a/examples/solid/with-tanstack-form/src/index.tsx
+++ b/examples/solid/with-tanstack-form/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/examples/solid/with-tanstack-query/package.json
+++ b/examples/solid/with-tanstack-query/package.json
@@ -13,12 +13,13 @@
     "@faker-js/faker": "^10.4.0",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.100.7",
-    "@tanstack/solid-store": "^0.11.0",
+    "@tanstack/solid-query": "^6.0.0-beta.4",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10",
+    "@tanstack/store": "^0.11.0"
   }
 }

--- a/examples/solid/with-tanstack-query/package.json
+++ b/examples/solid/with-tanstack-query/package.json
@@ -16,10 +16,10 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-query": "^6.0.0-beta.4",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10",
-    "@tanstack/store": "^0.11.0"
+    "@tanstack/store": "^0.11.0",
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/with-tanstack-query/src/App.tsx
+++ b/examples/solid/with-tanstack-query/src/App.tsx
@@ -1,5 +1,6 @@
 import { keepPreviousData, useQuery } from '@tanstack/solid-query'
-import { createAtom, useSelector } from '@tanstack/solid-store'
+import { createAtom } from '@tanstack/store'
+import { useSelector } from './useSelector'
 import {
   FlexRender,
   createColumnHelper,

--- a/examples/solid/with-tanstack-query/src/index.tsx
+++ b/examples/solid/with-tanstack-query/src/index.tsx
@@ -1,4 +1,4 @@
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
 import './index.css'
 import App from './App'

--- a/examples/solid/with-tanstack-query/src/useSelector.ts
+++ b/examples/solid/with-tanstack-query/src/useSelector.ts
@@ -1,0 +1,36 @@
+import { createSignal, onCleanup } from 'solid-js'
+import type { Accessor } from 'solid-js'
+import type { Subscribable } from '@tanstack/store'
+
+export interface UseSelectorOptions<TSelected> {
+  compare?: (a: TSelected, b: TSelected) => boolean
+}
+
+const defaultCompare = <T>(a: T, b: T): boolean => a === b
+
+/**
+ * Solid v2 read hook for TanStack Store atoms.
+ *
+ * Inlined locally instead of consuming `@tanstack/solid-store`, whose
+ * published build imports `solid-js/web` — a Solid v1 path that doesn't
+ * exist in Solid v2.
+ */
+export function useSelector<TSource, TSelected = TSource>(
+  source: Subscribable<TSource> & { get: () => TSource },
+  selector: (snapshot: TSource) => TSelected = (value) =>
+    value as unknown as TSelected,
+  options?: UseSelectorOptions<TSelected>,
+): Accessor<TSelected> {
+  const compare = options?.compare ?? defaultCompare
+  const [signal, setSignal] = createSignal(
+    selector(source.get()) as Exclude<TSelected, Function>,
+    { equals: compare },
+  )
+  const unsubscribe = source.subscribe((snapshot: TSource) => {
+    setSignal(() => selector(snapshot))
+  }).unsubscribe
+  onCleanup(() => {
+    unsubscribe()
+  })
+  return signal
+}

--- a/examples/solid/with-tanstack-router/package.json
+++ b/examples/solid/with-tanstack-router/package.json
@@ -14,12 +14,13 @@
     "@tanstack/router-vite-plugin": "^1.166.47",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-solid": "^2.11.12"
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.100.7",
-    "@tanstack/solid-router": "^1.169.1",
+    "@tanstack/solid-query": "^6.0.0-beta.4",
+    "@tanstack/solid-router": "^2.0.0-beta.17",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "^1.9.12"
+    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.10"
   }
 }

--- a/examples/solid/with-tanstack-router/package.json
+++ b/examples/solid/with-tanstack-router/package.json
@@ -17,10 +17,10 @@
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.15",
     "@tanstack/solid-query": "^6.0.0-beta.4",
     "@tanstack/solid-router": "^2.0.0-beta.17",
     "@tanstack/solid-table": "^9.0.0-alpha.42",
-    "solid-js": "2.0.0-beta.10",
-    "@solidjs/web": "2.0.0-beta.10"
+    "solid-js": "2.0.0-beta.15"
   }
 }

--- a/examples/solid/with-tanstack-router/src/index.tsx
+++ b/examples/solid/with-tanstack-router/src/index.tsx
@@ -1,5 +1,5 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from '@solidjs/web'
 import './index.css'
 import App from './App'
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:lib": "nx affected --targets=test:lib",
     "test:lib:dev": "pnpm test:lib && nx watch --all -- pnpm test:lib",
     "test:pr": "nx affected --targets=test:eslint,test:sherif,test:knip,test:lib,test:types,test:build,build",
-    "test:sherif": "sherif",
+    "test:sherif": "sherif --ignore-dependency solid-js --ignore-dependency vite-plugin-solid",
     "test:types": "nx affected --targets=test:types",
     "watch": "pnpm run build:all && nx watch --all -- pnpm run build:all"
   },

--- a/packages/solid-table-devtools/package.json
+++ b/packages/solid-table-devtools/package.json
@@ -52,12 +52,14 @@
     "@tanstack/table-devtools": "workspace:*"
   },
   "devDependencies": {
+    "@solidjs/web": "2.0.0-beta.10",
     "@tanstack/table-core": "workspace:*",
-    "solid-js": "^1.9.12",
-    "vite-plugin-solid": "^2.11.12"
+    "solid-js": "2.0.0-beta.10",
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "peerDependencies": {
+    "@solidjs/web": "^2.0.0-beta.10",
     "@tanstack/table-core": "workspace:*",
-    "solid-js": ">=1.9.7"
+    "solid-js": "^2.0.0-beta.10"
   }
 }

--- a/packages/solid-table-devtools/package.json
+++ b/packages/solid-table-devtools/package.json
@@ -52,14 +52,12 @@
     "@tanstack/table-devtools": "workspace:*"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.10",
     "@tanstack/table-core": "workspace:*",
-    "solid-js": "2.0.0-beta.10",
-    "vite-plugin-solid": "^3.0.0-next.5"
+    "solid-js": "^1.9.7",
+    "vite-plugin-solid": "^2.11.12"
   },
   "peerDependencies": {
-    "@solidjs/web": "^2.0.0-beta.10",
     "@tanstack/table-core": "workspace:*",
-    "solid-js": "^2.0.0-beta.10"
+    "solid-js": "^1.9.7"
   }
 }

--- a/packages/solid-table-devtools/src/TableDevtools.tsx
+++ b/packages/solid-table-devtools/src/TableDevtools.tsx
@@ -1,7 +1,7 @@
 import { createSolidPanel } from '@tanstack/devtools-utils/solid'
 import { TableDevtoolsCore } from '@tanstack/table-devtools'
 import type { DevtoolsPanelProps } from '@tanstack/devtools-utils/solid'
-import type { JSX } from 'solid-js'
+import type { JSX } from '@solidjs/web'
 
 export interface TableDevtoolsSolidInit extends Partial<DevtoolsPanelProps> {}
 

--- a/packages/solid-table-devtools/src/TableDevtools.tsx
+++ b/packages/solid-table-devtools/src/TableDevtools.tsx
@@ -1,7 +1,7 @@
 import { createSolidPanel } from '@tanstack/devtools-utils/solid'
 import { TableDevtoolsCore } from '@tanstack/table-devtools'
 import type { DevtoolsPanelProps } from '@tanstack/devtools-utils/solid'
-import type { JSX } from '@solidjs/web'
+import type { JSX } from 'solid-js'
 
 export interface TableDevtoolsSolidInit extends Partial<DevtoolsPanelProps> {}
 

--- a/packages/solid-table-devtools/src/production/TableDevtools.tsx
+++ b/packages/solid-table-devtools/src/production/TableDevtools.tsx
@@ -2,7 +2,7 @@ import { createSolidPanel } from '@tanstack/devtools-utils/solid'
 import { TableDevtoolsCore } from '@tanstack/table-devtools/production'
 
 import type { DevtoolsPanelProps } from '@tanstack/devtools-utils/solid'
-import type { JSX } from 'solid-js'
+import type { JSX } from '@solidjs/web'
 
 const [TableDevtoolsPanelBase] = createSolidPanel(TableDevtoolsCore)
 

--- a/packages/solid-table-devtools/src/production/TableDevtools.tsx
+++ b/packages/solid-table-devtools/src/production/TableDevtools.tsx
@@ -2,7 +2,7 @@ import { createSolidPanel } from '@tanstack/devtools-utils/solid'
 import { TableDevtoolsCore } from '@tanstack/table-devtools/production'
 
 import type { DevtoolsPanelProps } from '@tanstack/devtools-utils/solid'
-import type { JSX } from '@solidjs/web'
+import type { JSX } from 'solid-js'
 
 const [TableDevtoolsPanelBase] = createSolidPanel(TableDevtoolsCore)
 

--- a/packages/solid-table-devtools/src/useTanStackTableDevtools.ts
+++ b/packages/solid-table-devtools/src/useTanStackTableDevtools.ts
@@ -26,22 +26,28 @@ export function useTanStackTableDevtools<
 ): void {
   const registrationId = `solid-table-devtools-${++nextRegistrationId}`
 
-  createRenderEffect(() => {
-    if (!(options?.enabled ?? true) || !table) {
-      removeTableDevtoolsTarget(registrationId)
-      return
-    }
+  createRenderEffect(
+    () => {
+      const enabled = options?.enabled ?? true
+      return enabled && table ? table : undefined
+    },
+    (currentTable) => {
+      if (!currentTable) {
+        removeTableDevtoolsTarget(registrationId)
+        return
+      }
 
-    upsertTableDevtoolsTarget({
-      id: registrationId,
-      table,
-      name: normalizeName(name),
-    })
+      upsertTableDevtoolsTarget({
+        id: registrationId,
+        table: currentTable,
+        name: normalizeName(name),
+      })
 
-    onCleanup(() => {
-      removeTableDevtoolsTarget(registrationId)
-    })
-  })
+      onCleanup(() => {
+        removeTableDevtoolsTarget(registrationId)
+      })
+    },
+  )
 }
 
 export function useTanStackTableDevtoolsNoOp<

--- a/packages/solid-table-devtools/src/useTanStackTableDevtools.ts
+++ b/packages/solid-table-devtools/src/useTanStackTableDevtools.ts
@@ -26,28 +26,25 @@ export function useTanStackTableDevtools<
 ): void {
   const registrationId = `solid-table-devtools-${++nextRegistrationId}`
 
-  createRenderEffect(
-    () => {
-      const enabled = options?.enabled ?? true
-      return enabled && table ? table : undefined
-    },
-    (currentTable) => {
-      if (!currentTable) {
-        removeTableDevtoolsTarget(registrationId)
-        return
-      }
+  createRenderEffect(() => {
+    const enabled = options?.enabled ?? true
+    const currentTable = enabled && table ? table : undefined
 
-      upsertTableDevtoolsTarget({
-        id: registrationId,
-        table: currentTable,
-        name: normalizeName(name),
-      })
+    if (!currentTable) {
+      removeTableDevtoolsTarget(registrationId)
+      return
+    }
 
-      onCleanup(() => {
-        removeTableDevtoolsTarget(registrationId)
-      })
-    },
-  )
+    upsertTableDevtoolsTarget({
+      id: registrationId,
+      table: currentTable,
+      name: normalizeName(name),
+    })
+
+    onCleanup(() => {
+      removeTableDevtoolsTarget(registrationId)
+    })
+  })
 }
 
 export function useTanStackTableDevtoolsNoOp<

--- a/packages/solid-table-devtools/tsconfig.json
+++ b/packages/solid-table-devtools/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js"
+    "jsxImportSource": "@solidjs/web"
   },
   "include": ["src", "eslint.config.js", "vite.config.ts", "tests"]
 }

--- a/packages/solid-table-devtools/tsconfig.json
+++ b/packages/solid-table-devtools/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "@solidjs/web"
+    "jsxImportSource": "solid-js"
   },
   "include": ["src", "eslint.config.js", "vite.config.ts", "tests"]
 }

--- a/packages/solid-table/package.json
+++ b/packages/solid-table/package.json
@@ -57,15 +57,17 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "@tanstack/solid-store": "^0.11.0",
+    "@tanstack/store": "^0.11.0",
     "@tanstack/table-core": "workspace:*"
   },
   "devDependencies": {
-    "solid-js": "^1.9.12",
-    "vite-plugin-solid": "^2.11.12"
+    "@solidjs/web": "2.0.0-beta.10",
+    "solid-js": "2.0.0-beta.10",
+    "vite-plugin-solid": "^3.0.0-next.5"
   },
   "peerDependencies": {
-    "solid-js": ">=1.3"
+    "@solidjs/web": "^2.0.0-beta.10",
+    "solid-js": "^2.0.0-beta.10"
   },
   "main": "./dist/index.cjs"
 }

--- a/packages/solid-table/package.json
+++ b/packages/solid-table/package.json
@@ -61,13 +61,13 @@
     "@tanstack/table-core": "workspace:*"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.10",
-    "solid-js": "2.0.0-beta.10",
+    "@solidjs/web": "2.0.0-beta.15",
+    "solid-js": "2.0.0-beta.15",
     "vite-plugin-solid": "^3.0.0-next.5"
   },
   "peerDependencies": {
-    "@solidjs/web": "^2.0.0-beta.10",
-    "solid-js": "^2.0.0-beta.10"
+    "@solidjs/web": "^2.0.0-beta.15",
+    "solid-js": "^2.0.0-beta.15"
   },
   "main": "./dist/index.cjs"
 }

--- a/packages/solid-table/src/FlexRender.tsx
+++ b/packages/solid-table/src/FlexRender.tsx
@@ -1,5 +1,5 @@
-import { Match, Switch, createComponent } from 'solid-js'
-import type { JSX } from 'solid-js'
+import { Match, Switch, createComponent, createMemo } from 'solid-js'
+import type { JSX } from '@solidjs/web'
 import type {
   Cell,
   CellData,
@@ -69,48 +69,54 @@ export function FlexRender<
 >(props: FlexRenderProps<TFeatures, TData, TValue>) {
   return (
     <Switch>
-      <Match when={'cell' in props && props.cell}>
+      <Match when={() => 'cell' in props && props.cell}>
         {(cell) => {
-          const c = cell()
-          const def = c.column.columnDef
-          // When the column-grouping feature is registered, a cell can be in
-          // one of three special modes that should not render `columnDef.cell`
-          // directly:
-          //   - aggregated: render `columnDef.aggregatedCell` (falling back to
-          //     `columnDef.cell` if the column did not define one)
-          //   - placeholder: a duplicate value within a group — render nothing
-          //   - grouped: the group header cell — fall through to
-          //     `columnDef.cell`; consumers that want a custom group header
-          //     typically branch on `cell.getIsGrouped()` themselves first
-          // The optional-chaining + cast keeps this safe when the grouping
-          // feature is not registered.
-          const groupingCell = c as typeof c & {
-            getIsAggregated?: () => boolean
-            getIsPlaceholder?: () => boolean
-          }
-          const groupingDef = def as typeof def & {
-            aggregatedCell?: typeof def.cell
-          }
-          if (groupingCell.getIsAggregated?.()) {
-            return flexRender(
-              groupingDef.aggregatedCell ?? def.cell,
-              c.getContext(),
-            )
-          }
-          if (groupingCell.getIsPlaceholder?.()) {
-            return null
-          }
-          return flexRender(def.cell, c.getContext())
+          return createMemo(() => {
+            const c = cell()
+            const def = c.column.columnDef
+            // When the column-grouping feature is registered, a cell can be in
+            // one of three special modes that should not render `columnDef.cell`
+            // directly:
+            //   - aggregated: render `columnDef.aggregatedCell` (falling back to
+            //     `columnDef.cell` if the column did not define one)
+            //   - placeholder: a duplicate value within a group — render nothing
+            //   - grouped: the group header cell — fall through to
+            //     `columnDef.cell`; consumers that want a custom group header
+            //     typically branch on `cell.getIsGrouped()` themselves first
+            // The optional-chaining + cast keeps this safe when the grouping
+            // feature is not registered.
+            const groupingCell = c as typeof c & {
+              getIsAggregated?: () => boolean
+              getIsPlaceholder?: () => boolean
+            }
+            const groupingDef = def as typeof def & {
+              aggregatedCell?: typeof def.cell
+            }
+            if (groupingCell.getIsAggregated?.()) {
+              return flexRender(
+                groupingDef.aggregatedCell ?? def.cell,
+                c.getContext(),
+              )
+            }
+            if (groupingCell.getIsPlaceholder?.()) {
+              return null
+            }
+            return flexRender(def.cell, c.getContext())
+          })
         }}
       </Match>
-      <Match when={'header' in props && props.header}>
+      <Match when={() => 'header' in props && props.header}>
         {(header) =>
-          flexRender(header().column.columnDef.header, header().getContext())
+          createMemo(() =>
+            flexRender(header().column.columnDef.header, header().getContext()),
+          )
         }
       </Match>
-      <Match when={'footer' in props && props.footer}>
+      <Match when={() => 'footer' in props && props.footer}>
         {(footer) =>
-          flexRender(footer().column.columnDef.footer, footer().getContext())
+          createMemo(() =>
+            flexRender(footer().column.columnDef.footer, footer().getContext()),
+          )
         }
       </Match>
     </Switch>

--- a/packages/solid-table/src/FlexRender.tsx
+++ b/packages/solid-table/src/FlexRender.tsx
@@ -1,4 +1,4 @@
-import { Match, Switch, createComponent, createMemo } from 'solid-js'
+import { Match, Switch, createComponent } from 'solid-js'
 import type { JSX } from '@solidjs/web'
 import type {
   Cell,
@@ -69,54 +69,48 @@ export function FlexRender<
 >(props: FlexRenderProps<TFeatures, TData, TValue>) {
   return (
     <Switch>
-      <Match when={() => 'cell' in props && props.cell}>
+      <Match when={'cell' in props ? props.cell : undefined}>
         {(cell) => {
-          return createMemo(() => {
-            const c = cell()
-            const def = c.column.columnDef
-            // When the column-grouping feature is registered, a cell can be in
-            // one of three special modes that should not render `columnDef.cell`
-            // directly:
-            //   - aggregated: render `columnDef.aggregatedCell` (falling back to
-            //     `columnDef.cell` if the column did not define one)
-            //   - placeholder: a duplicate value within a group — render nothing
-            //   - grouped: the group header cell — fall through to
-            //     `columnDef.cell`; consumers that want a custom group header
-            //     typically branch on `cell.getIsGrouped()` themselves first
-            // The optional-chaining + cast keeps this safe when the grouping
-            // feature is not registered.
-            const groupingCell = c as typeof c & {
-              getIsAggregated?: () => boolean
-              getIsPlaceholder?: () => boolean
-            }
-            const groupingDef = def as typeof def & {
-              aggregatedCell?: typeof def.cell
-            }
-            if (groupingCell.getIsAggregated?.()) {
-              return flexRender(
-                groupingDef.aggregatedCell ?? def.cell,
-                c.getContext(),
-              )
-            }
-            if (groupingCell.getIsPlaceholder?.()) {
-              return null
-            }
-            return flexRender(def.cell, c.getContext())
-          })
+          const c = cell()
+          const def = c.column.columnDef
+          // When the column-grouping feature is registered, a cell can be in
+          // one of three special modes that should not render `columnDef.cell`
+          // directly:
+          //   - aggregated: render `columnDef.aggregatedCell` (falling back to
+          //     `columnDef.cell` if the column did not define one)
+          //   - placeholder: a duplicate value within a group — render nothing
+          //   - grouped: the group header cell — fall through to
+          //     `columnDef.cell`; consumers that want a custom group header
+          //     typically branch on `cell.getIsGrouped()` themselves first
+          // The optional-chaining + cast keeps this safe when the grouping
+          // feature is not registered.
+          const groupingCell = c as typeof c & {
+            getIsAggregated?: () => boolean
+            getIsPlaceholder?: () => boolean
+          }
+          const groupingDef = def as typeof def & {
+            aggregatedCell?: typeof def.cell
+          }
+          if (groupingCell.getIsAggregated?.()) {
+            return flexRender(
+              groupingDef.aggregatedCell ?? def.cell,
+              c.getContext(),
+            )
+          }
+          if (groupingCell.getIsPlaceholder?.()) {
+            return null
+          }
+          return flexRender(def.cell, c.getContext())
         }}
       </Match>
-      <Match when={() => 'header' in props && props.header}>
+      <Match when={'header' in props ? props.header : undefined}>
         {(header) =>
-          createMemo(() =>
-            flexRender(header().column.columnDef.header, header().getContext()),
-          )
+          flexRender(header().column.columnDef.header, header().getContext())
         }
       </Match>
-      <Match when={() => 'footer' in props && props.footer}>
+      <Match when={'footer' in props ? props.footer : undefined}>
         {(footer) =>
-          createMemo(() =>
-            flexRender(footer().column.columnDef.footer, footer().getContext()),
-          )
+          flexRender(footer().column.columnDef.footer, footer().getContext())
         }
       </Match>
     </Switch>

--- a/packages/solid-table/src/createTable.ts
+++ b/packages/solid-table/src/createTable.ts
@@ -1,10 +1,12 @@
 import { constructTable } from '@tanstack/table-core'
-import { createComputed, getOwner, mergeProps, untrack } from 'solid-js'
-import { shallow, useSelector } from '@tanstack/solid-store'
+import { createEffect, getOwner, merge, untrack } from 'solid-js'
+import { shallow } from '@tanstack/store'
 import { FlexRender } from './FlexRender'
 import { solidReactivity } from './reactivity'
-import type { Atom, ReadonlyAtom } from '@tanstack/solid-store'
-import type { Accessor, JSX } from 'solid-js'
+import { useSelector } from './useSelector'
+import type { Atom, ReadonlyAtom } from '@tanstack/store'
+import type { Accessor } from 'solid-js'
+import type { JSX } from '@solidjs/web'
 import type {
   RowData,
   Table,
@@ -73,20 +75,20 @@ export function createTable<
 ): SolidTable<TFeatures, TData, TSelected> {
   const owner = getOwner()!
 
-  const mergedOptions = mergeProps(tableOptions, {
+  const mergedOptions = merge(tableOptions, {
     _features: {
       coreReativityFeature: solidReactivity(owner),
       ...tableOptions._features,
     },
   }) as any
 
-  const resolvedOptions = mergeProps(
+  const resolvedOptions = merge(
     {
       mergeOptions: (
         defaultOptions: TableOptions<TFeatures, TData>,
         options: TableOptions<TFeatures, TData>,
       ) => {
-        return mergeProps(defaultOptions, options)
+        return merge(defaultOptions, options)
       },
     },
     mergedOptions,
@@ -98,20 +100,23 @@ export function createTable<
     TSelected
   >
 
-  createComputed(() => {
-    const userState = tableOptions.state
-    if (userState) {
-      for (const key in userState) {
-        void (userState as Record<string, unknown>)[key]
+  createEffect(
+    () => {
+      const userState = tableOptions.state
+      if (userState) {
+        for (const key in userState) {
+          void (userState as Record<string, unknown>)[key]
+        }
       }
-    }
-
-    untrack(() => {
-      table.setOptions((prev) => {
-        return mergeProps(prev, mergedOptions) as TableOptions<TFeatures, TData>
+    },
+    () => {
+      untrack(() => {
+        table.setOptions((prev) => {
+          return merge(prev, mergedOptions) as TableOptions<TFeatures, TData>
+        })
       })
-    })
-  })
+    },
+  )
 
   table.Subscribe = ((props: {
     source?: Atom<unknown> | ReadonlyAtom<unknown>

--- a/packages/solid-table/src/createTableHook.tsx
+++ b/packages/solid-table/src/createTableHook.tsx
@@ -1,9 +1,10 @@
 import { createColumnHelper as coreCreateColumnHelper } from '@tanstack/table-core'
-import { Show, createContext, mergeProps, useContext } from 'solid-js'
+import { Show, createContext, merge, useContext } from 'solid-js'
 import { createTable } from './createTable'
 import { FlexRender } from './FlexRender'
 import type { SolidTable } from './createTable'
-import type { Accessor, Component, JSXElement } from 'solid-js'
+import type { Accessor, Component } from 'solid-js'
+import type { JSX } from '@solidjs/web'
 import type {
   AccessorFn,
   AccessorFnColumnDef,
@@ -45,7 +46,7 @@ export type AppCellContext<
   TCellComponents extends Record<string, ComponentType<any>>,
 > = {
   cell: Cell<TFeatures, TData, TValue> &
-    TCellComponents & { FlexRender: () => JSXElement }
+    TCellComponents & { FlexRender: () => JSX.Element }
   column: Column<TFeatures, TData, TValue>
   getValue: CellContext<TFeatures, TData, TValue>['getValue']
   renderValue: CellContext<TFeatures, TData, TValue>['renderValue']
@@ -65,7 +66,7 @@ export type AppHeaderContext<
 > = {
   column: Column<TFeatures, TData, TValue>
   header: Header<TFeatures, TData, TValue> &
-    THeaderComponents & { FlexRender: () => JSXElement }
+    THeaderComponents & { FlexRender: () => JSX.Element }
   table: Table<TFeatures, TData>
 }
 
@@ -275,7 +276,7 @@ export type CreateTableHookOptions<
  * Props for AppTable component - without selector
  */
 export interface AppTablePropsWithoutSelector {
-  children: JSXElement
+  children: JSX.Element
   selector?: never
 }
 
@@ -286,7 +287,7 @@ export interface AppTablePropsWithSelector<
   TFeatures extends TableFeatures,
   TSelected,
 > {
-  children: (state: Accessor<TSelected>) => JSXElement
+  children: (state: Accessor<TSelected>) => JSX.Element
   selector: (state: TableState<TFeatures>) => TSelected
 }
 
@@ -302,8 +303,8 @@ export interface AppCellPropsWithoutSelector<
   cell: Cell<TFeatures, TData, TValue>
   children: (
     cell: Cell<TFeatures, TData, TValue> &
-      TCellComponents & { FlexRender: () => JSXElement },
-  ) => JSXElement
+      TCellComponents & { FlexRender: () => JSX.Element },
+  ) => JSX.Element
   selector?: never
 }
 
@@ -320,9 +321,9 @@ export interface AppCellPropsWithSelector<
   cell: Cell<TFeatures, TData, TValue>
   children: (
     cell: Cell<TFeatures, TData, TValue> &
-      TCellComponents & { FlexRender: () => JSXElement },
+      TCellComponents & { FlexRender: () => JSX.Element },
     state: Accessor<TSelected>,
-  ) => JSXElement
+  ) => JSX.Element
   selector: (state: TableState<TFeatures>) => TSelected
 }
 
@@ -338,8 +339,8 @@ export interface AppHeaderPropsWithoutSelector<
   header: Header<TFeatures, TData, TValue>
   children: (
     header: Header<TFeatures, TData, TValue> &
-      THeaderComponents & { FlexRender: () => JSXElement },
-  ) => JSXElement
+      THeaderComponents & { FlexRender: () => JSX.Element },
+  ) => JSX.Element
   selector?: never
 }
 
@@ -356,9 +357,9 @@ export interface AppHeaderPropsWithSelector<
   header: Header<TFeatures, TData, TValue>
   children: (
     header: Header<TFeatures, TData, TValue> &
-      THeaderComponents & { FlexRender: () => JSXElement },
+      THeaderComponents & { FlexRender: () => JSX.Element },
     state: Accessor<TSelected>,
-  ) => JSXElement
+  ) => JSX.Element
   selector: (state: TableState<TFeatures>) => TSelected
 }
 
@@ -377,7 +378,7 @@ export interface AppCellComponent<
       TValue,
       TCellComponents
     >,
-  ): JSXElement
+  ): JSX.Element
   <TValue extends CellData = CellData, TSelected = unknown>(
     props: AppCellPropsWithSelector<
       TFeatures,
@@ -386,7 +387,7 @@ export interface AppCellComponent<
       TCellComponents,
       TSelected
     >,
-  ): JSXElement
+  ): JSX.Element
 }
 
 /**
@@ -404,7 +405,7 @@ export interface AppHeaderComponent<
       TValue,
       THeaderComponents
     >,
-  ): JSXElement
+  ): JSX.Element
   <TValue extends CellData = CellData, TSelected = unknown>(
     props: AppHeaderPropsWithSelector<
       TFeatures,
@@ -413,17 +414,17 @@ export interface AppHeaderComponent<
       THeaderComponents,
       TSelected
     >,
-  ): JSXElement
+  ): JSX.Element
 }
 
 /**
  * Component type for AppTable - root wrapper with optional Subscribe
  */
 export interface AppTableComponent<TFeatures extends TableFeatures> {
-  (props: AppTablePropsWithoutSelector): JSXElement
+  (props: AppTablePropsWithoutSelector): JSX.Element
   <TSelected>(
     props: AppTablePropsWithSelector<TFeatures, TSelected>,
-  ): JSXElement
+  ): JSX.Element
 }
 
 /**
@@ -442,7 +443,7 @@ export type AppSolidTable<
      * Root wrapper component that provides table context with optional Subscribe.
      * @example
      * ```tsx
-     * // Without selector - children is JSXElement
+     * // Without selector - children is JSX.Element
      * <table.AppTable>
      *   <table>...</table>
      * </table.AppTable>
@@ -835,38 +836,38 @@ export function createTableHook<
     THeaderComponents
   > {
     // Merge default options with provided options (provided takes precedence)
-    const mergedProps = mergeProps(defaultTableOptions, tableOptions)
+    const mergedProps = merge(defaultTableOptions, tableOptions)
     const table = createTable<TFeatures, TData, TSelected>(
       mergedProps as TableOptions<TFeatures, TData>,
       selector,
     )
 
     // AppTable - Root wrapper that provides table context with optional state selector
-    function AppTable(props: AppTablePropsWithoutSelector): JSXElement
+    function AppTable(props: AppTablePropsWithoutSelector): JSX.Element
     function AppTable<TAppTableSelected>(
       props: AppTablePropsWithSelector<TFeatures, TAppTableSelected>,
-    ): JSXElement
+    ): JSX.Element
     function AppTable<TAppTableSelected>(
       props:
         | AppTablePropsWithoutSelector
         | AppTablePropsWithSelector<TFeatures, TAppTableSelected>,
-    ): JSXElement {
+    ): JSX.Element {
       return (
-        <TableContext.Provider value={table}>
-          <Show when={props.selector} fallback={props.children as JSXElement}>
+        <TableContext value={table}>
+          <Show when={props.selector} fallback={props.children as JSX.Element}>
             {(selector) => (
               <table.Subscribe selector={selector()}>
                 {(state: Accessor<TAppTableSelected>) =>
                   (
                     props.children as (
                       state: Accessor<TAppTableSelected>,
-                    ) => JSXElement
+                    ) => JSX.Element
                   )(state)
                 }
               </table.Subscribe>
             )}
           </Show>
-        </TableContext.Provider>
+        </TableContext>
       )
     }
 
@@ -878,7 +879,7 @@ export function createTableHook<
         TValue,
         TCellComponents
       >,
-    ): JSXElement
+    ): JSX.Element
     function AppCell<
       TValue extends CellData = CellData,
       TAppCellSelected = unknown,
@@ -890,7 +891,7 @@ export function createTableHook<
         TCellComponents,
         TAppCellSelected
       >,
-    ): JSXElement
+    ): JSX.Element
     function AppCell<
       TValue extends CellData = CellData,
       TAppCellSelected = unknown,
@@ -904,18 +905,18 @@ export function createTableHook<
             TCellComponents,
             TAppCellSelected
           >,
-    ): JSXElement {
+    ): JSX.Element {
       const extendedCell = Object.assign(props.cell, {
         FlexRender: CellFlexRender,
         ...cellComponents,
       }) as Cell<TFeatures, TData, TValue> &
-        TCellComponents & { FlexRender: () => JSXElement }
+        TCellComponents & { FlexRender: () => JSX.Element }
 
       return (
-        <CellContext.Provider value={props.cell}>
+        <CellContext value={props.cell}>
           <Show
             when={props.selector}
-            fallback={(props.children as (cell: any) => JSXElement)(
+            fallback={(props.children as (cell: any) => JSX.Element)(
               extendedCell as any,
             )}
           >
@@ -927,7 +928,7 @@ export function createTableHook<
               </table.Subscribe>
             )}
           </Show>
-        </CellContext.Provider>
+        </CellContext>
       )
     }
 
@@ -939,7 +940,7 @@ export function createTableHook<
         TValue,
         THeaderComponents
       >,
-    ): JSXElement
+    ): JSX.Element
     function AppHeader<
       TValue extends CellData = CellData,
       TAppHeaderSelected = unknown,
@@ -951,7 +952,7 @@ export function createTableHook<
         THeaderComponents,
         TAppHeaderSelected
       >,
-    ): JSXElement
+    ): JSX.Element
     function AppHeader<
       TValue extends CellData = CellData,
       TAppHeaderSelected = unknown,
@@ -970,18 +971,18 @@ export function createTableHook<
             THeaderComponents,
             TAppHeaderSelected
           >,
-    ): JSXElement {
+    ): JSX.Element {
       const extendedHeader = Object.assign(props.header, {
         FlexRender: HeaderFlexRender,
         ...headerComponents,
       }) as Header<TFeatures, TData, TValue> &
-        THeaderComponents & { FlexRender: () => JSXElement }
+        THeaderComponents & { FlexRender: () => JSX.Element }
 
       return (
-        <HeaderContext.Provider value={props.header}>
+        <HeaderContext value={props.header}>
           <Show
             when={props.selector}
-            fallback={(props.children as (header: any) => JSXElement)(
+            fallback={(props.children as (header: any) => JSX.Element)(
               extendedHeader as any,
             )}
           >
@@ -993,7 +994,7 @@ export function createTableHook<
               </table.Subscribe>
             )}
           </Show>
-        </HeaderContext.Provider>
+        </HeaderContext>
       )
     }
 
@@ -1005,7 +1006,7 @@ export function createTableHook<
         TValue,
         THeaderComponents
       >,
-    ): JSXElement
+    ): JSX.Element
     function AppFooter<
       TValue extends CellData = CellData,
       TAppFooterSelected = unknown,
@@ -1017,7 +1018,7 @@ export function createTableHook<
         THeaderComponents,
         TAppFooterSelected
       >,
-    ): JSXElement
+    ): JSX.Element
     function AppFooter<
       TValue extends CellData = CellData,
       TAppFooterSelected = unknown,
@@ -1036,18 +1037,18 @@ export function createTableHook<
             THeaderComponents,
             TAppFooterSelected
           >,
-    ): JSXElement {
+    ): JSX.Element {
       const extendedHeader = Object.assign(props.header, {
         FlexRender: FooterFlexRender,
         ...headerComponents,
       }) as Header<TFeatures, TData, TValue> &
-        THeaderComponents & { FlexRender: () => JSXElement }
+        THeaderComponents & { FlexRender: () => JSX.Element }
 
       return (
-        <HeaderContext.Provider value={props.header}>
+        <HeaderContext value={props.header}>
           <Show
             when={props.selector}
-            fallback={(props.children as (header: any) => JSXElement)(
+            fallback={(props.children as (header: any) => JSX.Element)(
               extendedHeader as any,
             )}
           >
@@ -1059,7 +1060,7 @@ export function createTableHook<
               </table.Subscribe>
             )}
           </Show>
-        </HeaderContext.Provider>
+        </HeaderContext>
       )
     }
 

--- a/packages/solid-table/src/reactivity.ts
+++ b/packages/solid-table/src/reactivity.ts
@@ -1,8 +1,7 @@
 import {
-  batch,
+  createEffect,
   createMemo,
   createSignal,
-  observable,
   runWithOwner,
   untrack,
 } from 'solid-js'
@@ -11,7 +10,76 @@ import type {
   TableAtomOptions,
   TableReactivityBindings,
 } from '@tanstack/table-core/reactivity'
-import type { Atom, Observer, ReadonlyAtom } from '@tanstack/solid-store'
+import type {
+  Atom,
+  Observer,
+  ReadonlyAtom,
+  Subscription,
+} from '@tanstack/store'
+
+function subscribeSignal<T>(
+  signal: Accessor<T>,
+  owner: Owner,
+  next: (value: T) => void,
+  error?: (err: unknown) => void,
+  complete?: () => void,
+): Subscription {
+  let active = true
+  runWithOwner(owner, () => {
+    let first = true
+    createEffect(
+      () => signal(),
+      (value: T) => {
+        if (first) {
+          first = false
+          return
+        }
+        if (!active) return
+        try {
+          next(value)
+        } catch (err) {
+          error?.(err)
+        }
+      },
+    )
+  })
+  return {
+    unsubscribe: () => {
+      if (!active) return
+      active = false
+      complete?.()
+    },
+  }
+}
+
+function makeSubscribe<T>(
+  signal: Accessor<T>,
+  owner: Owner,
+): Atom<T>['subscribe'] {
+  function subscribe(observer: Observer<T>): Subscription
+  function subscribe(
+    next: (value: T) => void,
+    error?: (error: any) => void,
+    complete?: () => void,
+  ): Subscription
+  function subscribe(
+    observerOrNext: Observer<T> | ((value: T) => void),
+    error?: (error: any) => void,
+    complete?: () => void,
+  ): Subscription {
+    if (typeof observerOrNext === 'function') {
+      return subscribeSignal(signal, owner, observerOrNext, error, complete)
+    }
+    return subscribeSignal(
+      signal,
+      owner,
+      (v: T) => observerOrNext.next?.(v),
+      (e) => observerOrNext.error?.(e),
+      () => observerOrNext.complete?.(),
+    )
+  }
+  return subscribe as Atom<T>['subscribe']
+}
 
 function signalToReadonlyAtom<T>(
   signal: Accessor<T>,
@@ -19,10 +87,8 @@ function signalToReadonlyAtom<T>(
 ): ReadonlyAtom<T> {
   return Object.assign(signal, {
     get: () => signal(),
-    subscribe: (observer: Observer<T>) => {
-      return runWithOwner(owner, () => observable(signal))!.subscribe(observer)
-    },
-  })
+    subscribe: makeSubscribe(signal, owner),
+  }) as unknown as ReadonlyAtom<T>
 }
 
 function signalToWritableAtom<T>(
@@ -30,17 +96,18 @@ function signalToWritableAtom<T>(
   owner: Owner,
 ): Atom<T> {
   const [signal, setSignal] = signalTuple
+  const set = ((updater: T | ((prevVal: T) => T)) => {
+    if (typeof updater === 'function') {
+      setSignal(updater as unknown as (prev: T) => T)
+    } else {
+      setSignal(() => updater)
+    }
+  }) as Atom<T>['set']
   return Object.assign(signal, {
-    set: (updater: T | ((prevVal: T) => T)) => {
-      typeof updater === 'function'
-        ? setSignal(updater as unknown as (prev: T) => T)
-        : setSignal(updater as Exclude<T, Function>)
-    },
+    set,
     get: () => signal(),
-    subscribe: (observer: Observer<T>) => {
-      return runWithOwner(owner, () => observable(signal))!.subscribe(observer)
-    },
-  })
+    subscribe: makeSubscribe(signal, owner),
+  }) as unknown as Atom<T>
 }
 
 export function solidReactivity(owner: Owner): TableReactivityBindings {
@@ -56,13 +123,17 @@ export function solidReactivity(owner: Owner): TableReactivityBindings {
       value: T,
       options?: TableAtomOptions<T>,
     ): Atom<T> => {
-      const writableSignal = createSignal(value, {
+      const writableSignal = createSignal<T>(value as Exclude<T, Function>, {
         equals: options?.compare,
         name: options?.debugName,
       })
       return signalToWritableAtom(writableSignal, owner)
     },
     untrack: untrack,
-    batch: batch,
+    // Solid v2 auto-batches synchronous writes via microtask scheduling, so
+    // the explicit batch wrapper is a no-op invocation of the callback.
+    batch: (fn: () => void) => {
+      fn()
+    },
   }
 }

--- a/packages/solid-table/src/reactivity.ts
+++ b/packages/solid-table/src/reactivity.ts
@@ -88,7 +88,7 @@ function signalToReadonlyAtom<T>(
   return Object.assign(signal, {
     get: () => signal(),
     subscribe: makeSubscribe(signal, owner),
-  }) as unknown as ReadonlyAtom<T>
+  })
 }
 
 function signalToWritableAtom<T>(
@@ -107,7 +107,7 @@ function signalToWritableAtom<T>(
     set,
     get: () => signal(),
     subscribe: makeSubscribe(signal, owner),
-  }) as unknown as Atom<T>
+  })
 }
 
 export function solidReactivity(owner: Owner): TableReactivityBindings {

--- a/packages/solid-table/src/useSelector.ts
+++ b/packages/solid-table/src/useSelector.ts
@@ -1,0 +1,38 @@
+import { createSignal, onCleanup } from 'solid-js'
+import type { Accessor } from 'solid-js'
+import type { Subscribable } from '@tanstack/store'
+
+export interface UseSelectorOptions<TSelected> {
+  compare?: (a: TSelected, b: TSelected) => boolean
+}
+
+const defaultCompare = <T>(a: T, b: T): boolean => a === b
+
+/**
+ * Solid read hook for TanStack Store atoms/stores. Returns a Solid Accessor
+ * for the selected slice and unsubscribes on cleanup.
+ *
+ * Inlined locally (instead of consuming `@tanstack/solid-store`) so we don't
+ * pull in `solid-js/web` (a Solid v1 path that doesn't exist in Solid v2).
+ */
+export function useSelector<TSource, TSelected = TSource>(
+  source: Subscribable<TSource> & { get: () => TSource },
+  selector: (snapshot: TSource) => TSelected = (value) =>
+    value as unknown as TSelected,
+  options?: UseSelectorOptions<TSelected>,
+): Accessor<TSelected> {
+  const compare = options?.compare ?? defaultCompare
+  const [signal, setSignal] = createSignal(
+    selector(source.get()) as Exclude<TSelected, Function>,
+    {
+      equals: compare,
+    },
+  )
+  const unsubscribe = source.subscribe((snapshot: TSource) => {
+    setSignal(() => selector(snapshot))
+  }).unsubscribe
+  onCleanup(() => {
+    unsubscribe()
+  })
+  return signal
+}

--- a/packages/solid-table/src/useSelector.ts
+++ b/packages/solid-table/src/useSelector.ts
@@ -2,7 +2,7 @@ import { createSignal, onCleanup } from 'solid-js'
 import type { Accessor } from 'solid-js'
 import type { Subscribable } from '@tanstack/store'
 
-export interface UseSelectorOptions<TSelected> {
+interface UseSelectorOptions<TSelected> {
   compare?: (a: TSelected, b: TSelected) => boolean
 }
 

--- a/packages/solid-table/tsconfig.json
+++ b/packages/solid-table/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js"
+    "jsxImportSource": "@solidjs/web"
   },
   "include": ["src", "eslint.config.js", "vite.config.ts"]
 }

--- a/packages/table-devtools/package.json
+++ b/packages/table-devtools/package.json
@@ -50,7 +50,7 @@
     "@tanstack/devtools-utils": "^0.4.0",
     "@tanstack/solid-store": "^0.11.0",
     "goober": "^2.1.18",
-    "solid-js": "^1.9.12"
+    "solid-js": "^1.9.7"
   },
   "peerDependencies": {
     "@tanstack/table-core": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2129,7 +2129,7 @@ importers:
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
       '@tanstack/preact-devtools':
         specifier: ^0.10.2
-        version: 0.10.2(preact@10.29.1)(solid-js@1.9.12)
+        version: 0.10.2(preact@10.29.1)(solid-js@2.0.0-beta.10)
       '@tanstack/preact-table-devtools':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/preact-table-devtools
@@ -2157,7 +2157,7 @@ importers:
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
       '@tanstack/preact-devtools':
         specifier: ^0.10.2
-        version: 0.10.2(preact@10.29.1)(solid-js@1.9.12)
+        version: 0.10.2(preact@10.29.1)(solid-js@2.0.0-beta.10)
       '@tanstack/preact-table-devtools':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/preact-table-devtools
@@ -3986,7 +3986,7 @@ importers:
         version: 6.0.3(rollup@4.60.2)
       '@tanstack/react-devtools':
         specifier: ^0.10.2
-        version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)
+        version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@2.0.0-beta.10)
       '@tanstack/react-table-devtools':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/react-table-devtools
@@ -4428,7 +4428,7 @@ importers:
         version: 6.0.3(rollup@4.60.2)
       '@tanstack/router-vite-plugin':
         specifier: ^1.166.47
-        version: 1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
+        version: 1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -4453,12 +4453,15 @@ importers:
       '@faker-js/faker':
         specifier: ^10.4.0
         version: 10.4.0
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4467,20 +4470,23 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/basic-external-atoms:
     dependencies:
-      '@tanstack/solid-store':
-        specifier: ^0.11.0
-        version: 0.11.0(solid-js@1.9.12)
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
+      '@tanstack/store':
+        specifier: ^0.11.0
+        version: 0.11.0
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4492,17 +4498,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/basic-external-state:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4514,17 +4523,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/basic-use-table:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4533,20 +4545,23 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-groups:
     dependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
         version: 10.4.0
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4555,17 +4570,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-ordering:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4577,17 +4595,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-pinning:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4599,17 +4620,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-pinning-split:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4621,17 +4645,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-pinning-sticky:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4643,20 +4670,23 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-resizing:
     dependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
         version: 10.4.0
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4665,17 +4695,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-resizing-performant:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4687,20 +4720,23 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-sizing:
     dependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
         version: 10.4.0
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4709,20 +4745,23 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-visibility:
     dependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
         version: 10.4.0
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4731,17 +4770,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/composable-tables:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4750,17 +4792,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/expanding:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4772,20 +4817,23 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/filters:
     dependencies:
       '@solid-primitives/scheduled':
         specifier: ^1.5.3
-        version: 1.5.3(solid-js@1.9.12)
+        version: 1.5.3(solid-js@2.0.0-beta.10)
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4797,20 +4845,23 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/filters-faceted:
     dependencies:
       '@solid-primitives/scheduled':
         specifier: ^1.5.3
-        version: 1.5.3(solid-js@1.9.12)
+        version: 1.5.3(solid-js@2.0.0-beta.10)
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4822,11 +4873,14 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/filters-fuzzy:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/match-sorter-utils':
         specifier: ^9.0.0-alpha.4
         version: link:../../../packages/match-sorter-utils
@@ -4834,8 +4888,8 @@ importers:
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4847,17 +4901,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/grouping:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4869,17 +4926,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/pagination:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4891,17 +4951,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/row-pinning:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4913,14 +4976,17 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/row-selection:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-devtools':
         specifier: ^0.8.2
-        version: 0.8.2(solid-js@1.9.12)
+        version: 0.8.2(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
@@ -4928,8 +4994,8 @@ importers:
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table-devtools
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4941,17 +5007,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/sorting:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4963,17 +5032,20 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/sub-components:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4985,20 +5057,23 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/virtualized-columns:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       '@tanstack/solid-virtual':
         specifier: ^3.13.24
-        version: 3.13.24(solid-js@1.9.12)
+        version: 3.13.24(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5010,26 +5085,29 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/virtualized-infinite-scrolling:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-query':
-        specifier: ^5.100.7
-        version: 5.100.7(solid-js@1.9.12)
-      '@tanstack/solid-store':
-        specifier: ^0.11.0
-        version: 0.11.0(solid-js@1.9.12)
+        specifier: ^6.0.0-beta.4
+        version: 6.0.0-beta.4(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       '@tanstack/solid-virtual':
         specifier: ^3.13.24
-        version: 3.13.24(solid-js@1.9.12)
+        version: 3.13.24(solid-js@2.0.0-beta.10)
+      '@tanstack/store':
+        specifier: ^0.11.0
+        version: 0.11.0
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5041,20 +5119,23 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/virtualized-rows:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       '@tanstack/solid-virtual':
         specifier: ^3.13.24
-        version: 3.13.24(solid-js@1.9.12)
+        version: 3.13.24(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5066,20 +5147,23 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/with-tanstack-form:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-form':
         specifier: ^1.29.1
-        version: 1.29.1(solid-js@1.9.12)
+        version: 1.29.1(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
       zod:
         specifier: ^4.4.2
         version: 4.4.2
@@ -5094,23 +5178,26 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/with-tanstack-query:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-query':
-        specifier: ^5.100.7
-        version: 5.100.7(solid-js@1.9.12)
-      '@tanstack/solid-store':
-        specifier: ^0.11.0
-        version: 0.11.0(solid-js@1.9.12)
+        specifier: ^6.0.0-beta.4
+        version: 6.0.0-beta.4(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
+      '@tanstack/store':
+        specifier: ^0.11.0
+        version: 0.11.0
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5122,30 +5209,33 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/with-tanstack-router:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/solid-query':
-        specifier: ^5.100.7
-        version: 5.100.7(solid-js@1.9.12)
+        specifier: ^6.0.0-beta.4
+        version: 6.0.0-beta.4(solid-js@2.0.0-beta.10)
       '@tanstack/solid-router':
-        specifier: ^1.169.1
-        version: 1.169.1(solid-js@1.9.12)
+        specifier: ^2.0.0-beta.17
+        version: 2.0.0-beta.17(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
         version: 10.4.0
       '@tanstack/router-vite-plugin':
         specifier: ^1.166.47
-        version: 1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
+        version: 1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -5153,8 +5243,8 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/svelte/basic-app-table:
     devDependencies:
@@ -6810,7 +6900,7 @@ importers:
         version: 10.4.0
       '@tanstack/vue-devtools':
         specifier: ^0.2.16
-        version: 0.2.16(solid-js@1.9.12)
+        version: 0.2.16(solid-js@2.0.0-beta.10)
       '@tanstack/vue-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/vue-table
@@ -7207,10 +7297,10 @@ importers:
     dependencies:
       '@tanstack/devtools-utils':
         specifier: ^0.4.0
-        version: 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@1.9.12)(vue@3.5.33(typescript@6.0.3))
+        version: 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@2.0.0-beta.10)(vue@3.5.33(typescript@6.0.3))
       '@tanstack/react-devtools':
         specifier: '>=0.10.0'
-        version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)
+        version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@2.0.0-beta.10)
       '@tanstack/table-devtools':
         specifier: workspace:*
         version: link:../table-devtools
@@ -7245,41 +7335,47 @@ importers:
 
   packages/solid-table:
     dependencies:
-      '@tanstack/solid-store':
+      '@tanstack/store':
         specifier: ^0.11.0
-        version: 0.11.0(solid-js@1.9.12)
+        version: 0.11.0
       '@tanstack/table-core':
         specifier: workspace:*
         version: link:../table-core
     devDependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   packages/solid-table-devtools:
     dependencies:
       '@tanstack/devtools':
         specifier: ^0.11.2
-        version: 0.11.2(csstype@3.2.3)(solid-js@1.9.12)
+        version: 0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)
       '@tanstack/devtools-utils':
         specifier: ^0.4.0
-        version: 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@1.9.12)(vue@3.5.33(typescript@6.0.3))
+        version: 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@2.0.0-beta.10)(vue@3.5.33(typescript@6.0.3))
       '@tanstack/table-devtools':
         specifier: workspace:*
         version: link:../table-devtools
     devDependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/table-core':
         specifier: workspace:*
         version: link:../table-core
       solid-js:
-        specifier: ^1.9.12
-        version: 1.9.12
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
       vite-plugin-solid:
-        specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   packages/svelte-table:
     dependencies:
@@ -7330,7 +7426,7 @@ importers:
         specifier: ^2.1.18
         version: 2.1.18(csstype@3.2.3)
       solid-js:
-        specifier: ^1.9.12
+        specifier: ^1.9.7
         version: 1.9.12
     devDependencies:
       vite-plugin-solid:
@@ -11649,6 +11745,14 @@ packages:
     peerDependencies:
       solid-js: '>=1.8.4'
 
+  '@solidjs/signals@2.0.0-beta.10':
+    resolution: {integrity: sha512-McdmbLNiSlz616zcykS8Rb1t9QTOTKdNAoaWd4/OjXEbcAUrPqRX1CWgR+caiWUk4qn0a+LesTTV4jZhFFPaSg==}
+
+  '@solidjs/web@2.0.0-beta.10':
+    resolution: {integrity: sha512-Ox7MBv19kuxHoHhWoLCCcc6aykSgaqzWvWT7RB66VqlFnQ8Lid2ncd30g5L4XC0GB+MN/WZVb68tiYrAFUDIAg==}
+    peerDependencies:
+      solid-js: ^2.0.0-beta.10
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -11886,6 +11990,9 @@ packages:
   '@tanstack/query-core@5.100.7':
     resolution: {integrity: sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ==}
 
+  '@tanstack/query-core@5.91.2':
+    resolution: {integrity: sha512-Uz2pTgPC1mhqrrSGg18RKCWT/pkduAYtxbcyIyKBhw7dTWjXZIzqmpzO2lBkyWr4hlImQgpu1m1pei3UnkFRWw==}
+
   '@tanstack/react-devtools@0.10.2':
     resolution: {integrity: sha512-1BmZyxOrI5SqmRJ5MgkYZNNdnlLsJxQRI2YgorrAvcF2MxK6x5RcuStvD8+YlXoMw3JtNukPxoITirKAnKYDQA==}
     engines: {node: '>=18'}
@@ -11933,6 +12040,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.168.9':
+    resolution: {integrity: sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g==}
+    engines: {node: '>=20.19'}
+    hasBin: true
 
   '@tanstack/router-core@1.169.1':
     resolution: {integrity: sha512-x+2gIGKTTE1qAn7tLieGfrB5ciOviDmmi2ox9fAWUubRV+yTU5ruGFXocoCIWF+lB+SOtnHjo2E9BLSWyYoEmA==}
@@ -11984,17 +12096,18 @@ packages:
     peerDependencies:
       solid-js: '>=1.9.9'
 
-  '@tanstack/solid-query@5.100.7':
-    resolution: {integrity: sha512-xoUwMH21RZvB3MbAIXEkn1lzxjTyMXx3XQhpVdGlOfjkS7YLjXrPNx1uKLG3yE9lu2ZxWiLK/a3muD1vEokwUQ==}
+  '@tanstack/solid-query@6.0.0-beta.4':
+    resolution: {integrity: sha512-g8o4Fqo1i/V14V4DXMhtu5vk6Ix1ShliBl9Y+3XsV5aB/ja2swAOksblJo2hFcXJdkKTlLru+xTHnEkL57/CeA==}
     peerDependencies:
-      solid-js: ^1.6.0
+      solid-js: '>=2.0.0-beta.0 <3.0.0'
 
-  '@tanstack/solid-router@1.169.1':
-    resolution: {integrity: sha512-Ij0kD/nh8h7JupF6obPZvmYFLPF74tlPDuwIGdWWS3vJWYx8SXuDrI11rMTJPmftnkgYDfhrwvhYQzz4K3/+cQ==}
+  '@tanstack/solid-router@2.0.0-beta.17':
+    resolution: {integrity: sha512-NJyYMv/NNnsm4N93wi1E7WMHtf+194fpQAQzFlguyK66fHQQ9gbif0stFh2WK9tOAtD5uZjRUGTlRPrnTLzd1w==}
     engines: {node: '>=20.19'}
     hasBin: true
     peerDependencies:
-      solid-js: ^1.9.10
+      '@solidjs/web': '>=2.0.0-0 <3.0.0'
+      solid-js: '>=2.0.0-0 <3.0.0'
 
   '@tanstack/solid-store@0.11.0':
     resolution: {integrity: sha512-2isL0ZnnyI1iN0V+QPrxE3OcPndohBgVlBcHZYoAOIAiU1WoWjVy0q5gb0suPu1Id0h5cKC23JnwzQTxWDZD0w==}
@@ -12810,6 +12923,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.20.12
 
+  babel-plugin-jsx-dom-expressions@0.50.0-next.6:
+    resolution: {integrity: sha512-D7SSrMu1EupiCFT3hBhWJj0EWzaI27HV1ysbLSKFcH1ROZe61DmnNVchrnr5QeAw5O8bqSdlMDLdEqMYzi4tTA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
@@ -12847,6 +12965,15 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
       solid-js: ^1.9.12
+    peerDependenciesMeta:
+      solid-js:
+        optional: true
+
+  babel-preset-solid@2.0.0-beta.10:
+    resolution: {integrity: sha512-lzGgPsh1fVtBJDl+UWLTCgimzPMda7X2Xzq7asCCOq/zHRwiF5vF3Eb3xj65dGyi7YpgVROTwJEpj+XiroKaww==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      solid-js: ^2.0.0-beta.10
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -13149,6 +13276,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@2.0.1:
+    resolution: {integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==}
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
@@ -15834,10 +15964,18 @@ packages:
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
+  solid-js@2.0.0-beta.10:
+    resolution: {integrity: sha512-EAfV6b1SC4c3wEBAoX4dMy063uTb4nfL5uXnN8yse4InH7RTw1LoB0I9HAy+pj3/GHqQE2tYZurlZtqU4pGyog==}
+
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
     peerDependencies:
       solid-js: ^1.3
+
+  solid-refresh@0.8.0-next.7:
+    resolution: {integrity: sha512-fqkPRAeiE0tqfo2ZljeQBIXwfYssU2w1FmaWFrXmnV33B/CfGfez7BjtOF0Y1/orUNRXI/DZcJlJThHllcCMsA==}
+    peerDependencies:
+      solid-js: '>=2.0.0-beta.7 <2.0.0-experimental.0'
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -16340,6 +16478,9 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  validate-html-nesting@1.2.4:
+    resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
+
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -16353,6 +16494,17 @@ packages:
     peerDependencies:
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
       solid-js: ^1.7.2
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@testing-library/jest-dom':
+        optional: true
+
+  vite-plugin-solid@3.0.0-next.5:
+    resolution: {integrity: sha512-hcn3mzevQDv6Oyo/Zv5LXdOrlWwKGeGVxNhc9fUq3AcN9aO6KABy52yq5cvnPDo3qaxmvOJVbNS1H4V5rx7AQg==}
+    peerDependencies:
+      '@solidjs/web': '>=2.0.0-beta.0 <2.0.0-experimental.0'
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
+      solid-js: '>=2.0.0-beta.0 <2.0.0-experimental.0'
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@testing-library/jest-dom':
@@ -21066,108 +21218,116 @@ snapshots:
       '@size-limit/file': 12.1.0(size-limit@12.1.0(jiti@2.6.1))
       size-limit: 12.1.0(jiti@2.6.1)
 
-  '@solid-devtools/debugger@0.28.1(solid-js@1.9.12)':
+  '@solid-devtools/debugger@0.28.1(solid-js@2.0.0-beta.10)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/shared': 0.20.0(solid-js@1.9.12)
-      '@solid-primitives/bounds': 0.1.5(solid-js@1.9.12)
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/keyboard': 1.3.5(solid-js@1.9.12)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-beta.10)
+      '@solid-primitives/bounds': 0.1.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/keyboard': 1.3.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-devtools/logger@0.9.11(solid-js@1.9.12)':
+  '@solid-devtools/logger@0.9.11(solid-js@2.0.0-beta.10)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/debugger': 0.28.1(solid-js@1.9.12)
-      '@solid-devtools/shared': 0.20.0(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-devtools/debugger': 0.28.1(solid-js@2.0.0-beta.10)
+      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-beta.10)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-devtools/shared@0.20.0(solid-js@1.9.12)':
+  '@solid-devtools/shared@0.20.0(solid-js@2.0.0-beta.10)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/media': 2.3.5(solid-js@1.9.12)
-      '@solid-primitives/refs': 1.1.3(solid-js@1.9.12)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.12)
-      '@solid-primitives/styles': 0.1.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/media': 2.3.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/refs': 1.1.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/styles': 0.1.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/bounds@0.1.5(solid-js@1.9.12)':
+  '@solid-primitives/bounds@0.1.5(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/resize-observer': 2.1.5(solid-js@1.9.12)
-      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/resize-observer': 2.1.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/event-listener@2.4.5(solid-js@1.9.12)':
+  '@solid-primitives/event-listener@2.4.5(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/keyboard@1.3.5(solid-js@1.9.12)':
+  '@solid-primitives/keyboard@1.3.5(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/media@2.3.5(solid-js@1.9.12)':
+  '@solid-primitives/media@2.3.5(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/refs@1.1.3(solid-js@1.9.12)':
+  '@solid-primitives/refs@1.1.3(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/resize-observer@2.1.5(solid-js@1.9.12)':
+  '@solid-primitives/resize-observer@2.1.5(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/rootless@1.5.3(solid-js@1.9.12)':
+  '@solid-primitives/rootless@1.5.3(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/scheduled@1.5.3(solid-js@1.9.12)':
+  '@solid-primitives/scheduled@1.5.3(solid-js@2.0.0-beta.10)':
     dependencies:
-      solid-js: 1.9.12
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/static-store@0.1.3(solid-js@1.9.12)':
+  '@solid-primitives/static-store@0.1.3(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/styles@0.1.3(solid-js@1.9.12)':
+  '@solid-primitives/styles@0.1.3(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@solid-primitives/utils@6.4.0(solid-js@1.9.12)':
+  '@solid-primitives/utils@6.4.0(solid-js@2.0.0-beta.10)':
     dependencies:
-      solid-js: 1.9.12
+      solid-js: 2.0.0-beta.10
 
-  '@solidjs/meta@0.29.4(solid-js@1.9.12)':
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.10)':
     dependencies:
-      solid-js: 1.9.12
+      solid-js: 2.0.0-beta.10
+
+  '@solidjs/signals@2.0.0-beta.10': {}
+
+  '@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10)':
+    dependencies:
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
+      solid-js: 2.0.0-beta.10
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -21310,6 +21470,15 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
+  '@tanstack/devtools-ui@0.5.1(csstype@3.2.3)(solid-js@2.0.0-beta.10)':
+    dependencies:
+      clsx: 2.1.1
+      dayjs: 1.11.20
+      goober: 2.1.18(csstype@3.2.3)
+      solid-js: 2.0.0-beta.10
+    transitivePeerDependencies:
+      - csstype
+
   '@tanstack/devtools-utils@0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@1.9.12)(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@types/react': 19.2.14
@@ -21318,17 +21487,25 @@ snapshots:
       solid-js: 1.9.12
       vue: 3.5.33(typescript@6.0.3)
 
-  '@tanstack/devtools@0.11.2(csstype@3.2.3)(solid-js@1.9.12)':
+  '@tanstack/devtools-utils@0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@2.0.0-beta.10)(vue@3.5.33(typescript@6.0.3))':
+    optionalDependencies:
+      '@types/react': 19.2.14
+      preact: 10.29.1
+      react: 19.2.5
+      solid-js: 2.0.0-beta.10
+      vue: 3.5.33(typescript@6.0.3)
+
+  '@tanstack/devtools@0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/keyboard': 1.3.5(solid-js@1.9.12)
-      '@solid-primitives/resize-observer': 2.1.5(solid-js@1.9.12)
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/keyboard': 1.3.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/resize-observer': 2.1.5(solid-js@2.0.0-beta.10)
       '@tanstack/devtools-client': 0.0.6
       '@tanstack/devtools-event-bus': 0.4.1
-      '@tanstack/devtools-ui': 0.5.1(csstype@3.2.3)(solid-js@1.9.12)
+      '@tanstack/devtools-ui': 0.5.1(csstype@3.2.3)(solid-js@2.0.0-beta.10)
       clsx: 2.1.1
       goober: 2.1.18(csstype@3.2.3)
-      solid-js: 1.9.12
+      solid-js: 2.0.0-beta.10
     transitivePeerDependencies:
       - bufferutil
       - csstype
@@ -21369,9 +21546,9 @@ snapshots:
 
   '@tanstack/pacer-lite@0.1.1': {}
 
-  '@tanstack/preact-devtools@0.10.2(preact@10.29.1)(solid-js@1.9.12)':
+  '@tanstack/preact-devtools@0.10.2(preact@10.29.1)(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@1.9.12)
+      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)
       preact: 10.29.1
     transitivePeerDependencies:
       - bufferutil
@@ -21400,9 +21577,11 @@ snapshots:
 
   '@tanstack/query-core@5.100.7': {}
 
-  '@tanstack/react-devtools@0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)':
+  '@tanstack/query-core@5.91.2': {}
+
+  '@tanstack/react-devtools@0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@1.9.12)
+      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.2.5
@@ -21455,6 +21634,13 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
+  '@tanstack/router-core@1.168.9':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      cookie-es: 2.0.1
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
+
   '@tanstack/router-core@1.169.1':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -21475,7 +21661,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))':
+  '@tanstack/router-plugin@1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -21493,7 +21679,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
-      vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+      vite-plugin-solid: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
       webpack: 5.105.2(esbuild@0.28.0)
     transitivePeerDependencies:
       - supports-color
@@ -21512,9 +21698,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-vite-plugin@1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))':
+  '@tanstack/router-vite-plugin@1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))':
     dependencies:
-      '@tanstack/router-plugin': 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
+      '@tanstack/router-plugin': 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@rsbuild/core'
       - '@tanstack/react-router'
@@ -21523,50 +21709,50 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/solid-devtools@0.8.2(solid-js@1.9.12)':
+  '@tanstack/solid-devtools@0.8.2(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
     transitivePeerDependencies:
       - bufferutil
       - csstype
       - utf-8-validate
 
-  '@tanstack/solid-form@1.29.1(solid-js@1.9.12)':
+  '@tanstack/solid-form@1.29.1(solid-js@2.0.0-beta.10)':
     dependencies:
       '@tanstack/form-core': 1.29.1
-      '@tanstack/solid-store': 0.9.3(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@tanstack/solid-store': 0.9.3(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.10
 
-  '@tanstack/solid-query@5.100.7(solid-js@1.9.12)':
+  '@tanstack/solid-query@6.0.0-beta.4(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@tanstack/query-core': 5.100.7
-      solid-js: 1.9.12
+      '@tanstack/query-core': 5.91.2
+      solid-js: 2.0.0-beta.10
 
-  '@tanstack/solid-router@1.169.1(solid-js@1.9.12)':
+  '@tanstack/solid-router@2.0.0-beta.17(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solid-devtools/logger': 0.9.11(solid-js@1.9.12)
-      '@solid-primitives/refs': 1.1.3(solid-js@1.9.12)
-      '@solidjs/meta': 0.29.4(solid-js@1.9.12)
+      '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-beta.10)
+      '@solidjs/meta': 0.29.4(solid-js@2.0.0-beta.10)
+      '@solidjs/web': 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/history': 1.161.6
-      '@tanstack/router-core': 1.169.1
+      '@tanstack/router-core': 1.168.9
       isbot: 5.1.39
-      solid-js: 1.9.12
+      solid-js: 2.0.0-beta.10
 
   '@tanstack/solid-store@0.11.0(solid-js@1.9.12)':
     dependencies:
       '@tanstack/store': 0.11.0
       solid-js: 1.9.12
 
-  '@tanstack/solid-store@0.9.3(solid-js@1.9.12)':
+  '@tanstack/solid-store@0.9.3(solid-js@2.0.0-beta.10)':
     dependencies:
       '@tanstack/store': 0.9.3
-      solid-js: 1.9.12
+      solid-js: 2.0.0-beta.10
 
-  '@tanstack/solid-virtual@3.13.24(solid-js@1.9.12)':
+  '@tanstack/solid-virtual@3.13.24(solid-js@2.0.0-beta.10)':
     dependencies:
       '@tanstack/virtual-core': 3.14.0
-      solid-js: 1.9.12
+      solid-js: 2.0.0-beta.10
 
   '@tanstack/store@0.11.0': {}
 
@@ -21610,9 +21796,9 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.161.7': {}
 
-  '@tanstack/vue-devtools@0.2.16(solid-js@1.9.12)':
+  '@tanstack/vue-devtools@0.2.16(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@1.9.12)
+      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)
     transitivePeerDependencies:
       - bufferutil
       - csstype
@@ -22539,6 +22725,16 @@ snapshots:
       html-entities: 2.3.3
       parse5: 7.3.0
 
+  babel-plugin-jsx-dom-expressions@0.50.0-next.6(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+      html-entities: 2.3.3
+      parse5: 7.3.0
+      validate-html-nesting: 1.2.4
+
   babel-plugin-macros@3.1.0:
     dependencies:
       '@babel/runtime': 7.29.2
@@ -22591,6 +22787,13 @@ snapshots:
       babel-plugin-jsx-dom-expressions: 0.40.6(@babel/core@7.29.0)
     optionalDependencies:
       solid-js: 1.9.12
+
+  babel-preset-solid@2.0.0-beta.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.10):
+    dependencies:
+      '@babel/core': 7.29.0
+      babel-plugin-jsx-dom-expressions: 0.50.0-next.6(@babel/core@7.29.0)
+    optionalDependencies:
+      solid-js: 2.0.0-beta.10
 
   balanced-match@1.0.2: {}
 
@@ -22926,6 +23129,8 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-es@2.0.1: {}
 
   cookie-es@3.1.1: {}
 
@@ -26107,6 +26312,13 @@ snapshots:
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
 
+  solid-js@2.0.0-beta.10:
+    dependencies:
+      '@solidjs/signals': 2.0.0-beta.10
+      csstype: 3.2.3
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
+
   solid-refresh@0.6.3(solid-js@1.9.12):
     dependencies:
       '@babel/generator': 7.29.1
@@ -26115,6 +26327,12 @@ snapshots:
       solid-js: 1.9.12
     transitivePeerDependencies:
       - supports-color
+
+  solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.10):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@babel/types': 7.29.0
+      solid-js: 2.0.0-beta.10
 
   source-map-js@1.2.1: {}
 
@@ -26615,6 +26833,8 @@ snapshots:
 
   uuid@8.3.2: {}
 
+  validate-html-nesting@1.2.4: {}
+
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
@@ -26627,6 +26847,22 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.12
       solid-refresh: 0.6.3(solid-js@1.9.12)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+    optionalDependencies:
+      '@testing-library/jest-dom': 6.9.1
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@solidjs/web': 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 2.0.0-beta.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.10)
+      merge-anything: 5.1.7
+      solid-js: 2.0.0-beta.10
+      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.10)
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vitefu: 1.1.3(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  babel-preset-solid@>=2.0.0-beta.0 <2.0.0-experimental.0: 2.0.0-beta.15
+
 importers:
 
   .:
@@ -2129,10 +2132,13 @@ importers:
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
       '@tanstack/preact-devtools':
         specifier: ^0.10.2
-        version: 0.10.2(preact@10.29.1)(solid-js@2.0.0-beta.10)
+        version: 0.10.2(preact@10.29.1)(solid-js@1.9.12)
       '@tanstack/preact-table-devtools':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/preact-table-devtools
+      solid-js:
+        specifier: ^1.9.7
+        version: 1.9.12
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2157,10 +2163,13 @@ importers:
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
       '@tanstack/preact-devtools':
         specifier: ^0.10.2
-        version: 0.10.2(preact@10.29.1)(solid-js@2.0.0-beta.10)
+        version: 0.10.2(preact@10.29.1)(solid-js@1.9.12)
       '@tanstack/preact-table-devtools':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/preact-table-devtools
+      solid-js:
+        specifier: ^1.9.7
+        version: 1.9.12
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -3986,7 +3995,7 @@ importers:
         version: 6.0.3(rollup@4.60.2)
       '@tanstack/react-devtools':
         specifier: ^0.10.2
-        version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@2.0.0-beta.10)
+        version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)
       '@tanstack/react-table-devtools':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/react-table-devtools
@@ -4002,6 +4011,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
+      solid-js:
+        specifier: ^1.9.7
+        version: 1.9.12
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -4428,7 +4440,7 @@ importers:
         version: 6.0.3(rollup@4.60.2)
       '@tanstack/router-vite-plugin':
         specifier: ^1.166.47
-        version: 1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
+        version: 1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -4454,14 +4466,14 @@ importers:
         specifier: ^10.4.0
         version: 10.4.0
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4471,13 +4483,13 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/basic-external-atoms:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
@@ -4485,8 +4497,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4499,19 +4511,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/basic-external-state:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4524,19 +4536,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/basic-use-table:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4546,7 +4558,7 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-groups:
     dependencies:
@@ -4554,14 +4566,14 @@ importers:
         specifier: ^10.4.0
         version: 10.4.0
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4571,19 +4583,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-ordering:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4596,19 +4608,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-pinning:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4621,19 +4633,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-pinning-split:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4646,19 +4658,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-pinning-sticky:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4671,7 +4683,7 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-resizing:
     dependencies:
@@ -4679,14 +4691,14 @@ importers:
         specifier: ^10.4.0
         version: 10.4.0
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4696,19 +4708,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-resizing-performant:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4721,7 +4733,7 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-sizing:
     dependencies:
@@ -4729,14 +4741,14 @@ importers:
         specifier: ^10.4.0
         version: 10.4.0
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4746,7 +4758,7 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/column-visibility:
     dependencies:
@@ -4754,14 +4766,14 @@ importers:
         specifier: ^10.4.0
         version: 10.4.0
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4771,19 +4783,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/composable-tables:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -4793,19 +4805,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/expanding:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4818,22 +4830,22 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/filters:
     dependencies:
       '@solid-primitives/scheduled':
         specifier: ^1.5.3
-        version: 1.5.3(solid-js@2.0.0-beta.10)
+        version: 1.5.3(solid-js@2.0.0-beta.15)
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4846,22 +4858,22 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/filters-faceted:
     dependencies:
       '@solid-primitives/scheduled':
         specifier: ^1.5.3
-        version: 1.5.3(solid-js@2.0.0-beta.10)
+        version: 1.5.3(solid-js@2.0.0-beta.15)
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4874,13 +4886,13 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/filters-fuzzy:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/match-sorter-utils':
         specifier: ^9.0.0-alpha.4
         version: link:../../../packages/match-sorter-utils
@@ -4888,8 +4900,8 @@ importers:
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4902,19 +4914,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/grouping:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4927,19 +4939,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/pagination:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4952,19 +4964,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/row-pinning:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -4977,16 +4989,16 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/row-selection:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-devtools':
         specifier: ^0.8.2
-        version: 0.8.2(solid-js@2.0.0-beta.10)
+        version: 0.8.2(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
@@ -4994,8 +5006,8 @@ importers:
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table-devtools
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5008,19 +5020,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/sorting:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5033,19 +5045,19 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/sub-components:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5058,22 +5070,22 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/virtualized-columns:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       '@tanstack/solid-virtual':
         specifier: ^3.13.24
-        version: 3.13.24(solid-js@2.0.0-beta.10)
+        version: 3.13.24(solid-js@2.0.0-beta.15)
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5086,28 +5098,28 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/virtualized-infinite-scrolling:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.4
-        version: 6.0.0-beta.4(solid-js@2.0.0-beta.10)
+        version: 6.0.0-beta.4(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       '@tanstack/solid-virtual':
         specifier: ^3.13.24
-        version: 3.13.24(solid-js@2.0.0-beta.10)
+        version: 3.13.24(solid-js@2.0.0-beta.15)
       '@tanstack/store':
         specifier: ^0.11.0
         version: 0.11.0
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5120,22 +5132,22 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/virtualized-rows:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       '@tanstack/solid-virtual':
         specifier: ^3.13.24
-        version: 3.13.24(solid-js@2.0.0-beta.10)
+        version: 3.13.24(solid-js@2.0.0-beta.15)
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5148,22 +5160,22 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/with-tanstack-form:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-form':
         specifier: ^1.29.1
-        version: 1.29.1(solid-js@2.0.0-beta.10)
+        version: 1.29.1(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
       zod:
         specifier: ^4.4.2
         version: 4.4.2
@@ -5179,16 +5191,16 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/with-tanstack-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.4
-        version: 6.0.0-beta.4(solid-js@2.0.0-beta.10)
+        version: 6.0.0-beta.4(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
@@ -5196,8 +5208,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
@@ -5210,32 +5222,32 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/solid/with-tanstack-router:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.4
-        version: 6.0.0-beta.4(solid-js@2.0.0-beta.10)
+        version: 6.0.0-beta.4(solid-js@2.0.0-beta.15)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.17
-        version: 2.0.0-beta.17(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)
+        version: 2.0.0-beta.17(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)
       '@tanstack/solid-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/solid-table
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.4.0
         version: 10.4.0
       '@tanstack/router-vite-plugin':
         specifier: ^1.166.47
-        version: 1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
+        version: 1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -5244,7 +5256,7 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   examples/svelte/basic-app-table:
     devDependencies:
@@ -6900,7 +6912,7 @@ importers:
         version: 10.4.0
       '@tanstack/vue-devtools':
         specifier: ^0.2.16
-        version: 0.2.16(solid-js@2.0.0-beta.10)
+        version: 0.2.16(solid-js@2.0.0-beta.15)
       '@tanstack/vue-table':
         specifier: ^9.0.0-alpha.42
         version: link:../../../packages/vue-table
@@ -7297,10 +7309,10 @@ importers:
     dependencies:
       '@tanstack/devtools-utils':
         specifier: ^0.4.0
-        version: 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@2.0.0-beta.10)(vue@3.5.33(typescript@6.0.3))
+        version: 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@2.0.0-beta.15)(vue@3.5.33(typescript@6.0.3))
       '@tanstack/react-devtools':
         specifier: '>=0.10.0'
-        version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@2.0.0-beta.10)
+        version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@2.0.0-beta.15)
       '@tanstack/table-devtools':
         specifier: workspace:*
         version: link:../table-devtools
@@ -7343,39 +7355,36 @@ importers:
         version: link:../table-core
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.15
+        version: 2.0.0-beta.15
       vite-plugin-solid:
         specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   packages/solid-table-devtools:
     dependencies:
       '@tanstack/devtools':
         specifier: ^0.11.2
-        version: 0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)
+        version: 0.11.2(csstype@3.2.3)(solid-js@1.9.12)
       '@tanstack/devtools-utils':
         specifier: ^0.4.0
-        version: 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@2.0.0-beta.10)(vue@3.5.33(typescript@6.0.3))
+        version: 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@1.9.12)(vue@3.5.33(typescript@6.0.3))
       '@tanstack/table-devtools':
         specifier: workspace:*
         version: link:../table-devtools
     devDependencies:
-      '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       '@tanstack/table-core':
         specifier: workspace:*
         version: link:../table-core
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: ^1.9.7
+        version: 1.9.12
       vite-plugin-solid:
-        specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^2.11.12
+        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
 
   packages/svelte-table:
     dependencies:
@@ -11745,13 +11754,13 @@ packages:
     peerDependencies:
       solid-js: '>=1.8.4'
 
-  '@solidjs/signals@2.0.0-beta.10':
-    resolution: {integrity: sha512-McdmbLNiSlz616zcykS8Rb1t9QTOTKdNAoaWd4/OjXEbcAUrPqRX1CWgR+caiWUk4qn0a+LesTTV4jZhFFPaSg==}
+  '@solidjs/signals@2.0.0-beta.15':
+    resolution: {integrity: sha512-lw4a4frNajnmVjILbyfrgJ4ksqU+YKhkepZ8glKK9Q68O3zq7W8qDLOtsz5v1mt0o3TB11/rozJFpgMTmnYegg==}
 
-  '@solidjs/web@2.0.0-beta.10':
-    resolution: {integrity: sha512-Ox7MBv19kuxHoHhWoLCCcc6aykSgaqzWvWT7RB66VqlFnQ8Lid2ncd30g5L4XC0GB+MN/WZVb68tiYrAFUDIAg==}
+  '@solidjs/web@2.0.0-beta.15':
+    resolution: {integrity: sha512-+LvmzzN5CHxQ+TeCGgA8DKuB8S4t0EHVlmDUlAp4hkLnh7My3ZGuKYHKWsFMd8w08nPgF6LdBZkH+c5iNcmcSA==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.10
+      solid-js: ^2.0.0-beta.15
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -12923,8 +12932,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  babel-plugin-jsx-dom-expressions@0.50.0-next.6:
-    resolution: {integrity: sha512-D7SSrMu1EupiCFT3hBhWJj0EWzaI27HV1ysbLSKFcH1ROZe61DmnNVchrnr5QeAw5O8bqSdlMDLdEqMYzi4tTA==}
+  babel-plugin-jsx-dom-expressions@0.50.0-next.14:
+    resolution: {integrity: sha512-eMUq8UuVs5ROCiYmtMBp/TWuRxL7GZ32JUs47CmTzZo8hX9AIayTnNtbsBmQlfEnJla3TaxgBYDvGxNlHCqVcA==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
@@ -12969,11 +12978,11 @@ packages:
       solid-js:
         optional: true
 
-  babel-preset-solid@2.0.0-beta.10:
-    resolution: {integrity: sha512-lzGgPsh1fVtBJDl+UWLTCgimzPMda7X2Xzq7asCCOq/zHRwiF5vF3Eb3xj65dGyi7YpgVROTwJEpj+XiroKaww==}
+  babel-preset-solid@2.0.0-beta.15:
+    resolution: {integrity: sha512-nXbT3ZlgHmVcH1VvEFwyrxcMQmpRJ55JoOLy+4wAxpaYtADw5YJh4t5UlT5WyuWfv6VC7URDCkFGEdAOjmTwjw==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.10
+      solid-js: ^2.0.0-beta.15
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -15964,8 +15973,8 @@ packages:
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
-  solid-js@2.0.0-beta.10:
-    resolution: {integrity: sha512-EAfV6b1SC4c3wEBAoX4dMy063uTb4nfL5uXnN8yse4InH7RTw1LoB0I9HAy+pj3/GHqQE2tYZurlZtqU4pGyog==}
+  solid-js@2.0.0-beta.15:
+    resolution: {integrity: sha512-3hvcmEFUgDlahc++/ulrPhnc5IM7aJbW1P4TUaKsMZpDY5qGcOagtL4nbXGdUPnVP0JsJhMuE9bXEcLdLE+2SA==}
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -21218,116 +21227,150 @@ snapshots:
       '@size-limit/file': 12.1.0(size-limit@12.1.0(jiti@2.6.1))
       size-limit: 12.1.0(jiti@2.6.1)
 
-  '@solid-devtools/debugger@0.28.1(solid-js@2.0.0-beta.10)':
+  '@solid-devtools/debugger@0.28.1(solid-js@2.0.0-beta.15)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-beta.10)
-      '@solid-primitives/bounds': 0.1.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/keyboard': 1.3.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-beta.15)
+      '@solid-primitives/bounds': 0.1.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/keyboard': 1.3.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@solid-devtools/logger@0.9.11(solid-js@2.0.0-beta.10)':
+  '@solid-devtools/logger@0.9.11(solid-js@2.0.0-beta.15)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/debugger': 0.28.1(solid-js@2.0.0-beta.10)
-      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-devtools/debugger': 0.28.1(solid-js@2.0.0-beta.15)
+      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-beta.15)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@solid-devtools/shared@0.20.0(solid-js@2.0.0-beta.10)':
+  '@solid-devtools/shared@0.20.0(solid-js@2.0.0-beta.15)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/media': 2.3.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/refs': 1.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/styles': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/media': 2.3.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/refs': 1.1.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/styles': 0.1.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@solid-primitives/bounds@0.1.5(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/bounds@0.1.5(solid-js@2.0.0-beta.15)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/resize-observer': 2.1.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/resize-observer': 2.1.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@solid-primitives/event-listener@2.4.5(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/event-listener@2.4.5(solid-js@1.9.12)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
+      solid-js: 1.9.12
 
-  '@solid-primitives/keyboard@1.3.5(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/event-listener@2.4.5(solid-js@2.0.0-beta.15)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@solid-primitives/media@2.3.5(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/keyboard@1.3.5(solid-js@1.9.12)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
+      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
+      solid-js: 1.9.12
 
-  '@solid-primitives/refs@1.1.3(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/keyboard@1.3.5(solid-js@2.0.0-beta.15)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@solid-primitives/resize-observer@2.1.5(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/media@2.3.5(solid-js@2.0.0-beta.15)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@solid-primitives/rootless@1.5.3(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/refs@1.1.3(solid-js@2.0.0-beta.15)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@solid-primitives/scheduled@1.5.3(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/resize-observer@2.1.5(solid-js@1.9.12)':
     dependencies:
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
+      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
+      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.12)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
+      solid-js: 1.9.12
 
-  '@solid-primitives/static-store@0.1.3(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/resize-observer@2.1.5(solid-js@2.0.0-beta.15)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@solid-primitives/styles@0.1.3(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/rootless@1.5.3(solid-js@1.9.12)':
     dependencies:
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
+      solid-js: 1.9.12
 
-  '@solid-primitives/utils@6.4.0(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/rootless@1.5.3(solid-js@2.0.0-beta.15)':
     dependencies:
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/scheduled@1.5.3(solid-js@2.0.0-beta.15)':
     dependencies:
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.15
 
-  '@solidjs/signals@2.0.0-beta.10': {}
+  '@solid-primitives/static-store@0.1.3(solid-js@1.9.12)':
+    dependencies:
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
+      solid-js: 1.9.12
 
-  '@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/static-store@0.1.3(solid-js@2.0.0-beta.15)':
+    dependencies:
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
+
+  '@solid-primitives/styles@0.1.3(solid-js@2.0.0-beta.15)':
+    dependencies:
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.15)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
+
+  '@solid-primitives/utils@6.4.0(solid-js@1.9.12)':
+    dependencies:
+      solid-js: 1.9.12
+
+  '@solid-primitives/utils@6.4.0(solid-js@2.0.0-beta.15)':
+    dependencies:
+      solid-js: 2.0.0-beta.15
+
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.15)':
+    dependencies:
+      solid-js: 2.0.0-beta.15
+
+  '@solidjs/signals@2.0.0-beta.15': {}
+
+  '@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15)':
     dependencies:
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.15
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -21470,12 +21513,12 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-ui@0.5.1(csstype@3.2.3)(solid-js@2.0.0-beta.10)':
+  '@tanstack/devtools-ui@0.5.1(solid-js@2.0.0-beta.15)':
     dependencies:
       clsx: 2.1.1
       dayjs: 1.11.20
       goober: 2.1.18(csstype@3.2.3)
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.15
     transitivePeerDependencies:
       - csstype
 
@@ -21487,25 +21530,57 @@ snapshots:
       solid-js: 1.9.12
       vue: 3.5.33(typescript@6.0.3)
 
-  '@tanstack/devtools-utils@0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@2.0.0-beta.10)(vue@3.5.33(typescript@6.0.3))':
+  '@tanstack/devtools-utils@0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.5)(solid-js@2.0.0-beta.15)(vue@3.5.33(typescript@6.0.3))':
     optionalDependencies:
       '@types/react': 19.2.14
       preact: 10.29.1
       react: 19.2.5
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.15
       vue: 3.5.33(typescript@6.0.3)
 
-  '@tanstack/devtools@0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)':
+  '@tanstack/devtools@0.11.2(csstype@3.2.3)(solid-js@1.9.12)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/keyboard': 1.3.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/resize-observer': 2.1.5(solid-js@2.0.0-beta.10)
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
+      '@solid-primitives/keyboard': 1.3.5(solid-js@1.9.12)
+      '@solid-primitives/resize-observer': 2.1.5(solid-js@1.9.12)
       '@tanstack/devtools-client': 0.0.6
       '@tanstack/devtools-event-bus': 0.4.1
-      '@tanstack/devtools-ui': 0.5.1(csstype@3.2.3)(solid-js@2.0.0-beta.10)
+      '@tanstack/devtools-ui': 0.5.1(csstype@3.2.3)(solid-js@1.9.12)
       clsx: 2.1.1
       goober: 2.1.18(csstype@3.2.3)
-      solid-js: 2.0.0-beta.10
+      solid-js: 1.9.12
+    transitivePeerDependencies:
+      - bufferutil
+      - csstype
+      - utf-8-validate
+
+  '@tanstack/devtools@0.11.2(solid-js@1.9.12)':
+    dependencies:
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
+      '@solid-primitives/keyboard': 1.3.5(solid-js@1.9.12)
+      '@solid-primitives/resize-observer': 2.1.5(solid-js@1.9.12)
+      '@tanstack/devtools-client': 0.0.6
+      '@tanstack/devtools-event-bus': 0.4.1
+      '@tanstack/devtools-ui': 0.5.1(csstype@3.2.3)(solid-js@1.9.12)
+      clsx: 2.1.1
+      goober: 2.1.18(csstype@3.2.3)
+      solid-js: 1.9.12
+    transitivePeerDependencies:
+      - bufferutil
+      - csstype
+      - utf-8-validate
+
+  '@tanstack/devtools@0.11.2(solid-js@2.0.0-beta.15)':
+    dependencies:
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/keyboard': 1.3.5(solid-js@2.0.0-beta.15)
+      '@solid-primitives/resize-observer': 2.1.5(solid-js@2.0.0-beta.15)
+      '@tanstack/devtools-client': 0.0.6
+      '@tanstack/devtools-event-bus': 0.4.1
+      '@tanstack/devtools-ui': 0.5.1(solid-js@2.0.0-beta.15)
+      clsx: 2.1.1
+      goober: 2.1.18(csstype@3.2.3)
+      solid-js: 2.0.0-beta.15
     transitivePeerDependencies:
       - bufferutil
       - csstype
@@ -21546,9 +21621,9 @@ snapshots:
 
   '@tanstack/pacer-lite@0.1.1': {}
 
-  '@tanstack/preact-devtools@0.10.2(preact@10.29.1)(solid-js@2.0.0-beta.10)':
+  '@tanstack/preact-devtools@0.10.2(preact@10.29.1)(solid-js@1.9.12)':
     dependencies:
-      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)
+      '@tanstack/devtools': 0.11.2(solid-js@1.9.12)
       preact: 10.29.1
     transitivePeerDependencies:
       - bufferutil
@@ -21579,9 +21654,22 @@ snapshots:
 
   '@tanstack/query-core@5.91.2': {}
 
-  '@tanstack/react-devtools@0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@2.0.0-beta.10)':
+  '@tanstack/react-devtools@0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)':
     dependencies:
-      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)
+      '@tanstack/devtools': 0.11.2(solid-js@1.9.12)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - bufferutil
+      - csstype
+      - solid-js
+      - utf-8-validate
+
+  '@tanstack/react-devtools@0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@2.0.0-beta.15)':
+    dependencies:
+      '@tanstack/devtools': 0.11.2(solid-js@2.0.0-beta.15)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.2.5
@@ -21661,7 +21749,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))':
+  '@tanstack/router-plugin@1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -21679,7 +21767,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
-      vite-plugin-solid: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+      vite-plugin-solid: 3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
       webpack: 5.105.2(esbuild@0.28.0)
     transitivePeerDependencies:
       - supports-color
@@ -21698,9 +21786,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-vite-plugin@1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))':
+  '@tanstack/router-vite-plugin@1.166.47(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))':
     dependencies:
-      '@tanstack/router-plugin': 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
+      '@tanstack/router-plugin': 1.167.32(@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))(webpack@5.105.2(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@rsbuild/core'
       - '@tanstack/react-router'
@@ -21709,50 +21797,50 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/solid-devtools@0.8.2(solid-js@2.0.0-beta.10)':
+  '@tanstack/solid-devtools@0.8.2(solid-js@2.0.0-beta.15)':
     dependencies:
-      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@tanstack/devtools': 0.11.2(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
     transitivePeerDependencies:
       - bufferutil
       - csstype
       - utf-8-validate
 
-  '@tanstack/solid-form@1.29.1(solid-js@2.0.0-beta.10)':
+  '@tanstack/solid-form@1.29.1(solid-js@2.0.0-beta.15)':
     dependencies:
       '@tanstack/form-core': 1.29.1
-      '@tanstack/solid-store': 0.9.3(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@tanstack/solid-store': 0.9.3(solid-js@2.0.0-beta.15)
+      solid-js: 2.0.0-beta.15
 
-  '@tanstack/solid-query@6.0.0-beta.4(solid-js@2.0.0-beta.10)':
+  '@tanstack/solid-query@6.0.0-beta.4(solid-js@2.0.0-beta.15)':
     dependencies:
       '@tanstack/query-core': 5.91.2
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.15
 
-  '@tanstack/solid-router@2.0.0-beta.17(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)':
+  '@tanstack/solid-router@2.0.0-beta.17(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)':
     dependencies:
-      '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-beta.10)
-      '@solidjs/meta': 0.29.4(solid-js@2.0.0-beta.10)
-      '@solidjs/web': 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+      '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-beta.15)
+      '@solidjs/meta': 0.29.4(solid-js@2.0.0-beta.15)
+      '@solidjs/web': 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@tanstack/history': 1.161.6
       '@tanstack/router-core': 1.168.9
       isbot: 5.1.39
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.15
 
   '@tanstack/solid-store@0.11.0(solid-js@1.9.12)':
     dependencies:
       '@tanstack/store': 0.11.0
       solid-js: 1.9.12
 
-  '@tanstack/solid-store@0.9.3(solid-js@2.0.0-beta.10)':
+  '@tanstack/solid-store@0.9.3(solid-js@2.0.0-beta.15)':
     dependencies:
       '@tanstack/store': 0.9.3
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.15
 
-  '@tanstack/solid-virtual@3.13.24(solid-js@2.0.0-beta.10)':
+  '@tanstack/solid-virtual@3.13.24(solid-js@2.0.0-beta.15)':
     dependencies:
       '@tanstack/virtual-core': 3.14.0
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.15
 
   '@tanstack/store@0.11.0': {}
 
@@ -21796,9 +21884,9 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.161.7': {}
 
-  '@tanstack/vue-devtools@0.2.16(solid-js@2.0.0-beta.10)':
+  '@tanstack/vue-devtools@0.2.16(solid-js@2.0.0-beta.15)':
     dependencies:
-      '@tanstack/devtools': 0.11.2(csstype@3.2.3)(solid-js@2.0.0-beta.10)
+      '@tanstack/devtools': 0.11.2(solid-js@2.0.0-beta.15)
     transitivePeerDependencies:
       - bufferutil
       - csstype
@@ -22725,7 +22813,7 @@ snapshots:
       html-entities: 2.3.3
       parse5: 7.3.0
 
-  babel-plugin-jsx-dom-expressions@0.50.0-next.6(@babel/core@7.29.0):
+  babel-plugin-jsx-dom-expressions@0.50.0-next.14(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.18.6
@@ -22788,12 +22876,12 @@ snapshots:
     optionalDependencies:
       solid-js: 1.9.12
 
-  babel-preset-solid@2.0.0-beta.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.10):
+  babel-preset-solid@2.0.0-beta.15(@babel/core@7.29.0)(solid-js@2.0.0-beta.15):
     dependencies:
       '@babel/core': 7.29.0
-      babel-plugin-jsx-dom-expressions: 0.50.0-next.6(@babel/core@7.29.0)
+      babel-plugin-jsx-dom-expressions: 0.50.0-next.14(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.15
 
   balanced-match@1.0.2: {}
 
@@ -26312,9 +26400,9 @@ snapshots:
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
 
-  solid-js@2.0.0-beta.10:
+  solid-js@2.0.0-beta.15:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.10
+      '@solidjs/signals': 2.0.0-beta.15
       csstype: 3.2.3
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
@@ -26328,11 +26416,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.10):
+  solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.15):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/types': 7.29.0
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.15
 
   source-map-js@1.2.1: {}
 
@@ -26854,15 +26942,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.10)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)):
+  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@testing-library/jest-dom@6.9.1)(solid-js@2.0.0-beta.15)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
-      '@solidjs/web': 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+      '@solidjs/web': 2.0.0-beta.15(solid-js@2.0.0-beta.15)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.10)
+      babel-preset-solid: 2.0.0-beta.15(@babel/core@7.29.0)(solid-js@2.0.0-beta.15)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.10
-      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.10)
+      solid-js: 2.0.0-beta.15
+      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.15)
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
       vitefu: 1.1.3(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,11 @@ cleanupUnusedCatalogs: true
 
 linkWorkspacePackages: true
 preferWorkspacePackages: true
+
+overrides:
+  # Keep the Solid v2 JSX compiler in lockstep with the @solidjs/web runtime.
+  # vite-plugin-solid allows the whole beta range, but the lockfile pinned the
+  # compiler to beta.10, which emits an `addEventListener` import that the
+  # beta.15 runtime renamed to `addEvent`. Scoped to the v2-beta range so the
+  # v1 devtools (babel-preset-solid@1.9.x) are untouched.
+  babel-preset-solid@>=2.0.0-beta.0 <2.0.0-experimental.0: 2.0.0-beta.15


### PR DESCRIPTION
- Wrap <Match when> props in FlexRender with accessor functions and use createMemo inside Match callbacks so reactive reads happen in tracking scopes (resolves STRICT_READ_UNTRACKED warnings).
- Update basic-app-table example to call accessor args (row(), cell(), header(), footerGroup()) returned by Solid v2's <For> callbacks.