### PR TITLE
feat: change default state selectors to all

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -823,6 +823,7 @@
             { "to": "framework/react/examples/basic-use-legacy-table", "label": "Basic (useLegacyTable)" },
             { "to": "framework/react/examples/basic-external-state", "label": "Basic (External State)" },
             { "to": "framework/react/examples/basic-external-atoms", "label": "Basic (External Atoms)" },
+            { "to": "framework/react/examples/basic-subscribe", "label": "Basic (Subscribe)" },
             { "to": "framework/react/examples/column-groups", "label": "Header Groups" }
           ]
         },
@@ -864,6 +865,7 @@
             { "to": "framework/preact/examples/basic-use-app-table", "label": "Basic (useAppTable)" },
             { "to": "framework/preact/examples/basic-external-state", "label": "Basic (External State)" },
             { "to": "framework/preact/examples/basic-external-atoms", "label": "Basic (External Atoms)" },
+            { "to": "framework/preact/examples/basic-subscribe", "label": "Basic (Subscribe)" },
             { "to": "framework/preact/examples/column-groups", "label": "Header Groups" }
           ]
         },

--- a/docs/framework/angular/reference/functions/injectTable.md
+++ b/docs/framework/angular/reference/functions/injectTable.md
@@ -6,10 +6,10 @@ title: injectTable
 # Function: injectTable()
 
 ```ts
-function injectTable<TFeatures, TData, TSelected>(options, selector): AngularTable<TFeatures, TData, TSelected>;
+function injectTable<TFeatures, TData, TSelected>(options, selector?): AngularTable<TFeatures, TData, TSelected>;
 ```
 
-Defined in: [injectTable.ts:124](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L124)
+Defined in: [injectTable.ts:133](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L133)
 
 Creates and returns an Angular-reactive table instance.
 
@@ -42,7 +42,7 @@ The returned table is also signal-reactive: table state and table APIs are wired
 
 () => `TableOptions`\<`TFeatures`, `TData`\>
 
-### selector
+### selector?
 
 (`state`) => `TSelected`
 

--- a/docs/framework/angular/reference/index.md
+++ b/docs/framework/angular/reference/index.md
@@ -38,6 +38,7 @@ title: "@tanstack/angular-table"
 - [FlexRenderContent](type-aliases/FlexRenderContent.md)
 - [FlexRenderInputContent](type-aliases/FlexRenderInputContent.md)
 - [RenderableComponent](type-aliases/RenderableComponent.md)
+- [SubscribeSource](type-aliases/SubscribeSource.md)
 
 ## Variables
 

--- a/docs/framework/angular/reference/interfaces/AngularTableComputed.md
+++ b/docs/framework/angular/reference/interfaces/AngularTableComputed.md
@@ -5,7 +5,7 @@ title: AngularTableComputed
 
 # Interface: AngularTableComputed()\<TFeatures\>
 
-Defined in: [injectTable.ts:28](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L28)
+Defined in: [injectTable.ts:40](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L40)
 
 Store mode: pass `selector` (required) to project from full table state.
 Source mode: pass `source` (atom or store); omit `selector` for the whole value
@@ -24,7 +24,7 @@ inference.
 AngularTableComputed<TSourceValue>(props): Signal<Readonly<TSourceValue>>;
 ```
 
-Defined in: [injectTable.ts:29](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L29)
+Defined in: [injectTable.ts:41](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L41)
 
 Store mode: pass `selector` (required) to project from full table state.
 Source mode: pass `source` (atom or store); omit `selector` for the whole value
@@ -51,7 +51,7 @@ inference.
 
 ##### source
 
-`Atom`\<`TSourceValue`\> \| `ReadonlyAtom`\<`TSourceValue`\>
+[`SubscribeSource`](../type-aliases/SubscribeSource.md)\<`TSourceValue`\>
 
 ### Returns
 
@@ -63,7 +63,7 @@ inference.
 AngularTableComputed<TSourceValue, TSubSelected>(props): Signal<Readonly<TSubSelected>>;
 ```
 
-Defined in: [injectTable.ts:34](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L34)
+Defined in: [injectTable.ts:46](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L46)
 
 Store mode: pass `selector` (required) to project from full table state.
 Source mode: pass `source` (atom or store); omit `selector` for the whole value
@@ -94,7 +94,7 @@ inference.
 
 ##### source
 
-`Atom`\<`TSourceValue`\> \| `ReadonlyAtom`\<`TSourceValue`\>
+[`SubscribeSource`](../type-aliases/SubscribeSource.md)\<`TSourceValue`\>
 
 ### Returns
 
@@ -106,7 +106,7 @@ inference.
 AngularTableComputed<TSubSelected>(props): Signal<Readonly<TSubSelected>>;
 ```
 
-Defined in: [injectTable.ts:39](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L39)
+Defined in: [injectTable.ts:51](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L51)
 
 Store mode: pass `selector` (required) to project from full table state.
 Source mode: pass `source` (atom or store); omit `selector` for the whole value

--- a/docs/framework/angular/reference/type-aliases/AngularTable.md
+++ b/docs/framework/angular/reference/type-aliases/AngularTable.md
@@ -9,41 +9,18 @@ title: AngularTable
 type AngularTable<TFeatures, TData, TSelected> = Table<TFeatures, TData> & object;
 ```
 
-Defined in: [injectTable.ts:45](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L45)
+Defined in: [injectTable.ts:57](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L57)
 
 ## Type Declaration
 
-### computed()
+### computed
 
 ```ts
-computed: <TSubSelected>(props) => Signal<Readonly<TSubSelected>>;
+computed: AngularTableComputed<TFeatures>;
 ```
 
 Creates a computed that subscribe to changes in the table store with a custom selector.
 Default equality function is "shallow".
-
-#### Type Parameters
-
-##### TSubSelected
-
-`TSubSelected` = \{
-\}
-
-#### Parameters
-
-##### props
-
-###### equal?
-
-`ValueEqualityFn`\<`TSubSelected`\>
-
-###### selector
-
-(`state`) => `TSubSelected`
-
-#### Returns
-
-`Signal`\<`Readonly`\<`TSubSelected`\>\>
 
 ### state
 

--- a/docs/framework/angular/reference/type-aliases/SubscribeSource.md
+++ b/docs/framework/angular/reference/type-aliases/SubscribeSource.md
@@ -1,0 +1,22 @@
+---
+id: SubscribeSource
+title: SubscribeSource
+---
+
+# Type Alias: SubscribeSource\<TValue\>
+
+```ts
+type SubscribeSource<TValue> = 
+  | Atom<TValue>
+  | ReadonlyAtom<TValue>
+  | Store<TValue>
+| ReadonlyStore<TValue>;
+```
+
+Defined in: [injectTable.ts:28](https://github.com/TanStack/table/blob/main/packages/angular-table/src/injectTable.ts#L28)
+
+## Type Parameters
+
+### TValue
+
+`TValue`

--- a/docs/framework/react/reference/index/functions/Subscribe.md
+++ b/docs/framework/react/reference/index/functions/Subscribe.md
@@ -8,10 +8,10 @@ title: Subscribe
 ## Call Signature
 
 ```ts
-function Subscribe<TFeatures, TData, TSourceValue>(props): ReactNode | Promise<ReactNode>;
+function Subscribe<TSourceValue>(props): ReactNode | Promise<ReactNode>;
 ```
 
-Defined in: [Subscribe.ts:148](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L148)
+Defined in: [Subscribe.ts:125](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L125)
 
 A React component that allows you to subscribe to the table state.
 
@@ -22,14 +22,6 @@ contextual typing works. This standalone component uses a union `props` type.
 
 ### Type Parameters
 
-#### TFeatures
-
-`TFeatures` *extends* `TableFeatures`
-
-#### TData
-
-`TData` *extends* `RowData`
-
 #### TSourceValue
 
 `TSourceValue`
@@ -38,7 +30,7 @@ contextual typing works. This standalone component uses a union `props` type.
 
 #### props
 
-[`SubscribePropsWithSourceIdentity`](../type-aliases/SubscribePropsWithSourceIdentity.md)\<`TFeatures`, `TData`, `TSourceValue`\>
+[`SubscribePropsWithSourceIdentity`](../type-aliases/SubscribePropsWithSourceIdentity.md)\<`TSourceValue`\>
 
 ### Returns
 
@@ -48,7 +40,7 @@ contextual typing works. This standalone component uses a union `props` type.
 
 ```tsx
 // As a standalone component — full store
-<Subscribe table={table} selector={(state) => ({ rowSelection: state.rowSelection })}>
+<Subscribe source={table.store} selector={(state) => ({ rowSelection: state.rowSelection })}>
   {({ rowSelection }) => (
     <div>Selected rows: {Object.keys(rowSelection).length}</div>
   )}
@@ -57,7 +49,7 @@ contextual typing works. This standalone component uses a union `props` type.
 
 ```tsx
 // Entire source (atom or store) — no selector
-<Subscribe table={table} source={table.atoms.rowSelection}>
+<Subscribe source={table.atoms.rowSelection}>
   {(rowSelection) => <div>...</div>}
 </Subscribe>
 ```
@@ -65,7 +57,6 @@ contextual typing works. This standalone component uses a union `props` type.
 ```tsx
 // Project source value (e.g. one row’s selection)
 <Subscribe
-  table={table}
   source={table.atoms.rowSelection}
   selector={(rowSelection) => rowSelection?.[row.id]}
 >
@@ -85,10 +76,10 @@ contextual typing works. This standalone component uses a union `props` type.
 ## Call Signature
 
 ```ts
-function Subscribe<TFeatures, TData, TSourceValue, TSelected>(props): ReactNode | Promise<ReactNode>;
+function Subscribe<TSourceValue, TSelected>(props): ReactNode | Promise<ReactNode>;
 ```
 
-Defined in: [Subscribe.ts:155](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L155)
+Defined in: [Subscribe.ts:128](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L128)
 
 A React component that allows you to subscribe to the table state.
 
@@ -98,14 +89,6 @@ For `table.Subscribe` from `useTable`, prefer that API — it uses overloads so 
 contextual typing works. This standalone component uses a union `props` type.
 
 ### Type Parameters
-
-#### TFeatures
-
-`TFeatures` *extends* `TableFeatures`
-
-#### TData
-
-`TData` *extends* `RowData`
 
 #### TSourceValue
 
@@ -119,7 +102,7 @@ contextual typing works. This standalone component uses a union `props` type.
 
 #### props
 
-[`SubscribePropsWithSourceWithSelector`](../type-aliases/SubscribePropsWithSourceWithSelector.md)\<`TFeatures`, `TData`, `TSourceValue`, `TSelected`\>
+[`SubscribePropsWithSourceWithSelector`](../type-aliases/SubscribePropsWithSourceWithSelector.md)\<`TSourceValue`, `TSelected`\>
 
 ### Returns
 
@@ -129,7 +112,7 @@ contextual typing works. This standalone component uses a union `props` type.
 
 ```tsx
 // As a standalone component — full store
-<Subscribe table={table} selector={(state) => ({ rowSelection: state.rowSelection })}>
+<Subscribe source={table.store} selector={(state) => ({ rowSelection: state.rowSelection })}>
   {({ rowSelection }) => (
     <div>Selected rows: {Object.keys(rowSelection).length}</div>
   )}
@@ -138,7 +121,7 @@ contextual typing works. This standalone component uses a union `props` type.
 
 ```tsx
 // Entire source (atom or store) — no selector
-<Subscribe table={table} source={table.atoms.rowSelection}>
+<Subscribe source={table.atoms.rowSelection}>
   {(rowSelection) => <div>...</div>}
 </Subscribe>
 ```
@@ -146,7 +129,6 @@ contextual typing works. This standalone component uses a union `props` type.
 ```tsx
 // Project source value (e.g. one row’s selection)
 <Subscribe
-  table={table}
   source={table.atoms.rowSelection}
   selector={(rowSelection) => rowSelection?.[row.id]}
 >
@@ -166,10 +148,10 @@ contextual typing works. This standalone component uses a union `props` type.
 ## Call Signature
 
 ```ts
-function Subscribe<TFeatures, TData, TSelected>(props): ReactNode | Promise<ReactNode>;
+function Subscribe<TFeatures, TSelected>(props): ReactNode | Promise<ReactNode>;
 ```
 
-Defined in: [Subscribe.ts:168](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L168)
+Defined in: [Subscribe.ts:131](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L131)
 
 A React component that allows you to subscribe to the table state.
 
@@ -184,10 +166,6 @@ contextual typing works. This standalone component uses a union `props` type.
 
 `TFeatures` *extends* `TableFeatures`
 
-#### TData
-
-`TData` *extends* `RowData`
-
 #### TSelected
 
 `TSelected`
@@ -196,7 +174,7 @@ contextual typing works. This standalone component uses a union `props` type.
 
 #### props
 
-[`SubscribePropsWithStore`](../type-aliases/SubscribePropsWithStore.md)\<`TFeatures`, `TData`, `TSelected`\>
+[`SubscribePropsWithStore`](../type-aliases/SubscribePropsWithStore.md)\<`TFeatures`, `TSelected`\>
 
 ### Returns
 
@@ -206,7 +184,7 @@ contextual typing works. This standalone component uses a union `props` type.
 
 ```tsx
 // As a standalone component — full store
-<Subscribe table={table} selector={(state) => ({ rowSelection: state.rowSelection })}>
+<Subscribe source={table.store} selector={(state) => ({ rowSelection: state.rowSelection })}>
   {({ rowSelection }) => (
     <div>Selected rows: {Object.keys(rowSelection).length}</div>
   )}
@@ -215,7 +193,7 @@ contextual typing works. This standalone component uses a union `props` type.
 
 ```tsx
 // Entire source (atom or store) — no selector
-<Subscribe table={table} source={table.atoms.rowSelection}>
+<Subscribe source={table.atoms.rowSelection}>
   {(rowSelection) => <div>...</div>}
 </Subscribe>
 ```
@@ -223,7 +201,6 @@ contextual typing works. This standalone component uses a union `props` type.
 ```tsx
 // Project source value (e.g. one row’s selection)
 <Subscribe
-  table={table}
   source={table.atoms.rowSelection}
   selector={(rowSelection) => rowSelection?.[row.id]}
 >

--- a/docs/framework/react/reference/index/functions/createTableHook.md
+++ b/docs/framework/react/reference/index/functions/createTableHook.md
@@ -110,8 +110,7 @@ TFeatures is already known from the createTableHook call; TData is inferred from
 
 ##### TSelected
 
-`TSelected` = \{
-\}
+`TSelected` = `TableState`\<`TFeatures`\>
 
 #### Parameters
 

--- a/docs/framework/react/reference/index/functions/useTable.md
+++ b/docs/framework/react/reference/index/functions/useTable.md
@@ -6,10 +6,10 @@ title: useTable
 # Function: useTable()
 
 ```ts
-function useTable<TFeatures, TData, TSelected>(tableOptions, selector): ReactTable<TFeatures, TData, TSelected>;
+function useTable<TFeatures, TData, TSelected>(tableOptions, selector?): ReactTable<TFeatures, TData, TSelected>;
 ```
 
-Defined in: [useTable.ts:112](https://github.com/TanStack/table/blob/main/packages/react-table/src/useTable.ts#L112)
+Defined in: [useTable.ts:108](https://github.com/TanStack/table/blob/main/packages/react-table/src/useTable.ts#L108)
 
 ## Type Parameters
 
@@ -23,8 +23,7 @@ Defined in: [useTable.ts:112](https://github.com/TanStack/table/blob/main/packag
 
 ### TSelected
 
-`TSelected` = \{
-\}
+`TSelected` = `TableState`\<`TFeatures`\>
 
 ## Parameters
 
@@ -32,7 +31,7 @@ Defined in: [useTable.ts:112](https://github.com/TanStack/table/blob/main/packag
 
 `TableOptions`\<`TFeatures`, `TData`\>
 
-### selector
+### selector?
 
 (`state`) => `TSelected`
 

--- a/docs/framework/react/reference/index/index.md
+++ b/docs/framework/react/reference/index/index.md
@@ -36,6 +36,7 @@ title: index
 - [SubscribePropsWithSourceIdentity](type-aliases/SubscribePropsWithSourceIdentity.md)
 - [SubscribePropsWithSourceWithSelector](type-aliases/SubscribePropsWithSourceWithSelector.md)
 - [SubscribePropsWithStore](type-aliases/SubscribePropsWithStore.md)
+- [SubscribeSource](type-aliases/SubscribeSource.md)
 
 ## Functions
 

--- a/docs/framework/react/reference/index/type-aliases/ReactTable.md
+++ b/docs/framework/react/reference/index/type-aliases/ReactTable.md
@@ -9,7 +9,7 @@ title: ReactTable
 type ReactTable<TFeatures, TData, TSelected> = Table<TFeatures, TData> & object;
 ```
 
-Defined in: [useTable.ts:22](https://github.com/TanStack/table/blob/main/packages/react-table/src/useTable.ts#L22)
+Defined in: [useTable.ts:21](https://github.com/TanStack/table/blob/main/packages/react-table/src/useTable.ts#L21)
 
 ## Type Declaration
 
@@ -114,7 +114,7 @@ The **source** overloads are listed first so `TSourceValue` is inferred from `so
 
 ###### source
 
-`Atom`\<`TSourceValue`\> \| `ReadonlyAtom`\<`TSourceValue`\>
+[`SubscribeSource`](SubscribeSource.md)\<`TSourceValue`\>
 
 ##### Returns
 
@@ -150,7 +150,7 @@ The **source** overloads are listed first so `TSourceValue` is inferred from `so
 
 ###### source
 
-`Atom`\<`TSourceValue`\> \| `ReadonlyAtom`\<`TSourceValue`\>
+[`SubscribeSource`](SubscribeSource.md)\<`TSourceValue`\>
 
 ##### Returns
 
@@ -172,7 +172,7 @@ The **source** overloads are listed first so `TSourceValue` is inferred from `so
 
 ###### props
 
-`Omit`\<[`SubscribePropsWithStore`](SubscribePropsWithStore.md)\<`TFeatures`, `TData`, `TSubSelected`\>, `"table"`\>
+`Omit`\<[`SubscribePropsWithStore`](SubscribePropsWithStore.md)\<`TFeatures`, `TSubSelected`\>, `"source"`\>
 
 ##### Returns
 
@@ -190,5 +190,4 @@ The **source** overloads are listed first so `TSourceValue` is inferred from `so
 
 ### TSelected
 
-`TSelected` = \{
-\}
+`TSelected` = `TableState`\<`TFeatures`\>

--- a/docs/framework/react/reference/index/type-aliases/SubscribeProps.md
+++ b/docs/framework/react/reference/index/type-aliases/SubscribeProps.md
@@ -3,26 +3,22 @@ id: SubscribeProps
 title: SubscribeProps
 ---
 
-# Type Alias: SubscribeProps\<TFeatures, TData, TSelected, TSourceValue\>
+# Type Alias: SubscribeProps\<TFeatures, TSelected, TSourceValue\>
 
 ```ts
-type SubscribeProps<TFeatures, TData, TSelected, TSourceValue> = 
-  | SubscribePropsWithStore<TFeatures, TData, TSelected>
-  | SubscribePropsWithSourceIdentity<TFeatures, TData, TSourceValue>
-| SubscribePropsWithSourceWithSelector<TFeatures, TData, TSourceValue, TSelected>;
+type SubscribeProps<TFeatures, TSelected, TSourceValue> = 
+  | SubscribePropsWithStore<TFeatures, TSelected>
+  | SubscribePropsWithSourceIdentity<TSourceValue>
+| SubscribePropsWithSourceWithSelector<TSourceValue, TSelected>;
 ```
 
-Defined in: [Subscribe.ts:85](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L85)
+Defined in: [Subscribe.ts:69](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L69)
 
 ## Type Parameters
 
 ### TFeatures
 
 `TFeatures` *extends* `TableFeatures`
-
-### TData
-
-`TData` *extends* `RowData`
 
 ### TSelected
 

--- a/docs/framework/react/reference/index/type-aliases/SubscribePropsWithSource.md
+++ b/docs/framework/react/reference/index/type-aliases/SubscribePropsWithSource.md
@@ -3,29 +3,21 @@ id: SubscribePropsWithSource
 title: SubscribePropsWithSource
 ---
 
-# Type Alias: SubscribePropsWithSource\<TFeatures, TData, TSourceValue, TSelected\>
+# Type Alias: SubscribePropsWithSource\<TSourceValue, TSelected\>
 
 ```ts
-type SubscribePropsWithSource<TFeatures, TData, TSourceValue, TSelected> = 
-  | SubscribePropsWithSourceIdentity<TFeatures, TData, TSourceValue>
-| SubscribePropsWithSourceWithSelector<TFeatures, TData, TSourceValue, TSelected>;
+type SubscribePropsWithSource<TSourceValue, TSelected> = 
+  | SubscribePropsWithSourceIdentity<TSourceValue>
+| SubscribePropsWithSourceWithSelector<TSourceValue, TSelected>;
 ```
 
-Defined in: [Subscribe.ts:71](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L71)
+Defined in: [Subscribe.ts:65](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L65)
 
 Subscribe to a single source — atom or store (identity or projected). Prefer
 [SubscribePropsWithSourceIdentity](SubscribePropsWithSourceIdentity.md) or [SubscribePropsWithSourceWithSelector](SubscribePropsWithSourceWithSelector.md)
 for clearer inference when `selector` is omitted.
 
 ## Type Parameters
-
-### TFeatures
-
-`TFeatures` *extends* `TableFeatures`
-
-### TData
-
-`TData` *extends* `RowData`
 
 ### TSourceValue
 

--- a/docs/framework/react/reference/index/type-aliases/SubscribePropsWithSourceIdentity.md
+++ b/docs/framework/react/reference/index/type-aliases/SubscribePropsWithSourceIdentity.md
@@ -3,27 +3,19 @@ id: SubscribePropsWithSourceIdentity
 title: SubscribePropsWithSourceIdentity
 ---
 
-# Type Alias: SubscribePropsWithSourceIdentity\<TFeatures, TData, TSourceValue\>
+# Type Alias: SubscribePropsWithSourceIdentity\<TSourceValue\>
 
 ```ts
-type SubscribePropsWithSourceIdentity<TFeatures, TData, TSourceValue> = object;
+type SubscribePropsWithSourceIdentity<TSourceValue> = object;
 ```
 
-Defined in: [Subscribe.ts:39](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L39)
+Defined in: [Subscribe.ts:44](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L44)
 
 Subscribe to the full value of a source (e.g. `table.atoms.rowSelection` or
 `table.optionsStore`). Omitting `selector` is equivalent to the identity
 selector — children receive `TSourceValue`.
 
 ## Type Parameters
-
-### TFeatures
-
-`TFeatures` *extends* `TableFeatures`
-
-### TData
-
-`TData` *extends* `RowData`
 
 ### TSourceValue
 
@@ -54,17 +46,7 @@ Defined in: [Subscribe.ts:46](https://github.com/TanStack/table/blob/main/packag
 ### source
 
 ```ts
-source: Atom<TSourceValue> | ReadonlyAtom<TSourceValue>;
+source: SubscribeSource<TSourceValue>;
 ```
 
 Defined in: [Subscribe.ts:45](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L45)
-
-***
-
-### table
-
-```ts
-table: Table<TFeatures, TData>;
-```
-
-Defined in: [Subscribe.ts:44](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L44)

--- a/docs/framework/react/reference/index/type-aliases/SubscribePropsWithSourceWithSelector.md
+++ b/docs/framework/react/reference/index/type-aliases/SubscribePropsWithSourceWithSelector.md
@@ -3,10 +3,10 @@ id: SubscribePropsWithSourceWithSelector
 title: SubscribePropsWithSourceWithSelector
 ---
 
-# Type Alias: SubscribePropsWithSourceWithSelector\<TFeatures, TData, TSourceValue, TSelected\>
+# Type Alias: SubscribePropsWithSourceWithSelector\<TSourceValue, TSelected\>
 
 ```ts
-type SubscribePropsWithSourceWithSelector<TFeatures, TData, TSourceValue, TSelected> = object;
+type SubscribePropsWithSourceWithSelector<TSourceValue, TSelected> = object;
 ```
 
 Defined in: [Subscribe.ts:54](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L54)
@@ -15,14 +15,6 @@ Subscribe to a projected value from a source (atom or store). The selector
 receives the source value; children receive the projected `TSelected`.
 
 ## Type Parameters
-
-### TFeatures
-
-`TFeatures` *extends* `TableFeatures`
-
-### TData
-
-`TData` *extends* `RowData`
 
 ### TSourceValue
 
@@ -40,7 +32,7 @@ receives the source value; children receive the projected `TSelected`.
 children: (state) => ReactNode | ReactNode;
 ```
 
-Defined in: [Subscribe.ts:63](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L63)
+Defined in: [Subscribe.ts:57](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L57)
 
 ***
 
@@ -50,7 +42,7 @@ Defined in: [Subscribe.ts:63](https://github.com/TanStack/table/blob/main/packag
 selector: (state) => TSelected;
 ```
 
-Defined in: [Subscribe.ts:62](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L62)
+Defined in: [Subscribe.ts:56](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L56)
 
 #### Parameters
 
@@ -67,17 +59,7 @@ Defined in: [Subscribe.ts:62](https://github.com/TanStack/table/blob/main/packag
 ### source
 
 ```ts
-source: Atom<TSourceValue> | ReadonlyAtom<TSourceValue>;
+source: SubscribeSource<TSourceValue>;
 ```
 
-Defined in: [Subscribe.ts:61](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L61)
-
-***
-
-### table
-
-```ts
-table: Table<TFeatures, TData>;
-```
-
-Defined in: [Subscribe.ts:60](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L60)
+Defined in: [Subscribe.ts:55](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L55)

--- a/docs/framework/react/reference/index/type-aliases/SubscribePropsWithStore.md
+++ b/docs/framework/react/reference/index/type-aliases/SubscribePropsWithStore.md
@@ -3,13 +3,13 @@ id: SubscribePropsWithStore
 title: SubscribePropsWithStore
 ---
 
-# Type Alias: SubscribePropsWithStore\<TFeatures, TData, TSelected\>
+# Type Alias: SubscribePropsWithStore\<TFeatures, TSelected\>
 
 ```ts
-type SubscribePropsWithStore<TFeatures, TData, TSelected> = object;
+type SubscribePropsWithStore<TFeatures, TSelected> = object;
 ```
 
-Defined in: [Subscribe.ts:17](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L17)
+Defined in: [Subscribe.ts:23](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L23)
 
 Subscribe to `table.store` (full table state). The selector receives the full
 TableState.
@@ -19,10 +19,6 @@ TableState.
 ### TFeatures
 
 `TFeatures` *extends* `TableFeatures`
-
-### TData
-
-`TData` *extends* `RowData`
 
 ### TSelected
 
@@ -36,7 +32,7 @@ TableState.
 children: (state) => ReactNode | ReactNode;
 ```
 
-Defined in: [Subscribe.ts:31](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L31)
+Defined in: [Subscribe.ts:36](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L36)
 
 ***
 
@@ -46,7 +42,7 @@ Defined in: [Subscribe.ts:31](https://github.com/TanStack/table/blob/main/packag
 selector: (state) => TSelected;
 ```
 
-Defined in: [Subscribe.ts:30](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L30)
+Defined in: [Subscribe.ts:35](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L35)
 
 Select from full table state. Re-renders when the selected value changes
 (shallow compare).
@@ -66,10 +62,10 @@ store without an explicit projection.
 
 ***
 
-### table
+### source
 
 ```ts
-table: Table<TFeatures, TData>;
+source: SubscribeSource<TableState<TFeatures>>;
 ```
 
-Defined in: [Subscribe.ts:22](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L22)
+Defined in: [Subscribe.ts:27](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L27)

--- a/docs/framework/react/reference/index/type-aliases/SubscribeSource.md
+++ b/docs/framework/react/reference/index/type-aliases/SubscribeSource.md
@@ -1,0 +1,22 @@
+---
+id: SubscribeSource
+title: SubscribeSource
+---
+
+# Type Alias: SubscribeSource\<TValue\>
+
+```ts
+type SubscribeSource<TValue> = 
+  | Atom<TValue>
+  | ReadonlyAtom<TValue>
+  | Store<TValue>
+| ReadonlyStore<TValue>;
+```
+
+Defined in: [Subscribe.ts:13](https://github.com/TanStack/table/blob/main/packages/react-table/src/Subscribe.ts#L13)
+
+## Type Parameters
+
+### TValue
+
+`TValue`

--- a/examples/angular/composable-tables/src/app/components/products-table/products-table.html
+++ b/examples/angular/composable-tables/src/app/components/products-table/products-table.html
@@ -1,10 +1,9 @@
 <div class="table-container" [tanStackTable]="table">
-  <button (click)="refreshData()" class="demo-button demo-button-spaced">Regenerate Data</button>
-  <button (click)="stressTest()" class="demo-button demo-button-spaced">
-    Stress Test (200k rows)
-  </button>
   <ng-container
-    *ngComponentOutlet="table.TableToolbar; inputs: { title: 'Products Table', onRefresh }"
+    *ngComponentOutlet="
+      table.TableToolbar;
+      inputs: { title: 'Products Table', onRefresh, onStressTest: stressTest }
+    "
   />
 
   <table>

--- a/examples/angular/composable-tables/src/app/components/table-components.ts
+++ b/examples/angular/composable-tables/src/app/components/table-components.ts
@@ -11,12 +11,16 @@ import { injectTableContext } from '../table'
   template: `
     <div class="table-toolbar">
       <h2>{{ title() }}</h2>
-      <button (click)="table().resetColumnFilters()">Clear filters</button>
-      <button (click)="table().resetSorting()">Clear sorting</button>
-
-      @if (onRefresh(); as onRefresh) {
-        <button (click)="onRefresh()">Refresh data</button>
-      }
+      <div class="table-toolbar-actions">
+        @if (onRefresh(); as onRefresh) {
+          <button (click)="onRefresh()">Regenerate Data</button>
+        }
+        @if (onStressTest(); as onStressTest) {
+          <button (click)="onStressTest()">Stress Test (200k rows)</button>
+        }
+        <button (click)="table().resetColumnFilters()">Clear Filters</button>
+        <button (click)="table().resetSorting()">Clear Sorting</button>
+      </div>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -24,6 +28,7 @@ import { injectTableContext } from '../table'
 export class TableToolbar {
   readonly title = input.required<string>()
   readonly onRefresh = input<() => void>()
+  readonly onStressTest = input<() => void>()
 
   readonly table = injectTableContext()
 

--- a/examples/angular/composable-tables/src/app/components/users-table/users-table.html
+++ b/examples/angular/composable-tables/src/app/components/users-table/users-table.html
@@ -1,10 +1,9 @@
 <div class="table-container" [tanStackTable]="table">
-  <button (click)="refreshData()" class="demo-button demo-button-spaced">Regenerate Data</button>
-  <button (click)="stressTest()" class="demo-button demo-button-spaced">
-    Stress Test (200k rows)
-  </button>
   <ng-container
-    *ngComponentOutlet="table.TableToolbar; inputs: { title: 'Users Table', onRefresh }"
+    *ngComponentOutlet="
+      table.TableToolbar;
+      inputs: { title: 'Users Table', onRefresh, onStressTest: stressTest }
+    "
   />
 
   <table>

--- a/examples/angular/composable-tables/src/styles.css
+++ b/examples/angular/composable-tables/src/styles.css
@@ -174,6 +174,12 @@ tfoot th {
   border-spacing: 0;
 }
 
+.table-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .table-toolbar button {
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/examples/lit/column-ordering/src/main.ts
+++ b/examples/lit/column-ordering/src/main.ts
@@ -13,7 +13,7 @@ import { makeData } from './makeData'
 import type {
   ColumnDef,
   ColumnOrderState,
-  VisibilityState,
+  ColumnVisibilityState,
 } from '@tanstack/lit-table'
 import type { Person } from './makeData'
 
@@ -85,7 +85,7 @@ class LitTableExample extends LitElement {
   private columnOrder: ColumnOrderState = []
 
   @state()
-  private columnVisibility: VisibilityState = {}
+  private columnVisibility: ColumnVisibilityState = {}
 
   protected render() {
     const table = this.tableController.table(

--- a/examples/lit/column-pinning-split/src/main.ts
+++ b/examples/lit/column-pinning-split/src/main.ts
@@ -15,7 +15,7 @@ import type {
   ColumnDef,
   ColumnOrderState,
   ColumnPinningState,
-  VisibilityState,
+  ColumnVisibilityState,
 } from '@tanstack/lit-table'
 import type { Person } from './makeData'
 
@@ -88,7 +88,7 @@ class LitTableExample extends LitElement {
   private columnOrder: ColumnOrderState = []
 
   @state()
-  private columnVisibility: VisibilityState = {}
+  private columnVisibility: ColumnVisibilityState = {}
 
   @state()
   private columnPinning: ColumnPinningState = { left: [], right: [] }

--- a/examples/lit/column-pinning/src/main.ts
+++ b/examples/lit/column-pinning/src/main.ts
@@ -15,7 +15,7 @@ import type {
   ColumnDef,
   ColumnOrderState,
   ColumnPinningState,
-  VisibilityState,
+  ColumnVisibilityState,
 } from '@tanstack/lit-table'
 import type { Person } from './makeData'
 
@@ -88,7 +88,7 @@ class LitTableExample extends LitElement {
   private columnOrder: ColumnOrderState = []
 
   @state()
-  private columnVisibility: VisibilityState = {}
+  private columnVisibility: ColumnVisibilityState = {}
 
   @state()
   private columnPinning: ColumnPinningState = { left: [], right: [] }

--- a/examples/lit/composable-tables/src/components/products-table.ts
+++ b/examples/lit/composable-tables/src/components/products-table.ts
@@ -78,26 +78,13 @@ export class ProductsTable extends LitElement {
 
     return html`
       <div class="table-container">
-        <div>
-          <button
-            @click=${() => {
-              this.data = makeProductData(500)
-            }}
-          >
-            Regenerate Data
-          </button>
-          <button
-            @click=${() => {
-              this.data = makeProductData(200_000)
-            }}
-          >
-            Stress Test (200k rows)
-          </button>
-        </div>
         <!-- Table toolbar using the same context-based custom element -->
         <table-toolbar
           .title=${'Products Table'}
           .onRefresh=${this.refreshData}
+          .onStressTest=${() => {
+            this.data = makeProductData(200_000)
+          }}
         ></table-toolbar>
 
         <!-- Table element -->

--- a/examples/lit/composable-tables/src/components/table-components.ts
+++ b/examples/lit/composable-tables/src/components/table-components.ts
@@ -113,6 +113,9 @@ export class TableToolbar extends LitElement {
   @property({ attribute: false })
   declare onRefresh: (() => void) | undefined
 
+  @property({ attribute: false })
+  declare onStressTest: (() => void) | undefined
+
   createRenderRoot() {
     return this
   }
@@ -124,14 +127,19 @@ export class TableToolbar extends LitElement {
     return html`
       <div class="table-toolbar">
         <h2>${this.title}</h2>
-        <div style="display: flex; gap: 8px">
+        <div class="table-toolbar-actions">
+          ${this.onRefresh
+            ? html`<button @click=${this.onRefresh}>Regenerate Data</button>`
+            : nothing}
+          ${this.onStressTest
+            ? html`<button @click=${this.onStressTest}>
+                Stress Test (200k rows)
+              </button>`
+            : nothing}
           <button @click=${() => table.resetColumnFilters()}>
             Clear Filters
           </button>
           <button @click=${() => table.resetSorting()}>Clear Sorting</button>
-          ${this.onRefresh
-            ? html`<button @click=${this.onRefresh}>Regenerate Data</button>`
-            : nothing}
         </div>
       </div>
     `

--- a/examples/lit/composable-tables/src/components/users-table.ts
+++ b/examples/lit/composable-tables/src/components/users-table.ts
@@ -92,26 +92,13 @@ export class UsersTable extends LitElement {
 
     return html`
       <div class="table-container">
-        <div>
-          <button
-            @click=${() => {
-              this.data = makeData(1_000)
-            }}
-          >
-            Regenerate Data
-          </button>
-          <button
-            @click=${() => {
-              this.data = makeData(200_000)
-            }}
-          >
-            Stress Test (200k rows)
-          </button>
-        </div>
         <!-- Table toolbar using context-based custom element -->
         <table-toolbar
           .title=${'Users Table'}
           .onRefresh=${this.refreshData}
+          .onStressTest=${() => {
+            this.data = makeData(200_000)
+          }}
         ></table-toolbar>
 
         <!-- Table element -->

--- a/examples/lit/composable-tables/src/index.css
+++ b/examples/lit/composable-tables/src/index.css
@@ -174,6 +174,12 @@ tfoot th {
   border-spacing: 0;
 }
 
+.table-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .table-toolbar button {
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/examples/preact/basic-external-atoms/src/main.tsx
+++ b/examples/preact/basic-external-atoms/src/main.tsx
@@ -74,20 +74,23 @@ function App() {
   const pagination = useSelector(paginationAtom, (s) => s)
 
   // Create the table and pass your per-slice external atoms.
-  const table = useTable({
-    _features,
-    _rowModels: {
-      sortedRowModel: createSortedRowModel(sortFns),
-      paginatedRowModel: createPaginatedRowModel(),
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        sortedRowModel: createSortedRowModel(sortFns),
+        paginatedRowModel: createPaginatedRowModel(),
+      },
+      columns,
+      data,
+      atoms: {
+        sorting: sortingAtom,
+        pagination: paginationAtom,
+      },
+      debugTable: pagination.pageIndex > 2,
     },
-    columns,
-    data,
-    atoms: {
-      sorting: sortingAtom,
-      pagination: paginationAtom,
-    },
-    debugTable: pagination.pageIndex > 2,
-  })
+    (state) => state, // default selector
+  )
 
   return (
     <div className="demo-root">

--- a/examples/preact/basic-external-state/src/main.tsx
+++ b/examples/preact/basic-external-state/src/main.tsx
@@ -73,22 +73,25 @@ function App() {
   console.log('pagination', pagination)
 
   // Create the table and pass state + onChange handlers
-  const table = useTable({
-    debugTable: true,
-    _features,
-    _rowModels: {
-      sortedRowModel: createSortedRowModel(sortFns),
-      paginatedRowModel: createPaginatedRowModel(),
+  const table = useTable(
+    {
+      debugTable: true,
+      _features,
+      _rowModels: {
+        sortedRowModel: createSortedRowModel(sortFns),
+        paginatedRowModel: createPaginatedRowModel(),
+      },
+      columns,
+      data,
+      state: {
+        sorting, // connect our sorting state back down to the table
+        pagination, // connect our pagination state back down to the table
+      },
+      onSortingChange: setSorting, // raise sorting state changes to our own state management
+      onPaginationChange: setPagination, // raise pagination state changes to our own state management
     },
-    columns,
-    data,
-    state: {
-      sorting, // connect our sorting state back down to the table
-      pagination, // connect our pagination state back down to the table
-    },
-    onSortingChange: setSorting, // raise sorting state changes to our own state management
-    onPaginationChange: setPagination, // raise pagination state changes to our own state management
-  })
+    (state) => state, // default selector
+  )
 
   return (
     <div className="demo-root">

--- a/examples/preact/basic-subscribe/index.html
+++ b/examples/preact/basic-subscribe/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + Preact</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/preact/basic-subscribe/package.json
+++ b/examples/preact/basic-subscribe/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "tanstack-preact-table-example-basic-subscribe",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview",
+    "start": "vite",
+    "lint": "eslint ./src",
+    "test:types": "tsc"
+  },
+  "dependencies": {
+    "@faker-js/faker": "^10.4.0",
+    "@tanstack/preact-store": "^0.13.0",
+    "@tanstack/preact-table": "^9.0.0-alpha.44",
+    "preact": "^10.29.1"
+  },
+  "devDependencies": {
+    "@preact/preset-vite": "^2.10.5",
+    "@tanstack/preact-devtools": "^0.10.2",
+    "@tanstack/preact-table-devtools": "^9.0.0-alpha.43",
+    "typescript": "6.0.3",
+    "vite": "^8.0.10"
+  }
+}

--- a/examples/preact/basic-subscribe/src/index.css
+++ b/examples/preact/basic-subscribe/src/index.css
@@ -1,0 +1,372 @@
+html {
+  font-family: sans-serif;
+  font-size: 14px;
+}
+
+table {
+  border: 1px solid lightgray;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+tbody {
+  border-bottom: 1px solid lightgray;
+}
+
+th {
+  border-bottom: 1px solid lightgray;
+  border-right: 1px solid lightgray;
+  padding: 2px 4px;
+}
+
+tfoot {
+  color: gray;
+}
+
+tfoot th {
+  font-weight: normal;
+}
+
+button:disabled,
+button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* Demo layout utilities for plain example styling. */
+.demo-root {
+  padding: 0.5rem;
+}
+
+.spacer-xs {
+  height: 0.25rem;
+}
+
+.spacer-sm {
+  height: 0.5rem;
+}
+
+.spacer-md {
+  height: 1rem;
+}
+
+.controls,
+.button-row,
+.inline-controls,
+.pin-actions,
+.filter-row,
+.form-actions {
+  display: flex;
+  align-items: center;
+}
+
+.button-row {
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.controls {
+  gap: 0.5rem;
+}
+
+.inline-controls,
+.pin-actions {
+  gap: 0.25rem;
+}
+
+.pin-actions {
+  justify-content: center;
+}
+
+.filter-row {
+  gap: 0.5rem;
+}
+
+.form-actions {
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.split-tables {
+  display: flex;
+  gap: 1rem;
+}
+
+.table-row-group {
+  display: flex;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.vertical-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.column-toggle-panel {
+  display: inline-block;
+  border: 1px solid #000;
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
+}
+
+.column-toggle-panel-header {
+  border-bottom: 1px solid #000;
+  padding: 0 0.25rem;
+}
+
+.column-toggle-row,
+.selection-cell {
+  padding: 0 0.25rem;
+}
+
+.selection-cell {
+  display: block;
+}
+
+.demo-button,
+.pin-button,
+.compact-input,
+.filter-input,
+.filter-select,
+.page-size-input,
+.text-input,
+.number-input,
+.wide-action-button,
+.primary-action,
+.secondary-action,
+.success-action {
+  border: 1px solid currentColor;
+  border-radius: 0.25rem;
+}
+
+.demo-button {
+  padding: 0.5rem;
+}
+
+.demo-button-sm {
+  padding: 0.25rem;
+}
+
+.demo-button-spaced {
+  margin-bottom: 0.5rem;
+}
+
+.pin-button {
+  padding: 0 0.5rem;
+}
+
+.outlined-table {
+  border: 2px solid #000;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.outlined-control {
+  border-color: #000;
+}
+
+.nowrap {
+  white-space: nowrap;
+}
+
+.demo-note {
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.section-title {
+  font-size: 1.25rem;
+}
+
+.scroll-container {
+  overflow-x: auto;
+}
+
+.page-size-input {
+  width: 4rem;
+  padding: 0.25rem;
+}
+
+.number-input {
+  width: 5rem;
+  padding: 0 0.25rem;
+}
+
+.filter-input,
+.filter-select {
+  width: 6rem;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
+}
+
+.filter-select {
+  width: 9rem;
+}
+
+.text-input {
+  width: 100%;
+  padding: 0 0.25rem;
+}
+
+.compact-input {
+  padding: 0 0.25rem;
+}
+
+.wide-action-button {
+  width: 16rem;
+}
+
+.summary-panel {
+  border: 1px solid currentColor;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
+  padding: 0.5rem;
+}
+
+.sortable-header,
+.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.primary-action,
+.success-action,
+.secondary-action {
+  color: #fff;
+}
+
+.primary-action {
+  background: #3b82f6;
+}
+
+.success-action {
+  background: #22c55e;
+}
+
+.secondary-action {
+  background: #6b7280;
+}
+
+.submit-button:disabled {
+  opacity: 0.5;
+}
+
+.error-text {
+  color: #ef4444;
+  font-size: 0.75rem;
+}
+
+.success-text {
+  color: #16a34a;
+}
+
+.warning-text {
+  color: #ca8a04;
+}
+
+.muted-text {
+  color: #9ca3af;
+}
+
+.label-offset {
+  margin-left: 0.5rem;
+}
+
+.cell-padding {
+  padding: 0.25rem;
+}
+
+.table-spacer {
+  margin-bottom: 0.5rem;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.warning-panel {
+  margin-bottom: 1rem;
+  border: 1px solid #facc15;
+  border-radius: 0.25rem;
+  background: #fef9c3;
+  padding: 0.5rem;
+}
+
+.code-block {
+  overflow: auto;
+  border-radius: 0.25rem;
+  background: #f3f4f6;
+  padding: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.router-root {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+
+.page-title {
+  margin-bottom: 0.25rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.disabled-button:disabled {
+  color: #6b7280;
+  cursor: not-allowed;
+}
+
+.pagination-controls {
+  margin-block: 0.5rem;
+}
+
+.column-size-input {
+  width: 6rem;
+  margin-left: 0.5rem;
+  border: 1px solid currentColor;
+  border-radius: 0.25rem;
+  padding: 0.25rem;
+}
+
+.form-status {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.875rem;
+}
+
+.centered-button-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.split-gap {
+  gap: 1rem;
+}
+
+.demo-link {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.capitalized-text {
+  text-transform: capitalize;
+}
+
+.centered-text {
+  text-align: center;
+}
+
+.centered-strong-text {
+  text-align: center;
+  font-weight: 600;
+}
+
+.virtualized-title {
+  text-align: center;
+  font-size: 1.875rem;
+  font-weight: 700;
+}

--- a/examples/preact/basic-subscribe/src/main.tsx
+++ b/examples/preact/basic-subscribe/src/main.tsx
@@ -1,0 +1,478 @@
+import { useEffect, useMemo, useReducer, useRef, useState } from 'preact/hooks'
+import { render } from 'preact'
+import {
+  Subscribe,
+  columnFilteringFeature,
+  createColumnHelper,
+  createFilteredRowModel,
+  createPaginatedRowModel,
+  filterFns,
+  globalFilteringFeature,
+  rowPaginationFeature,
+  rowSelectionFeature,
+  tableFeatures,
+  useTable,
+} from '@tanstack/preact-table'
+import {
+  tableDevtoolsPlugin,
+  useTanStackTableDevtools,
+} from '@tanstack/preact-table-devtools'
+import { TanStackDevtools } from '@tanstack/preact-devtools'
+import { useCreateAtom } from '@tanstack/preact-store'
+import { makeData } from './makeData'
+import type {
+  Column,
+  PreactTable,
+  RowSelectionState,
+} from '@tanstack/preact-table'
+import type { JSX } from 'preact'
+import type { Person } from './makeData'
+import './index.css'
+
+const _features = tableFeatures({
+  rowPaginationFeature,
+  rowSelectionFeature,
+  columnFilteringFeature,
+  globalFilteringFeature,
+})
+
+const columnHelper = createColumnHelper<typeof _features, Person>()
+
+/**
+ * This is an example showing how to use advanced re-rendering optimizations with more fine-grained control over what is subscribed to.
+ * Subscribe/table.Subscribe is a higher-order component that allows you to subscribe to the table state or individual atoms/stores.
+ * This is useful for making sure that re-renders only happen at certain parts of the preact tree exactly where need to be.
+ * We recommend only using these patterns when you run into specific performance issues.
+ */
+function App() {
+  const rerender = useReducer(() => ({}), {})[1]
+
+  const columns = useMemo(
+    () =>
+      columnHelper.columns([
+        columnHelper.display({
+          id: 'select',
+          header: ({ table }) => {
+            return (
+              // just import Subscribe component if "preact" table is not available in scope and pass in the table store as source
+              <Subscribe
+                source={table.store}
+                // It can be difficult to know what to subscribe to, unless you understand everything that can be a state dependency for internal APIs
+                // Be careful to test and validate that it re-renders when you expect it to
+                selector={(state) => ({
+                  columnFilters: state.columnFilters,
+                  globalFilter: state.globalFilter,
+                  rowSelection: state.rowSelection,
+                })}
+              >
+                {() => (
+                  <IndeterminateCheckbox
+                    checked={table.getIsAllRowsSelected()}
+                    indeterminate={table.getIsSomeRowsSelected()}
+                    onChange={table.getToggleAllRowsSelectedHandler()}
+                  />
+                )}
+              </Subscribe>
+            )
+          },
+          cell: ({ row }) => (
+            <Subscribe
+              source={table.atoms.rowSelection} // optimize to subscribe only to the row selection atom
+              selector={(rowSelection) => rowSelection[row.id]} // optimize to only re-render when the row selection changes for this row
+            >
+              {(isRowSelected) => (
+                <div className="column-toggle-row">
+                  {/* Select only this row's selection value so toggling one row only re-renders that row's checkbox. */}
+                  <IndeterminateCheckbox
+                    checked={!!isRowSelected}
+                    disabled={!row.getCanSelect()}
+                    indeterminate={row.getIsSomeSelected()}
+                    onChange={row.getToggleSelectedHandler()}
+                  />
+                </div>
+              )}
+            </Subscribe>
+          ),
+        }),
+        columnHelper.accessor('firstName', {
+          header: 'First Name',
+          cell: (info) => info.getValue(),
+          footer: (props) => props.column.id,
+        }),
+        columnHelper.accessor((row) => row.lastName, {
+          id: 'lastName',
+          header: () => <span>Last Name</span>,
+          cell: (info) => info.getValue(),
+          footer: (props) => props.column.id,
+        }),
+        columnHelper.accessor('age', {
+          header: () => 'Age',
+          footer: (props) => props.column.id,
+        }),
+        columnHelper.accessor('visits', {
+          header: () => <span>Visits</span>,
+          footer: (props) => props.column.id,
+        }),
+        columnHelper.accessor('status', {
+          header: 'Status',
+          footer: (props) => props.column.id,
+        }),
+        columnHelper.accessor('progress', {
+          header: 'Profile Progress',
+          footer: (props) => props.column.id,
+        }),
+      ]),
+    [],
+  )
+
+  const [data, setData] = useState(() => makeData(1_000))
+  const refreshData = () => setData(() => makeData(1_000))
+  const stressTest = () => setData(() => makeData(200_000))
+
+  // optionally, raise the selection state to your own atom
+  const rowSelectionAtom = useCreateAtom<RowSelectionState>({})
+
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel(filterFns),
+        paginatedRowModel: createPaginatedRowModel(),
+      },
+      atoms: {
+        rowSelection: rowSelectionAtom,
+      },
+      columns,
+      data,
+      getRowId: (row) => row.id,
+      enableRowSelection: true, // enable row selection for all rows
+      // enableRowSelection: row => row.original.age > 18, // or enable row selection conditionally per row
+      debugTable: true,
+    },
+    () => null, // subscribe to no table state by default; use table.Subscribe below for targeted updates
+  )
+
+  useTanStackTableDevtools(table, 'Basic Subscribe Example')
+
+  return (
+    <div className="demo-root">
+      <div>
+        <button
+          className="demo-button demo-button-spaced"
+          onClick={() => refreshData()}
+        >
+          Regenerate Data
+        </button>
+        <button
+          className="demo-button demo-button-spaced"
+          onClick={() => stressTest()}
+        >
+          Stress Test (200k rows)
+        </button>
+      </div>
+      <div>
+        <table.Subscribe source={table.atoms.globalFilter}>
+          {(globalFilter) => (
+            <input
+              value={globalFilter ?? ''}
+              onInput={(e) =>
+                table.setGlobalFilter((e.target as HTMLInputElement).value)
+              }
+              className="summary-panel"
+              placeholder="Search all columns..."
+            />
+          )}
+        </table.Subscribe>
+      </div>
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <>
+                        <table.FlexRender header={header} />
+                        {header.column.getCanFilter() ? (
+                          <div>
+                            <Filter column={header.column} table={table} />
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                  </th>
+                )
+              })}
+            </tr>
+          ))}
+        </thead>
+        {/* Subscribe the row model to filtering and pagination only. Row selection is handled per row below. */}
+        <table.Subscribe
+          selector={(state) => ({
+            columnFilters: state.columnFilters,
+            globalFilter: state.globalFilter,
+            pagination: state.pagination,
+          })}
+        >
+          {() => (
+            <>
+              <tbody>
+                {table.getRowModel().rows.map((row) => {
+                  return (
+                    <tr key={row.id}>
+                      {row.getAllCells().map((cell) => {
+                        return (
+                          <td key={cell.id}>
+                            <table.FlexRender cell={cell} />
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  )
+                })}
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td className="cell-padding">
+                    <table.Subscribe source={table.atoms.rowSelection}>
+                      {() => (
+                        <IndeterminateCheckbox
+                          checked={table.getIsAllPageRowsSelected()}
+                          indeterminate={table.getIsSomePageRowsSelected()}
+                          onChange={table.getToggleAllPageRowsSelectedHandler()}
+                        />
+                      )}
+                    </table.Subscribe>
+                  </td>
+                  <td colSpan={20}>
+                    Page Rows (
+                    {table.getRowModel().rows.length.toLocaleString()})
+                  </td>
+                </tr>
+              </tfoot>
+            </>
+          )}
+        </table.Subscribe>
+      </table>
+      <div className="spacer-sm" />
+      <table.Subscribe
+        selector={(state) => ({
+          columnFilters: state.columnFilters,
+          globalFilter: state.globalFilter,
+          pagination: state.pagination,
+        })}
+      >
+        {({ pagination }) => (
+          <div className="controls">
+            <button
+              className="demo-button demo-button-sm"
+              onClick={() => table.setPageIndex(0)}
+              disabled={!table.getCanPreviousPage()}
+            >
+              {'<<'}
+            </button>
+            <button
+              className="demo-button demo-button-sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              {'<'}
+            </button>
+            <button
+              className="demo-button demo-button-sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              {'>'}
+            </button>
+            <button
+              className="demo-button demo-button-sm"
+              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+              disabled={!table.getCanNextPage()}
+            >
+              {'>>'}
+            </button>
+            <span className="inline-controls">
+              <div>Page</div>
+              <strong>
+                {(pagination.pageIndex + 1).toLocaleString()} of{' '}
+                {table.getPageCount().toLocaleString()}
+              </strong>
+            </span>
+            <span className="inline-controls">
+              | Go to page:
+              <input
+                type="number"
+                min="1"
+                max={table.getPageCount()}
+                defaultValue={pagination.pageIndex + 1}
+                onChange={(e) => {
+                  const value = (e.target as HTMLInputElement).value
+                  const page = value ? Number(value) - 1 : 0
+                  table.setPageIndex(page)
+                }}
+                className="page-size-input"
+              />
+            </span>
+            <select
+              value={pagination.pageSize}
+              onChange={(e) => {
+                table.setPageSize(Number((e.target as HTMLInputElement).value))
+              }}
+            >
+              {[10, 20, 30, 40, 50].map((pageSize) => (
+                <option key={pageSize} value={pageSize}>
+                  Show {pageSize}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </table.Subscribe>
+      <br />
+      <table.Subscribe source={table.atoms.rowSelection}>
+        {(rowSelection) => (
+          <div>
+            <>{Object.keys(rowSelection).length.toLocaleString()} of </>
+            {table.getPreFilteredRowModel().rows.length.toLocaleString()} Total
+            Rows Selected
+          </div>
+        )}
+      </table.Subscribe>
+      <hr />
+      <br />
+      <div>
+        <button
+          className="demo-button demo-button-spaced"
+          onClick={() => rerender(0)}
+        >
+          Force Rerender
+        </button>
+      </div>
+      <div>
+        <button
+          className="demo-button demo-button-spaced"
+          onClick={() =>
+            console.info(
+              'table.getSelectedRowModel().flatRows',
+              table.getSelectedRowModel().flatRows,
+            )
+          }
+        >
+          Log table.getSelectedRowModel().flatRows
+        </button>
+      </div>
+      <div>
+        <label>Table State:</label>
+        {/* subscribe to the entire table state */}
+        <table.Subscribe selector={(state) => state}>
+          {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
+        </table.Subscribe>
+      </div>
+    </div>
+  )
+}
+
+function Filter({
+  column,
+  table,
+}: {
+  column: Column<typeof _features, Person>
+  table: PreactTable<typeof _features, Person, null>
+}) {
+  const firstValue = table
+    .getPreFilteredRowModel()
+    .flatRows[0]?.getValue(column.id)
+
+  return (
+    <table.Subscribe source={table.atoms.columnFilters}>
+      {() =>
+        typeof firstValue === 'number' ? (
+          <div className="filter-row">
+            <input
+              type="number"
+              value={((column.getFilterValue() as any)?.[0] ?? '') as string}
+              onInput={(e) =>
+                column.setFilterValue((old: any) => [
+                  (e.target as HTMLInputElement).value,
+                  old?.[1],
+                ])
+              }
+              placeholder={`Min`}
+              className="filter-input"
+            />
+            <input
+              type="number"
+              value={((column.getFilterValue() as any)?.[1] ?? '') as string}
+              onInput={(e) =>
+                column.setFilterValue((old: any) => [
+                  old?.[0],
+                  (e.target as HTMLInputElement).value,
+                ])
+              }
+              placeholder={`Max`}
+              className="filter-input"
+            />
+          </div>
+        ) : (
+          <input
+            type="text"
+            value={(column.getFilterValue() ?? '') as string}
+            onInput={(e) =>
+              column.setFilterValue((e.target as HTMLInputElement).value)
+            }
+            placeholder={`Search...`}
+            className="filter-select"
+          />
+        )
+      }
+    </table.Subscribe>
+  )
+}
+
+function IndeterminateCheckbox({
+  indeterminate,
+  className = '',
+  checked,
+  onChange,
+  disabled,
+  ...rest
+}: {
+  indeterminate?: boolean
+  checked?: boolean
+  disabled?: boolean
+  onChange?: (event: Event) => void
+} & Record<string, any>) {
+  const ref = useRef<HTMLInputElement>(null!)
+
+  useEffect(() => {
+    if (typeof indeterminate === 'boolean') {
+      ref.current.indeterminate = !checked && indeterminate
+    }
+  }, [ref, indeterminate, checked])
+
+  return (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={className + ' sortable-header'}
+      checked={checked}
+      onChange={onChange}
+      disabled={disabled}
+      {...rest}
+    />
+  )
+}
+
+const rootElement = document.getElementById('root')
+if (!rootElement) throw new Error('Failed to find the root element')
+
+render(
+  <>
+    <App />
+    <TanStackDevtools plugins={[tableDevtoolsPlugin()]} />
+  </>,
+  rootElement,
+)

--- a/examples/preact/basic-subscribe/src/makeData.ts
+++ b/examples/preact/basic-subscribe/src/makeData.ts
@@ -1,0 +1,50 @@
+import { faker } from '@faker-js/faker'
+
+export type Person = {
+  id: string
+  firstName: string
+  lastName: string
+  age: number
+  visits: number
+  progress: number
+  status: 'relationship' | 'complicated' | 'single'
+  subRows?: Array<Person>
+}
+
+const range = (len: number) => {
+  const arr: Array<number> = []
+  for (let i = 0; i < len; i++) {
+    arr.push(i)
+  }
+  return arr
+}
+
+const newPerson = (): Person => {
+  return {
+    id: faker.string.uuid(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    age: faker.number.int(40),
+    visits: faker.number.int(1000),
+    progress: faker.number.int(100),
+    status: faker.helpers.shuffle<Person['status']>([
+      'relationship',
+      'complicated',
+      'single',
+    ])[0],
+  }
+}
+
+export function makeData(...lens: Array<number>) {
+  const makeDataLevel = (depth = 0): Array<Person> => {
+    const len = lens[depth]
+    return range(len).map((_d): Person => {
+      return {
+        ...newPerson(),
+        subRows: lens[depth + 1] ? makeDataLevel(depth + 1) : undefined,
+      }
+    })
+  }
+
+  return makeDataLevel()
+}

--- a/examples/preact/basic-subscribe/src/vite-env.d.ts
+++ b/examples/preact/basic-subscribe/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/preact/basic-subscribe/tsconfig.json
+++ b/examples/preact/basic-subscribe/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "skipLibCheck": true,
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react-dom": ["./node_modules/preact/compat/"]
+    }
+  },
+  "include": [
+    "node_modules/vite/client.d.ts",
+    "src/**/*",
+    "vite.config.js",
+    "vite.config.ts"
+  ],
+  "exclude": ["dist/**/*", "node_modules"]
+}

--- a/examples/preact/basic-subscribe/vite.config.ts
+++ b/examples/preact/basic-subscribe/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import preact from '@preact/preset-vite'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [preact({ babel: {} })],
+})

--- a/examples/preact/basic-use-app-table/src/main.tsx
+++ b/examples/preact/basic-use-app-table/src/main.tsx
@@ -103,12 +103,15 @@ function App() {
 
   // 7. Create the table instance with the required columns and data.
   // Features and row models are already defined in the createTableHook call above
-  const table = useAppTable({
-    debugTable: true,
-    columns,
-    data,
-    // add additional table options here or in the createTableHook call above
-  })
+  const table = useAppTable(
+    {
+      debugTable: true,
+      columns,
+      data,
+      // add additional table options here or in the createTableHook call above
+    },
+    (state) => state, // default selector
+  )
 
   // 8. Render your table markup from the table instance APIs
   return (

--- a/examples/preact/basic-use-table/src/main.tsx
+++ b/examples/preact/basic-use-table/src/main.tsx
@@ -96,14 +96,17 @@ function App() {
   const rerender = useReducer(() => ({}), {})[1]
 
   // 6. Create the table instance with required _features, columns, and data
-  const table = useTable({
-    debugTable: true,
-    _features, // new required option in V9. Tell the table which features you are importing and using (better tree-shaking)
-    _rowModels: {}, // `Core` row model is now included by default, but you can still override it here
-    columns,
-    data,
-    // add additional table options here
-  })
+  const table = useTable(
+    {
+      debugTable: true,
+      _features, // new required option in V9. Tell the table which features you are importing and using (better tree-shaking)
+      _rowModels: {}, // `Core` row model is now included by default, but you can still override it here
+      columns,
+      data,
+      // add additional table options here
+    },
+    (state) => state, // default selector
+  )
 
   // 7. Render your table markup from the table instance APIs
   return (

--- a/examples/preact/column-groups/src/main.tsx
+++ b/examples/preact/column-groups/src/main.tsx
@@ -66,13 +66,16 @@ function App() {
   const stressTest = () => setData(makeData(1_000))
   const rerender = useReducer(() => ({}), {})[1]
 
-  const table = useTable({
-    debugTable: true,
-    _features,
-    _rowModels: {},
-    columns,
-    data,
-  })
+  const table = useTable(
+    {
+      debugTable: true,
+      _features,
+      _rowModels: {},
+      columns,
+      data,
+    },
+    (state) => state, // default selector
+  )
 
   return (
     <div className="demo-root">

--- a/examples/preact/column-ordering/src/main.tsx
+++ b/examples/preact/column-ordering/src/main.tsx
@@ -72,15 +72,18 @@ function App() {
   const refreshData = () => setData(() => makeData(20))
   const stressTest = () => setData(() => makeData(1_000))
 
-  const table = useTable({
-    _features,
-    _rowModels: {},
-    columns,
-    data,
-    debugTable: true,
-    debugHeaders: true,
-    debugColumns: true,
-  })
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {},
+      columns,
+      data,
+      debugTable: true,
+      debugHeaders: true,
+      debugColumns: true,
+    },
+    (state) => state, // default selector
+  )
 
   const randomizeColumns = () => {
     table.setColumnOrder(
@@ -89,108 +92,96 @@ function App() {
   }
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        // subscribe to only the column order and visibility state changes at root level
-        columnOrder: state.columnOrder,
-        columnVisibility: state.columnVisibility,
-      })}
-    >
-      {(_state) => (
-        <div className="demo-root">
-          <div className="column-toggle-panel">
-            <div className="column-toggle-panel-header">
+    <div className="demo-root">
+      <div className="column-toggle-panel">
+        <div className="column-toggle-panel-header">
+          <label>
+            <input
+              type="checkbox"
+              checked={table.getIsAllColumnsVisible()}
+              onChange={table.getToggleAllColumnsVisibilityHandler()}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map((column) => {
+          return (
+            <div key={column.id} className="column-toggle-row">
               <label>
                 <input
                   type="checkbox"
-                  checked={table.getIsAllColumnsVisible()}
-                  onChange={table.getToggleAllColumnsVisibilityHandler()}
+                  checked={column.getIsVisible()}
+                  onChange={column.getToggleVisibilityHandler()}
                 />{' '}
-                Toggle All
+                {column.id}
               </label>
             </div>
-            {table.getAllLeafColumns().map((column) => {
-              return (
-                <div key={column.id} className="column-toggle-row">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                    />{' '}
-                    {column.id}
-                  </label>
-                </div>
-              )
-            })}
-          </div>
-          <div className="spacer-md" />
-          <div className="button-row">
-            <button
-              onClick={() => refreshData()}
-              className="demo-button demo-button-sm"
-            >
-              Regenerate Data
-            </button>
-            <button
-              onClick={() => stressTest()}
-              className="demo-button demo-button-sm"
-            >
-              Stress Test (1k rows)
-            </button>
-            <button
-              onClick={() => randomizeColumns()}
-              className="demo-button demo-button-sm"
-            >
-              Shuffle Columns
-            </button>
-          </div>
-          <div className="spacer-md" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <th key={header.id} colSpan={header.colSpan}>
-                      {header.isPlaceholder ? null : (
-                        <table.FlexRender header={header} />
-                      )}
-                    </th>
-                  ))}
-                </tr>
+          )
+        })}
+      </div>
+      <div className="spacer-md" />
+      <div className="button-row">
+        <button
+          onClick={() => refreshData()}
+          className="demo-button demo-button-sm"
+        >
+          Regenerate Data
+        </button>
+        <button
+          onClick={() => stressTest()}
+          className="demo-button demo-button-sm"
+        >
+          Stress Test (1k rows)
+        </button>
+        <button
+          onClick={() => randomizeColumns()}
+          className="demo-button demo-button-sm"
+        >
+          Shuffle Columns
+        </button>
+      </div>
+      <div className="spacer-md" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : (
+                    <table.FlexRender header={header} />
+                  )}
+                </th>
               ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => (
-                <tr key={row.id}>
-                  {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id}>
-                      <table.FlexRender cell={cell} />
-                    </td>
-                  ))}
-                </tr>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>
+                  <table.FlexRender cell={cell} />
+                </td>
               ))}
-            </tbody>
-            <tfoot>
-              {table.getFooterGroups().map((footerGroup) => (
-                <tr key={footerGroup.id}>
-                  {footerGroup.headers.map((header) => (
-                    <th key={header.id} colSpan={header.colSpan}>
-                      {header.isPlaceholder ? null : (
-                        <table.FlexRender footer={header} />
-                      )}
-                    </th>
-                  ))}
-                </tr>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          {table.getFooterGroups().map((footerGroup) => (
+            <tr key={footerGroup.id}>
+              {footerGroup.headers.map((header) => (
+                <th key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : (
+                    <table.FlexRender footer={header} />
+                  )}
+                </th>
               ))}
-            </tfoot>
-          </table>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </tfoot>
+      </table>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/preact/column-pinning-split/src/main.tsx
+++ b/examples/preact/column-pinning-split/src/main.tsx
@@ -78,15 +78,18 @@ function App() {
   const refreshData = () => setData(() => makeData(1_000))
   const stressTest = () => setData(() => makeData(500_000))
 
-  const table = useTable({
-    _features,
-    _rowModels: {},
-    columns,
-    data,
-    debugTable: true,
-    debugHeaders: true,
-    debugColumns: true,
-  })
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {},
+      columns,
+      data,
+      debugTable: true,
+      debugHeaders: true,
+      debugColumns: true,
+    },
+    (state) => state, // default selector
+  )
 
   const randomizeColumns = () => {
     table.setColumnOrder(
@@ -95,282 +98,270 @@ function App() {
   }
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnVisibility: state.columnVisibility,
-        columnOrder: state.columnOrder,
-        columnPinning: state.columnPinning,
-      })}
-    >
-      {(_state) => (
-        <div className="demo-root">
-          <div className="column-toggle-panel">
-            <div className="column-toggle-panel-header">
+    <div className="demo-root">
+      <div className="column-toggle-panel">
+        <div className="column-toggle-panel-header">
+          <label>
+            <input
+              type="checkbox"
+              checked={table.getIsAllColumnsVisible()}
+              onChange={table.getToggleAllColumnsVisibilityHandler()}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map((column) => {
+          return (
+            <div key={column.id} className="column-toggle-row">
               <label>
                 <input
                   type="checkbox"
-                  checked={table.getIsAllColumnsVisible()}
-                  onChange={table.getToggleAllColumnsVisibilityHandler()}
+                  checked={column.getIsVisible()}
+                  onChange={column.getToggleVisibilityHandler()}
                 />{' '}
-                Toggle All
+                {column.id}
               </label>
             </div>
-            {table.getAllLeafColumns().map((column) => {
-              return (
-                <div key={column.id} className="column-toggle-row">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                    />{' '}
-                    {column.id}
-                  </label>
-                </div>
-              )
-            })}
-          </div>
-          <div className="spacer-md" />
-          <div className="button-row">
-            <button
-              onClick={() => refreshData()}
-              className="demo-button demo-button-sm"
-            >
-              Regenerate Data
-            </button>
-            <button
-              onClick={() => stressTest()}
-              className="demo-button demo-button-sm"
-            >
-              Stress Test (500k rows)
-            </button>
-            <button
-              onClick={() => randomizeColumns()}
-              className="demo-button demo-button-sm"
-            >
-              Shuffle Columns
-            </button>
-          </div>
-          <div className="spacer-md" />
-          <p className="demo-note">
-            This example takes advantage of the "splitting" APIs. (APIs that
-            have "left, "center", and "right" modifiers)
-          </p>
-          <div className="split-tables">
-            <table className="outlined-table">
-              <thead>
-                {table.getLeftHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        <div className="nowrap">
-                          {header.isPlaceholder ? null : (
-                            <table.FlexRender header={header} />
-                          )}
-                        </div>
-                        {!header.isPlaceholder && header.column.getCanPin() && (
-                          <div className="pin-actions">
-                            {header.column.getIsPinned() !== 'left' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('left')
-                                }}
-                              >
-                                {'<='}
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin(false)
-                                }}
-                              >
-                                X
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() !== 'right' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('right')
-                                }}
-                              >
-                                {'=>'}
-                              </button>
-                            ) : null}
-                          </div>
-                        )}
-                      </th>
-                    ))}
-                  </tr>
+          )
+        })}
+      </div>
+      <div className="spacer-md" />
+      <div className="button-row">
+        <button
+          onClick={() => refreshData()}
+          className="demo-button demo-button-sm"
+        >
+          Regenerate Data
+        </button>
+        <button
+          onClick={() => stressTest()}
+          className="demo-button demo-button-sm"
+        >
+          Stress Test (500k rows)
+        </button>
+        <button
+          onClick={() => randomizeColumns()}
+          className="demo-button demo-button-sm"
+        >
+          Shuffle Columns
+        </button>
+      </div>
+      <div className="spacer-md" />
+      <p className="demo-note">
+        This example takes advantage of the "splitting" APIs. (APIs that have
+        "left, "center", and "right" modifiers)
+      </p>
+      <div className="split-tables">
+        <table className="outlined-table">
+          <thead>
+            {table.getLeftHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    <div className="nowrap">
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </div>
+                    {!header.isPlaceholder && header.column.getCanPin() && (
+                      <div className="pin-actions">
+                        {header.column.getIsPinned() !== 'left' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('left')
+                            }}
+                          >
+                            {'<='}
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin(false)
+                            }}
+                          >
+                            X
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() !== 'right' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('right')
+                            }}
+                          >
+                            {'=>'}
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                  </th>
                 ))}
-              </thead>
-              <tbody>
-                {table
-                  .getRowModel()
-                  .rows.slice(0, 20)
-                  .map((row) => {
-                    return (
-                      <tr key={row.id}>
-                        {row.getLeftVisibleCells().map((cell) => {
-                          return (
-                            <td key={cell.id}>
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )
-                        })}
-                      </tr>
-                    )
-                  })}
-              </tbody>
-            </table>
-            <table className="outlined-table">
-              <thead>
-                {table.getCenterHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        <div className="nowrap">
-                          {header.isPlaceholder ? null : (
-                            <table.FlexRender header={header} />
-                          )}
-                        </div>
-                        {!header.isPlaceholder && header.column.getCanPin() && (
-                          <div className="pin-actions">
-                            {header.column.getIsPinned() !== 'left' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('left')
-                                }}
-                              >
-                                {'<='}
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin(false)
-                                }}
-                              >
-                                X
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() !== 'right' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('right')
-                                }}
-                              >
-                                {'=>'}
-                              </button>
-                            ) : null}
-                          </div>
-                        )}
-                      </th>
-                    ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table
+              .getRowModel()
+              .rows.slice(0, 20)
+              .map((row) => {
+                return (
+                  <tr key={row.id}>
+                    {row.getLeftVisibleCells().map((cell) => {
+                      return (
+                        <td key={cell.id}>
+                          <table.FlexRender cell={cell} />
+                        </td>
+                      )
+                    })}
                   </tr>
+                )
+              })}
+          </tbody>
+        </table>
+        <table className="outlined-table">
+          <thead>
+            {table.getCenterHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    <div className="nowrap">
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </div>
+                    {!header.isPlaceholder && header.column.getCanPin() && (
+                      <div className="pin-actions">
+                        {header.column.getIsPinned() !== 'left' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('left')
+                            }}
+                          >
+                            {'<='}
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin(false)
+                            }}
+                          >
+                            X
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() !== 'right' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('right')
+                            }}
+                          >
+                            {'=>'}
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                  </th>
                 ))}
-              </thead>
-              <tbody>
-                {table
-                  .getRowModel()
-                  .rows.slice(0, 20)
-                  .map((row) => {
-                    return (
-                      <tr key={row.id}>
-                        {row.getCenterVisibleCells().map((cell) => {
-                          return (
-                            <td key={cell.id}>
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )
-                        })}
-                      </tr>
-                    )
-                  })}
-              </tbody>
-            </table>
-            <table className="outlined-table">
-              <thead>
-                {table.getRightHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        <div className="nowrap">
-                          {header.isPlaceholder ? null : (
-                            <table.FlexRender header={header} />
-                          )}
-                        </div>
-                        {!header.isPlaceholder && header.column.getCanPin() && (
-                          <div className="pin-actions">
-                            {header.column.getIsPinned() !== 'left' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('left')
-                                }}
-                              >
-                                {'<='}
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin(false)
-                                }}
-                              >
-                                X
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() !== 'right' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('right')
-                                }}
-                              >
-                                {'=>'}
-                              </button>
-                            ) : null}
-                          </div>
-                        )}
-                      </th>
-                    ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table
+              .getRowModel()
+              .rows.slice(0, 20)
+              .map((row) => {
+                return (
+                  <tr key={row.id}>
+                    {row.getCenterVisibleCells().map((cell) => {
+                      return (
+                        <td key={cell.id}>
+                          <table.FlexRender cell={cell} />
+                        </td>
+                      )
+                    })}
                   </tr>
+                )
+              })}
+          </tbody>
+        </table>
+        <table className="outlined-table">
+          <thead>
+            {table.getRightHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    <div className="nowrap">
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </div>
+                    {!header.isPlaceholder && header.column.getCanPin() && (
+                      <div className="pin-actions">
+                        {header.column.getIsPinned() !== 'left' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('left')
+                            }}
+                          >
+                            {'<='}
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin(false)
+                            }}
+                          >
+                            X
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() !== 'right' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('right')
+                            }}
+                          >
+                            {'=>'}
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                  </th>
                 ))}
-              </thead>
-              <tbody>
-                {table
-                  .getRowModel()
-                  .rows.slice(0, 20)
-                  .map((row) => {
-                    return (
-                      <tr key={row.id}>
-                        {row.getRightVisibleCells().map((cell) => {
-                          return (
-                            <td key={cell.id}>
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )
-                        })}
-                      </tr>
-                    )
-                  })}
-              </tbody>
-            </table>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table
+              .getRowModel()
+              .rows.slice(0, 20)
+              .map((row) => {
+                return (
+                  <tr key={row.id}>
+                    {row.getRightVisibleCells().map((cell) => {
+                      return (
+                        <td key={cell.id}>
+                          <table.FlexRender cell={cell} />
+                        </td>
+                      )
+                    })}
+                  </tr>
+                )
+              })}
+          </tbody>
+        </table>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/preact/column-pinning-sticky/src/main.tsx
+++ b/examples/preact/column-pinning-sticky/src/main.tsx
@@ -116,7 +116,7 @@ function App() {
       debugColumns: true,
       columnResizeMode: 'onChange',
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   const randomizeColumns = () => {
@@ -126,196 +126,153 @@ function App() {
   }
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnVisibility: state.columnVisibility,
-        columnOrder: state.columnOrder,
-        columnPinning: state.columnPinning,
-        columnSizing: state.columnSizing,
-        columnResizing: state.columnResizing,
-      })}
-    >
-      {(_topLevelState) => (
-        <div className="demo-root">
-          <div className="column-toggle-panel">
-            <div className="column-toggle-panel-header">
+    <div className="demo-root">
+      <div className="column-toggle-panel">
+        <div className="column-toggle-panel-header">
+          <label>
+            <input
+              type="checkbox"
+              checked={table.getIsAllColumnsVisible()}
+              onChange={table.getToggleAllColumnsVisibilityHandler()}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map((column) => {
+          return (
+            <div key={column.id} className="column-toggle-row">
               <label>
                 <input
                   type="checkbox"
-                  checked={table.getIsAllColumnsVisible()}
-                  onChange={table.getToggleAllColumnsVisibilityHandler()}
+                  checked={column.getIsVisible()}
+                  onChange={column.getToggleVisibilityHandler()}
                 />{' '}
-                Toggle All
+                {column.id}
               </label>
             </div>
-            {table.getAllLeafColumns().map((column) => {
-              return (
-                <div key={column.id} className="column-toggle-row">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                    />{' '}
-                    {column.id}
-                  </label>
-                </div>
-              )
-            })}
-          </div>
-          <div className="spacer-md" />
-          <div className="button-row">
-            <button
-              onClick={() => refreshData()}
-              className="demo-button demo-button-sm"
-            >
-              Regenerate Data
-            </button>
-            <button
-              onClick={() => stressTest()}
-              className="demo-button demo-button-sm"
-            >
-              Stress Test (1k rows)
-            </button>
-            <button
-              onClick={() => randomizeColumns()}
-              className="demo-button demo-button-sm"
-            >
-              Shuffle Columns
-            </button>
-          </div>
-          <div className="spacer-md" />
-          <div className="table-container">
-            <table
-              style={{
-                width: table.getTotalSize(),
-              }}
-            >
-              <thead>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => {
-                      const { column } = header
+          )
+        })}
+      </div>
+      <div className="spacer-md" />
+      <div className="button-row">
+        <button
+          onClick={() => refreshData()}
+          className="demo-button demo-button-sm"
+        >
+          Regenerate Data
+        </button>
+        <button
+          onClick={() => stressTest()}
+          className="demo-button demo-button-sm"
+        >
+          Stress Test (1k rows)
+        </button>
+        <button
+          onClick={() => randomizeColumns()}
+          className="demo-button demo-button-sm"
+        >
+          Shuffle Columns
+        </button>
+      </div>
+      <div className="spacer-md" />
+      <div className="table-container">
+        <table
+          style={{
+            width: table.getTotalSize(),
+          }}
+        >
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  const { column } = header
 
-                      return (
-                        <table.Subscribe
-                          // subscribe only to the column resizing and sizing state changes
-                          selector={(state) => ({
-                            isResizingColumn:
-                              state.columnResizing.isResizingColumn ===
-                              column.id,
-                            columnSize: state.columnSizing[column.id],
-                          })}
-                        >
-                          {() => (
-                            <th
-                              key={header.id}
-                              colSpan={header.colSpan}
-                              // IMPORTANT: This is where the magic happens!
-                              style={{ ...getCommonPinningStyles(column) }}
+                  return (
+                    <th
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      // IMPORTANT: This is where the magic happens!
+                      style={{ ...getCommonPinningStyles(column) }}
+                    >
+                      <div className="nowrap">
+                        {header.isPlaceholder ? null : (
+                          <>
+                            <table.FlexRender header={header} />{' '}
+                          </>
+                        )}
+                        {/* Demo getIndex behavior */}
+                        {column.getIndex(column.getIsPinned() || 'center')}
+                      </div>
+                      {!header.isPlaceholder && header.column.getCanPin() && (
+                        <div className="pin-actions">
+                          {header.column.getIsPinned() !== 'left' ? (
+                            <button
+                              className="pin-button"
+                              onClick={() => {
+                                header.column.pin('left')
+                              }}
                             >
-                              <div className="nowrap">
-                                {header.isPlaceholder ? null : (
-                                  <>
-                                    <table.FlexRender header={header} />{' '}
-                                  </>
-                                )}
-                                {/* Demo getIndex behavior */}
-                                {column.getIndex(
-                                  column.getIsPinned() || 'center',
-                                )}
-                              </div>
-                              {!header.isPlaceholder &&
-                                header.column.getCanPin() && (
-                                  <div className="pin-actions">
-                                    {header.column.getIsPinned() !== 'left' ? (
-                                      <button
-                                        className="pin-button"
-                                        onClick={() => {
-                                          header.column.pin('left')
-                                        }}
-                                      >
-                                        {'<='}
-                                      </button>
-                                    ) : null}
-                                    {header.column.getIsPinned() ? (
-                                      <button
-                                        className="pin-button"
-                                        onClick={() => {
-                                          header.column.pin(false)
-                                        }}
-                                      >
-                                        X
-                                      </button>
-                                    ) : null}
-                                    {header.column.getIsPinned() !== 'right' ? (
-                                      <button
-                                        className="pin-button"
-                                        onClick={() => {
-                                          header.column.pin('right')
-                                        }}
-                                      >
-                                        {'=>'}
-                                      </button>
-                                    ) : null}
-                                  </div>
-                                )}
-                              <div
-                                onDblClick={() => header.column.resetSize()}
-                                onMouseDown={header.getResizeHandler()}
-                                onTouchStart={header.getResizeHandler()}
-                                className={`resizer ${
-                                  header.column.getIsResizing()
-                                    ? 'isResizing'
-                                    : ''
-                                }`}
-                              />
-                            </th>
-                          )}
-                        </table.Subscribe>
-                      )
-                    })}
-                  </tr>
-                ))}
-              </thead>
-              <tbody>
-                {table.getRowModel().rows.map((row) => (
-                  <tr key={row.id}>
-                    {row.getVisibleCells().map((cell) => {
-                      const { column } = cell
-                      return (
-                        <table.Subscribe
-                          // subscribe only to the column resizing and sizing state changes
-                          selector={(state) => ({
-                            isResizingColumn:
-                              state.columnResizing.isResizingColumn ===
-                              column.id,
-                            columnSize: state.columnSizing[column.id],
-                          })}
-                        >
-                          {() => (
-                            <td
-                              key={cell.id}
-                              // IMPORTANT: This is where the magic happens!
-                              style={{ ...getCommonPinningStyles(column) }}
+                              {'<='}
+                            </button>
+                          ) : null}
+                          {header.column.getIsPinned() ? (
+                            <button
+                              className="pin-button"
+                              onClick={() => {
+                                header.column.pin(false)
+                              }}
                             >
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )}
-                        </table.Subscribe>
-                      )
-                    })}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+                              X
+                            </button>
+                          ) : null}
+                          {header.column.getIsPinned() !== 'right' ? (
+                            <button
+                              className="pin-button"
+                              onClick={() => {
+                                header.column.pin('right')
+                              }}
+                            >
+                              {'=>'}
+                            </button>
+                          ) : null}
+                        </div>
+                      )}
+                      <div
+                        onDblClick={() => header.column.resetSize()}
+                        onMouseDown={header.getResizeHandler()}
+                        onTouchStart={header.getResizeHandler()}
+                        className={`resizer ${
+                          header.column.getIsResizing() ? 'isResizing' : ''
+                        }`}
+                      />
+                    </th>
+                  )
+                })}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => {
+                  const { column } = cell
+                  return (
+                    <td
+                      key={cell.id}
+                      // IMPORTANT: This is where the magic happens!
+                      style={{ ...getCommonPinningStyles(column) }}
+                    >
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/preact/column-pinning/src/main.tsx
+++ b/examples/preact/column-pinning/src/main.tsx
@@ -80,11 +80,14 @@ function App() {
   const refreshData = () => setData(() => makeData(1_000))
   const stressTest = () => setData(() => makeData(500_000))
 
-  const table = useAppTable({
-    debugTable: true,
-    columns,
-    data,
-  })
+  const table = useAppTable(
+    {
+      debugTable: true,
+      columns,
+      data,
+    },
+    (state) => state, // default selector
+  )
 
   const randomizeColumns = () => {
     table.setColumnOrder(
@@ -93,144 +96,132 @@ function App() {
   }
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnVisibility: state.columnVisibility,
-        columnOrder: state.columnOrder,
-        columnPinning: state.columnPinning,
-      })}
-    >
-      {(_state) => (
-        <div className="demo-root">
-          <div className="column-toggle-panel">
-            <div className="column-toggle-panel-header">
+    <div className="demo-root">
+      <div className="column-toggle-panel">
+        <div className="column-toggle-panel-header">
+          <label>
+            <input
+              type="checkbox"
+              checked={table.getIsAllColumnsVisible()}
+              onChange={table.getToggleAllColumnsVisibilityHandler()}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map((column) => {
+          return (
+            <div key={column.id} className="column-toggle-row">
               <label>
                 <input
                   type="checkbox"
-                  checked={table.getIsAllColumnsVisible()}
-                  onChange={table.getToggleAllColumnsVisibilityHandler()}
+                  checked={column.getIsVisible()}
+                  onChange={column.getToggleVisibilityHandler()}
                 />{' '}
-                Toggle All
+                {column.id}
               </label>
             </div>
-            {table.getAllLeafColumns().map((column) => {
-              return (
-                <div key={column.id} className="column-toggle-row">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                    />{' '}
-                    {column.id}
-                  </label>
-                </div>
-              )
-            })}
-          </div>
-          <div className="spacer-md" />
-          <div className="button-row">
-            <button
-              onClick={() => refreshData()}
-              className="demo-button demo-button-sm"
-            >
-              Regenerate Data
-            </button>
-            <button
-              onClick={() => stressTest()}
-              className="demo-button demo-button-sm"
-            >
-              Stress Test (500k rows)
-            </button>
-            <button
-              onClick={() => randomizeColumns()}
-              className="demo-button demo-button-sm"
-            >
-              Shuffle Columns
-            </button>
-          </div>
-          <div className="spacer-md" />
-          <p className="demo-note">
-            This example using the non-split APIs. Columns are just reordered
-            within 1 table instead of being split into 3 different tables.
-          </p>
-          <div className="table-row-group">
-            <table className="outlined-table">
-              <thead>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        <div className="nowrap">
-                          {header.isPlaceholder ? null : (
-                            <table.FlexRender header={header} />
-                          )}
-                        </div>
-                        {!header.isPlaceholder && header.column.getCanPin() && (
-                          <div className="pin-actions">
-                            {header.column.getIsPinned() !== 'left' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('left')
-                                }}
-                              >
-                                {'<='}
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin(false)
-                                }}
-                              >
-                                X
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() !== 'right' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('right')
-                                }}
-                              >
-                                {'=>'}
-                              </button>
-                            ) : null}
-                          </div>
-                        )}
-                      </th>
-                    ))}
-                  </tr>
+          )
+        })}
+      </div>
+      <div className="spacer-md" />
+      <div className="button-row">
+        <button
+          onClick={() => refreshData()}
+          className="demo-button demo-button-sm"
+        >
+          Regenerate Data
+        </button>
+        <button
+          onClick={() => stressTest()}
+          className="demo-button demo-button-sm"
+        >
+          Stress Test (500k rows)
+        </button>
+        <button
+          onClick={() => randomizeColumns()}
+          className="demo-button demo-button-sm"
+        >
+          Shuffle Columns
+        </button>
+      </div>
+      <div className="spacer-md" />
+      <p className="demo-note">
+        This example using the non-split APIs. Columns are just reordered within
+        1 table instead of being split into 3 different tables.
+      </p>
+      <div className="table-row-group">
+        <table className="outlined-table">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    <div className="nowrap">
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </div>
+                    {!header.isPlaceholder && header.column.getCanPin() && (
+                      <div className="pin-actions">
+                        {header.column.getIsPinned() !== 'left' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('left')
+                            }}
+                          >
+                            {'<='}
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin(false)
+                            }}
+                          >
+                            X
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() !== 'right' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('right')
+                            }}
+                          >
+                            {'=>'}
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                  </th>
                 ))}
-              </thead>
-              <tbody>
-                {table
-                  .getRowModel()
-                  .rows.slice(0, 20)
-                  .map((row) => {
-                    return (
-                      <tr key={row.id}>
-                        {row.getVisibleCells().map((cell) => {
-                          return (
-                            <td key={cell.id}>
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )
-                        })}
-                      </tr>
-                    )
-                  })}
-              </tbody>
-            </table>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table
+              .getRowModel()
+              .rows.slice(0, 20)
+              .map((row) => {
+                return (
+                  <tr key={row.id}>
+                    {row.getVisibleCells().map((cell) => {
+                      return (
+                        <td key={cell.id}>
+                          <table.FlexRender cell={cell} />
+                        </td>
+                      )
+                    })}
+                  </tr>
+                )
+              })}
+          </tbody>
+        </table>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/preact/column-resizing-performant/src/main.tsx
+++ b/examples/preact/column-resizing-performant/src/main.tsx
@@ -137,13 +137,9 @@ function App() {
       <button onClick={() => rerender(0)} className="demo-button">
         Rerender
       </button>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => (
-          <pre style={{ minHeight: '10rem' }}>
-            {JSON.stringify(state, null, 2)}
-          </pre>
-        )}
-      </table.Subscribe>
+      <pre style={{ minHeight: '10rem' }}>
+        {JSON.stringify(table.state, null, 2)}
+      </pre>
       <div className="spacer-md" />({data.length.toLocaleString()} rows)
       <div className="scroll-container">
         {/* Here in the <table> equivalent element (surrounds all table head and data cells), we will define our CSS variables for column sizes */}

--- a/examples/preact/column-resizing/src/main.tsx
+++ b/examples/preact/column-resizing/src/main.tsx
@@ -90,7 +90,7 @@ function App() {
       debugHeaders: true,
       debugColumns: true,
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   return (
@@ -338,9 +338,7 @@ function App() {
       <button onClick={() => rerender(0)} className="demo-button">
         Rerender
       </button>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-      </table.Subscribe>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
     </div>
   )
 }

--- a/examples/preact/column-sizing/src/main.tsx
+++ b/examples/preact/column-sizing/src/main.tsx
@@ -71,7 +71,7 @@ function App() {
       debugHeaders: true,
       debugColumns: true,
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   return (
@@ -267,9 +267,7 @@ function App() {
       <button onClick={() => rerender(0)} className="demo-button">
         Rerender
       </button>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-      </table.Subscribe>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
     </div>
   )
 }

--- a/examples/preact/column-visibility/src/main.tsx
+++ b/examples/preact/column-visibility/src/main.tsx
@@ -66,106 +66,99 @@ function App() {
   const stressTest = () => setData(makeData(1_000))
   const rerender = useReducer(() => ({}), {})[1]
 
-  const table = useTable({
-    _features,
-    _rowModels: {},
-    columns,
-    data,
-    debugTable: true,
-    debugHeaders: true,
-    debugColumns: true,
-  })
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {},
+      columns,
+      data,
+      debugTable: true,
+      debugHeaders: true,
+      debugColumns: true,
+    },
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnVisibility: state.columnVisibility,
-      })}
-    >
-      {(_state) => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>Stress Test (1k rows)</button>
-          </div>
-          <div className="spacer-md" />
-          <div className="column-toggle-panel">
-            <div className="column-toggle-panel-header">
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()}>Regenerate Data</button>
+        <button onClick={() => stressTest()}>Stress Test (1k rows)</button>
+      </div>
+      <div className="spacer-md" />
+      <div className="column-toggle-panel">
+        <div className="column-toggle-panel-header">
+          <label>
+            <input
+              type="checkbox"
+              checked={table.getIsAllColumnsVisible()}
+              onChange={table.getToggleAllColumnsVisibilityHandler()}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map((column) => {
+          return (
+            <div key={column.id} className="column-toggle-row">
               <label>
                 <input
                   type="checkbox"
-                  checked={table.getIsAllColumnsVisible()}
-                  onChange={table.getToggleAllColumnsVisibilityHandler()}
+                  checked={column.getIsVisible()}
+                  onChange={column.getToggleVisibilityHandler()}
                 />{' '}
-                Toggle All
+                {column.id}
               </label>
             </div>
-            {table.getAllLeafColumns().map((column) => {
-              return (
-                <div key={column.id} className="column-toggle-row">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                    />{' '}
-                    {column.id}
-                  </label>
-                </div>
-              )
-            })}
-          </div>
-          <div className="spacer-md" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <th key={header.id} colSpan={header.colSpan}>
-                      {header.isPlaceholder ? null : (
-                        <table.FlexRender header={header} />
-                      )}
-                    </th>
-                  ))}
-                </tr>
+          )
+        })}
+      </div>
+      <div className="spacer-md" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : (
+                    <table.FlexRender header={header} />
+                  )}
+                </th>
               ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => (
-                <tr key={row.id}>
-                  {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id}>
-                      <table.FlexRender cell={cell} />
-                    </td>
-                  ))}
-                </tr>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>
+                  <table.FlexRender cell={cell} />
+                </td>
               ))}
-            </tbody>
-            <tfoot>
-              {table.getFooterGroups().map((footerGroup) => (
-                <tr key={footerGroup.id}>
-                  {footerGroup.headers.map((header) => (
-                    <th key={header.id} colSpan={header.colSpan}>
-                      {header.isPlaceholder ? null : (
-                        <table.FlexRender footer={header} />
-                      )}
-                    </th>
-                  ))}
-                </tr>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          {table.getFooterGroups().map((footerGroup) => (
+            <tr key={footerGroup.id}>
+              {footerGroup.headers.map((header) => (
+                <th key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : (
+                    <table.FlexRender footer={header} />
+                  )}
+                </th>
               ))}
-            </tfoot>
-          </table>
-          <div className="spacer-md" />
-          <button onClick={() => rerender(0)} className="demo-button">
-            Rerender
-          </button>
-          <div className="spacer-md" />
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </tfoot>
+      </table>
+      <div className="spacer-md" />
+      <button onClick={() => rerender(0)} className="demo-button">
+        Rerender
+      </button>
+      <div className="spacer-md" />
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/preact/composable-tables/src/components/table-components.tsx
+++ b/examples/preact/composable-tables/src/components/table-components.tsx
@@ -14,71 +14,66 @@ export function PaginationControls() {
   const table = useTableContext()
 
   return (
-    <table.Subscribe source={table.atoms.pagination}>
-      {/* whole pagination slice — no selector needed */}
-      {(pagination: PaginationState) => (
-        <div className="pagination">
-          <button
-            onClick={() => table.firstPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            {'<<'}
-          </button>
-          <button
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            {'<'}
-          </button>
-          <button
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-          >
-            {'>'}
-          </button>
-          <button
-            onClick={() => table.lastPage()}
-            disabled={!table.getCanNextPage()}
-          >
-            {'>>'}
-          </button>
-          <span>
-            Page{' '}
-            <strong>
-              {(pagination.pageIndex + 1).toLocaleString()} of{' '}
-              {table.getPageCount().toLocaleString()}
-            </strong>
-          </span>
-          <span>
-            | Go to page:
-            <input
-              type="number"
-              min="1"
-              max={table.getPageCount()}
-              defaultValue={pagination.pageIndex + 1}
-              onChange={(e) => {
-                const page = (e.target as HTMLInputElement).value
-                  ? Number((e.target as HTMLInputElement).value) - 1
-                  : 0
-                table.setPageIndex(page)
-              }}
-            />
-          </span>
-          <select
-            value={pagination.pageSize}
-            onChange={(e) => {
-              table.setPageSize(Number((e.target as HTMLInputElement).value))
-            }}
-          >
-            {[10, 20, 30, 40, 50].map((pageSize) => (
-              <option key={pageSize} value={pageSize}>
-                Show {pageSize}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
-    </table.Subscribe>
+    <div className="pagination">
+      <button
+        onClick={() => table.firstPage()}
+        disabled={!table.getCanPreviousPage()}
+      >
+        {'<<'}
+      </button>
+      <button
+        onClick={() => table.previousPage()}
+        disabled={!table.getCanPreviousPage()}
+      >
+        {'<'}
+      </button>
+      <button
+        onClick={() => table.nextPage()}
+        disabled={!table.getCanNextPage()}
+      >
+        {'>'}
+      </button>
+      <button
+        onClick={() => table.lastPage()}
+        disabled={!table.getCanNextPage()}
+      >
+        {'>>'}
+      </button>
+      <span>
+        Page{' '}
+        <strong>
+          {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+          {table.getPageCount().toLocaleString()}
+        </strong>
+      </span>
+      <span>
+        | Go to page:
+        <input
+          type="number"
+          min="1"
+          max={table.getPageCount()}
+          defaultValue={table.state.pagination.pageIndex + 1}
+          onChange={(e) => {
+            const page = (e.target as HTMLInputElement).value
+              ? Number((e.target as HTMLInputElement).value) - 1
+              : 0
+            table.setPageIndex(page)
+          }}
+        />
+      </span>
+      <select
+        value={table.state.pagination.pageSize}
+        onChange={(e) => {
+          table.setPageSize(Number((e.target as HTMLInputElement).value))
+        }}
+      >
+        {[10, 20, 30, 40, 50].map((pageSize) => (
+          <option key={pageSize} value={pageSize}>
+            Show {pageSize}
+          </option>
+        ))}
+      </select>
+    </div>
   )
 }
 
@@ -113,15 +108,15 @@ export function TableToolbar({
   return (
     <div className="table-toolbar">
       <h2>{title}</h2>
-      <div>
-        <button onClick={() => table.resetColumnFilters()}>
-          Clear Filters
-        </button>
-        <button onClick={() => table.resetSorting()}>Clear Sorting</button>
+      <div className="table-toolbar-actions">
         {onRefresh && <button onClick={onRefresh}>Regenerate Data</button>}
         {onStressTest && (
           <button onClick={onStressTest}>Stress Test (200k rows)</button>
         )}
+        <button onClick={() => table.resetColumnFilters()}>
+          Clear Filters
+        </button>
+        <button onClick={() => table.resetSorting()}>Clear Sorting</button>
       </div>
     </div>
   )

--- a/examples/preact/composable-tables/src/index.css
+++ b/examples/preact/composable-tables/src/index.css
@@ -174,6 +174,12 @@ tfoot th {
   border-spacing: 0;
 }
 
+.table-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .table-toolbar button {
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/examples/preact/composable-tables/src/main.tsx
+++ b/examples/preact/composable-tables/src/main.tsx
@@ -76,7 +76,7 @@ function UsersTable() {
       debugTable: true,
       // more table options
     },
-    // (state) => state, // alternatively, subscribe to the entire state instead of using table.Subscribe or selectors down below
+    (state) => state, // default selector
   )
 
   return (
@@ -264,12 +264,15 @@ function ProductsTable() {
   )
 
   // Create the table using the same useAppTable hook
-  const table = useAppTable({
-    debugTable: true,
-    columns,
-    data,
-    getRowId: (row) => row.id,
-  })
+  const table = useAppTable(
+    {
+      debugTable: true,
+      columns,
+      data,
+      getRowId: (row) => row.id,
+    },
+    (state) => state, // default selector
+  )
 
   return (
     <table.AppTable

--- a/examples/preact/custom-plugin/src/main.tsx
+++ b/examples/preact/custom-plugin/src/main.tsx
@@ -152,21 +152,24 @@ function App() {
   const stressTest = () => setData(makeData(200_000))
   const [density, setDensity] = useState<DensityState>('md')
 
-  const table = useTable({
-    _features,
-    _rowModels: {
-      filteredRowModel: createFilteredRowModel(filterFns),
-      paginatedRowModel: createPaginatedRowModel(),
-      sortedRowModel: createSortedRowModel(sortFns),
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel(filterFns),
+        paginatedRowModel: createPaginatedRowModel(),
+        sortedRowModel: createSortedRowModel(sortFns),
+      },
+      columns,
+      data,
+      debugTable: true,
+      state: {
+        density, // passing the density state to the table, TS is still happy :)
+      },
+      onDensityChange: setDensity, // using the new onDensityChange option, TS is still happy :)
     },
-    columns,
-    data,
-    debugTable: true,
-    state: {
-      density, // passing the density state to the table, TS is still happy :)
-    },
-    onDensityChange: setDensity, // using the new onDensityChange option, TS is still happy :)
-  })
+    (state) => state, // default selector
+  )
 
   return (
     <div className="demo-root">
@@ -320,9 +323,7 @@ function App() {
         Showing {table.getRowModel().rows.length.toLocaleString()} of{' '}
         {table.getRowCount().toLocaleString()} Rows
       </div>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-      </table.Subscribe>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
     </div>
   )
 }

--- a/examples/preact/expanding/src/main.tsx
+++ b/examples/preact/expanding/src/main.tsx
@@ -115,154 +115,143 @@ function App() {
   const refreshData = () => setData(() => makeData(100, 5, 3))
   const stressTest = () => setData(() => makeData(10_000, 5, 3))
 
-  const table = useTable({
-    _features,
-    _rowModels: {
-      expandedRowModel: createExpandedRowModel(),
-      filteredRowModel: createFilteredRowModel(filterFns),
-      paginatedRowModel: createPaginatedRowModel(),
-      sortedRowModel: createSortedRowModel(sortFns),
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        expandedRowModel: createExpandedRowModel(),
+        filteredRowModel: createFilteredRowModel(filterFns),
+        paginatedRowModel: createPaginatedRowModel(),
+        sortedRowModel: createSortedRowModel(sortFns),
+      },
+      columns,
+      data,
+      getSubRows: (row) => row.subRows,
+      // filterFromLeafRows: true,
+      // maxLeafRowFilterDepth: 0,
+      debugTable: true,
     },
-    columns,
-    data,
-    getSubRows: (row) => row.subRows,
-    // filterFromLeafRows: true,
-    // maxLeafRowFilterDepth: 0,
-    debugTable: true,
-  })
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        expanded: state.expanded,
-        pagination: state.pagination,
-        rowSelection: state.rowSelection,
-        columnFilters: state.columnFilters,
-        sorting: state.sorting,
-      })}
-    >
-      {(state) => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>Stress Test (10k rows)</button>
-          </div>
-          <div className="spacer-sm" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <div>
-                            <table.FlexRender header={header} />
-                            {header.column.getCanFilter() ? (
-                              <div>
-                                <Filter column={header.column} table={table} />
-                              </div>
-                            ) : null}
-                          </div>
-                        )}
-                      </th>
-                    )
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()}>Regenerate Data</button>
+        <button onClick={() => stressTest()}>Stress Test (10k rows)</button>
+      </div>
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
                 return (
-                  <tr key={row.id}>
-                    {row.getAllCells().map((cell) => {
-                      return (
-                        <td key={cell.id}>
-                          <table.FlexRender cell={cell} />
-                        </td>
-                      )
-                    })}
-                  </tr>
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <div>
+                        <table.FlexRender header={header} />
+                        {header.column.getCanFilter() ? (
+                          <div>
+                            <Filter column={header.column} table={table} />
+                          </div>
+                        ) : null}
+                      </div>
+                    )}
+                  </th>
                 )
               })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div className="controls">
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(0)}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
-            <span className="inline-controls">
-              <div>Page</div>
-              <strong>
-                {(state.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                {table.getPageCount().toLocaleString()}
-              </strong>
-            </span>
-            <span className="inline-controls">
-              | Go to page:
-              <input
-                type="number"
-                min="1"
-                max={table.getPageCount()}
-                defaultValue={state.pagination.pageIndex + 1}
-                onChange={(e) => {
-                  const page = (e.target as HTMLInputElement).value
-                    ? Number((e.target as HTMLInputElement).value) - 1
-                    : 0
-                  table.setPageIndex(page)
-                }}
-                className="page-size-input"
-              />
-            </span>
-            <select
-              value={state.pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number((e.target as HTMLSelectElement).value))
-              }}
-            >
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
-          <div>
-            <button onClick={() => rerender(0)}>Force Rerender</button>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getAllCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div className="controls">
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(0)}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>>'}
+        </button>
+        <span className="inline-controls">
+          <div>Page</div>
+          <strong>
+            {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+            {table.getPageCount().toLocaleString()}
+          </strong>
+        </span>
+        <span className="inline-controls">
+          | Go to page:
+          <input
+            type="number"
+            min="1"
+            max={table.getPageCount()}
+            defaultValue={table.state.pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = (e.target as HTMLInputElement).value
+                ? Number((e.target as HTMLInputElement).value) - 1
+                : 0
+              table.setPageIndex(page)
+            }}
+            className="page-size-input"
+          />
+        </span>
+        <select
+          value={table.state.pagination.pageSize}
+          onChange={(e) => {
+            table.setPageSize(Number((e.target as HTMLSelectElement).value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map((pageSize) => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
+      <div>
+        <button onClick={() => rerender(0)}>Force Rerender</button>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/preact/filters-faceted/src/main.tsx
+++ b/examples/preact/filters-faceted/src/main.tsx
@@ -89,154 +89,144 @@ function App() {
   const stressTest = () => setData((_old) => makeData(200_000))
   const rerender = useReducer(() => ({}), {})[1]
 
-  const table = useTable({
-    _features,
-    _rowModels: {
-      filteredRowModel: createFilteredRowModel(filterFns), // client-side filtering
-      paginatedRowModel: createPaginatedRowModel(),
-      facetedRowModel: createFacetedRowModel(), // client-side faceting
-      facetedMinMaxValues: createFacetedMinMaxValues(), // generate min/max values for range filter
-      facetedUniqueValues: createFacetedUniqueValues(), // generate unique values for select filter/autocomplete
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel(filterFns), // client-side filtering
+        paginatedRowModel: createPaginatedRowModel(),
+        facetedRowModel: createFacetedRowModel(), // client-side faceting
+        facetedMinMaxValues: createFacetedMinMaxValues(), // generate min/max values for range filter
+        facetedUniqueValues: createFacetedUniqueValues(), // generate unique values for select filter/autocomplete
+      },
+      columns,
+      data,
+      debugTable: true,
+      debugHeaders: true,
+      debugColumns: false,
     },
-    columns,
-    data,
-    debugTable: true,
-    debugHeaders: true,
-    debugColumns: false,
-  })
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnFilters: state.columnFilters,
-        pagination: state.pagination,
-      })}
-    >
-      {(state) => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>
-              Stress Test (200k rows)
-            </button>
-          </div>
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <>
-                            <div>
-                              <table.FlexRender header={header} />
-                            </div>
-                            {header.column.getCanFilter() ? (
-                              <div>
-                                <Filter column={header.column} />
-                              </div>
-                            ) : null}
-                          </>
-                        )}
-                      </th>
-                    )
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()}>Regenerate Data</button>
+        <button onClick={() => stressTest()}>Stress Test (200k rows)</button>
+      </div>
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
                 return (
-                  <tr key={row.id}>
-                    {row.getAllCells().map((cell) => {
-                      return (
-                        <td key={cell.id}>
-                          <table.FlexRender cell={cell} />
-                        </td>
-                      )
-                    })}
-                  </tr>
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <>
+                        <div>
+                          <table.FlexRender header={header} />
+                        </div>
+                        {header.column.getCanFilter() ? (
+                          <div>
+                            <Filter column={header.column} />
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                  </th>
                 )
               })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div className="controls">
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(0)}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
-            <span className="inline-controls">
-              <div>Page</div>
-              <strong>
-                {(state.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                {table.getPageCount().toLocaleString()}
-              </strong>
-            </span>
-            <span className="inline-controls">
-              | Go to page:
-              <input
-                type="number"
-                defaultValue={state.pagination.pageIndex + 1}
-                onChange={(e) => {
-                  const page = (e.target as HTMLInputElement).value
-                    ? Number((e.target as HTMLInputElement).value) - 1
-                    : 0
-                  table.setPageIndex(page)
-                }}
-                className="page-size-input"
-              />
-            </span>
-            <select
-              value={state.pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number((e.target as HTMLSelectElement).value))
-              }}
-            >
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
-          </div>
-          <div>
-            <button onClick={rerender}>Force Rerender</button>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getAllCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div className="controls">
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(0)}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>>'}
+        </button>
+        <span className="inline-controls">
+          <div>Page</div>
+          <strong>
+            {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+            {table.getPageCount().toLocaleString()}
+          </strong>
+        </span>
+        <span className="inline-controls">
+          | Go to page:
+          <input
+            type="number"
+            defaultValue={table.state.pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = (e.target as HTMLInputElement).value
+                ? Number((e.target as HTMLInputElement).value) - 1
+                : 0
+              table.setPageIndex(page)
+            }}
+            className="page-size-input"
+          />
+        </span>
+        <select
+          value={table.state.pagination.pageSize}
+          onChange={(e) => {
+            table.setPageSize(Number((e.target as HTMLSelectElement).value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map((pageSize) => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
+      </div>
+      <div>
+        <button onClick={rerender}>Force Rerender</button>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/preact/filters-fuzzy/src/main.tsx
+++ b/examples/preact/filters-fuzzy/src/main.tsx
@@ -114,23 +114,26 @@ function App() {
   const refreshData = () => setData((_old) => makeData(5_000))
   const stressTest = () => setData((_old) => makeData(200_000))
 
-  const table = useTable<typeof _features, Person>({
-    _features,
-    _rowModels: {
-      filteredRowModel: createFilteredRowModel({
-        ...filterFns,
-        fuzzy: fuzzyFilter,
-      }),
-      paginatedRowModel: createPaginatedRowModel(),
-      sortedRowModel: createSortedRowModel(sortFns),
+  const table = useTable<typeof _features, Person>(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel({
+          ...filterFns,
+          fuzzy: fuzzyFilter,
+        }),
+        paginatedRowModel: createPaginatedRowModel(),
+        sortedRowModel: createSortedRowModel(sortFns),
+      },
+      columns,
+      data,
+      globalFilterFn: 'fuzzy', // apply fuzzy filter to the global filter (most common use case for fuzzy filter)
+      debugTable: true,
+      debugHeaders: true,
+      debugColumns: false,
     },
-    columns,
-    data,
-    globalFilterFn: 'fuzzy', // apply fuzzy filter to the global filter (most common use case for fuzzy filter)
-    debugTable: true,
-    debugHeaders: true,
-    debugColumns: false,
-  })
+    (state) => state, // default selector
+  )
 
   // apply the fuzzy sort if the fullName column is being filtered
   useEffect(() => {
@@ -142,159 +145,142 @@ function App() {
   }, [table.store.state.columnFilters[0]?.id])
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnFilters: state.columnFilters,
-        globalFilter: state.globalFilter,
-        pagination: state.pagination,
-        sorting: state.sorting,
-      })}
-    >
-      {(state) => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>
-              Stress Test (200k rows)
-            </button>
-          </div>
-          <div>
-            <DebouncedInput
-              value={state.globalFilter ?? ''}
-              onChange={(value) => table.setGlobalFilter(String(value))}
-              className="summary-panel"
-              placeholder="Search all columns..."
-            />
-          </div>
-          <div className="spacer-sm" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <>
-                            <div
-                              className={
-                                header.column.getCanSort()
-                                  ? 'sortable-header'
-                                  : ''
-                              }
-                              onClick={header.column.getToggleSortingHandler()}
-                            >
-                              <table.FlexRender header={header} />
-                              {{
-                                asc: ' 🔼',
-                                desc: ' 🔽',
-                              }[header.column.getIsSorted() as string] ?? null}
-                            </div>
-                            {header.column.getCanFilter() ? (
-                              <div>
-                                <Filter column={header.column} />
-                              </div>
-                            ) : null}
-                          </>
-                        )}
-                      </th>
-                    )
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()}>Regenerate Data</button>
+        <button onClick={() => stressTest()}>Stress Test (200k rows)</button>
+      </div>
+      <div>
+        <DebouncedInput
+          value={table.state.globalFilter ?? ''}
+          onChange={(value) => table.setGlobalFilter(String(value))}
+          className="summary-panel"
+          placeholder="Search all columns..."
+        />
+      </div>
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
                 return (
-                  <tr key={row.id}>
-                    {row.getAllCells().map((cell) => {
-                      return (
-                        <td key={cell.id}>
-                          <table.FlexRender cell={cell} />
-                        </td>
-                      )
-                    })}
-                  </tr>
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <>
+                        <div
+                          className={
+                            header.column.getCanSort() ? 'sortable-header' : ''
+                          }
+                          onClick={header.column.getToggleSortingHandler()}
+                        >
+                          <table.FlexRender header={header} />
+                          {{
+                            asc: ' 🔼',
+                            desc: ' 🔽',
+                          }[header.column.getIsSorted() as string] ?? null}
+                        </div>
+                        {header.column.getCanFilter() ? (
+                          <div>
+                            <Filter column={header.column} />
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                  </th>
                 )
               })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div className="controls">
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(0)}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
-            <span className="inline-controls">
-              <div>Page</div>
-              <strong>
-                {(state.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                {table.getPageCount().toLocaleString()}
-              </strong>
-            </span>
-            <span className="inline-controls">
-              | Go to page:
-              <input
-                type="number"
-                defaultValue={state.pagination.pageIndex + 1}
-                onChange={(e) => {
-                  const page = (e.target as HTMLInputElement).value
-                    ? Number((e.target as HTMLInputElement).value) - 1
-                    : 0
-                  table.setPageIndex(page)
-                }}
-                className="page-size-input"
-              />
-            </span>
-            <select
-              value={state.pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number((e.target as HTMLSelectElement).value))
-              }}
-            >
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
-          </div>
-          <div>
-            <button onClick={() => rerender(0)}>Force Rerender</button>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getAllCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div className="controls">
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(0)}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>>'}
+        </button>
+        <span className="inline-controls">
+          <div>Page</div>
+          <strong>
+            {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+            {table.getPageCount().toLocaleString()}
+          </strong>
+        </span>
+        <span className="inline-controls">
+          | Go to page:
+          <input
+            type="number"
+            defaultValue={table.state.pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = (e.target as HTMLInputElement).value
+                ? Number((e.target as HTMLInputElement).value) - 1
+                : 0
+              table.setPageIndex(page)
+            }}
+            className="page-size-input"
+          />
+        </span>
+        <select
+          value={table.state.pagination.pageSize}
+          onChange={(e) => {
+            table.setPageSize(Number((e.target as HTMLSelectElement).value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map((pageSize) => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
+      </div>
+      <div>
+        <button onClick={() => rerender(0)}>Force Rerender</button>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/preact/filters/src/main.tsx
+++ b/examples/preact/filters/src/main.tsx
@@ -90,152 +90,142 @@ function App() {
   const refreshData = () => setData((_old) => makeData(5_000))
   const stressTest = () => setData((_old) => makeData(200_000))
 
-  const table = useTable({
-    _features,
-    _rowModels: {
-      filteredRowModel: createFilteredRowModel(filterFns), // client side filtering
-      paginatedRowModel: createPaginatedRowModel(),
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel(filterFns), // client side filtering
+        paginatedRowModel: createPaginatedRowModel(),
+      },
+      columns,
+      data,
+      debugTable: true,
+      debugColumns: true,
     },
-    columns,
-    data,
-    debugTable: true,
-    debugColumns: true,
-  })
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnFilters: state.columnFilters,
-        pagination: state.pagination,
-      })}
-    >
-      {(state) => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>
-              Stress Test (200k rows)
-            </button>
-          </div>
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <>
-                            <div>
-                              <table.FlexRender header={header} />
-                            </div>
-                            {header.column.getCanFilter() ? (
-                              <div>
-                                <Filter column={header.column} />
-                              </div>
-                            ) : null}
-                          </>
-                        )}
-                      </th>
-                    )
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()}>Regenerate Data</button>
+        <button onClick={() => stressTest()}>Stress Test (200k rows)</button>
+      </div>
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
                 return (
-                  <tr key={row.id}>
-                    {row.getAllCells().map((cell) => {
-                      return (
-                        <td key={cell.id}>
-                          <table.FlexRender cell={cell} />
-                        </td>
-                      )
-                    })}
-                  </tr>
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <>
+                        <div>
+                          <table.FlexRender header={header} />
+                        </div>
+                        {header.column.getCanFilter() ? (
+                          <div>
+                            <Filter column={header.column} />
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                  </th>
                 )
               })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div className="controls">
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(0)}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
-            <span className="inline-controls">
-              <div>Page</div>
-              <strong>
-                {(state.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                {table.getPageCount().toLocaleString()}
-              </strong>
-            </span>
-            <span className="inline-controls">
-              | Go to page:
-              <input
-                type="number"
-                min="1"
-                max={table.getPageCount()}
-                defaultValue={state.pagination.pageIndex + 1}
-                onChange={(e) => {
-                  const page = (e.target as HTMLInputElement).value
-                    ? Number((e.target as HTMLInputElement).value) - 1
-                    : 0
-                  table.setPageIndex(page)
-                }}
-                className="page-size-input"
-              />
-            </span>
-            <select
-              value={state.pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number((e.target as HTMLSelectElement).value))
-              }}
-            >
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
-          </div>
-          <div>
-            <button onClick={() => rerender(0)}>Force Rerender</button>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getAllCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div className="controls">
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(0)}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>>'}
+        </button>
+        <span className="inline-controls">
+          <div>Page</div>
+          <strong>
+            {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+            {table.getPageCount().toLocaleString()}
+          </strong>
+        </span>
+        <span className="inline-controls">
+          | Go to page:
+          <input
+            type="number"
+            min="1"
+            max={table.getPageCount()}
+            defaultValue={table.state.pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = (e.target as HTMLInputElement).value
+                ? Number((e.target as HTMLInputElement).value) - 1
+                : 0
+              table.setPageIndex(page)
+            }}
+            className="page-size-input"
+          />
+        </span>
+        <select
+          value={table.state.pagination.pageSize}
+          onChange={(e) => {
+            table.setPageSize(Number((e.target as HTMLSelectElement).value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map((pageSize) => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
+      </div>
+      <div>
+        <button onClick={() => rerender(0)}>Force Rerender</button>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/preact/grouping/src/main.tsx
+++ b/examples/preact/grouping/src/main.tsx
@@ -96,7 +96,7 @@ function App() {
       data,
       debugTable: true,
     },
-    (state) => state, // subscribe to all state changes
+    (state) => state, // default selector
   )
 
   return (
@@ -253,9 +253,7 @@ function App() {
       <div>
         <button onClick={() => rerender(0)}>Force Rerender</button>
       </div>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-      </table.Subscribe>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
     </div>
   )
 }

--- a/examples/preact/pagination/src/main.tsx
+++ b/examples/preact/pagination/src/main.tsx
@@ -79,134 +79,127 @@ function MyTable({
   data: Array<Person>
   columns: ReturnType<typeof columnHelper.columns>
 }) {
-  const table = useTable({
-    _features,
-    _rowModels: {
-      paginatedRowModel: createPaginatedRowModel(),
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        paginatedRowModel: createPaginatedRowModel(),
+      },
+      columns,
+      data,
+      debugTable: true,
+      // no need to pass pageCount or rowCount with client-side pagination as it is calculated automatically
     },
-    columns,
-    data,
-    debugTable: true,
-    // no need to pass pageCount or rowCount with client-side pagination as it is calculated automatically
-  })
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        pagination: state.pagination,
-      })}
-    >
-      {(state) => (
-        <div className="demo-root">
-          <div className="spacer-sm" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        <div>
-                          <table.FlexRender header={header} />
-                        </div>
-                      </th>
-                    )
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
+    <div className="demo-root">
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
                 return (
-                  <tr key={row.id}>
-                    {row.getAllCells().map((cell) => {
-                      return (
-                        <td key={cell.id}>
-                          <table.FlexRender cell={cell} />
-                        </td>
-                      )
-                    })}
-                  </tr>
+                  <th key={header.id} colSpan={header.colSpan}>
+                    <div>
+                      <table.FlexRender header={header} />
+                    </div>
+                  </th>
                 )
               })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div className="controls">
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.firstPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.lastPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
-            <span className="inline-controls">
-              <div>Page</div>
-              <strong>
-                {(state.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                {table.getPageCount().toLocaleString()}
-              </strong>
-            </span>
-            <span className="inline-controls">
-              | Go to page:
-              <input
-                type="number"
-                min="1"
-                max={table.getPageCount()}
-                defaultValue={state.pagination.pageIndex + 1}
-                onChange={(e) => {
-                  const page = (e.target as HTMLInputElement).value
-                    ? Number((e.target as HTMLInputElement).value) - 1
-                    : 0
-                  table.setPageIndex(page)
-                }}
-                className="page-size-input"
-              />
-            </span>
-            <select
-              value={state.pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number((e.target as HTMLInputElement).value))
-              }}
-            >
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            Showing {table.getRowModel().rows.length.toLocaleString()} of{' '}
-            {table.getRowCount().toLocaleString()} Rows
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getAllCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div className="controls">
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.firstPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.lastPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>>'}
+        </button>
+        <span className="inline-controls">
+          <div>Page</div>
+          <strong>
+            {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+            {table.getPageCount().toLocaleString()}
+          </strong>
+        </span>
+        <span className="inline-controls">
+          | Go to page:
+          <input
+            type="number"
+            min="1"
+            max={table.getPageCount()}
+            defaultValue={table.state.pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = (e.target as HTMLInputElement).value
+                ? Number((e.target as HTMLInputElement).value) - 1
+                : 0
+              table.setPageIndex(page)
+            }}
+            className="page-size-input"
+          />
+        </span>
+        <select
+          value={table.state.pagination.pageSize}
+          onChange={(e) => {
+            table.setPageSize(Number((e.target as HTMLInputElement).value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map((pageSize) => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        Showing {table.getRowModel().rows.length.toLocaleString()} of{' '}
+        {table.getRowCount().toLocaleString()} Rows
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/preact/row-pinning/src/main.tsx
+++ b/examples/preact/row-pinning/src/main.tsx
@@ -170,7 +170,7 @@ function App() {
       keepPinnedRows,
       debugAll: true,
     },
-    (state) => state, // subscribe to all re-renders
+    (state) => state, // default selector
   )
 
   return (

--- a/examples/preact/row-selection/src/main.tsx
+++ b/examples/preact/row-selection/src/main.tsx
@@ -48,17 +48,11 @@ function App() {
           id: 'select',
           header: () => {
             return (
-              <table.Subscribe
-                source={table.atoms.rowSelection} // slice atom only — not the full derived store
-              >
-                {() => (
-                  <IndeterminateCheckbox
-                    checked={table.getIsAllRowsSelected()}
-                    indeterminate={table.getIsSomeRowsSelected()}
-                    onChange={table.getToggleAllRowsSelectedHandler()}
-                  />
-                )}
-              </table.Subscribe>
+              <IndeterminateCheckbox
+                checked={table.getIsAllRowsSelected()}
+                indeterminate={table.getIsSomeRowsSelected()}
+                onChange={table.getToggleAllRowsSelectedHandler()}
+              />
             )
           },
           cell: ({ row }) => (
@@ -126,223 +120,185 @@ function App() {
       // enableRowSelection: row => row.original.age > 18, // or enable row selection conditionally per row
       debugTable: true,
     },
-    // (state) => state, // uncomment to subscribe to the entire table state (this is how v8 used to work by default)
+    (state) => state, // default selector
   )
 
   useTanStackTableDevtools(table, 'Row Selection Example')
 
   return (
     <>
-      <table.Subscribe
-        selector={(state) => ({
-          // Store mode: multiple slices — must use table.store + explicit selector
-          columnFilters: state.columnFilters,
-          globalFilter: state.globalFilter,
-          pagination: state.pagination,
-        })}
-      >
-        {(state) => (
-          <div className="demo-root">
-            <div>
-              <button onClick={() => refreshData()}>Regenerate Data</button>
-              <button onClick={() => stressTest()}>
-                Stress Test (200k rows)
-              </button>
-            </div>
-            <div>
-              <input
-                value={state.globalFilter ?? ''}
-                onInput={(e) =>
-                  table.setGlobalFilter((e.target as HTMLInputElement).value)
-                }
-                className="summary-panel"
-                placeholder="Search all columns..."
-              />
-            </div>
-            <div className="spacer-sm" />
-            <table>
-              <thead>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => {
-                      return (
-                        <th key={header.id} colSpan={header.colSpan}>
-                          {header.isPlaceholder ? null : (
-                            <>
-                              <table.FlexRender header={header} />
-                              {header.column.getCanFilter() ? (
-                                <div>
-                                  <Filter
-                                    column={header.column}
-                                    table={table}
-                                  />
-                                </div>
-                              ) : null}
-                            </>
-                          )}
-                        </th>
-                      )
-                    })}
-                  </tr>
-                ))}
-              </thead>
-              <tbody>
-                {table.getRowModel().rows.map((row) => {
+      <div className="demo-root">
+        <div>
+          <button onClick={() => refreshData()}>Regenerate Data</button>
+          <button onClick={() => stressTest()}>Stress Test (200k rows)</button>
+        </div>
+        <div>
+          <input
+            value={table.state.globalFilter ?? ''}
+            onInput={(e) =>
+              table.setGlobalFilter((e.target as HTMLInputElement).value)
+            }
+            className="summary-panel"
+            placeholder="Search all columns..."
+          />
+        </div>
+        <div className="spacer-sm" />
+        <table>
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
                   return (
-                    <table.Subscribe
-                      key={row.id}
-                      source={rowSelectionAtom}
-                      selector={(rowSelection) => rowSelection?.[row.id]} // optional: narrow to this row id
-                    >
-                      {(_isRowSelected) => (
-                        <tr key={row.id}>
-                          {row.getAllCells().map((cell) => {
-                            return (
-                              <td key={cell.id}>
-                                <table.FlexRender cell={cell} />
-                              </td>
-                            )
-                          })}
-                        </tr>
+                    <th key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : (
+                        <>
+                          <table.FlexRender header={header} />
+                          {header.column.getCanFilter() ? (
+                            <div>
+                              <Filter column={header.column} table={table} />
+                            </div>
+                          ) : null}
+                        </>
                       )}
-                    </table.Subscribe>
+                    </th>
                   )
                 })}
-              </tbody>
-              <tfoot>
-                <tr>
-                  <td className="cell-padding">
-                    <table.Subscribe source={table.atoms.rowSelection}>
-                      {(_rowSelection) => (
-                        <IndeterminateCheckbox
-                          checked={table.getIsAllPageRowsSelected()}
-                          indeterminate={table.getIsSomePageRowsSelected()}
-                          onChange={table.getToggleAllPageRowsSelectedHandler()}
-                        />
-                      )}
-                    </table.Subscribe>
-                  </td>
-                  <td colSpan={20}>
-                    Page Rows (
-                    {table.getRowModel().rows.length.toLocaleString()})
-                  </td>
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => {
+              return (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => {
+                    return (
+                      <td key={cell.id}>
+                        <table.FlexRender cell={cell} />
+                      </td>
+                    )
+                  })}
                 </tr>
-              </tfoot>
-            </table>
-            <div className="spacer-sm" />
-            <div className="controls">
-              <button
-                className="demo-button demo-button-sm"
-                onClick={() => table.setPageIndex(0)}
-                disabled={!table.getCanPreviousPage()}
-              >
-                {'<<'}
-              </button>
-              <button
-                className="demo-button demo-button-sm"
-                onClick={() => table.previousPage()}
-                disabled={!table.getCanPreviousPage()}
-              >
-                {'<'}
-              </button>
-              <button
-                className="demo-button demo-button-sm"
-                onClick={() => table.nextPage()}
-                disabled={!table.getCanNextPage()}
-              >
-                {'>'}
-              </button>
-              <button
-                className="demo-button demo-button-sm"
-                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-                disabled={!table.getCanNextPage()}
-              >
-                {'>>'}
-              </button>
-              <span className="inline-controls">
-                <div>Page</div>
-                <strong>
-                  {(
-                    table.store.state.pagination.pageIndex + 1
-                  ).toLocaleString()}{' '}
-                  of {table.getPageCount().toLocaleString()}
-                </strong>
-              </span>
-              <span className="inline-controls">
-                | Go to page:
-                <input
-                  type="number"
-                  min="1"
-                  max={table.getPageCount()}
-                  defaultValue={table.store.state.pagination.pageIndex + 1}
-                  onChange={(e) => {
-                    const page = (e.target as HTMLInputElement).value
-                      ? Number((e.target as HTMLInputElement).value) - 1
-                      : 0
-                    table.setPageIndex(page)
-                  }}
-                  className="page-size-input"
+              )
+            })}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td className="cell-padding">
+                <IndeterminateCheckbox
+                  checked={table.getIsAllPageRowsSelected()}
+                  indeterminate={table.getIsSomePageRowsSelected()}
+                  onChange={table.getToggleAllPageRowsSelectedHandler()}
                 />
-              </span>
-              <select
-                value={table.store.state.pagination.pageSize}
-                onChange={(e) => {
-                  table.setPageSize(
-                    Number((e.target as HTMLInputElement).value),
-                  )
-                }}
-              >
-                {[10, 20, 30, 40, 50].map((pageSize) => (
-                  <option key={pageSize} value={pageSize}>
-                    Show {pageSize}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <br />
-            <div>
-              <table.Subscribe
-                selector={(state) => ({
-                  numSelected: Object.keys(state.rowSelection).length,
-                })}
-              >
-                {({ numSelected }) => <>{numSelected.toLocaleString()} of </>}
-              </table.Subscribe>
-              {table.getPreFilteredRowModel().rows.length.toLocaleString()}{' '}
-              Total Rows Selected
-            </div>
-            <hr />
-            <br />
-            <div>
-              <button
-                className="demo-button demo-button-spaced"
-                onClick={() => rerender(0)}
-              >
-                Force Rerender
-              </button>
-            </div>
-            <div>
-              <button
-                className="demo-button demo-button-spaced"
-                onClick={() =>
-                  console.info(
-                    'table.getSelectedRowModel().flatRows',
-                    table.getSelectedRowModel().flatRows,
-                  )
-                }
-              >
-                Log table.getSelectedRowModel().flatRows
-              </button>
-            </div>
-            <div>
-              <label>Row Selection State:</label>
-              <table.Subscribe selector={(state) => state}>
-                {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-              </table.Subscribe>
-            </div>
-          </div>
-        )}
-      </table.Subscribe>
+              </td>
+              <td colSpan={20}>
+                Page Rows ({table.getRowModel().rows.length.toLocaleString()})
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <div className="spacer-sm" />
+        <div className="controls">
+          <button
+            className="demo-button demo-button-sm"
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            {'<<'}
+          </button>
+          <button
+            className="demo-button demo-button-sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            {'<'}
+          </button>
+          <button
+            className="demo-button demo-button-sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            {'>'}
+          </button>
+          <button
+            className="demo-button demo-button-sm"
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            {'>>'}
+          </button>
+          <span className="inline-controls">
+            <div>Page</div>
+            <strong>
+              {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+              {table.getPageCount().toLocaleString()}
+            </strong>
+          </span>
+          <span className="inline-controls">
+            | Go to page:
+            <input
+              type="number"
+              min="1"
+              max={table.getPageCount()}
+              defaultValue={table.state.pagination.pageIndex + 1}
+              onChange={(e) => {
+                const page = (e.target as HTMLInputElement).value
+                  ? Number((e.target as HTMLInputElement).value) - 1
+                  : 0
+                table.setPageIndex(page)
+              }}
+              className="page-size-input"
+            />
+          </span>
+          <select
+            value={table.state.pagination.pageSize}
+            onChange={(e) => {
+              table.setPageSize(Number((e.target as HTMLInputElement).value))
+            }}
+          >
+            {[10, 20, 30, 40, 50].map((pageSize) => (
+              <option key={pageSize} value={pageSize}>
+                Show {pageSize}
+              </option>
+            ))}
+          </select>
+        </div>
+        <br />
+        <div>
+          <>
+            {Object.keys(table.state.rowSelection).length.toLocaleString()}{' '}
+            of{' '}
+          </>
+          {table.getPreFilteredRowModel().rows.length.toLocaleString()} Total
+          Rows Selected
+        </div>
+        <hr />
+        <br />
+        <div>
+          <button
+            className="demo-button demo-button-spaced"
+            onClick={() => rerender(0)}
+          >
+            Force Rerender
+          </button>
+        </div>
+        <div>
+          <button
+            className="demo-button demo-button-spaced"
+            onClick={() =>
+              console.info(
+                'table.getSelectedRowModel().flatRows',
+                table.getSelectedRowModel().flatRows,
+              )
+            }
+          >
+            Log table.getSelectedRowModel().flatRows
+          </button>
+        </div>
+        <div>
+          <label>Row Selection State:</label>
+          <pre>{JSON.stringify(table.state, null, 2)}</pre>
+        </div>
+      </div>
     </>
   )
 }

--- a/examples/preact/sorting/src/main.tsx
+++ b/examples/preact/sorting/src/main.tsx
@@ -111,7 +111,7 @@ function App() {
       // isMultiSortEvent: (e) => true, //Make all clicks multi-sort - default requires `shift` key
       // maxMultiSortColCount: 3, // only allow 3 columns to be sorted at once - default is Infinity
     },
-    // (state) => ({ state }), // uncomment to subscribe to the entire table state (this is how it worked in v8 by default)
+    (state) => state, // default selector
   )
 
   useTanStackTableDevtools(table, 'Sorting Example')
@@ -122,80 +122,70 @@ function App() {
         <button onClick={() => refreshData()}>Regenerate Data</button>
         <button onClick={() => stressTest()}>Stress Test (500k rows)</button>
       </div>
-      <table.Subscribe source={table.atoms.sorting}>
-        {(_state) => (
-          <>
-            <div className="spacer-sm" />
-            <table>
-              <thead>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => {
+      <>
+        <div className="spacer-sm" />
+        <table>
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : (
+                        <div
+                          className={
+                            header.column.getCanSort() ? 'sortable-header' : ''
+                          }
+                          onClick={header.column.getToggleSortingHandler()}
+                          title={
+                            header.column.getCanSort()
+                              ? header.column.getNextSortingOrder() === 'asc'
+                                ? 'Sort ascending'
+                                : header.column.getNextSortingOrder() === 'desc'
+                                  ? 'Sort descending'
+                                  : 'Clear sort'
+                              : undefined
+                          }
+                        >
+                          <table.FlexRender header={header} />
+                          {{
+                            asc: ' 🔼',
+                            desc: ' 🔽',
+                          }[header.column.getIsSorted() as string] ?? null}
+                        </div>
+                      )}
+                    </th>
+                  )
+                })}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table
+              .getRowModel()
+              .rows.slice(0, 10)
+              .map((row) => {
+                return (
+                  <tr key={row.id}>
+                    {row.getAllCells().map((cell) => {
                       return (
-                        <th key={header.id} colSpan={header.colSpan}>
-                          {header.isPlaceholder ? null : (
-                            <div
-                              className={
-                                header.column.getCanSort()
-                                  ? 'sortable-header'
-                                  : ''
-                              }
-                              onClick={header.column.getToggleSortingHandler()}
-                              title={
-                                header.column.getCanSort()
-                                  ? header.column.getNextSortingOrder() ===
-                                    'asc'
-                                    ? 'Sort ascending'
-                                    : header.column.getNextSortingOrder() ===
-                                        'desc'
-                                      ? 'Sort descending'
-                                      : 'Clear sort'
-                                  : undefined
-                              }
-                            >
-                              <table.FlexRender header={header} />
-                              {{
-                                asc: ' 🔼',
-                                desc: ' 🔽',
-                              }[header.column.getIsSorted() as string] ?? null}
-                            </div>
-                          )}
-                        </th>
+                        <td key={cell.id}>
+                          <table.FlexRender cell={cell} />
+                        </td>
                       )
                     })}
                   </tr>
-                ))}
-              </thead>
-              <tbody>
-                {table
-                  .getRowModel()
-                  .rows.slice(0, 10)
-                  .map((row) => {
-                    return (
-                      <tr key={row.id}>
-                        {row.getAllCells().map((cell) => {
-                          return (
-                            <td key={cell.id}>
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )
-                        })}
-                      </tr>
-                    )
-                  })}
-              </tbody>
-            </table>
-            <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
-            <div>
-              <button onClick={() => rerender(0)}>Force Rerender</button>
-            </div>
-            {/* Store mode: full state for debugging */}
-            <table.Subscribe selector={(state) => state}>
-              {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-            </table.Subscribe>
-          </>
-        )}
-      </table.Subscribe>
+                )
+              })}
+          </tbody>
+        </table>
+        <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
+        <div>
+          <button onClick={() => rerender(0)}>Force Rerender</button>
+        </div>
+        {/* Store mode: full state for debugging */}
+        <pre>{JSON.stringify(table.state, null, 2)}</pre>
+      </>
     </div>
   )
 }

--- a/examples/preact/sub-components/src/main.tsx
+++ b/examples/preact/sub-components/src/main.tsx
@@ -91,72 +91,71 @@ function Table({
   getRowCanExpand,
   renderSubComponent,
 }: TableProps<typeof _features, Person>): JSX.Element {
-  const table = useTable({
-    debugTable: true,
-    _features,
-    _rowModels: {
-      expandedRowModel: createExpandedRowModel(),
+  const table = useTable(
+    {
+      debugTable: true,
+      _features,
+      _rowModels: {
+        expandedRowModel: createExpandedRowModel(),
+      },
+      columns,
+      data,
+      getRowCanExpand,
     },
-    columns,
-    data,
-    getRowCanExpand,
-  })
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe selector={(state) => state}>
-      {() => (
-        <div className="demo-root">
-          <div className="spacer-sm" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
+    <div className="demo-root">
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <div>
+                        <table.FlexRender header={header} />
+                      </div>
+                    )}
+                  </th>
+                )
+              })}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <Fragment key={row.id}>
+                <tr>
+                  {/* first row is a normal row */}
+                  {row.getAllCells().map((cell) => {
                     return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <div>
-                            <table.FlexRender header={header} />
-                          </div>
-                        )}
-                      </th>
+                      <td key={cell.id}>
+                        <table.FlexRender cell={cell} />
+                      </td>
                     )
                   })}
                 </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
-                return (
-                  <Fragment key={row.id}>
-                    <tr>
-                      {/* first row is a normal row */}
-                      {row.getAllCells().map((cell) => {
-                        return (
-                          <td key={cell.id}>
-                            <table.FlexRender cell={cell} />
-                          </td>
-                        )
-                      })}
-                    </tr>
-                    {row.getIsExpanded() && (
-                      <tr>
-                        {/* 2nd row is a custom 1 cell row */}
-                        <td colSpan={row.getAllCells().length}>
-                          {renderSubComponent({ row })}
-                        </td>
-                      </tr>
-                    )}
-                  </Fragment>
-                )
-              })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
-        </div>
-      )}
-    </table.Subscribe>
+                {row.getIsExpanded() && (
+                  <tr>
+                    {/* 2nd row is a custom 1 cell row */}
+                    <td colSpan={row.getAllCells().length}>
+                      {renderSubComponent({ row })}
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
+    </div>
   )
 }
 

--- a/examples/preact/with-tanstack-query/src/main.tsx
+++ b/examples/preact/with-tanstack-query/src/main.tsx
@@ -69,18 +69,21 @@ function App() {
 
   const defaultData = useMemo(() => [], [])
 
-  const table = useTable({
-    _features,
-    _rowModels: {},
-    columns,
-    data: dataQuery.data?.rows ?? defaultData,
-    rowCount: dataQuery.data?.rowCount,
-    atoms: {
-      pagination: paginationAtom,
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {},
+      columns,
+      data: dataQuery.data?.rows ?? defaultData,
+      rowCount: dataQuery.data?.rowCount,
+      atoms: {
+        pagination: paginationAtom,
+      },
+      manualPagination: true, // we're doing manual "server-side" pagination
+      debugTable: true,
     },
-    manualPagination: true, // we're doing manual "server-side" pagination
-    debugTable: true,
-  })
+    (state) => state, // default selector
+  )
 
   return (
     <div className="demo-root">

--- a/examples/react/basic-external-atoms/src/main.tsx
+++ b/examples/react/basic-external-atoms/src/main.tsx
@@ -92,7 +92,7 @@ function App() {
       },
       debugTable: true,
     },
-    (state) => state, // subscribe to all state changes for re-rendering
+    (state) => state, // default selector
   )
 
   return (

--- a/examples/react/basic-external-state/src/main.tsx
+++ b/examples/react/basic-external-state/src/main.tsx
@@ -73,22 +73,25 @@ function App() {
   // console.log('pagination', pagination)
 
   // Create the table and pass state + onChange handlers
-  const table = useTable({
-    debugTable: true,
-    _features,
-    _rowModels: {
-      sortedRowModel: createSortedRowModel(sortFns),
-      paginatedRowModel: createPaginatedRowModel(),
+  const table = useTable(
+    {
+      debugTable: true,
+      _features,
+      _rowModels: {
+        sortedRowModel: createSortedRowModel(sortFns),
+        paginatedRowModel: createPaginatedRowModel(),
+      },
+      columns,
+      data,
+      state: {
+        sorting, // connect our sorting state back down to the table
+        pagination, // connect our pagination state back down to the table
+      },
+      onSortingChange: setSorting, // raise sorting state changes to our own state management
+      onPaginationChange: setPagination, // raise pagination state changes to our own state management
     },
-    columns,
-    data,
-    state: {
-      sorting, // connect our sorting state back down to the table
-      pagination, // connect our pagination state back down to the table
-    },
-    onSortingChange: setSorting, // raise sorting state changes to our own state management
-    onPaginationChange: setPagination, // raise pagination state changes to our own state management
-  })
+    (state) => state, // default selector
+  )
 
   return (
     <div className="demo-root">

--- a/examples/react/basic-subscribe/.gitignore
+++ b/examples/react/basic-subscribe/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+dist-ssr
+*.local

--- a/examples/react/basic-subscribe/README.md
+++ b/examples/react/basic-subscribe/README.md
@@ -1,0 +1,6 @@
+# Basic Subscribe Example
+
+To run this example:
+
+- `pnpm install`
+- `pnpm start`

--- a/examples/react/basic-subscribe/index.html
+++ b/examples/react/basic-subscribe/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+    <script src="https://unpkg.com/react-scan/dist/auto.global.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react/basic-subscribe/package.json
+++ b/examples/react/basic-subscribe/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "tanstack-react-table-example-basic-subscribe",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview",
+    "start": "vite",
+    "lint": "eslint ./src",
+    "test:types": "tsc"
+  },
+  "dependencies": {
+    "@faker-js/faker": "^10.4.0",
+    "@tanstack/react-store": "^0.11.0",
+    "@tanstack/react-table": "^9.0.0-alpha.44",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
+  },
+  "devDependencies": {
+    "@rolldown/plugin-babel": "^0.2.3",
+    "@rollup/plugin-replace": "^6.0.3",
+    "@tanstack/react-devtools": "^0.10.2",
+    "@tanstack/react-table-devtools": "^9.0.0-alpha.43",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "typescript": "6.0.3",
+    "vite": "^8.0.10"
+  }
+}

--- a/examples/react/basic-subscribe/src/index.css
+++ b/examples/react/basic-subscribe/src/index.css
@@ -1,0 +1,372 @@
+html {
+  font-family: sans-serif;
+  font-size: 14px;
+}
+
+table {
+  border: 1px solid lightgray;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+tbody {
+  border-bottom: 1px solid lightgray;
+}
+
+th {
+  border-bottom: 1px solid lightgray;
+  border-right: 1px solid lightgray;
+  padding: 2px 4px;
+}
+
+tfoot {
+  color: gray;
+}
+
+tfoot th {
+  font-weight: normal;
+}
+
+button:disabled,
+button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* Demo layout utilities for plain example styling. */
+.demo-root {
+  padding: 0.5rem;
+}
+
+.spacer-xs {
+  height: 0.25rem;
+}
+
+.spacer-sm {
+  height: 0.5rem;
+}
+
+.spacer-md {
+  height: 1rem;
+}
+
+.controls,
+.button-row,
+.inline-controls,
+.pin-actions,
+.filter-row,
+.form-actions {
+  display: flex;
+  align-items: center;
+}
+
+.button-row {
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.controls {
+  gap: 0.5rem;
+}
+
+.inline-controls,
+.pin-actions {
+  gap: 0.25rem;
+}
+
+.pin-actions {
+  justify-content: center;
+}
+
+.filter-row {
+  gap: 0.5rem;
+}
+
+.form-actions {
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.split-tables {
+  display: flex;
+  gap: 1rem;
+}
+
+.table-row-group {
+  display: flex;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.vertical-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.column-toggle-panel {
+  display: inline-block;
+  border: 1px solid #000;
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
+}
+
+.column-toggle-panel-header {
+  border-bottom: 1px solid #000;
+  padding: 0 0.25rem;
+}
+
+.column-toggle-row,
+.selection-cell {
+  padding: 0 0.25rem;
+}
+
+.selection-cell {
+  display: block;
+}
+
+.demo-button,
+.pin-button,
+.compact-input,
+.filter-input,
+.filter-select,
+.page-size-input,
+.text-input,
+.number-input,
+.wide-action-button,
+.primary-action,
+.secondary-action,
+.success-action {
+  border: 1px solid currentColor;
+  border-radius: 0.25rem;
+}
+
+.demo-button {
+  padding: 0.5rem;
+}
+
+.demo-button-sm {
+  padding: 0.25rem;
+}
+
+.demo-button-spaced {
+  margin-bottom: 0.5rem;
+}
+
+.pin-button {
+  padding: 0 0.5rem;
+}
+
+.outlined-table {
+  border: 2px solid #000;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.outlined-control {
+  border-color: #000;
+}
+
+.nowrap {
+  white-space: nowrap;
+}
+
+.demo-note {
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.section-title {
+  font-size: 1.25rem;
+}
+
+.scroll-container {
+  overflow-x: auto;
+}
+
+.page-size-input {
+  width: 4rem;
+  padding: 0.25rem;
+}
+
+.number-input {
+  width: 5rem;
+  padding: 0 0.25rem;
+}
+
+.filter-input,
+.filter-select {
+  width: 6rem;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
+}
+
+.filter-select {
+  width: 9rem;
+}
+
+.text-input {
+  width: 100%;
+  padding: 0 0.25rem;
+}
+
+.compact-input {
+  padding: 0 0.25rem;
+}
+
+.wide-action-button {
+  width: 16rem;
+}
+
+.summary-panel {
+  border: 1px solid currentColor;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
+  padding: 0.5rem;
+}
+
+.sortable-header,
+.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.primary-action,
+.success-action,
+.secondary-action {
+  color: #fff;
+}
+
+.primary-action {
+  background: #3b82f6;
+}
+
+.success-action {
+  background: #22c55e;
+}
+
+.secondary-action {
+  background: #6b7280;
+}
+
+.submit-button:disabled {
+  opacity: 0.5;
+}
+
+.error-text {
+  color: #ef4444;
+  font-size: 0.75rem;
+}
+
+.success-text {
+  color: #16a34a;
+}
+
+.warning-text {
+  color: #ca8a04;
+}
+
+.muted-text {
+  color: #9ca3af;
+}
+
+.label-offset {
+  margin-left: 0.5rem;
+}
+
+.cell-padding {
+  padding: 0.25rem;
+}
+
+.table-spacer {
+  margin-bottom: 0.5rem;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.warning-panel {
+  margin-bottom: 1rem;
+  border: 1px solid #facc15;
+  border-radius: 0.25rem;
+  background: #fef9c3;
+  padding: 0.5rem;
+}
+
+.code-block {
+  overflow: auto;
+  border-radius: 0.25rem;
+  background: #f3f4f6;
+  padding: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.router-root {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+
+.page-title {
+  margin-bottom: 0.25rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.disabled-button:disabled {
+  color: #6b7280;
+  cursor: not-allowed;
+}
+
+.pagination-controls {
+  margin-block: 0.5rem;
+}
+
+.column-size-input {
+  width: 6rem;
+  margin-left: 0.5rem;
+  border: 1px solid currentColor;
+  border-radius: 0.25rem;
+  padding: 0.25rem;
+}
+
+.form-status {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.875rem;
+}
+
+.centered-button-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.split-gap {
+  gap: 1rem;
+}
+
+.demo-link {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.capitalized-text {
+  text-transform: capitalize;
+}
+
+.centered-text {
+  text-align: center;
+}
+
+.centered-strong-text {
+  text-align: center;
+  font-weight: 600;
+}
+
+.virtualized-title {
+  text-align: center;
+  font-size: 1.875rem;
+  font-weight: 700;
+}

--- a/examples/react/basic-subscribe/src/main.tsx
+++ b/examples/react/basic-subscribe/src/main.tsx
@@ -1,0 +1,489 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import {
+  Subscribe,
+  columnFilteringFeature,
+  createColumnHelper,
+  createFilteredRowModel,
+  createPaginatedRowModel,
+  filterFns,
+  globalFilteringFeature,
+  rowPaginationFeature,
+  rowSelectionFeature,
+  tableFeatures,
+  useTable,
+} from '@tanstack/react-table'
+import {
+  tableDevtoolsPlugin,
+  useTanStackTableDevtools,
+} from '@tanstack/react-table-devtools'
+import { TanStackDevtools } from '@tanstack/react-devtools'
+import { useCreateAtom } from '@tanstack/react-store'
+import { makeData } from './makeData'
+import type { HTMLProps } from 'react'
+import type { Person } from './makeData'
+import type {
+  Column,
+  ReactTable,
+  RowSelectionState,
+} from '@tanstack/react-table'
+import './index.css'
+
+const _features = tableFeatures({
+  rowPaginationFeature,
+  rowSelectionFeature,
+  columnFilteringFeature,
+  globalFilteringFeature,
+})
+
+const columnHelper = createColumnHelper<typeof _features, Person>()
+
+/**
+ * This is an example showing how to use advanced re-rendering optimizations with more fine-grained control over what is subscribed to.
+ * Subscribe/table.Subscribe is a higher-order component that allows you to subscribe to the table state or individual atoms/stores.
+ * This is useful for making sure that re-renders only happen at certain parts of the react tree exactly where need to be.
+ * We recommend only using these patterns when you run into specific performance issues.
+ */
+function App() {
+  const rerender = React.useReducer(() => ({}), {})[1]
+
+  const columns = React.useMemo(
+    () =>
+      columnHelper.columns([
+        columnHelper.display({
+          id: 'select',
+          header: ({ table }) => {
+            return (
+              // just import Subscribe component if "react" table is not available in scope and pass in the table store as source
+              <Subscribe
+                source={table.store}
+                // It can be difficult to know what to subscribe to, unless you understand everything that can be a state dependency for internal APIs
+                // Be careful to test and validate that it re-renders when you expect it to
+                selector={(state) => ({
+                  columnFilters: state.columnFilters,
+                  globalFilter: state.globalFilter,
+                  rowSelection: state.rowSelection,
+                })}
+              >
+                {() => (
+                  <IndeterminateCheckbox
+                    checked={table.getIsAllRowsSelected()}
+                    indeterminate={table.getIsSomeRowsSelected()}
+                    onChange={table.getToggleAllRowsSelectedHandler()}
+                  />
+                )}
+              </Subscribe>
+            )
+          },
+          cell: ({ row }) => (
+            <Subscribe
+              source={table.atoms.rowSelection} // optimize to subscribe only to the row selection atom
+              selector={(rowSelection) => rowSelection[row.id]} // optimize to only re-render when the row selection changes for this row
+            >
+              {(isRowSelected) => (
+                <div className="column-toggle-row">
+                  {/* Select only this row's selection value so toggling one row only re-renders that row's checkbox. */}
+                  <IndeterminateCheckbox
+                    checked={!!isRowSelected}
+                    disabled={!row.getCanSelect()}
+                    indeterminate={row.getIsSomeSelected()}
+                    onChange={row.getToggleSelectedHandler()}
+                  />
+                </div>
+              )}
+            </Subscribe>
+          ),
+        }),
+        columnHelper.accessor('firstName', {
+          header: 'First Name',
+          cell: (info) => info.getValue(),
+          footer: (props) => props.column.id,
+        }),
+        columnHelper.accessor((row) => row.lastName, {
+          id: 'lastName',
+          header: () => <span>Last Name</span>,
+          cell: (info) => info.getValue(),
+          footer: (props) => props.column.id,
+        }),
+        columnHelper.accessor('age', {
+          header: () => 'Age',
+          footer: (props) => props.column.id,
+        }),
+        columnHelper.accessor('visits', {
+          header: () => <span>Visits</span>,
+          footer: (props) => props.column.id,
+        }),
+        columnHelper.accessor('status', {
+          header: 'Status',
+          footer: (props) => props.column.id,
+        }),
+        columnHelper.accessor('progress', {
+          header: 'Profile Progress',
+          footer: (props) => props.column.id,
+        }),
+      ]),
+    [],
+  )
+
+  const [data, setData] = React.useState(() => makeData(1_000))
+  const refreshData = () => setData(makeData(1_000))
+  const stressTest = () => setData(makeData(200_000))
+
+  // optionally, raise the selection state to your own atom
+  const rowSelectionAtom = useCreateAtom<RowSelectionState>({})
+
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel(filterFns),
+        paginatedRowModel: createPaginatedRowModel(),
+      },
+      atoms: {
+        rowSelection: rowSelectionAtom,
+      },
+      columns,
+      data,
+      getRowId: (row) => row.id,
+      enableRowSelection: true, // enable row selection for all rows
+      // enableRowSelection: row => row.original.age > 18, // or enable row selection conditionally per row
+      debugTable: true,
+    },
+    () => null, // subscribe to no table state by default; use table.Subscribe below for targeted updates
+  )
+
+  useTanStackTableDevtools(table, 'Basic Subscribe Example')
+
+  return (
+    <div className="demo-root">
+      <div>
+        <button
+          className="demo-button demo-button-spaced"
+          onClick={() => refreshData()}
+        >
+          Regenerate Data
+        </button>
+        <button
+          className="demo-button demo-button-spaced"
+          onClick={() => stressTest()}
+        >
+          Stress Test (200k rows)
+        </button>
+      </div>
+      <div>
+        <table.Subscribe source={table.atoms.globalFilter}>
+          {(globalFilter) => (
+            <DebouncedInput
+              value={globalFilter ?? ''}
+              onChange={(value) => table.setGlobalFilter(value)}
+              className="summary-panel"
+              placeholder="Search all columns..."
+            />
+          )}
+        </table.Subscribe>
+      </div>
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <>
+                        <table.FlexRender header={header} />
+                        {header.column.getCanFilter() ? (
+                          <div>
+                            <Filter column={header.column} table={table} />
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                  </th>
+                )
+              })}
+            </tr>
+          ))}
+        </thead>
+        {/* Subscribe the row model to filtering and pagination only. Row selection is handled per row below. */}
+        <table.Subscribe
+          selector={(state) => ({
+            columnFilters: state.columnFilters,
+            globalFilter: state.globalFilter,
+            pagination: state.pagination,
+          })}
+        >
+          {() => (
+            <>
+              <tbody>
+                {table.getRowModel().rows.map((row) => {
+                  return (
+                    <tr key={row.id}>
+                      {row.getAllCells().map((cell) => {
+                        return (
+                          <td key={cell.id}>
+                            <table.FlexRender cell={cell} />
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  )
+                })}
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td className="cell-padding">
+                    <table.Subscribe source={table.atoms.rowSelection}>
+                      {() => (
+                        <IndeterminateCheckbox
+                          checked={table.getIsAllPageRowsSelected()}
+                          indeterminate={table.getIsSomePageRowsSelected()}
+                          onChange={table.getToggleAllPageRowsSelectedHandler()}
+                        />
+                      )}
+                    </table.Subscribe>
+                  </td>
+                  <td colSpan={20}>
+                    Page Rows (
+                    {table.getRowModel().rows.length.toLocaleString()})
+                  </td>
+                </tr>
+              </tfoot>
+            </>
+          )}
+        </table.Subscribe>
+      </table>
+      <div className="spacer-sm" />
+      <table.Subscribe
+        selector={(state) => ({
+          columnFilters: state.columnFilters,
+          globalFilter: state.globalFilter,
+          pagination: state.pagination,
+        })}
+      >
+        {({ pagination }) => (
+          <div className="controls">
+            <button
+              className="demo-button demo-button-sm"
+              onClick={() => table.setPageIndex(0)}
+              disabled={!table.getCanPreviousPage()}
+            >
+              {'<<'}
+            </button>
+            <button
+              className="demo-button demo-button-sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              {'<'}
+            </button>
+            <button
+              className="demo-button demo-button-sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              {'>'}
+            </button>
+            <button
+              className="demo-button demo-button-sm"
+              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+              disabled={!table.getCanNextPage()}
+            >
+              {'>>'}
+            </button>
+            <span className="inline-controls">
+              <div>Page</div>
+              <strong>
+                {(pagination.pageIndex + 1).toLocaleString()} of{' '}
+                {table.getPageCount().toLocaleString()}
+              </strong>
+            </span>
+            <span className="inline-controls">
+              | Go to page:
+              <input
+                type="number"
+                min="1"
+                max={table.getPageCount()}
+                defaultValue={pagination.pageIndex + 1}
+                onChange={(e) => {
+                  const page = e.target.value ? Number(e.target.value) - 1 : 0
+                  table.setPageIndex(page)
+                }}
+                className="page-size-input"
+              />
+            </span>
+            <select
+              value={pagination.pageSize}
+              onChange={(e) => {
+                table.setPageSize(Number(e.target.value))
+              }}
+            >
+              {[10, 20, 30, 40, 50].map((pageSize) => (
+                <option key={pageSize} value={pageSize}>
+                  Show {pageSize}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </table.Subscribe>
+      <br />
+      <table.Subscribe source={table.atoms.rowSelection}>
+        {(rowSelection) => (
+          <div>
+            <>{Object.keys(rowSelection).length.toLocaleString()} of </>
+            {table.getPreFilteredRowModel().rows.length.toLocaleString()} Total
+            Rows Selected
+          </div>
+        )}
+      </table.Subscribe>
+      <hr />
+      <br />
+      <div>
+        <button
+          className="demo-button demo-button-spaced"
+          onClick={() => rerender()}
+        >
+          Force Rerender
+        </button>
+      </div>
+      <div>
+        <button
+          className="demo-button demo-button-spaced"
+          onClick={() =>
+            console.info(
+              'table.getSelectedRowModel().flatRows',
+              table.getSelectedRowModel().flatRows,
+            )
+          }
+        >
+          Log table.getSelectedRowModel().flatRows
+        </button>
+      </div>
+      <div>
+        <label>Table State:</label>
+        {/* subscribe to the entire table state */}
+        <table.Subscribe selector={(state) => state}>
+          {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
+        </table.Subscribe>
+      </div>
+    </div>
+  )
+}
+
+function Filter({
+  column,
+  table,
+}: {
+  column: Column<typeof _features, Person>
+  table: ReactTable<typeof _features, Person, null>
+}) {
+  const firstValue = table
+    .getPreFilteredRowModel()
+    .flatRows[0]?.getValue(column.id)
+
+  return (
+    <table.Subscribe source={table.atoms.columnFilters}>
+      {() =>
+        typeof firstValue === 'number' ? (
+          <div className="filter-row">
+            <DebouncedInput
+              type="number"
+              value={((column.getFilterValue() as any)?.[0] ?? '') as string}
+              onChange={(value) =>
+                column.setFilterValue((old: any) => [value, old?.[1]])
+              }
+              placeholder={`Min`}
+              className="filter-input"
+            />
+            <DebouncedInput
+              type="number"
+              value={((column.getFilterValue() as any)?.[1] ?? '') as string}
+              onChange={(value) =>
+                column.setFilterValue((old: any) => [old?.[0], value])
+              }
+              placeholder={`Max`}
+              className="filter-input"
+            />
+          </div>
+        ) : (
+          <DebouncedInput
+            type="text"
+            value={(column.getFilterValue() ?? '') as string}
+            onChange={(value) => column.setFilterValue(value)}
+            placeholder={`Search...`}
+            className="filter-select"
+          />
+        )
+      }
+    </table.Subscribe>
+  )
+}
+
+// A debounced input react component
+function DebouncedInput({
+  value: initialValue,
+  onChange,
+  debounce = 500,
+  ...props
+}: {
+  value: string | number
+  onChange: (value: string | number) => void
+  debounce?: number
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>) {
+  const [value, setValue] = React.useState(initialValue)
+
+  React.useEffect(() => {
+    setValue(initialValue)
+  }, [initialValue])
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => {
+      onChange(value)
+    }, debounce)
+
+    return () => clearTimeout(timeout)
+  }, [value])
+
+  return (
+    <input
+      {...props}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  )
+}
+
+function IndeterminateCheckbox({
+  indeterminate,
+  className = '',
+  ...rest
+}: { indeterminate?: boolean } & HTMLProps<HTMLInputElement>) {
+  const ref = React.useRef<HTMLInputElement>(null!)
+
+  React.useEffect(() => {
+    if (typeof indeterminate === 'boolean') {
+      ref.current.indeterminate = !rest.checked && indeterminate
+    }
+  }, [ref, indeterminate])
+
+  return (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={className + ' sortable-header'}
+      {...rest}
+    />
+  )
+}
+
+const rootElement = document.getElementById('root')
+if (!rootElement) throw new Error('Failed to find the root element')
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+    <TanStackDevtools plugins={[tableDevtoolsPlugin()]} />
+  </React.StrictMode>,
+)

--- a/examples/react/basic-subscribe/src/makeData.ts
+++ b/examples/react/basic-subscribe/src/makeData.ts
@@ -1,0 +1,50 @@
+import { faker } from '@faker-js/faker'
+
+export type Person = {
+  id: string
+  firstName: string
+  lastName: string
+  age: number
+  visits: number
+  progress: number
+  status: 'relationship' | 'complicated' | 'single'
+  subRows?: Array<Person>
+}
+
+const range = (len: number) => {
+  const arr: Array<number> = []
+  for (let i = 0; i < len; i++) {
+    arr.push(i)
+  }
+  return arr
+}
+
+const newPerson = (): Person => {
+  return {
+    id: faker.string.uuid(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    age: faker.number.int(40),
+    visits: faker.number.int(1000),
+    progress: faker.number.int(100),
+    status: faker.helpers.shuffle<Person['status']>([
+      'relationship',
+      'complicated',
+      'single',
+    ])[0],
+  }
+}
+
+export function makeData(...lens: Array<number>) {
+  const makeDataLevel = (depth = 0): Array<Person> => {
+    const len = lens[depth]
+    return range(len).map((_d): Person => {
+      return {
+        ...newPerson(),
+        subRows: lens[depth + 1] ? makeDataLevel(depth + 1) : undefined,
+      }
+    })
+  }
+
+  return makeDataLevel()
+}

--- a/examples/react/basic-subscribe/src/vite-env.d.ts
+++ b/examples/react/basic-subscribe/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/react/basic-subscribe/tsconfig.json
+++ b/examples/react/basic-subscribe/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowJs": true
+  },
+  "include": ["src", "vite.config.js", "vite.config.ts"]
+}

--- a/examples/react/basic-subscribe/vite.config.js
+++ b/examples/react/basic-subscribe/vite.config.js
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite'
+import react, { reactCompilerPreset } from '@vitejs/plugin-react'
+import babel from '@rolldown/plugin-babel'
+import rollupReplace from '@rollup/plugin-replace'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    rollupReplace({
+      preventAssignment: true,
+      values: {
+        __DEV__: JSON.stringify(true),
+        'process.env.NODE_ENV': JSON.stringify('development'),
+      },
+    }),
+    react(),
+    // React Compiler - comment out the next line to disable
+    babel({
+      presets: [reactCompilerPreset()],
+      include: [/\/src\/.*\.[jt]sx?$/],
+    }),
+  ],
+})

--- a/examples/react/basic-use-app-table/src/main.tsx
+++ b/examples/react/basic-use-app-table/src/main.tsx
@@ -103,12 +103,15 @@ function App() {
 
   // 7. Create the table instance with the required columns and data.
   // Features and row models are already defined in the createTableHook call above
-  const table = useAppTable({
-    debugTable: true,
-    columns,
-    data,
-    // add additional table options here or in the createTableHook call above
-  })
+  const table = useAppTable(
+    {
+      debugTable: true,
+      columns,
+      data,
+      // add additional table options here or in the createTableHook call above
+    },
+    (state) => state, // default selector
+  )
 
   // 8. Render your table markup from the table instance APIs
   return (

--- a/examples/react/basic-use-table/src/main.tsx
+++ b/examples/react/basic-use-table/src/main.tsx
@@ -96,14 +96,17 @@ function App() {
   const rerender = React.useReducer(() => ({}), {})[1]
 
   // 6. Create the table instance with required _features, columns, and data
-  const table = useTable({
-    debugTable: true,
-    _features, // new required option in V9. Tell the table which features you are importing and using (better tree-shaking)
-    _rowModels: {}, // `Core` row model is now included by default, but you can still override it here
-    columns,
-    data,
-    // add additional table options here
-  })
+  const table = useTable(
+    {
+      debugTable: true,
+      _features, // new required option in V9. Tell the table which features you are importing and using (better tree-shaking)
+      _rowModels: {}, // `Core` row model is now included by default, but you can still override it here
+      columns,
+      data,
+      // add additional table options here
+    },
+    (state) => state, // default selector
+  )
 
   // 7. Render your table markup from the table instance APIs
   return (

--- a/examples/react/column-dnd/src/main.tsx
+++ b/examples/react/column-dnd/src/main.tsx
@@ -146,7 +146,7 @@ function App() {
         columnOrder: columns.map((c) => c.id!),
       },
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   // reorder columns after drag & drop
@@ -223,9 +223,7 @@ function App() {
             ))}
           </tbody>
         </table>
-        <table.Subscribe selector={(state) => state}>
-          {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-        </table.Subscribe>
+        <pre>{JSON.stringify(table.state, null, 2)}</pre>
       </div>
     </DndContext>
   )

--- a/examples/react/column-groups/src/main.tsx
+++ b/examples/react/column-groups/src/main.tsx
@@ -66,13 +66,16 @@ function App() {
   const stressTest = () => setData(makeData(1_000))
   const rerender = React.useReducer(() => ({}), {})[1]
 
-  const table = useTable({
-    debugTable: true,
-    _features,
-    _rowModels: {},
-    columns,
-    data,
-  })
+  const table = useTable(
+    {
+      debugTable: true,
+      _features,
+      _rowModels: {},
+      columns,
+      data,
+    },
+    (state) => state, // default selector
+  )
 
   return (
     <div className="demo-root">

--- a/examples/react/column-ordering/src/main.tsx
+++ b/examples/react/column-ordering/src/main.tsx
@@ -72,15 +72,18 @@ function App() {
   const refreshData = () => setData(makeData(20))
   const stressTest = () => setData(makeData(1_000))
 
-  const table = useTable({
-    _features,
-    _rowModels: {},
-    columns,
-    data,
-    debugTable: true,
-    debugHeaders: true,
-    debugColumns: true,
-  })
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {},
+      columns,
+      data,
+      debugTable: true,
+      debugHeaders: true,
+      debugColumns: true,
+    },
+    (state) => state, // default selector
+  )
 
   const randomizeColumns = () => {
     table.setColumnOrder(
@@ -89,108 +92,96 @@ function App() {
   }
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        // subscribe to only the column order and visibility state changes at root level
-        columnOrder: state.columnOrder,
-        columnVisibility: state.columnVisibility,
-      })}
-    >
-      {(_state) => (
-        <div className="demo-root">
-          <div className="column-toggle-panel">
-            <div className="column-toggle-panel-header">
+    <div className="demo-root">
+      <div className="column-toggle-panel">
+        <div className="column-toggle-panel-header">
+          <label>
+            <input
+              type="checkbox"
+              checked={table.getIsAllColumnsVisible()}
+              onChange={table.getToggleAllColumnsVisibilityHandler()}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map((column) => {
+          return (
+            <div key={column.id} className="column-toggle-row">
               <label>
                 <input
                   type="checkbox"
-                  checked={table.getIsAllColumnsVisible()}
-                  onChange={table.getToggleAllColumnsVisibilityHandler()}
+                  checked={column.getIsVisible()}
+                  onChange={column.getToggleVisibilityHandler()}
                 />{' '}
-                Toggle All
+                {column.id}
               </label>
             </div>
-            {table.getAllLeafColumns().map((column) => {
-              return (
-                <div key={column.id} className="column-toggle-row">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                    />{' '}
-                    {column.id}
-                  </label>
-                </div>
-              )
-            })}
-          </div>
-          <div className="spacer-md" />
-          <div className="button-row">
-            <button
-              onClick={() => refreshData()}
-              className="demo-button demo-button-sm"
-            >
-              Regenerate Data
-            </button>
-            <button
-              onClick={() => stressTest()}
-              className="demo-button demo-button-sm"
-            >
-              Stress Test (1k rows)
-            </button>
-            <button
-              onClick={() => randomizeColumns()}
-              className="demo-button demo-button-sm"
-            >
-              Shuffle Columns
-            </button>
-          </div>
-          <div className="spacer-md" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <th key={header.id} colSpan={header.colSpan}>
-                      {header.isPlaceholder ? null : (
-                        <table.FlexRender header={header} />
-                      )}
-                    </th>
-                  ))}
-                </tr>
+          )
+        })}
+      </div>
+      <div className="spacer-md" />
+      <div className="button-row">
+        <button
+          onClick={() => refreshData()}
+          className="demo-button demo-button-sm"
+        >
+          Regenerate Data
+        </button>
+        <button
+          onClick={() => stressTest()}
+          className="demo-button demo-button-sm"
+        >
+          Stress Test (1k rows)
+        </button>
+        <button
+          onClick={() => randomizeColumns()}
+          className="demo-button demo-button-sm"
+        >
+          Shuffle Columns
+        </button>
+      </div>
+      <div className="spacer-md" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : (
+                    <table.FlexRender header={header} />
+                  )}
+                </th>
               ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => (
-                <tr key={row.id}>
-                  {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id}>
-                      <table.FlexRender cell={cell} />
-                    </td>
-                  ))}
-                </tr>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>
+                  <table.FlexRender cell={cell} />
+                </td>
               ))}
-            </tbody>
-            <tfoot>
-              {table.getFooterGroups().map((footerGroup) => (
-                <tr key={footerGroup.id}>
-                  {footerGroup.headers.map((header) => (
-                    <th key={header.id} colSpan={header.colSpan}>
-                      {header.isPlaceholder ? null : (
-                        <table.FlexRender footer={header} />
-                      )}
-                    </th>
-                  ))}
-                </tr>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          {table.getFooterGroups().map((footerGroup) => (
+            <tr key={footerGroup.id}>
+              {footerGroup.headers.map((header) => (
+                <th key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : (
+                    <table.FlexRender footer={header} />
+                  )}
+                </th>
               ))}
-            </tfoot>
-          </table>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </tfoot>
+      </table>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/column-pinning-split/src/main.tsx
+++ b/examples/react/column-pinning-split/src/main.tsx
@@ -78,15 +78,18 @@ function App() {
   const refreshData = () => setData(makeData(1_000))
   const stressTest = () => setData(makeData(500_000))
 
-  const table = useTable({
-    _features,
-    _rowModels: {},
-    columns,
-    data,
-    debugTable: true,
-    debugHeaders: true,
-    debugColumns: true,
-  })
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {},
+      columns,
+      data,
+      debugTable: true,
+      debugHeaders: true,
+      debugColumns: true,
+    },
+    (state) => state, // default selector
+  )
 
   const randomizeColumns = () => {
     table.setColumnOrder(
@@ -95,282 +98,270 @@ function App() {
   }
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnVisibility: state.columnVisibility,
-        columnOrder: state.columnOrder,
-        columnPinning: state.columnPinning,
-      })}
-    >
-      {(_state) => (
-        <div className="demo-root">
-          <div className="column-toggle-panel">
-            <div className="column-toggle-panel-header">
+    <div className="demo-root">
+      <div className="column-toggle-panel">
+        <div className="column-toggle-panel-header">
+          <label>
+            <input
+              type="checkbox"
+              checked={table.getIsAllColumnsVisible()}
+              onChange={table.getToggleAllColumnsVisibilityHandler()}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map((column) => {
+          return (
+            <div key={column.id} className="column-toggle-row">
               <label>
                 <input
                   type="checkbox"
-                  checked={table.getIsAllColumnsVisible()}
-                  onChange={table.getToggleAllColumnsVisibilityHandler()}
+                  checked={column.getIsVisible()}
+                  onChange={column.getToggleVisibilityHandler()}
                 />{' '}
-                Toggle All
+                {column.id}
               </label>
             </div>
-            {table.getAllLeafColumns().map((column) => {
-              return (
-                <div key={column.id} className="column-toggle-row">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                    />{' '}
-                    {column.id}
-                  </label>
-                </div>
-              )
-            })}
-          </div>
-          <div className="spacer-md" />
-          <div className="button-row">
-            <button
-              onClick={() => refreshData()}
-              className="demo-button demo-button-sm"
-            >
-              Regenerate Data
-            </button>
-            <button
-              onClick={() => stressTest()}
-              className="demo-button demo-button-sm"
-            >
-              Stress Test (500k rows)
-            </button>
-            <button
-              onClick={() => randomizeColumns()}
-              className="demo-button demo-button-sm"
-            >
-              Shuffle Columns
-            </button>
-          </div>
-          <div className="spacer-md" />
-          <p className="demo-note">
-            This example takes advantage of the "splitting" APIs. (APIs that
-            have "left, "center", and "right" modifiers)
-          </p>
-          <div className="split-tables">
-            <table className="outlined-table">
-              <thead>
-                {table.getLeftHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        <div className="nowrap">
-                          {header.isPlaceholder ? null : (
-                            <table.FlexRender header={header} />
-                          )}
-                        </div>
-                        {!header.isPlaceholder && header.column.getCanPin() && (
-                          <div className="pin-actions">
-                            {header.column.getIsPinned() !== 'left' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('left')
-                                }}
-                              >
-                                {'<='}
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin(false)
-                                }}
-                              >
-                                X
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() !== 'right' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('right')
-                                }}
-                              >
-                                {'=>'}
-                              </button>
-                            ) : null}
-                          </div>
-                        )}
-                      </th>
-                    ))}
-                  </tr>
+          )
+        })}
+      </div>
+      <div className="spacer-md" />
+      <div className="button-row">
+        <button
+          onClick={() => refreshData()}
+          className="demo-button demo-button-sm"
+        >
+          Regenerate Data
+        </button>
+        <button
+          onClick={() => stressTest()}
+          className="demo-button demo-button-sm"
+        >
+          Stress Test (500k rows)
+        </button>
+        <button
+          onClick={() => randomizeColumns()}
+          className="demo-button demo-button-sm"
+        >
+          Shuffle Columns
+        </button>
+      </div>
+      <div className="spacer-md" />
+      <p className="demo-note">
+        This example takes advantage of the "splitting" APIs. (APIs that have
+        "left, "center", and "right" modifiers)
+      </p>
+      <div className="split-tables">
+        <table className="outlined-table">
+          <thead>
+            {table.getLeftHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    <div className="nowrap">
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </div>
+                    {!header.isPlaceholder && header.column.getCanPin() && (
+                      <div className="pin-actions">
+                        {header.column.getIsPinned() !== 'left' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('left')
+                            }}
+                          >
+                            {'<='}
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin(false)
+                            }}
+                          >
+                            X
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() !== 'right' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('right')
+                            }}
+                          >
+                            {'=>'}
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                  </th>
                 ))}
-              </thead>
-              <tbody>
-                {table
-                  .getRowModel()
-                  .rows.slice(0, 20)
-                  .map((row) => {
-                    return (
-                      <tr key={row.id}>
-                        {row.getLeftVisibleCells().map((cell) => {
-                          return (
-                            <td key={cell.id}>
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )
-                        })}
-                      </tr>
-                    )
-                  })}
-              </tbody>
-            </table>
-            <table className="outlined-table">
-              <thead>
-                {table.getCenterHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        <div className="nowrap">
-                          {header.isPlaceholder ? null : (
-                            <table.FlexRender header={header} />
-                          )}
-                        </div>
-                        {!header.isPlaceholder && header.column.getCanPin() && (
-                          <div className="pin-actions">
-                            {header.column.getIsPinned() !== 'left' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('left')
-                                }}
-                              >
-                                {'<='}
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin(false)
-                                }}
-                              >
-                                X
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() !== 'right' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('right')
-                                }}
-                              >
-                                {'=>'}
-                              </button>
-                            ) : null}
-                          </div>
-                        )}
-                      </th>
-                    ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table
+              .getRowModel()
+              .rows.slice(0, 20)
+              .map((row) => {
+                return (
+                  <tr key={row.id}>
+                    {row.getLeftVisibleCells().map((cell) => {
+                      return (
+                        <td key={cell.id}>
+                          <table.FlexRender cell={cell} />
+                        </td>
+                      )
+                    })}
                   </tr>
+                )
+              })}
+          </tbody>
+        </table>
+        <table className="outlined-table">
+          <thead>
+            {table.getCenterHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    <div className="nowrap">
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </div>
+                    {!header.isPlaceholder && header.column.getCanPin() && (
+                      <div className="pin-actions">
+                        {header.column.getIsPinned() !== 'left' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('left')
+                            }}
+                          >
+                            {'<='}
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin(false)
+                            }}
+                          >
+                            X
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() !== 'right' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('right')
+                            }}
+                          >
+                            {'=>'}
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                  </th>
                 ))}
-              </thead>
-              <tbody>
-                {table
-                  .getRowModel()
-                  .rows.slice(0, 20)
-                  .map((row) => {
-                    return (
-                      <tr key={row.id}>
-                        {row.getCenterVisibleCells().map((cell) => {
-                          return (
-                            <td key={cell.id}>
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )
-                        })}
-                      </tr>
-                    )
-                  })}
-              </tbody>
-            </table>
-            <table className="outlined-table">
-              <thead>
-                {table.getRightHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        <div className="nowrap">
-                          {header.isPlaceholder ? null : (
-                            <table.FlexRender header={header} />
-                          )}
-                        </div>
-                        {!header.isPlaceholder && header.column.getCanPin() && (
-                          <div className="pin-actions">
-                            {header.column.getIsPinned() !== 'left' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('left')
-                                }}
-                              >
-                                {'<='}
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin(false)
-                                }}
-                              >
-                                X
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() !== 'right' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('right')
-                                }}
-                              >
-                                {'=>'}
-                              </button>
-                            ) : null}
-                          </div>
-                        )}
-                      </th>
-                    ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table
+              .getRowModel()
+              .rows.slice(0, 20)
+              .map((row) => {
+                return (
+                  <tr key={row.id}>
+                    {row.getCenterVisibleCells().map((cell) => {
+                      return (
+                        <td key={cell.id}>
+                          <table.FlexRender cell={cell} />
+                        </td>
+                      )
+                    })}
                   </tr>
+                )
+              })}
+          </tbody>
+        </table>
+        <table className="outlined-table">
+          <thead>
+            {table.getRightHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    <div className="nowrap">
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </div>
+                    {!header.isPlaceholder && header.column.getCanPin() && (
+                      <div className="pin-actions">
+                        {header.column.getIsPinned() !== 'left' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('left')
+                            }}
+                          >
+                            {'<='}
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin(false)
+                            }}
+                          >
+                            X
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() !== 'right' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('right')
+                            }}
+                          >
+                            {'=>'}
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                  </th>
                 ))}
-              </thead>
-              <tbody>
-                {table
-                  .getRowModel()
-                  .rows.slice(0, 20)
-                  .map((row) => {
-                    return (
-                      <tr key={row.id}>
-                        {row.getRightVisibleCells().map((cell) => {
-                          return (
-                            <td key={cell.id}>
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )
-                        })}
-                      </tr>
-                    )
-                  })}
-              </tbody>
-            </table>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table
+              .getRowModel()
+              .rows.slice(0, 20)
+              .map((row) => {
+                return (
+                  <tr key={row.id}>
+                    {row.getRightVisibleCells().map((cell) => {
+                      return (
+                        <td key={cell.id}>
+                          <table.FlexRender cell={cell} />
+                        </td>
+                      )
+                    })}
+                  </tr>
+                )
+              })}
+          </tbody>
+        </table>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/column-pinning-sticky/src/main.tsx
+++ b/examples/react/column-pinning-sticky/src/main.tsx
@@ -116,7 +116,7 @@ function App() {
       debugColumns: true,
       columnResizeMode: 'onChange',
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   const randomizeColumns = () => {
@@ -126,196 +126,153 @@ function App() {
   }
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnVisibility: state.columnVisibility,
-        columnOrder: state.columnOrder,
-        columnPinning: state.columnPinning,
-        columnSizing: state.columnSizing,
-        columnResizing: state.columnResizing,
-      })}
-    >
-      {(_topLevelState) => (
-        <div className="demo-root">
-          <div className="column-toggle-panel">
-            <div className="column-toggle-panel-header">
+    <div className="demo-root">
+      <div className="column-toggle-panel">
+        <div className="column-toggle-panel-header">
+          <label>
+            <input
+              type="checkbox"
+              checked={table.getIsAllColumnsVisible()}
+              onChange={table.getToggleAllColumnsVisibilityHandler()}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map((column) => {
+          return (
+            <div key={column.id} className="column-toggle-row">
               <label>
                 <input
                   type="checkbox"
-                  checked={table.getIsAllColumnsVisible()}
-                  onChange={table.getToggleAllColumnsVisibilityHandler()}
+                  checked={column.getIsVisible()}
+                  onChange={column.getToggleVisibilityHandler()}
                 />{' '}
-                Toggle All
+                {column.id}
               </label>
             </div>
-            {table.getAllLeafColumns().map((column) => {
-              return (
-                <div key={column.id} className="column-toggle-row">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                    />{' '}
-                    {column.id}
-                  </label>
-                </div>
-              )
-            })}
-          </div>
-          <div className="spacer-md" />
-          <div className="button-row">
-            <button
-              onClick={() => refreshData()}
-              className="demo-button demo-button-sm"
-            >
-              Regenerate Data
-            </button>
-            <button
-              onClick={() => stressTest()}
-              className="demo-button demo-button-sm"
-            >
-              Stress Test (1k rows)
-            </button>
-            <button
-              onClick={() => randomizeColumns()}
-              className="demo-button demo-button-sm"
-            >
-              Shuffle Columns
-            </button>
-          </div>
-          <div className="spacer-md" />
-          <div className="table-container">
-            <table
-              style={{
-                width: table.getTotalSize(),
-              }}
-            >
-              <thead>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => {
-                      const { column } = header
+          )
+        })}
+      </div>
+      <div className="spacer-md" />
+      <div className="button-row">
+        <button
+          onClick={() => refreshData()}
+          className="demo-button demo-button-sm"
+        >
+          Regenerate Data
+        </button>
+        <button
+          onClick={() => stressTest()}
+          className="demo-button demo-button-sm"
+        >
+          Stress Test (1k rows)
+        </button>
+        <button
+          onClick={() => randomizeColumns()}
+          className="demo-button demo-button-sm"
+        >
+          Shuffle Columns
+        </button>
+      </div>
+      <div className="spacer-md" />
+      <div className="table-container">
+        <table
+          style={{
+            width: table.getTotalSize(),
+          }}
+        >
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  const { column } = header
 
-                      return (
-                        <table.Subscribe
-                          // subscribe only to the column resizing and sizing state changes
-                          selector={(state) => ({
-                            isResizingColumn:
-                              state.columnResizing.isResizingColumn ===
-                              column.id,
-                            columnSize: state.columnSizing[column.id],
-                          })}
-                        >
-                          {() => (
-                            <th
-                              key={header.id}
-                              colSpan={header.colSpan}
-                              // IMPORTANT: This is where the magic happens!
-                              style={{ ...getCommonPinningStyles(column) }}
+                  return (
+                    <th
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      // IMPORTANT: This is where the magic happens!
+                      style={{ ...getCommonPinningStyles(column) }}
+                    >
+                      <div className="nowrap">
+                        {header.isPlaceholder ? null : (
+                          <>
+                            <table.FlexRender header={header} />{' '}
+                          </>
+                        )}
+                        {/* Demo getIndex behavior */}
+                        {column.getIndex(column.getIsPinned() || 'center')}
+                      </div>
+                      {!header.isPlaceholder && header.column.getCanPin() && (
+                        <div className="pin-actions">
+                          {header.column.getIsPinned() !== 'left' ? (
+                            <button
+                              className="pin-button"
+                              onClick={() => {
+                                header.column.pin('left')
+                              }}
                             >
-                              <div className="nowrap">
-                                {header.isPlaceholder ? null : (
-                                  <>
-                                    <table.FlexRender header={header} />{' '}
-                                  </>
-                                )}
-                                {/* Demo getIndex behavior */}
-                                {column.getIndex(
-                                  column.getIsPinned() || 'center',
-                                )}
-                              </div>
-                              {!header.isPlaceholder &&
-                                header.column.getCanPin() && (
-                                  <div className="pin-actions">
-                                    {header.column.getIsPinned() !== 'left' ? (
-                                      <button
-                                        className="pin-button"
-                                        onClick={() => {
-                                          header.column.pin('left')
-                                        }}
-                                      >
-                                        {'<='}
-                                      </button>
-                                    ) : null}
-                                    {header.column.getIsPinned() ? (
-                                      <button
-                                        className="pin-button"
-                                        onClick={() => {
-                                          header.column.pin(false)
-                                        }}
-                                      >
-                                        X
-                                      </button>
-                                    ) : null}
-                                    {header.column.getIsPinned() !== 'right' ? (
-                                      <button
-                                        className="pin-button"
-                                        onClick={() => {
-                                          header.column.pin('right')
-                                        }}
-                                      >
-                                        {'=>'}
-                                      </button>
-                                    ) : null}
-                                  </div>
-                                )}
-                              <div
-                                onDoubleClick={() => header.column.resetSize()}
-                                onMouseDown={header.getResizeHandler()}
-                                onTouchStart={header.getResizeHandler()}
-                                className={`resizer ${
-                                  header.column.getIsResizing()
-                                    ? 'isResizing'
-                                    : ''
-                                }`}
-                              />
-                            </th>
-                          )}
-                        </table.Subscribe>
-                      )
-                    })}
-                  </tr>
-                ))}
-              </thead>
-              <tbody>
-                {table.getRowModel().rows.map((row) => (
-                  <tr key={row.id}>
-                    {row.getVisibleCells().map((cell) => {
-                      const { column } = cell
-                      return (
-                        <table.Subscribe
-                          // subscribe only to the column resizing and sizing state changes
-                          selector={(state) => ({
-                            isResizingColumn:
-                              state.columnResizing.isResizingColumn ===
-                              column.id,
-                            columnSize: state.columnSizing[column.id],
-                          })}
-                        >
-                          {() => (
-                            <td
-                              key={cell.id}
-                              // IMPORTANT: This is where the magic happens!
-                              style={{ ...getCommonPinningStyles(column) }}
+                              {'<='}
+                            </button>
+                          ) : null}
+                          {header.column.getIsPinned() ? (
+                            <button
+                              className="pin-button"
+                              onClick={() => {
+                                header.column.pin(false)
+                              }}
                             >
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )}
-                        </table.Subscribe>
-                      )
-                    })}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+                              X
+                            </button>
+                          ) : null}
+                          {header.column.getIsPinned() !== 'right' ? (
+                            <button
+                              className="pin-button"
+                              onClick={() => {
+                                header.column.pin('right')
+                              }}
+                            >
+                              {'=>'}
+                            </button>
+                          ) : null}
+                        </div>
+                      )}
+                      <div
+                        onDoubleClick={() => header.column.resetSize()}
+                        onMouseDown={header.getResizeHandler()}
+                        onTouchStart={header.getResizeHandler()}
+                        className={`resizer ${
+                          header.column.getIsResizing() ? 'isResizing' : ''
+                        }`}
+                      />
+                    </th>
+                  )
+                })}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => {
+                  const { column } = cell
+                  return (
+                    <td
+                      key={cell.id}
+                      // IMPORTANT: This is where the magic happens!
+                      style={{ ...getCommonPinningStyles(column) }}
+                    >
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/column-pinning/src/main.tsx
+++ b/examples/react/column-pinning/src/main.tsx
@@ -80,11 +80,14 @@ function App() {
   const refreshData = () => setData(makeData(1_000))
   const stressTest = () => setData(makeData(500_000))
 
-  const table = useAppTable({
-    debugTable: true,
-    columns,
-    data,
-  })
+  const table = useAppTable(
+    {
+      debugTable: true,
+      columns,
+      data,
+    },
+    (state) => state, // default selector
+  )
 
   const randomizeColumns = () => {
     table.setColumnOrder(
@@ -93,144 +96,132 @@ function App() {
   }
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnVisibility: state.columnVisibility,
-        columnOrder: state.columnOrder,
-        columnPinning: state.columnPinning,
-      })}
-    >
-      {(_state) => (
-        <div className="demo-root">
-          <div className="column-toggle-panel">
-            <div className="column-toggle-panel-header">
+    <div className="demo-root">
+      <div className="column-toggle-panel">
+        <div className="column-toggle-panel-header">
+          <label>
+            <input
+              type="checkbox"
+              checked={table.getIsAllColumnsVisible()}
+              onChange={table.getToggleAllColumnsVisibilityHandler()}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map((column) => {
+          return (
+            <div key={column.id} className="column-toggle-row">
               <label>
                 <input
                   type="checkbox"
-                  checked={table.getIsAllColumnsVisible()}
-                  onChange={table.getToggleAllColumnsVisibilityHandler()}
+                  checked={column.getIsVisible()}
+                  onChange={column.getToggleVisibilityHandler()}
                 />{' '}
-                Toggle All
+                {column.id}
               </label>
             </div>
-            {table.getAllLeafColumns().map((column) => {
-              return (
-                <div key={column.id} className="column-toggle-row">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                    />{' '}
-                    {column.id}
-                  </label>
-                </div>
-              )
-            })}
-          </div>
-          <div className="spacer-md" />
-          <div className="button-row">
-            <button
-              onClick={() => refreshData()}
-              className="demo-button demo-button-sm"
-            >
-              Regenerate Data
-            </button>
-            <button
-              onClick={() => stressTest()}
-              className="demo-button demo-button-sm"
-            >
-              Stress Test (500k rows)
-            </button>
-            <button
-              onClick={() => randomizeColumns()}
-              className="demo-button demo-button-sm"
-            >
-              Shuffle Columns
-            </button>
-          </div>
-          <div className="spacer-md" />
-          <p className="demo-note">
-            This example using the non-split APIs. Columns are just reordered
-            within 1 table instead of being split into 3 different tables.
-          </p>
-          <div className="table-row-group">
-            <table className="outlined-table">
-              <thead>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        <div className="nowrap">
-                          {header.isPlaceholder ? null : (
-                            <table.FlexRender header={header} />
-                          )}
-                        </div>
-                        {!header.isPlaceholder && header.column.getCanPin() && (
-                          <div className="pin-actions">
-                            {header.column.getIsPinned() !== 'left' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('left')
-                                }}
-                              >
-                                {'<='}
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin(false)
-                                }}
-                              >
-                                X
-                              </button>
-                            ) : null}
-                            {header.column.getIsPinned() !== 'right' ? (
-                              <button
-                                className="pin-button"
-                                onClick={() => {
-                                  header.column.pin('right')
-                                }}
-                              >
-                                {'=>'}
-                              </button>
-                            ) : null}
-                          </div>
-                        )}
-                      </th>
-                    ))}
-                  </tr>
+          )
+        })}
+      </div>
+      <div className="spacer-md" />
+      <div className="button-row">
+        <button
+          onClick={() => refreshData()}
+          className="demo-button demo-button-sm"
+        >
+          Regenerate Data
+        </button>
+        <button
+          onClick={() => stressTest()}
+          className="demo-button demo-button-sm"
+        >
+          Stress Test (500k rows)
+        </button>
+        <button
+          onClick={() => randomizeColumns()}
+          className="demo-button demo-button-sm"
+        >
+          Shuffle Columns
+        </button>
+      </div>
+      <div className="spacer-md" />
+      <p className="demo-note">
+        This example using the non-split APIs. Columns are just reordered within
+        1 table instead of being split into 3 different tables.
+      </p>
+      <div className="table-row-group">
+        <table className="outlined-table">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    <div className="nowrap">
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </div>
+                    {!header.isPlaceholder && header.column.getCanPin() && (
+                      <div className="pin-actions">
+                        {header.column.getIsPinned() !== 'left' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('left')
+                            }}
+                          >
+                            {'<='}
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin(false)
+                            }}
+                          >
+                            X
+                          </button>
+                        ) : null}
+                        {header.column.getIsPinned() !== 'right' ? (
+                          <button
+                            className="pin-button"
+                            onClick={() => {
+                              header.column.pin('right')
+                            }}
+                          >
+                            {'=>'}
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                  </th>
                 ))}
-              </thead>
-              <tbody>
-                {table
-                  .getRowModel()
-                  .rows.slice(0, 20)
-                  .map((row) => {
-                    return (
-                      <tr key={row.id}>
-                        {row.getVisibleCells().map((cell) => {
-                          return (
-                            <td key={cell.id}>
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )
-                        })}
-                      </tr>
-                    )
-                  })}
-              </tbody>
-            </table>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table
+              .getRowModel()
+              .rows.slice(0, 20)
+              .map((row) => {
+                return (
+                  <tr key={row.id}>
+                    {row.getVisibleCells().map((cell) => {
+                      return (
+                        <td key={cell.id}>
+                          <table.FlexRender cell={cell} />
+                        </td>
+                      )
+                    })}
+                  </tr>
+                )
+              })}
+          </tbody>
+        </table>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/column-resizing-performant/src/main.tsx
+++ b/examples/react/column-resizing-performant/src/main.tsx
@@ -140,13 +140,9 @@ function App() {
       <button onClick={() => rerender()} className="demo-button">
         Rerender
       </button>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => (
-          <pre style={{ minHeight: '10rem' }}>
-            {JSON.stringify(state, null, 2)}
-          </pre>
-        )}
-      </table.Subscribe>
+      <pre style={{ minHeight: '10rem' }}>
+        {JSON.stringify(table.state, null, 2)}
+      </pre>
       <div className="spacer-md" />({data.length.toLocaleString()} rows)
       <div className="scroll-container">
         {/* Here in the <table> equivalent element (surrounds all table head and data cells), we will define our CSS variables for column sizes */}

--- a/examples/react/column-resizing/src/main.tsx
+++ b/examples/react/column-resizing/src/main.tsx
@@ -90,7 +90,7 @@ function App() {
       debugHeaders: true,
       debugColumns: true,
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   return (
@@ -339,9 +339,7 @@ function App() {
       <button onClick={() => rerender()} className="demo-button">
         Rerender
       </button>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-      </table.Subscribe>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
     </div>
   )
 }

--- a/examples/react/column-sizing/src/main.tsx
+++ b/examples/react/column-sizing/src/main.tsx
@@ -71,7 +71,7 @@ function App() {
       debugHeaders: true,
       debugColumns: true,
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   return (
@@ -272,9 +272,7 @@ function App() {
       <button onClick={() => rerender()} className="demo-button">
         Rerender
       </button>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-      </table.Subscribe>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
     </div>
   )
 }

--- a/examples/react/column-visibility/src/main.tsx
+++ b/examples/react/column-visibility/src/main.tsx
@@ -66,110 +66,103 @@ function App() {
   const stressTest = () => setData(makeData(1_000))
   const rerender = React.useReducer(() => ({}), {})[1]
 
-  const table = useTable({
-    _features,
-    _rowModels: {},
-    columns,
-    data,
-    debugTable: true,
-    debugHeaders: true,
-    debugColumns: true,
-  })
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {},
+      columns,
+      data,
+      debugTable: true,
+      debugHeaders: true,
+      debugColumns: true,
+    },
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnVisibility: state.columnVisibility,
-      })}
-    >
-      {(_state) => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()} className="demo-button">
-              Regenerate Data
-            </button>
-            <button onClick={() => stressTest()} className="demo-button">
-              Stress Test (1k rows)
-            </button>
-          </div>
-          <div className="spacer-md" />
-          <div className="column-toggle-panel">
-            <div className="column-toggle-panel-header">
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()} className="demo-button">
+          Regenerate Data
+        </button>
+        <button onClick={() => stressTest()} className="demo-button">
+          Stress Test (1k rows)
+        </button>
+      </div>
+      <div className="spacer-md" />
+      <div className="column-toggle-panel">
+        <div className="column-toggle-panel-header">
+          <label>
+            <input
+              type="checkbox"
+              checked={table.getIsAllColumnsVisible()}
+              onChange={table.getToggleAllColumnsVisibilityHandler()}
+            />{' '}
+            Toggle All
+          </label>
+        </div>
+        {table.getAllLeafColumns().map((column) => {
+          return (
+            <div key={column.id} className="column-toggle-row">
               <label>
                 <input
                   type="checkbox"
-                  checked={table.getIsAllColumnsVisible()}
-                  onChange={table.getToggleAllColumnsVisibilityHandler()}
+                  checked={column.getIsVisible()}
+                  onChange={column.getToggleVisibilityHandler()}
                 />{' '}
-                Toggle All
+                {column.id}
               </label>
             </div>
-            {table.getAllLeafColumns().map((column) => {
-              return (
-                <div key={column.id} className="column-toggle-row">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={column.getIsVisible()}
-                      onChange={column.getToggleVisibilityHandler()}
-                    />{' '}
-                    {column.id}
-                  </label>
-                </div>
-              )
-            })}
-          </div>
-          <div className="spacer-md" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <th key={header.id} colSpan={header.colSpan}>
-                      {header.isPlaceholder ? null : (
-                        <table.FlexRender header={header} />
-                      )}
-                    </th>
-                  ))}
-                </tr>
+          )
+        })}
+      </div>
+      <div className="spacer-md" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : (
+                    <table.FlexRender header={header} />
+                  )}
+                </th>
               ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => (
-                <tr key={row.id}>
-                  {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id}>
-                      <table.FlexRender cell={cell} />
-                    </td>
-                  ))}
-                </tr>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>
+                  <table.FlexRender cell={cell} />
+                </td>
               ))}
-            </tbody>
-            <tfoot>
-              {table.getFooterGroups().map((footerGroup) => (
-                <tr key={footerGroup.id}>
-                  {footerGroup.headers.map((header) => (
-                    <th key={header.id} colSpan={header.colSpan}>
-                      {header.isPlaceholder ? null : (
-                        <table.FlexRender footer={header} />
-                      )}
-                    </th>
-                  ))}
-                </tr>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          {table.getFooterGroups().map((footerGroup) => (
+            <tr key={footerGroup.id}>
+              {footerGroup.headers.map((header) => (
+                <th key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : (
+                    <table.FlexRender footer={header} />
+                  )}
+                </th>
               ))}
-            </tfoot>
-          </table>
-          <div className="spacer-md" />
-          <button onClick={() => rerender()} className="demo-button">
-            Rerender
-          </button>
-          <div className="spacer-md" />
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </tfoot>
+      </table>
+      <div className="spacer-md" />
+      <button onClick={() => rerender()} className="demo-button">
+        Rerender
+      </button>
+      <div className="spacer-md" />
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/composable-tables/src/components/table-components.tsx
+++ b/examples/react/composable-tables/src/components/table-components.tsx
@@ -5,7 +5,6 @@
  * directly on the table object, e.g., <table.PaginationControls />
  */
 import { useTableContext } from '../hooks/table'
-import type { PaginationState } from '@tanstack/react-table'
 
 /**
  * Pagination controls for the table
@@ -14,69 +13,64 @@ export function PaginationControls() {
   const table = useTableContext()
 
   return (
-    <table.Subscribe source={table.atoms.pagination}>
-      {/* whole pagination slice — no selector needed */}
-      {(pagination: PaginationState) => (
-        <div className="pagination">
-          <button
-            onClick={() => table.firstPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            {'<<'}
-          </button>
-          <button
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            {'<'}
-          </button>
-          <button
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-          >
-            {'>'}
-          </button>
-          <button
-            onClick={() => table.lastPage()}
-            disabled={!table.getCanNextPage()}
-          >
-            {'>>'}
-          </button>
-          <span>
-            Page{' '}
-            <strong>
-              {(pagination.pageIndex + 1).toLocaleString()} of{' '}
-              {table.getPageCount().toLocaleString()}
-            </strong>
-          </span>
-          <span>
-            | Go to page:
-            <input
-              type="number"
-              min="1"
-              max={table.getPageCount()}
-              defaultValue={pagination.pageIndex + 1}
-              onChange={(e) => {
-                const page = e.target.value ? Number(e.target.value) - 1 : 0
-                table.setPageIndex(page)
-              }}
-            />
-          </span>
-          <select
-            value={pagination.pageSize}
-            onChange={(e) => {
-              table.setPageSize(Number(e.target.value))
-            }}
-          >
-            {[10, 20, 30, 40, 50].map((pageSize) => (
-              <option key={pageSize} value={pageSize}>
-                Show {pageSize}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
-    </table.Subscribe>
+    <div className="pagination">
+      <button
+        onClick={() => table.firstPage()}
+        disabled={!table.getCanPreviousPage()}
+      >
+        {'<<'}
+      </button>
+      <button
+        onClick={() => table.previousPage()}
+        disabled={!table.getCanPreviousPage()}
+      >
+        {'<'}
+      </button>
+      <button
+        onClick={() => table.nextPage()}
+        disabled={!table.getCanNextPage()}
+      >
+        {'>'}
+      </button>
+      <button
+        onClick={() => table.lastPage()}
+        disabled={!table.getCanNextPage()}
+      >
+        {'>>'}
+      </button>
+      <span>
+        Page{' '}
+        <strong>
+          {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+          {table.getPageCount().toLocaleString()}
+        </strong>
+      </span>
+      <span>
+        | Go to page:
+        <input
+          type="number"
+          min="1"
+          max={table.getPageCount()}
+          defaultValue={table.state.pagination.pageIndex + 1}
+          onChange={(e) => {
+            const page = e.target.value ? Number(e.target.value) - 1 : 0
+            table.setPageIndex(page)
+          }}
+        />
+      </span>
+      <select
+        value={table.state.pagination.pageSize}
+        onChange={(e) => {
+          table.setPageSize(Number(e.target.value))
+        }}
+      >
+        {[10, 20, 30, 40, 50].map((pageSize) => (
+          <option key={pageSize} value={pageSize}>
+            Show {pageSize}
+          </option>
+        ))}
+      </select>
+    </div>
   )
 }
 
@@ -100,21 +94,26 @@ export function RowCount() {
 export function TableToolbar({
   title,
   onRefresh,
+  onStressTest,
 }: {
   title: string
   onRefresh?: () => void
+  onStressTest?: () => void
 }) {
   const table = useTableContext()
 
   return (
     <div className="table-toolbar">
       <h2>{title}</h2>
-      <div>
+      <div className="table-toolbar-actions">
+        {onRefresh && <button onClick={onRefresh}>Regenerate Data</button>}
+        {onStressTest && (
+          <button onClick={onStressTest}>Stress Test (200k rows)</button>
+        )}
         <button onClick={() => table.resetColumnFilters()}>
           Clear Filters
         </button>
         <button onClick={() => table.resetSorting()}>Clear Sorting</button>
-        {onRefresh && <button onClick={onRefresh}>Regenerate Data</button>}
       </div>
     </div>
   )

--- a/examples/react/composable-tables/src/index.css
+++ b/examples/react/composable-tables/src/index.css
@@ -174,6 +174,12 @@ tfoot th {
   border-spacing: 0;
 }
 
+.table-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .table-toolbar button {
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/examples/react/composable-tables/src/main.tsx
+++ b/examples/react/composable-tables/src/main.tsx
@@ -77,7 +77,7 @@ function UsersTable() {
       debugTable: true,
       // more table options
     },
-    // (state) => state, // alternatively, subscribe to the entire state instead of using table.Subscribe or selectors down below
+    (state) => state, // default selector
   )
 
   return (
@@ -93,13 +93,11 @@ function UsersTable() {
       {({ sorting, columnFilters }) => (
         <div className="table-container">
           {/* Table toolbar using pre-bound component */}
-          <table.TableToolbar title="Users Table" onRefresh={refreshData} />
-          <div style={{ marginBottom: '8px' }}>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>
-              Stress Test (200k rows)
-            </button>
-          </div>
+          <table.TableToolbar
+            title="Users Table"
+            onRefresh={refreshData}
+            onStressTest={stressTest}
+          />
 
           {/* Table element */}
           <table>
@@ -267,12 +265,15 @@ function ProductsTable() {
   )
 
   // Create the table using the same useAppTable hook
-  const table = useAppTable({
-    debugTable: true,
-    columns,
-    data,
-    getRowId: (row) => row.id,
-  })
+  const table = useAppTable(
+    {
+      debugTable: true,
+      columns,
+      data,
+      getRowId: (row) => row.id,
+    },
+    (state) => state, // default selector
+  )
 
   return (
     <table.AppTable
@@ -285,13 +286,11 @@ function ProductsTable() {
       {({ sorting, columnFilters }) => (
         <div className="table-container">
           {/* Table toolbar using the same pre-bound component */}
-          <table.TableToolbar title="Products Table" onRefresh={refreshData} />
-          <div style={{ marginBottom: '8px' }}>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>
-              Stress Test (200k rows)
-            </button>
-          </div>
+          <table.TableToolbar
+            title="Products Table"
+            onRefresh={refreshData}
+            onStressTest={stressTest}
+          />
 
           {/* Table element */}
           <table>

--- a/examples/react/custom-plugin/src/main.tsx
+++ b/examples/react/custom-plugin/src/main.tsx
@@ -152,21 +152,24 @@ function App() {
   const stressTest = () => setData(makeData(200_000))
   const [density, setDensity] = React.useState<DensityState>('md')
 
-  const table = useTable({
-    _features,
-    _rowModels: {
-      filteredRowModel: createFilteredRowModel(filterFns),
-      paginatedRowModel: createPaginatedRowModel(),
-      sortedRowModel: createSortedRowModel(sortFns),
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel(filterFns),
+        paginatedRowModel: createPaginatedRowModel(),
+        sortedRowModel: createSortedRowModel(sortFns),
+      },
+      columns,
+      data,
+      debugTable: true,
+      state: {
+        density, // passing the density state to the table, TS is still happy :)
+      },
+      onDensityChange: setDensity, // using the new onDensityChange option, TS is still happy :)
     },
-    columns,
-    data,
-    debugTable: true,
-    state: {
-      density, // passing the density state to the table, TS is still happy :)
-    },
-    onDensityChange: setDensity, // using the new onDensityChange option, TS is still happy :)
-  })
+    (state) => state, // default selector
+  )
 
   return (
     <div className="demo-root">
@@ -322,9 +325,7 @@ function App() {
         Showing {table.getRowModel().rows.length.toLocaleString()} of{' '}
         {table.getRowCount().toLocaleString()} Rows
       </div>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-      </table.Subscribe>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
     </div>
   )
 }

--- a/examples/react/expanding/src/main.tsx
+++ b/examples/react/expanding/src/main.tsx
@@ -115,152 +115,141 @@ function App() {
   const refreshData = () => setData(makeData(100, 5, 3))
   const stressTest = () => setData(makeData(10_000, 5, 3))
 
-  const table = useTable({
-    _features,
-    _rowModels: {
-      expandedRowModel: createExpandedRowModel(),
-      filteredRowModel: createFilteredRowModel(filterFns),
-      paginatedRowModel: createPaginatedRowModel(),
-      sortedRowModel: createSortedRowModel(sortFns),
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        expandedRowModel: createExpandedRowModel(),
+        filteredRowModel: createFilteredRowModel(filterFns),
+        paginatedRowModel: createPaginatedRowModel(),
+        sortedRowModel: createSortedRowModel(sortFns),
+      },
+      columns,
+      data,
+      getSubRows: (row) => row.subRows,
+      // filterFromLeafRows: true,
+      // maxLeafRowFilterDepth: 0,
+      debugTable: true,
     },
-    columns,
-    data,
-    getSubRows: (row) => row.subRows,
-    // filterFromLeafRows: true,
-    // maxLeafRowFilterDepth: 0,
-    debugTable: true,
-  })
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        expanded: state.expanded,
-        pagination: state.pagination,
-        rowSelection: state.rowSelection,
-        columnFilters: state.columnFilters,
-        sorting: state.sorting,
-      })}
-    >
-      {(state) => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>Stress Test (10k rows)</button>
-          </div>
-          <div className="spacer-sm" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <div>
-                            <table.FlexRender header={header} />
-                            {header.column.getCanFilter() ? (
-                              <div>
-                                <Filter column={header.column} table={table} />
-                              </div>
-                            ) : null}
-                          </div>
-                        )}
-                      </th>
-                    )
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()}>Regenerate Data</button>
+        <button onClick={() => stressTest()}>Stress Test (10k rows)</button>
+      </div>
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
                 return (
-                  <tr key={row.id}>
-                    {row.getAllCells().map((cell) => {
-                      return (
-                        <td key={cell.id}>
-                          <table.FlexRender cell={cell} />
-                        </td>
-                      )
-                    })}
-                  </tr>
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <div>
+                        <table.FlexRender header={header} />
+                        {header.column.getCanFilter() ? (
+                          <div>
+                            <Filter column={header.column} table={table} />
+                          </div>
+                        ) : null}
+                      </div>
+                    )}
+                  </th>
                 )
               })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div className="controls">
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(0)}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
-            <span className="inline-controls">
-              <div>Page</div>
-              <strong>
-                {(state.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                {table.getPageCount().toLocaleString()}
-              </strong>
-            </span>
-            <span className="inline-controls">
-              | Go to page:
-              <input
-                type="number"
-                min="1"
-                max={table.getPageCount()}
-                defaultValue={state.pagination.pageIndex + 1}
-                onChange={(e) => {
-                  const page = e.target.value ? Number(e.target.value) - 1 : 0
-                  table.setPageIndex(page)
-                }}
-                className="page-size-input"
-              />
-            </span>
-            <select
-              value={state.pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number(e.target.value))
-              }}
-            >
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
-          <div>
-            <button onClick={() => rerender()}>Force Rerender</button>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getAllCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div className="controls">
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(0)}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>>'}
+        </button>
+        <span className="inline-controls">
+          <div>Page</div>
+          <strong>
+            {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+            {table.getPageCount().toLocaleString()}
+          </strong>
+        </span>
+        <span className="inline-controls">
+          | Go to page:
+          <input
+            type="number"
+            min="1"
+            max={table.getPageCount()}
+            defaultValue={table.state.pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = e.target.value ? Number(e.target.value) - 1 : 0
+              table.setPageIndex(page)
+            }}
+            className="page-size-input"
+          />
+        </span>
+        <select
+          value={table.state.pagination.pageSize}
+          onChange={(e) => {
+            table.setPageSize(Number(e.target.value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map((pageSize) => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
+      <div>
+        <button onClick={() => rerender()}>Force Rerender</button>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/filters-faceted/src/main.tsx
+++ b/examples/react/filters-faceted/src/main.tsx
@@ -88,152 +88,142 @@ function App() {
   const stressTest = () => setData(makeData(200_000))
   const rerender = React.useReducer(() => ({}), {})[1]
 
-  const table = useTable({
-    _features,
-    _rowModels: {
-      filteredRowModel: createFilteredRowModel(filterFns), // client-side filtering
-      paginatedRowModel: createPaginatedRowModel(),
-      facetedRowModel: createFacetedRowModel(), // client-side faceting
-      facetedMinMaxValues: createFacetedMinMaxValues(), // generate min/max values for range filter
-      facetedUniqueValues: createFacetedUniqueValues(), // generate unique values for select filter/autocomplete
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel(filterFns), // client-side filtering
+        paginatedRowModel: createPaginatedRowModel(),
+        facetedRowModel: createFacetedRowModel(), // client-side faceting
+        facetedMinMaxValues: createFacetedMinMaxValues(), // generate min/max values for range filter
+        facetedUniqueValues: createFacetedUniqueValues(), // generate unique values for select filter/autocomplete
+      },
+      columns,
+      data,
+      debugTable: true,
+      debugHeaders: true,
+      debugColumns: false,
     },
-    columns,
-    data,
-    debugTable: true,
-    debugHeaders: true,
-    debugColumns: false,
-  })
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnFilters: state.columnFilters,
-        pagination: state.pagination,
-      })}
-    >
-      {(state) => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>
-              Stress Test (200k rows)
-            </button>
-          </div>
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <>
-                            <div>
-                              <table.FlexRender header={header} />
-                            </div>
-                            {header.column.getCanFilter() ? (
-                              <div>
-                                <Filter column={header.column} />
-                              </div>
-                            ) : null}
-                          </>
-                        )}
-                      </th>
-                    )
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()}>Regenerate Data</button>
+        <button onClick={() => stressTest()}>Stress Test (200k rows)</button>
+      </div>
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
                 return (
-                  <tr key={row.id}>
-                    {row.getAllCells().map((cell) => {
-                      return (
-                        <td key={cell.id}>
-                          <table.FlexRender cell={cell} />
-                        </td>
-                      )
-                    })}
-                  </tr>
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <>
+                        <div>
+                          <table.FlexRender header={header} />
+                        </div>
+                        {header.column.getCanFilter() ? (
+                          <div>
+                            <Filter column={header.column} />
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                  </th>
                 )
               })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div className="controls">
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(0)}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
-            <span className="inline-controls">
-              <div>Page</div>
-              <strong>
-                {(state.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                {table.getPageCount().toLocaleString()}
-              </strong>
-            </span>
-            <span className="inline-controls">
-              | Go to page:
-              <input
-                type="number"
-                defaultValue={state.pagination.pageIndex + 1}
-                onChange={(e) => {
-                  const page = e.target.value ? Number(e.target.value) - 1 : 0
-                  table.setPageIndex(page)
-                }}
-                className="page-size-input"
-              />
-            </span>
-            <select
-              value={state.pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number(e.target.value))
-              }}
-            >
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
-          </div>
-          <div>
-            <button onClick={rerender}>Force Rerender</button>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getAllCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div className="controls">
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(0)}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>>'}
+        </button>
+        <span className="inline-controls">
+          <div>Page</div>
+          <strong>
+            {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+            {table.getPageCount().toLocaleString()}
+          </strong>
+        </span>
+        <span className="inline-controls">
+          | Go to page:
+          <input
+            type="number"
+            defaultValue={table.state.pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = e.target.value ? Number(e.target.value) - 1 : 0
+              table.setPageIndex(page)
+            }}
+            className="page-size-input"
+          />
+        </span>
+        <select
+          value={table.state.pagination.pageSize}
+          onChange={(e) => {
+            table.setPageSize(Number(e.target.value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map((pageSize) => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
+      </div>
+      <div>
+        <button onClick={rerender}>Force Rerender</button>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/filters-fuzzy/src/main.tsx
+++ b/examples/react/filters-fuzzy/src/main.tsx
@@ -113,23 +113,26 @@ function App() {
   const refreshData = () => setData(makeData(5_000))
   const stressTest = () => setData(makeData(200_000))
 
-  const table = useTable<typeof _features, Person>({
-    _features,
-    _rowModels: {
-      filteredRowModel: createFilteredRowModel({
-        ...filterFns,
-        fuzzy: fuzzyFilter,
-      }),
-      paginatedRowModel: createPaginatedRowModel(),
-      sortedRowModel: createSortedRowModel(sortFns),
+  const table = useTable<typeof _features, Person>(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel({
+          ...filterFns,
+          fuzzy: fuzzyFilter,
+        }),
+        paginatedRowModel: createPaginatedRowModel(),
+        sortedRowModel: createSortedRowModel(sortFns),
+      },
+      columns,
+      data,
+      globalFilterFn: 'fuzzy', // apply fuzzy filter to the global filter (most common use case for fuzzy filter)
+      debugTable: true,
+      debugHeaders: true,
+      debugColumns: false,
     },
-    columns,
-    data,
-    globalFilterFn: 'fuzzy', // apply fuzzy filter to the global filter (most common use case for fuzzy filter)
-    debugTable: true,
-    debugHeaders: true,
-    debugColumns: false,
-  })
+    (state) => state, // default selector
+  )
 
   // apply the fuzzy sort if the fullName column is being filtered
   React.useEffect(() => {
@@ -141,157 +144,140 @@ function App() {
   }, [table.store.state.columnFilters[0]?.id])
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnFilters: state.columnFilters,
-        globalFilter: state.globalFilter,
-        pagination: state.pagination,
-        sorting: state.sorting,
-      })}
-    >
-      {(state) => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>
-              Stress Test (200k rows)
-            </button>
-          </div>
-          <div>
-            <DebouncedInput
-              value={state.globalFilter ?? ''}
-              onChange={(value) => table.setGlobalFilter(String(value))}
-              className="summary-panel"
-              placeholder="Search all columns..."
-            />
-          </div>
-          <div className="spacer-sm" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <>
-                            <div
-                              className={
-                                header.column.getCanSort()
-                                  ? 'sortable-header'
-                                  : ''
-                              }
-                              onClick={header.column.getToggleSortingHandler()}
-                            >
-                              <table.FlexRender header={header} />
-                              {{
-                                asc: ' 🔼',
-                                desc: ' 🔽',
-                              }[header.column.getIsSorted() as string] ?? null}
-                            </div>
-                            {header.column.getCanFilter() ? (
-                              <div>
-                                <Filter column={header.column} />
-                              </div>
-                            ) : null}
-                          </>
-                        )}
-                      </th>
-                    )
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()}>Regenerate Data</button>
+        <button onClick={() => stressTest()}>Stress Test (200k rows)</button>
+      </div>
+      <div>
+        <DebouncedInput
+          value={table.state.globalFilter ?? ''}
+          onChange={(value) => table.setGlobalFilter(String(value))}
+          className="summary-panel"
+          placeholder="Search all columns..."
+        />
+      </div>
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
                 return (
-                  <tr key={row.id}>
-                    {row.getAllCells().map((cell) => {
-                      return (
-                        <td key={cell.id}>
-                          <table.FlexRender cell={cell} />
-                        </td>
-                      )
-                    })}
-                  </tr>
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <>
+                        <div
+                          className={
+                            header.column.getCanSort() ? 'sortable-header' : ''
+                          }
+                          onClick={header.column.getToggleSortingHandler()}
+                        >
+                          <table.FlexRender header={header} />
+                          {{
+                            asc: ' 🔼',
+                            desc: ' 🔽',
+                          }[header.column.getIsSorted() as string] ?? null}
+                        </div>
+                        {header.column.getCanFilter() ? (
+                          <div>
+                            <Filter column={header.column} />
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                  </th>
                 )
               })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div className="controls">
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(0)}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
-            <span className="inline-controls">
-              <div>Page</div>
-              <strong>
-                {(state.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                {table.getPageCount().toLocaleString()}
-              </strong>
-            </span>
-            <span className="inline-controls">
-              | Go to page:
-              <input
-                type="number"
-                defaultValue={state.pagination.pageIndex + 1}
-                onChange={(e) => {
-                  const page = e.target.value ? Number(e.target.value) - 1 : 0
-                  table.setPageIndex(page)
-                }}
-                className="page-size-input"
-              />
-            </span>
-            <select
-              value={state.pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number(e.target.value))
-              }}
-            >
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
-          </div>
-          <div>
-            <button onClick={() => rerender()}>Force Rerender</button>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getAllCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div className="controls">
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(0)}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>>'}
+        </button>
+        <span className="inline-controls">
+          <div>Page</div>
+          <strong>
+            {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+            {table.getPageCount().toLocaleString()}
+          </strong>
+        </span>
+        <span className="inline-controls">
+          | Go to page:
+          <input
+            type="number"
+            defaultValue={table.state.pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = e.target.value ? Number(e.target.value) - 1 : 0
+              table.setPageIndex(page)
+            }}
+            className="page-size-input"
+          />
+        </span>
+        <select
+          value={table.state.pagination.pageSize}
+          onChange={(e) => {
+            table.setPageSize(Number(e.target.value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map((pageSize) => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
+      </div>
+      <div>
+        <button onClick={() => rerender()}>Force Rerender</button>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/filters/src/main.tsx
+++ b/examples/react/filters/src/main.tsx
@@ -89,150 +89,140 @@ function App() {
   const refreshData = () => setData(makeData(5_000))
   const stressTest = () => setData(makeData(200_000))
 
-  const table = useTable({
-    _features,
-    _rowModels: {
-      filteredRowModel: createFilteredRowModel(filterFns), // client side filtering
-      paginatedRowModel: createPaginatedRowModel(),
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel(filterFns), // client side filtering
+        paginatedRowModel: createPaginatedRowModel(),
+      },
+      columns,
+      data,
+      debugTable: true,
+      debugColumns: true,
     },
-    columns,
-    data,
-    debugTable: true,
-    debugColumns: true,
-  })
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        columnFilters: state.columnFilters,
-        pagination: state.pagination,
-      })}
-    >
-      {(state) => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>
-              Stress Test (200k rows)
-            </button>
-          </div>
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <>
-                            <div>
-                              <table.FlexRender header={header} />
-                            </div>
-                            {header.column.getCanFilter() ? (
-                              <div>
-                                <Filter column={header.column} />
-                              </div>
-                            ) : null}
-                          </>
-                        )}
-                      </th>
-                    )
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()}>Regenerate Data</button>
+        <button onClick={() => stressTest()}>Stress Test (200k rows)</button>
+      </div>
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
                 return (
-                  <tr key={row.id}>
-                    {row.getAllCells().map((cell) => {
-                      return (
-                        <td key={cell.id}>
-                          <table.FlexRender cell={cell} />
-                        </td>
-                      )
-                    })}
-                  </tr>
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <>
+                        <div>
+                          <table.FlexRender header={header} />
+                        </div>
+                        {header.column.getCanFilter() ? (
+                          <div>
+                            <Filter column={header.column} />
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                  </th>
                 )
               })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div className="controls">
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(0)}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
-            <span className="inline-controls">
-              <div>Page</div>
-              <strong>
-                {(state.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                {table.getPageCount().toLocaleString()}
-              </strong>
-            </span>
-            <span className="inline-controls">
-              | Go to page:
-              <input
-                type="number"
-                min="1"
-                max={table.getPageCount()}
-                defaultValue={state.pagination.pageIndex + 1}
-                onChange={(e) => {
-                  const page = e.target.value ? Number(e.target.value) - 1 : 0
-                  table.setPageIndex(page)
-                }}
-                className="page-size-input"
-              />
-            </span>
-            <select
-              value={state.pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number(e.target.value))
-              }}
-            >
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
-          </div>
-          <div>
-            <button onClick={() => rerender()}>Force Rerender</button>
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getAllCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div className="controls">
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(0)}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>>'}
+        </button>
+        <span className="inline-controls">
+          <div>Page</div>
+          <strong>
+            {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+            {table.getPageCount().toLocaleString()}
+          </strong>
+        </span>
+        <span className="inline-controls">
+          | Go to page:
+          <input
+            type="number"
+            min="1"
+            max={table.getPageCount()}
+            defaultValue={table.state.pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = e.target.value ? Number(e.target.value) - 1 : 0
+              table.setPageIndex(page)
+            }}
+            className="page-size-input"
+          />
+        </span>
+        <select
+          value={table.state.pagination.pageSize}
+          onChange={(e) => {
+            table.setPageSize(Number(e.target.value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map((pageSize) => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        {table.getPrePaginatedRowModel().rows.length.toLocaleString()} Rows
+      </div>
+      <div>
+        <button onClick={() => rerender()}>Force Rerender</button>
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/grouping/src/main.tsx
+++ b/examples/react/grouping/src/main.tsx
@@ -96,7 +96,7 @@ function App() {
       data,
       debugTable: true,
     },
-    (state) => state, // subscribe to all state changes
+    (state) => state, // default selector
   )
 
   return (
@@ -251,9 +251,7 @@ function App() {
       <div>
         <button onClick={() => rerender()}>Force Rerender</button>
       </div>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-      </table.Subscribe>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
     </div>
   )
 }

--- a/examples/react/kitchen-sink-hero-ui/src/main.tsx
+++ b/examples/react/kitchen-sink-hero-ui/src/main.tsx
@@ -1360,7 +1360,7 @@ function App() {
       columnResizeMode: 'onChange',
       debugTable: true,
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   const columnSizeVars = React.useMemo(() => {

--- a/examples/react/kitchen-sink-mantine/src/main.tsx
+++ b/examples/react/kitchen-sink-mantine/src/main.tsx
@@ -1416,7 +1416,7 @@ function App() {
       columnResizeMode: 'onChange',
       debugTable: true,
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   const columnSizeVars = React.useMemo(() => {

--- a/examples/react/kitchen-sink-material-ui/src/main.tsx
+++ b/examples/react/kitchen-sink-material-ui/src/main.tsx
@@ -1436,7 +1436,7 @@ function App({
       columnResizeMode: 'onChange',
       debugTable: true,
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   const columnSizeVars = React.useMemo(() => {

--- a/examples/react/kitchen-sink-react-aria/src/main.tsx
+++ b/examples/react/kitchen-sink-react-aria/src/main.tsx
@@ -1368,7 +1368,7 @@ function App() {
       columnResizeMode: 'onChange',
       debugTable: true,
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   const columnSizeVars = React.useMemo(() => {

--- a/examples/react/kitchen-sink-shadcn-base/src/main.tsx
+++ b/examples/react/kitchen-sink-shadcn-base/src/main.tsx
@@ -447,7 +447,7 @@ function App() {
       columnResizeMode: 'onChange',
       debugTable: true,
     },
-    (state) => state, // subscribe to all re-renders
+    (state) => state, // default selector
   )
 
   const columnSizeVars = React.useMemo(() => {

--- a/examples/react/kitchen-sink-shadcn-radix/src/main.tsx
+++ b/examples/react/kitchen-sink-shadcn-radix/src/main.tsx
@@ -446,7 +446,7 @@ function App() {
       columnResizeMode: 'onChange',
       debugTable: true,
     },
-    (state) => state, // subscribe to all re-renders
+    (state) => state, // default selector
   )
 
   const columnSizeVars = React.useMemo(() => {

--- a/examples/react/lib-hero-ui/src/main.tsx
+++ b/examples/react/lib-hero-ui/src/main.tsx
@@ -127,7 +127,7 @@ function App() {
       data,
       globalFilterFn: 'includesString',
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   const pageIndex = table.state.pagination.pageIndex

--- a/examples/react/lib-mantine/src/main.tsx
+++ b/examples/react/lib-mantine/src/main.tsx
@@ -105,7 +105,7 @@ function App() {
       data,
       globalFilterFn: 'includesString',
     },
-    (state) => state,
+    (state) => state, // default selector
   )
   return (
     <Container size="lg" py="xl">

--- a/examples/react/lib-material-ui/src/main.tsx
+++ b/examples/react/lib-material-ui/src/main.tsx
@@ -108,7 +108,7 @@ function App() {
       data,
       globalFilterFn: 'includesString',
     },
-    (state) => state,
+    (state) => state, // default selector
   )
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>

--- a/examples/react/lib-react-aria/src/main.tsx
+++ b/examples/react/lib-react-aria/src/main.tsx
@@ -137,7 +137,7 @@ function App() {
       data,
       globalFilterFn: 'includesString',
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   const pageIndex = table.state.pagination.pageIndex

--- a/examples/react/lib-shadcn-base/src/main.tsx
+++ b/examples/react/lib-shadcn-base/src/main.tsx
@@ -108,7 +108,7 @@ function App() {
       data,
       globalFilterFn: 'includesString',
     },
-    (state) => state,
+    (state) => state, // default selector
   )
   // 7. Render your table markup from the table instance APIs.
   return (

--- a/examples/react/lib-shadcn-radix/src/main.tsx
+++ b/examples/react/lib-shadcn-radix/src/main.tsx
@@ -108,7 +108,7 @@ function App() {
       data,
       globalFilterFn: 'includesString',
     },
-    (state) => state,
+    (state) => state, // default selector
   )
   // 7. Render your table markup from the table instance APIs.
   return (

--- a/examples/react/mantine-react-table/src/mantine-react-table/hooks/useMRT_TableInstance.ts
+++ b/examples/react/mantine-react-table/src/mantine-react-table/hooks/useMRT_TableInstance.ts
@@ -314,7 +314,7 @@ export const useMRT_TableInstance = <TData extends MRT_RowData>(
         pagination: paginationAtom,
       },
     },
-    (state) => state,
+    (state) => state, // default selector
   ) as unknown as MRT_TableInstance<TData>
 
   // v9 spells the resize setter `setcolumnResizing` (lowercase 'c') because

--- a/examples/react/material-react-table/src/material-react-table/hooks/useMRT_TableInstance.ts
+++ b/examples/react/material-react-table/src/material-react-table/hooks/useMRT_TableInstance.ts
@@ -318,7 +318,7 @@ export const useMRT_TableInstance = <TData extends MRT_RowData>(
         pagination: paginationAtom,
       },
     },
-    (state) => state,
+    (state) => state, // default selector
   ) as unknown as MRT_TableInstance<TData>
 
   // v9 spells the resize setter `setcolumnResizing` (lowercase 'c') because

--- a/examples/react/pagination/src/main.tsx
+++ b/examples/react/pagination/src/main.tsx
@@ -79,132 +79,125 @@ function MyTable({
   data: Array<Person>
   columns: ReturnType<typeof columnHelper.columns>
 }) {
-  const table = useTable({
-    _features,
-    _rowModels: {
-      paginatedRowModel: createPaginatedRowModel(),
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        paginatedRowModel: createPaginatedRowModel(),
+      },
+      columns,
+      data,
+      debugTable: true,
+      // no need to pass pageCount or rowCount with client-side pagination as it is calculated automatically
     },
-    columns,
-    data,
-    debugTable: true,
-    // no need to pass pageCount or rowCount with client-side pagination as it is calculated automatically
-  })
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe
-      selector={(state) => ({
-        pagination: state.pagination,
-      })}
-    >
-      {(state) => (
-        <div className="demo-root">
-          <div className="spacer-sm" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        <div>
-                          <table.FlexRender header={header} />
-                        </div>
-                      </th>
-                    )
-                  })}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
+    <div className="demo-root">
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
                 return (
-                  <tr key={row.id}>
-                    {row.getAllCells().map((cell) => {
-                      return (
-                        <td key={cell.id}>
-                          <table.FlexRender cell={cell} />
-                        </td>
-                      )
-                    })}
-                  </tr>
+                  <th key={header.id} colSpan={header.colSpan}>
+                    <div>
+                      <table.FlexRender header={header} />
+                    </div>
+                  </th>
                 )
               })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div className="controls">
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.firstPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              {'<'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>'}
-            </button>
-            <button
-              className="demo-button demo-button-sm"
-              onClick={() => table.lastPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              {'>>'}
-            </button>
-            <span className="inline-controls">
-              <div>Page</div>
-              <strong>
-                {(state.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                {table.getPageCount().toLocaleString()}
-              </strong>
-            </span>
-            <span className="inline-controls">
-              | Go to page:
-              <input
-                type="number"
-                min="1"
-                max={table.getPageCount()}
-                defaultValue={state.pagination.pageIndex + 1}
-                onChange={(e) => {
-                  const page = e.target.value ? Number(e.target.value) - 1 : 0
-                  table.setPageIndex(page)
-                }}
-                className="page-size-input"
-              />
-            </span>
-            <select
-              value={state.pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number(e.target.value))
-              }}
-            >
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            Showing {table.getRowModel().rows.length.toLocaleString()} of{' '}
-            {table.getRowCount().toLocaleString()} Rows
-          </div>
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr key={row.id}>
+                {row.getAllCells().map((cell) => {
+                  return (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div className="controls">
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.firstPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          {'<'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>'}
+        </button>
+        <button
+          className="demo-button demo-button-sm"
+          onClick={() => table.lastPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          {'>>'}
+        </button>
+        <span className="inline-controls">
+          <div>Page</div>
+          <strong>
+            {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+            {table.getPageCount().toLocaleString()}
+          </strong>
+        </span>
+        <span className="inline-controls">
+          | Go to page:
+          <input
+            type="number"
+            min="1"
+            max={table.getPageCount()}
+            defaultValue={table.state.pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = e.target.value ? Number(e.target.value) - 1 : 0
+              table.setPageIndex(page)
+            }}
+            className="page-size-input"
+          />
+        </span>
+        <select
+          value={table.state.pagination.pageSize}
+          onChange={(e) => {
+            table.setPageSize(Number(e.target.value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map((pageSize) => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        Showing {table.getRowModel().rows.length.toLocaleString()} of{' '}
+        {table.getRowCount().toLocaleString()} Rows
+      </div>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/row-dnd/src/main.tsx
+++ b/examples/react/row-dnd/src/main.tsx
@@ -134,7 +134,7 @@ function App() {
       data,
       getRowId: (row) => row.userId, // required because row indexes will change
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   // reorder rows after drag & drop
@@ -205,9 +205,7 @@ function App() {
             </SortableContext>
           </tbody>
         </table>
-        <table.Subscribe selector={(state) => state}>
-          {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-        </table.Subscribe>
+        <pre>{JSON.stringify(table.state, null, 2)}</pre>
       </div>
     </DndContext>
   )

--- a/examples/react/row-pinning/src/main.tsx
+++ b/examples/react/row-pinning/src/main.tsx
@@ -170,7 +170,7 @@ function App() {
       keepPinnedRows,
       debugAll: true,
     },
-    (state) => state, // subscribe to all re-renders
+    (state) => state, // default selector
   )
 
   // console.log(table.getBottomRows)

--- a/examples/react/row-selection/src/main.tsx
+++ b/examples/react/row-selection/src/main.tsx
@@ -43,18 +43,11 @@ function App() {
           id: 'select',
           header: () => {
             return (
-              <table.Subscribe
-                source={table.atoms.rowSelection} // slice atom only — not the full derived store
-                // omit selector to subscribe to the whole rowSelection slice
-              >
-                {() => (
-                  <IndeterminateCheckbox
-                    checked={table.getIsAllRowsSelected()}
-                    indeterminate={table.getIsSomeRowsSelected()}
-                    onChange={table.getToggleAllRowsSelectedHandler()}
-                  />
-                )}
-              </table.Subscribe>
+              <IndeterminateCheckbox
+                checked={table.getIsAllRowsSelected()}
+                indeterminate={table.getIsSomeRowsSelected()}
+                onChange={table.getToggleAllRowsSelectedHandler()}
+              />
             )
           },
           cell: ({ row }) => (
@@ -103,6 +96,7 @@ function App() {
   const refreshData = () => setData(makeData(1_000))
   const stressTest = () => setData(makeData(200_000))
 
+  // optionally, raise the selection state to your own atom
   const rowSelectionAtom = useCreateAtom<RowSelectionState>({})
 
   const table = useTable(
@@ -122,228 +116,191 @@ function App() {
       // enableRowSelection: row => row.original.age > 18, // or enable row selection conditionally per row
       debugTable: true,
     },
-    // (state) => state, // uncomment to subscribe to the entire table state (this is how v8 used to work by default)
+    (state) => state, // default selector
   )
 
   useTanStackTableDevtools(table, 'Row Selection Example')
 
   return (
     <>
-      <table.Subscribe
-        selector={(state) => ({
-          // Store mode: multiple slices — must use table.store + explicit selector
-          columnFilters: state.columnFilters,
-          globalFilter: state.globalFilter,
-          pagination: state.pagination,
-        })}
-      >
-        {(state) => (
-          <div className="demo-root">
-            <div>
-              <button
-                className="demo-button demo-button-spaced"
-                onClick={() => refreshData()}
-              >
-                Regenerate Data
-              </button>
-              <button
-                className="demo-button demo-button-spaced"
-                onClick={() => stressTest()}
-              >
-                Stress Test (200k rows)
-              </button>
-            </div>
-            <div>
-              <DebouncedInput
-                value={state.globalFilter ?? ''}
-                onChange={(value) => table.setGlobalFilter(value)}
-                className="summary-panel"
-                placeholder="Search all columns..."
-              />
-            </div>
-            <div className="spacer-sm" />
-            <table>
-              <thead>
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => {
-                      return (
-                        <th key={header.id} colSpan={header.colSpan}>
-                          {header.isPlaceholder ? null : (
-                            <>
-                              <table.FlexRender header={header} />
-                              {header.column.getCanFilter() ? (
-                                <div>
-                                  <Filter
-                                    column={header.column}
-                                    table={table}
-                                  />
-                                </div>
-                              ) : null}
-                            </>
-                          )}
-                        </th>
-                      )
-                    })}
-                  </tr>
-                ))}
-              </thead>
-              <tbody>
-                {table.getRowModel().rows.map((row) => {
+      <div className="demo-root">
+        <div>
+          <button
+            className="demo-button demo-button-spaced"
+            onClick={() => refreshData()}
+          >
+            Regenerate Data
+          </button>
+          <button
+            className="demo-button demo-button-spaced"
+            onClick={() => stressTest()}
+          >
+            Stress Test (200k rows)
+          </button>
+        </div>
+        <div>
+          <DebouncedInput
+            value={table.state.globalFilter ?? ''}
+            onChange={(value) => table.setGlobalFilter(value)}
+            className="summary-panel"
+            placeholder="Search all columns..."
+          />
+        </div>
+        <div className="spacer-sm" />
+        <table>
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
                   return (
-                    <table.Subscribe
-                      key={row.id}
-                      source={table.atoms.rowSelection} // same slice as table.atoms.rowSelection; external atom for clarity
-                      selector={(rowSelection) => rowSelection?.[row.id]} // optional: narrow to this row so the row re-renders only when this id toggles
-                    >
-                      {(_isRowSelected) => (
-                        <tr key={row.id}>
-                          {row.getAllCells().map((cell) => {
-                            return (
-                              <td key={cell.id}>
-                                <table.FlexRender cell={cell} />
-                              </td>
-                            )
-                          })}
-                        </tr>
+                    <th key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : (
+                        <>
+                          <table.FlexRender header={header} />
+                          {header.column.getCanFilter() ? (
+                            <div>
+                              <Filter column={header.column} table={table} />
+                            </div>
+                          ) : null}
+                        </>
                       )}
-                    </table.Subscribe>
+                    </th>
                   )
                 })}
-              </tbody>
-              <tfoot>
-                <tr>
-                  <td className="cell-padding">
-                    <table.Subscribe
-                      source={table.atoms.rowSelection} // whole slice; footer toggles don’t need per-row projection
-                      selector={(a) => a}
-                    >
-                      {() => (
-                        <IndeterminateCheckbox
-                          checked={table.getIsAllPageRowsSelected()}
-                          indeterminate={table.getIsSomePageRowsSelected()}
-                          onChange={table.getToggleAllPageRowsSelectedHandler()}
-                        />
-                      )}
-                    </table.Subscribe>
-                  </td>
-                  <td colSpan={20}>
-                    Page Rows (
-                    {table.getRowModel().rows.length.toLocaleString()})
-                  </td>
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => {
+              return (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => {
+                    return (
+                      <td key={cell.id}>
+                        <table.FlexRender cell={cell} />
+                      </td>
+                    )
+                  })}
                 </tr>
-              </tfoot>
-            </table>
-            <div className="spacer-sm" />
-            <div className="controls">
-              <button
-                className="demo-button demo-button-sm"
-                onClick={() => table.setPageIndex(0)}
-                disabled={!table.getCanPreviousPage()}
-              >
-                {'<<'}
-              </button>
-              <button
-                className="demo-button demo-button-sm"
-                onClick={() => table.previousPage()}
-                disabled={!table.getCanPreviousPage()}
-              >
-                {'<'}
-              </button>
-              <button
-                className="demo-button demo-button-sm"
-                onClick={() => table.nextPage()}
-                disabled={!table.getCanNextPage()}
-              >
-                {'>'}
-              </button>
-              <button
-                className="demo-button demo-button-sm"
-                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-                disabled={!table.getCanNextPage()}
-              >
-                {'>>'}
-              </button>
-              <span className="inline-controls">
-                <div>Page</div>
-                <strong>
-                  {(
-                    table.store.state.pagination.pageIndex + 1
-                  ).toLocaleString()}{' '}
-                  of {table.getPageCount().toLocaleString()}
-                </strong>
-              </span>
-              <span className="inline-controls">
-                | Go to page:
-                <input
-                  type="number"
-                  min="1"
-                  max={table.getPageCount()}
-                  defaultValue={table.store.state.pagination.pageIndex + 1}
-                  onChange={(e) => {
-                    const page = e.target.value ? Number(e.target.value) - 1 : 0
-                    table.setPageIndex(page)
-                  }}
-                  className="page-size-input"
+              )
+            })}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td className="cell-padding">
+                <IndeterminateCheckbox
+                  checked={table.getIsAllPageRowsSelected()}
+                  indeterminate={table.getIsSomePageRowsSelected()}
+                  onChange={table.getToggleAllPageRowsSelectedHandler()}
                 />
-              </span>
-              <select
-                value={table.store.state.pagination.pageSize}
-                onChange={(e) => {
-                  table.setPageSize(Number(e.target.value))
-                }}
-              >
-                {[10, 20, 30, 40, 50].map((pageSize) => (
-                  <option key={pageSize} value={pageSize}>
-                    Show {pageSize}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <br />
-            <div>
-              <table.Subscribe
-                selector={(state) => ({
-                  numSelected: Object.keys(state.rowSelection).length,
-                })}
-              >
-                {({ numSelected }) => <>{numSelected.toLocaleString()} of </>}
-              </table.Subscribe>
-              {table.getPreFilteredRowModel().rows.length.toLocaleString()}{' '}
-              Total Rows Selected
-            </div>
-            <hr />
-            <br />
-            <div>
-              <button
-                className="demo-button demo-button-spaced"
-                onClick={() => rerender()}
-              >
-                Force Rerender
-              </button>
-            </div>
-            <div>
-              <button
-                className="demo-button demo-button-spaced"
-                onClick={() =>
-                  console.info(
-                    'table.getSelectedRowModel().flatRows',
-                    table.getSelectedRowModel().flatRows,
-                  )
-                }
-              >
-                Log table.getSelectedRowModel().flatRows
-              </button>
-            </div>
-            <div>
-              <label>Row Selection State:</label>
-              <table.Subscribe selector={(state) => state}>
-                {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-              </table.Subscribe>
-            </div>
-          </div>
-        )}
-      </table.Subscribe>
+              </td>
+              <td colSpan={20}>
+                Page Rows ({table.getRowModel().rows.length.toLocaleString()})
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+        <div className="spacer-sm" />
+        <div className="controls">
+          <button
+            className="demo-button demo-button-sm"
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            {'<<'}
+          </button>
+          <button
+            className="demo-button demo-button-sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            {'<'}
+          </button>
+          <button
+            className="demo-button demo-button-sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            {'>'}
+          </button>
+          <button
+            className="demo-button demo-button-sm"
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            {'>>'}
+          </button>
+          <span className="inline-controls">
+            <div>Page</div>
+            <strong>
+              {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+              {table.getPageCount().toLocaleString()}
+            </strong>
+          </span>
+          <span className="inline-controls">
+            | Go to page:
+            <input
+              type="number"
+              min="1"
+              max={table.getPageCount()}
+              defaultValue={table.state.pagination.pageIndex + 1}
+              onChange={(e) => {
+                const page = e.target.value ? Number(e.target.value) - 1 : 0
+                table.setPageIndex(page)
+              }}
+              className="page-size-input"
+            />
+          </span>
+          <select
+            value={table.state.pagination.pageSize}
+            onChange={(e) => {
+              table.setPageSize(Number(e.target.value))
+            }}
+          >
+            {[10, 20, 30, 40, 50].map((pageSize) => (
+              <option key={pageSize} value={pageSize}>
+                Show {pageSize}
+              </option>
+            ))}
+          </select>
+        </div>
+        <br />
+        <div>
+          <>
+            {Object.keys(table.state.rowSelection).length.toLocaleString()}{' '}
+            of{' '}
+          </>
+          {table.getPreFilteredRowModel().rows.length.toLocaleString()} Total
+          Rows Selected
+        </div>
+        <hr />
+        <br />
+        <div>
+          <button
+            className="demo-button demo-button-spaced"
+            onClick={() => rerender()}
+          >
+            Force Rerender
+          </button>
+        </div>
+        <div>
+          <button
+            className="demo-button demo-button-spaced"
+            onClick={() =>
+              console.info(
+                'table.getSelectedRowModel().flatRows',
+                table.getSelectedRowModel().flatRows,
+              )
+            }
+          >
+            Log table.getSelectedRowModel().flatRows
+          </button>
+        </div>
+        <div>
+          <label>Row Selection State:</label>
+          <pre>{JSON.stringify(table.state, null, 2)}</pre>
+        </div>
+      </div>
     </>
   )
 }

--- a/examples/react/sorting/src/main.tsx
+++ b/examples/react/sorting/src/main.tsx
@@ -93,90 +93,78 @@ function App() {
       // isMultiSortEvent: (e) => true, //Make all clicks multi-sort - default requires `shift` key
       // maxMultiSortColCount: 3, // only allow 3 columns to be sorted at once - default is Infinity
     },
-    // (state) => state, // uncomment to subscribe to the entire table state (this is how v8 used to work by default)
+    (state) => state, // default selector
   )
 
   return (
-    <table.Subscribe source={table.atoms.sorting}>
-      {/* omit selector to subscribe to the entire sorting slice */}
-      {() => (
-        <div className="demo-root">
-          <div>
-            <button onClick={() => refreshData()}>Regenerate Data</button>
-            <button onClick={() => stressTest()}>
-              Stress Test (500k rows)
-            </button>
-          </div>
-          <div className="spacer-sm" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
+    <div className="demo-root">
+      <div>
+        <button onClick={() => refreshData()}>Regenerate Data</button>
+        <button onClick={() => stressTest()}>Stress Test (500k rows)</button>
+      </div>
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <div
+                        className={
+                          header.column.getCanSort() ? 'sortable-header' : ''
+                        }
+                        onClick={header.column.getToggleSortingHandler()}
+                        title={
+                          header.column.getCanSort()
+                            ? header.column.getNextSortingOrder() === 'asc'
+                              ? 'Sort ascending'
+                              : header.column.getNextSortingOrder() === 'desc'
+                                ? 'Sort descending'
+                                : 'Clear sort'
+                            : undefined
+                        }
+                      >
+                        <table.FlexRender header={header} />
+                        {{
+                          asc: ' 🔼',
+                          desc: ' 🔽',
+                        }[header.column.getIsSorted() as string] ?? null}
+                      </div>
+                    )}
+                  </th>
+                )
+              })}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table
+            .getRowModel()
+            .rows.slice(0, 10)
+            .map((row) => {
+              return (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => {
                     return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <div
-                            className={
-                              header.column.getCanSort()
-                                ? 'sortable-header'
-                                : ''
-                            }
-                            onClick={header.column.getToggleSortingHandler()}
-                            title={
-                              header.column.getCanSort()
-                                ? header.column.getNextSortingOrder() === 'asc'
-                                  ? 'Sort ascending'
-                                  : header.column.getNextSortingOrder() ===
-                                      'desc'
-                                    ? 'Sort descending'
-                                    : 'Clear sort'
-                                : undefined
-                            }
-                          >
-                            <table.FlexRender header={header} />
-                            {{
-                              asc: ' 🔼',
-                              desc: ' 🔽',
-                            }[header.column.getIsSorted() as string] ?? null}
-                          </div>
-                        )}
-                      </th>
+                      <td key={cell.id}>
+                        <table.FlexRender cell={cell} />
+                      </td>
                     )
                   })}
                 </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table
-                .getRowModel()
-                .rows.slice(0, 10)
-                .map((row) => {
-                  return (
-                    <tr key={row.id}>
-                      {row.getAllCells().map((cell) => {
-                        return (
-                          <td key={cell.id}>
-                            <table.FlexRender cell={cell} />
-                          </td>
-                        )
-                      })}
-                    </tr>
-                  )
-                })}
-            </tbody>
-          </table>
-          <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
-          <div>
-            <button onClick={() => rerender()}>Force Rerender</button>
-          </div>
-          {/* Store mode: dump full table state for debugging — selector required */}
-          <table.Subscribe selector={(state) => state}>
-            {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-          </table.Subscribe>
-        </div>
-      )}
-    </table.Subscribe>
+              )
+            })}
+        </tbody>
+      </table>
+      <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
+      <div>
+        <button onClick={() => rerender()}>Force Rerender</button>
+      </div>
+      {/* Store mode: dump full table state for debugging */}
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
+    </div>
   )
 }
 

--- a/examples/react/sub-components/src/main.tsx
+++ b/examples/react/sub-components/src/main.tsx
@@ -92,72 +92,71 @@ function Table({
   getRowCanExpand,
   renderSubComponent,
 }: TableProps<typeof _features, Person>): React.JSX.Element {
-  const table = useTable({
-    debugTable: true,
-    _features,
-    _rowModels: {
-      expandedRowModel: createExpandedRowModel(),
+  const table = useTable(
+    {
+      debugTable: true,
+      _features,
+      _rowModels: {
+        expandedRowModel: createExpandedRowModel(),
+      },
+      columns,
+      data,
+      getRowCanExpand,
     },
-    columns,
-    data,
-    getRowCanExpand,
-  })
+    (state) => state, // default selector
+  )
 
   return (
-    <table.Subscribe selector={(state) => state}>
-      {() => (
-        <div className="demo-root">
-          <div className="spacer-sm" />
-          <table>
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
+    <div className="demo-root">
+      <div className="spacer-sm" />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <th key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder ? null : (
+                      <div>
+                        <table.FlexRender header={header} />
+                      </div>
+                    )}
+                  </th>
+                )
+              })}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <Fragment key={row.id}>
+                <tr>
+                  {/* first row is a normal row */}
+                  {row.getAllCells().map((cell) => {
                     return (
-                      <th key={header.id} colSpan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <div>
-                            <table.FlexRender header={header} />
-                          </div>
-                        )}
-                      </th>
+                      <td key={cell.id}>
+                        <table.FlexRender cell={cell} />
+                      </td>
                     )
                   })}
                 </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => {
-                return (
-                  <Fragment key={row.id}>
-                    <tr>
-                      {/* first row is a normal row */}
-                      {row.getAllCells().map((cell) => {
-                        return (
-                          <td key={cell.id}>
-                            <table.FlexRender cell={cell} />
-                          </td>
-                        )
-                      })}
-                    </tr>
-                    {row.getIsExpanded() && (
-                      <tr>
-                        {/* 2nd row is a custom 1 cell row */}
-                        <td colSpan={row.getAllCells().length}>
-                          {renderSubComponent({ row })}
-                        </td>
-                      </tr>
-                    )}
-                  </Fragment>
-                )
-              })}
-            </tbody>
-          </table>
-          <div className="spacer-sm" />
-          <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
-        </div>
-      )}
-    </table.Subscribe>
+                {row.getIsExpanded() && (
+                  <tr>
+                    {/* 2nd row is a custom 1 cell row */}
+                    <td colSpan={row.getAllCells().length}>
+                      {renderSubComponent({ row })}
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="spacer-sm" />
+      <div>{table.getRowModel().rows.length.toLocaleString()} Rows</div>
+    </div>
   )
 }
 

--- a/examples/react/virtualized-columns-experimental/src/main.tsx
+++ b/examples/react/virtualized-columns-experimental/src/main.tsx
@@ -45,13 +45,16 @@ function App() {
   }, [columns])
 
   // The table does not live in the same scope as the virtualizers
-  const table = useTable({
-    _features,
-    _rowModels: { sortedRowModel: createSortedRowModel(sortFns) },
-    columns,
-    data,
-    debugTable: true,
-  })
+  const table = useTable(
+    {
+      _features,
+      _rowModels: { sortedRowModel: createSortedRowModel(sortFns) },
+      columns,
+      data,
+      debugTable: true,
+    },
+    (state) => state, // default selector
+  )
 
   return (
     <div className="app">
@@ -124,19 +127,15 @@ function TableContainer({ table }: TableContainerProps) {
         height: '800px', // should be a fixed height
       }}
     >
-      <table.Subscribe source={table.atoms.sorting}>
-        {() => (
-          // Even though we're still using sematic table tags, we must use CSS grid and flexbox for dynamic row heights
-          <table style={{ display: 'grid' }}>
-            <TableHead table={table} columnVirtualizer={columnVirtualizer} />
-            <TableBody
-              columnVirtualizer={columnVirtualizer}
-              table={table}
-              tableContainerRef={tableContainerRef}
-            />
-          </table>
-        )}
-      </table.Subscribe>
+      {/* Even though we're still using sematic table tags, we must use CSS grid and flexbox for dynamic row heights */}
+      <table style={{ display: 'grid' }}>
+        <TableHead table={table} columnVirtualizer={columnVirtualizer} />
+        <TableBody
+          columnVirtualizer={columnVirtualizer}
+          table={table}
+          tableContainerRef={tableContainerRef}
+        />
+      </table>
     </div>
   )
 }
@@ -151,6 +150,7 @@ function TableHead({ table, columnVirtualizer }: TableHeadProps) {
     <thead
       style={{
         display: 'grid',
+        height: '34px',
         position: 'sticky',
         top: 0,
         zIndex: 1,
@@ -176,7 +176,10 @@ function TableHeadRow({ columnVirtualizer, headerGroup }: TableHeadRowProps) {
   const virtualColumnIndexes = columnVirtualizer.getVirtualIndexes()
 
   return (
-    <tr key={headerGroup.id} style={{ display: 'flex', width: '100%' }}>
+    <tr
+      key={headerGroup.id}
+      style={{ display: 'flex', height: '34px', width: '100%' }}
+    >
       {/* fake empty column to the left for virtualization scroll padding */}
       <th className="left-column-spacer" />
       {virtualColumnIndexes.map((virtualColumnIndex) => {
@@ -208,7 +211,9 @@ function TableHeadCell({
     <th
       key={header.id}
       style={{
+        alignItems: 'center',
         display: 'flex',
+        height: '34px',
         width: header.getSize(),
       }}
     >

--- a/examples/react/virtualized-columns/src/main.tsx
+++ b/examples/react/virtualized-columns/src/main.tsx
@@ -44,13 +44,16 @@ function App() {
     setData(makeData(10_000, columns))
   }, [columns])
 
-  const table = useTable({
-    _features: features,
-    _rowModels: { sortedRowModel: createSortedRowModel(sortFns) },
-    columns,
-    data,
-    debugTable: true,
-  })
+  const table = useTable(
+    {
+      _features: features,
+      _rowModels: { sortedRowModel: createSortedRowModel(sortFns) },
+      columns,
+      data,
+      debugTable: true,
+    },
+    (state) => state, // default selector
+  )
 
   // All important CSS styles are included as inline styles for this example. This is not recommended for your code.
   return (

--- a/examples/react/virtualized-infinite-scrolling/src/main.tsx
+++ b/examples/react/virtualized-infinite-scrolling/src/main.tsx
@@ -123,17 +123,20 @@ function App() {
     fetchMoreOnBottomReached(tableContainerRef.current)
   }, [fetchMoreOnBottomReached])
 
-  const table = useTable({
-    _features,
-    _rowModels: { sortedRowModel: createSortedRowModel(sortFns) },
-    data: flatData,
-    columns,
-    state: {
-      sorting,
+  const table = useTable(
+    {
+      _features,
+      _rowModels: { sortedRowModel: createSortedRowModel(sortFns) },
+      data: flatData,
+      columns,
+      state: {
+        sorting,
+      },
+      manualSorting: true,
+      debugTable: true,
     },
-    manualSorting: true,
-    debugTable: true,
-  })
+    (state) => state, // default selector
+  )
 
   // scroll to top of table when sorting changes
   const handleSortingChange: OnChangeFn<SortingState> = (updater) => {

--- a/examples/react/virtualized-rows-experimental/src/main.tsx
+++ b/examples/react/virtualized-rows-experimental/src/main.tsx
@@ -73,13 +73,16 @@ function App() {
   const refreshData = () => setData(makeData(50_000))
   const stressTest = () => setData(makeData(500_000))
 
-  const table = useTable({
-    _features,
-    _rowModels: { sortedRowModel: createSortedRowModel(sortFns) },
-    columns,
-    data,
-    debugTable: true,
-  })
+  const table = useTable(
+    {
+      _features,
+      _rowModels: { sortedRowModel: createSortedRowModel(sortFns) },
+      columns,
+      data,
+      debugTable: true,
+    },
+    (state) => state, // default selector
+  )
 
   // The virtualizer needs to know the scrollable container element
   const tableContainerRef = React.useRef<HTMLDivElement>(null)
@@ -108,69 +111,65 @@ function App() {
           height: '800px', // should be a fixed height
         }}
       >
-        <table.Subscribe source={table.atoms.sorting}>
-          {() => (
-            // Even though we're still using sematic table tags, we must use CSS grid and flexbox for dynamic row heights
-            <table style={{ display: 'grid' }}>
-              <thead
-                style={{
-                  display: 'grid',
-                  position: 'sticky',
-                  top: 0,
-                  zIndex: 1,
-                }}
+        {/* Even though we're still using sematic table tags, we must use CSS grid and flexbox for dynamic row heights */}
+        <table style={{ display: 'grid' }}>
+          <thead
+            style={{
+              display: 'grid',
+              height: '34px',
+              position: 'sticky',
+              top: 0,
+              zIndex: 1,
+            }}
+          >
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr
+                key={headerGroup.id}
+                style={{ display: 'flex', height: '34px', width: '100%' }}
               >
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <tr
-                    key={headerGroup.id}
-                    style={{ display: 'flex', width: '100%' }}
-                  >
-                    {headerGroup.headers.map((header) => {
-                      return (
-                        <th
-                          key={header.id}
-                          style={{
-                            display: 'flex',
-                            width: header.getSize(),
-                          }}
-                        >
-                          <div
-                            className={
-                              header.column.getCanSort()
-                                ? 'sortable-header'
-                                : ''
-                            }
-                            onClick={header.column.getToggleSortingHandler()}
-                            title={
-                              header.column.getCanSort()
-                                ? header.column.getNextSortingOrder() === 'asc'
-                                  ? 'Sort ascending'
-                                  : header.column.getNextSortingOrder() ===
-                                      'desc'
-                                    ? 'Sort descending'
-                                    : 'Clear sort'
-                                : undefined
-                            }
-                          >
-                            <FlexRender header={header} />
-                            {{
-                              asc: ' 🔼',
-                              desc: ' 🔽',
-                            }[header.column.getIsSorted() as string] ?? null}
-                          </div>
-                        </th>
-                      )
-                    })}
-                  </tr>
-                ))}
-              </thead>
-              <TableBodyWrapper
-                table={table}
-                tableContainerRef={tableContainerRef}
-              />
-            </table>
-          )}
-        </table.Subscribe>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <th
+                      key={header.id}
+                      style={{
+                        alignItems: 'center',
+                        display: 'flex',
+                        height: '34px',
+                        width: header.getSize(),
+                      }}
+                    >
+                      <div
+                        className={
+                          header.column.getCanSort() ? 'sortable-header' : ''
+                        }
+                        onClick={header.column.getToggleSortingHandler()}
+                        title={
+                          header.column.getCanSort()
+                            ? header.column.getNextSortingOrder() === 'asc'
+                              ? 'Sort ascending'
+                              : header.column.getNextSortingOrder() === 'desc'
+                                ? 'Sort descending'
+                                : 'Clear sort'
+                            : undefined
+                        }
+                      >
+                        <FlexRender header={header} />
+                        {{
+                          asc: ' 🔼',
+                          desc: ' 🔽',
+                        }[header.column.getIsSorted() as string] ?? null}
+                      </div>
+                    </th>
+                  )
+                })}
+              </tr>
+            ))}
+          </thead>
+          <TableBodyWrapper
+            table={table}
+            tableContainerRef={tableContainerRef}
+          />
+        </table>
       </div>
     </div>
   )

--- a/examples/react/virtualized-rows-experimental/vite.config.js
+++ b/examples/react/virtualized-rows-experimental/vite.config.js
@@ -15,9 +15,9 @@ export default defineConfig({
     }),
     react(),
     // React Compiler - comment out the next line to disable
-    babel({
-      presets: [reactCompilerPreset()],
-      include: [/\/src\/.*\.[jt]sx?$/],
-    }),
+    // babel({
+    //   presets: [reactCompilerPreset()],
+    //   include: [/\/src\/.*\.[jt]sx?$/],
+    // }),
   ],
 })

--- a/examples/react/virtualized-rows/src/main.tsx
+++ b/examples/react/virtualized-rows/src/main.tsx
@@ -83,13 +83,16 @@ function App() {
     setData(makeData(1_000_000))
   }, [])
 
-  const table = useTable({
-    _features: features,
-    _rowModels: { sortedRowModel: createSortedRowModel(sortFns) },
-    columns,
-    data,
-    debugTable: true,
-  })
+  const table = useTable(
+    {
+      _features: features,
+      _rowModels: { sortedRowModel: createSortedRowModel(sortFns) },
+      columns,
+      data,
+      debugTable: true,
+    },
+    (state) => state, // default selector
+  )
 
   // All important CSS styles are included as inline styles for this example. This is not recommended for your code.
   return (
@@ -116,65 +119,58 @@ function App() {
             height: '800px', // should be a fixed height
           }}
         >
-          <table.Subscribe selector={(state) => state}>
-            {() => (
-              // Even though we're still using sematic table tags, we must use CSS grid and flexbox for dynamic row heights
-              <table style={{ display: 'grid' }}>
-                <thead
-                  style={{
-                    display: 'grid',
-                    position: 'sticky',
-                    top: 0,
-                    zIndex: 1,
-                  }}
+          {/* Even though we're still using sematic table tags, we must use CSS grid and flexbox for dynamic row heights */}
+          <table style={{ display: 'grid' }}>
+            <thead
+              style={{
+                display: 'grid',
+                height: '34px',
+                position: 'sticky',
+                top: 0,
+                zIndex: 1,
+              }}
+            >
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr
+                  key={headerGroup.id}
+                  style={{ display: 'flex', height: '34px', width: '100%' }}
                 >
-                  {table.getHeaderGroups().map((headerGroup) => (
-                    <tr
-                      key={headerGroup.id}
-                      style={{ display: 'flex', width: '100%' }}
-                    >
-                      {headerGroup.headers.map((header) => {
-                        return (
-                          <th
-                            key={header.id}
-                            style={{
-                              display: 'flex',
-                              width: header.getSize(),
-                            }}
-                          >
-                            <div
-                              {...{
-                                className: header.column.getCanSort()
-                                  ? 'sortable-header'
-                                  : '',
-                                onClick:
-                                  header.column.getToggleSortingHandler(),
-                              }}
-                            >
-                              <table.FlexRender header={header} />
-                              {{
-                                asc: ' 🔼',
-                                desc: ' 🔽',
-                              }[header.column.getIsSorted() as string] ?? null}
-                            </div>
-                          </th>
-                        )
-                      })}
-                    </tr>
-                  ))}
-                </thead>
-                <TableBody
-                  table={table}
-                  tableContainerRef={tableContainerRef}
-                />
-              </table>
-            )}
-          </table.Subscribe>
+                  {headerGroup.headers.map((header) => {
+                    return (
+                      <th
+                        key={header.id}
+                        style={{
+                          alignItems: 'center',
+                          display: 'flex',
+                          height: '34px',
+                          width: header.getSize(),
+                        }}
+                      >
+                        <div
+                          {...{
+                            className: header.column.getCanSort()
+                              ? 'sortable-header'
+                              : '',
+                            onClick: header.column.getToggleSortingHandler(),
+                          }}
+                        >
+                          <table.FlexRender header={header} />
+                          {{
+                            asc: ' 🔼',
+                            desc: ' 🔽',
+                          }[header.column.getIsSorted() as string] ?? null}
+                        </div>
+                      </th>
+                    )
+                  })}
+                </tr>
+              ))}
+            </thead>
+            <TableBody table={table} tableContainerRef={tableContainerRef} />
+          </table>
         </div>
       </div>
-      <table.Subscribe selector={(state) => state}>
-        {(state) => <pre>{JSON.stringify(state, null, 2)}</pre>}
-      </table.Subscribe>
+      <pre>{JSON.stringify(table.state, null, 2)}</pre>
     </>
   )
 }

--- a/examples/react/with-tanstack-form/src/main.tsx
+++ b/examples/react/with-tanstack-form/src/main.tsx
@@ -166,16 +166,19 @@ function App() {
 
   // Create table using form state as data source
   // The table gets fresh data on each render, cells handle their own field state
-  const table = useTable({
-    _features,
-    _rowModels: {
-      filteredRowModel: createFilteredRowModel(filterFns),
-      paginatedRowModel: createPaginatedRowModel(),
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {
+        filteredRowModel: createFilteredRowModel(filterFns),
+        paginatedRowModel: createPaginatedRowModel(),
+      },
+      columns,
+      data: form.state.values.data,
+      debugTable: true,
     },
-    columns,
-    data: form.state.values.data,
-    debugTable: true,
-  })
+    (state) => state, // default selector
+  )
 
   const refreshData = () => {
     const data: Array<FormRow> = makeData(100)
@@ -239,136 +242,122 @@ function App() {
         </div>
 
         {/* Table */}
-        <table.Subscribe
-          selector={(state) => ({
-            pagination: state.pagination,
-            columnFilters: state.columnFilters,
-          })}
-        >
-          {(tableState) => (
-            <>
-              <div className="spacer-sm" />
-              <table>
-                <thead>
-                  {table.getHeaderGroups().map((headerGroup) => (
-                    <tr key={headerGroup.id}>
-                      {headerGroup.headers.map((header) => {
-                        return (
-                          <th key={header.id} colSpan={header.colSpan}>
-                            {header.isPlaceholder ? null : (
-                              <div>
-                                <table.FlexRender header={header} />
-                                {header.column.getCanFilter() ? (
-                                  <div>
-                                    <Filter
-                                      column={header.column}
-                                      table={table}
-                                    />
-                                  </div>
-                                ) : null}
-                              </div>
-                            )}
-                          </th>
-                        )
-                      })}
-                    </tr>
-                  ))}
-                </thead>
-                <tbody>
-                  {table.getRowModel().rows.map((row) => {
+        <>
+          <div className="spacer-sm" />
+          <table>
+            <thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
                     return (
-                      <tr key={row.id}>
-                        {row.getAllCells().map((cell) => {
-                          return (
-                            <td key={cell.id}>
-                              <table.FlexRender cell={cell} />
-                            </td>
-                          )
-                        })}
-                      </tr>
+                      <th key={header.id} colSpan={header.colSpan}>
+                        {header.isPlaceholder ? null : (
+                          <div>
+                            <table.FlexRender header={header} />
+                            {header.column.getCanFilter() ? (
+                              <div>
+                                <Filter column={header.column} table={table} />
+                              </div>
+                            ) : null}
+                          </div>
+                        )}
+                      </th>
                     )
                   })}
-                </tbody>
-              </table>
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {table.getRowModel().rows.map((row) => {
+                return (
+                  <tr key={row.id}>
+                    {row.getAllCells().map((cell) => {
+                      return (
+                        <td key={cell.id}>
+                          <table.FlexRender cell={cell} />
+                        </td>
+                      )
+                    })}
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
 
-              {/* Pagination controls */}
-              <div className="spacer-sm" />
-              <div className="controls">
-                <button
-                  type="button"
-                  className="demo-button demo-button-sm"
-                  onClick={() => table.firstPage()}
-                  disabled={!table.getCanPreviousPage()}
-                >
-                  {'<<'}
-                </button>
-                <button
-                  type="button"
-                  className="demo-button demo-button-sm"
-                  onClick={() => table.previousPage()}
-                  disabled={!table.getCanPreviousPage()}
-                >
-                  {'<'}
-                </button>
-                <button
-                  type="button"
-                  className="demo-button demo-button-sm"
-                  onClick={() => table.nextPage()}
-                  disabled={!table.getCanNextPage()}
-                >
-                  {'>'}
-                </button>
-                <button
-                  type="button"
-                  className="demo-button demo-button-sm"
-                  onClick={() => table.lastPage()}
-                  disabled={!table.getCanNextPage()}
-                >
-                  {'>>'}
-                </button>
-                <span className="inline-controls">
-                  <div>Page</div>
-                  <strong>
-                    {(tableState.pagination.pageIndex + 1).toLocaleString()} of{' '}
-                    {table.getPageCount().toLocaleString()}
-                  </strong>
-                </span>
-                <span className="inline-controls">
-                  | Go to page:
-                  <input
-                    type="number"
-                    min="1"
-                    max={table.getPageCount()}
-                    defaultValue={tableState.pagination.pageIndex + 1}
-                    onChange={(e) => {
-                      const page = e.target.value
-                        ? Number(e.target.value) - 1
-                        : 0
-                      table.setPageIndex(page)
-                    }}
-                    className="page-size-input"
-                  />
-                </span>
-                <select
-                  value={tableState.pagination.pageSize}
-                  onChange={(e) => {
-                    table.setPageSize(Number(e.target.value))
-                  }}
-                >
-                  {[10, 20, 30, 40, 50].map((pageSize) => (
-                    <option key={pageSize} value={pageSize}>
-                      Show {pageSize}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                Showing {table.getRowModel().rows.length.toLocaleString()} of{' '}
-                {table.getRowCount().toLocaleString()} Rows
-              </div>
-            </>
-          )}
-        </table.Subscribe>
+          {/* Pagination controls */}
+          <div className="spacer-sm" />
+          <div className="controls">
+            <button
+              type="button"
+              className="demo-button demo-button-sm"
+              onClick={() => table.firstPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              {'<<'}
+            </button>
+            <button
+              type="button"
+              className="demo-button demo-button-sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              {'<'}
+            </button>
+            <button
+              type="button"
+              className="demo-button demo-button-sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              {'>'}
+            </button>
+            <button
+              type="button"
+              className="demo-button demo-button-sm"
+              onClick={() => table.lastPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              {'>>'}
+            </button>
+            <span className="inline-controls">
+              <div>Page</div>
+              <strong>
+                {(table.state.pagination.pageIndex + 1).toLocaleString()} of{' '}
+                {table.getPageCount().toLocaleString()}
+              </strong>
+            </span>
+            <span className="inline-controls">
+              | Go to page:
+              <input
+                type="number"
+                min="1"
+                max={table.getPageCount()}
+                defaultValue={table.state.pagination.pageIndex + 1}
+                onChange={(e) => {
+                  const page = e.target.value ? Number(e.target.value) - 1 : 0
+                  table.setPageIndex(page)
+                }}
+                className="page-size-input"
+              />
+            </span>
+            <select
+              value={table.state.pagination.pageSize}
+              onChange={(e) => {
+                table.setPageSize(Number(e.target.value))
+              }}
+            >
+              {[10, 20, 30, 40, 50].map((pageSize) => (
+                <option key={pageSize} value={pageSize}>
+                  Show {pageSize}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            Showing {table.getRowModel().rows.length.toLocaleString()} of{' '}
+            {table.getRowCount().toLocaleString()} Rows
+          </div>
+        </>
       </form>
     </div>
   )

--- a/examples/react/with-tanstack-query/src/main.tsx
+++ b/examples/react/with-tanstack-query/src/main.tsx
@@ -69,18 +69,21 @@ function App() {
 
   const defaultData = React.useMemo(() => [], [])
 
-  const table = useTable({
-    _features,
-    _rowModels: {},
-    columns,
-    data: dataQuery.data?.rows ?? defaultData,
-    rowCount: dataQuery.data?.rowCount,
-    atoms: {
-      pagination: paginationAtom,
+  const table = useTable(
+    {
+      _features,
+      _rowModels: {},
+      columns,
+      data: dataQuery.data?.rows ?? defaultData,
+      rowCount: dataQuery.data?.rowCount,
+      atoms: {
+        pagination: paginationAtom,
+      },
+      manualPagination: true, // we're doing manual "server-side" pagination
+      debugTable: true,
     },
-    manualPagination: true, // we're doing manual "server-side" pagination
-    debugTable: true,
-  })
+    (state) => state, // default selector
+  )
 
   return (
     <div className="demo-root">

--- a/examples/react/with-tanstack-router/src/components/table.tsx
+++ b/examples/react/with-tanstack-router/src/components/table.tsx
@@ -64,7 +64,7 @@ export default function Table<T extends Record<string, string | number>>({
       onSortingChange,
       ...paginationOptions,
     },
-    (state) => state,
+    (state) => state, // default selector
   )
 
   // Sync controlled state with per-slice base atoms

--- a/examples/solid/composable-tables/src/App.tsx
+++ b/examples/solid/composable-tables/src/App.tsx
@@ -88,13 +88,11 @@ function UsersTable() {
         return (
           <div class="table-container">
             {/* Table toolbar using pre-bound component */}
-            <table.TableToolbar title="Users Table" onRefresh={refreshData} />
-            <div>
-              <button onClick={() => refreshData()}>Regenerate Data</button>
-              <button onClick={() => stressTest()}>
-                Stress Test (200k rows)
-              </button>
-            </div>
+            <table.TableToolbar
+              title="Users Table"
+              onRefresh={refreshData}
+              onStressTest={stressTest}
+            />
 
             {/* Table element */}
             <table>
@@ -297,13 +295,8 @@ function ProductsTable() {
             <table.TableToolbar
               title="Products Table"
               onRefresh={refreshData}
+              onStressTest={stressTest}
             />
-            <div>
-              <button onClick={() => refreshData()}>Regenerate Data</button>
-              <button onClick={() => stressTest()}>
-                Stress Test (200k rows)
-              </button>
-            </div>
 
             {/* Table element */}
             <table>

--- a/examples/solid/composable-tables/src/components/table-components.tsx
+++ b/examples/solid/composable-tables/src/components/table-components.tsx
@@ -95,21 +95,26 @@ export function RowCount() {
 export function TableToolbar({
   title,
   onRefresh,
+  onStressTest,
 }: {
   title: string
   onRefresh?: () => void
+  onStressTest?: () => void
 }) {
   const table = useTableContext()
 
   return (
     <div class="table-toolbar">
       <h2>{title}</h2>
-      <div>
+      <div class="table-toolbar-actions">
+        {onRefresh && <button onClick={onRefresh}>Regenerate Data</button>}
+        {onStressTest && (
+          <button onClick={onStressTest}>Stress Test (200k rows)</button>
+        )}
         <button onClick={() => table.resetColumnFilters()}>
           Clear Filters
         </button>
         <button onClick={() => table.resetSorting()}>Clear Sorting</button>
-        {onRefresh && <button onClick={onRefresh}>Regenerate Data</button>}
       </div>
     </div>
   )

--- a/examples/solid/composable-tables/src/index.css
+++ b/examples/solid/composable-tables/src/index.css
@@ -174,6 +174,12 @@ tfoot th {
   border-spacing: 0;
 }
 
+.table-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .table-toolbar button {
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/examples/svelte/composable-tables/src/components/ProductsTable.svelte
+++ b/examples/svelte/composable-tables/src/components/ProductsTable.svelte
@@ -76,14 +76,12 @@
 
 <table.AppTable>
   <div class="table-container">
-    <div>
-      <button onclick={() => refreshData()
-      }>Regenerate Data</button>
-      <button onclick={() => stressTest()}>Stress Test (200k rows)</button>
-    </div>
     <!-- Table toolbar using the same pre-bound component -->
-    <table.TableToolbar title="Products Table" onRefresh={refreshData
-    } />
+    <table.TableToolbar
+      title="Products Table"
+      onRefresh={refreshData}
+      onStressTest={stressTest}
+    />
 
     <!-- Table element -->
     <table>

--- a/examples/svelte/composable-tables/src/components/TableToolbar.svelte
+++ b/examples/svelte/composable-tables/src/components/TableToolbar.svelte
@@ -3,31 +3,33 @@
   Uses useTableContext to access the table instance.
 -->
 <script lang="ts">
-  import { useTableContext
-  } from '../hooks/table'
+  import { useTableContext } from '../hooks/table'
 
   interface Props {
     title: string
     onRefresh?: () => void
+    onStressTest?: () => void
   }
 
-  let { title, onRefresh }: Props = $props()
+  let { title, onRefresh, onStressTest }: Props = $props()
 
   const table = useTableContext()
 </script>
 
 <div class="table-toolbar">
-  <h2>{title
-  }</h2>
-  <div>
+  <h2>{title}</h2>
+  <div class="table-toolbar-actions">
+    {#if onRefresh}
+      <button onclick={onRefresh}>Regenerate Data</button>
+    {/if}
+    {#if onStressTest}
+      <button onclick={onStressTest}>Stress Test (200k rows)</button>
+    {/if}
     <button onclick={() => table.resetColumnFilters()}>
       Clear Filters
     </button>
     <button onclick={() => table.resetSorting()}>
       Clear Sorting
     </button>
-    {#if onRefresh}
-      <button onclick={onRefresh}>Regenerate Data</button>
-    {/if}
   </div>
 </div>

--- a/examples/svelte/composable-tables/src/components/UsersTable.svelte
+++ b/examples/svelte/composable-tables/src/components/UsersTable.svelte
@@ -88,14 +88,12 @@
 
 <table.AppTable>
   <div class="table-container">
-    <div>
-      <button onclick={() => refreshData()
-      }>Regenerate Data</button>
-      <button onclick={() => stressTest()}>Stress Test (200k rows)</button>
-    </div>
     <!-- Table toolbar using pre-bound component -->
-    <table.TableToolbar title="Users Table" onRefresh={refreshData
-    } />
+    <table.TableToolbar
+      title="Users Table"
+      onRefresh={refreshData}
+      onStressTest={stressTest}
+    />
 
     <!-- Table element -->
     <table>

--- a/examples/svelte/composable-tables/src/index.css
+++ b/examples/svelte/composable-tables/src/index.css
@@ -174,6 +174,12 @@ tfoot th {
   border-spacing: 0;
 }
 
+.table-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .table-toolbar button {
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/examples/svelte/row-selection/src/App.svelte
+++ b/examples/svelte/row-selection/src/App.svelte
@@ -298,7 +298,10 @@
   </div>
 </div>
 
-{#snippet Filter(column: Column<typeof _features, Person>, table: SvelteTable<typeof _features, Person>)}
+{#snippet Filter(
+  column: Column<typeof _features, Person>,
+  table: SvelteTable<typeof _features, Person, any>,
+)}
   {@const firstValue = table
     .getPreFilteredRowModel()
     .flatRows[0]?.getValue(column.id)}

--- a/examples/vue/composable-tables/src/components/ProductsTable.vue
+++ b/examples/vue/composable-tables/src/components/ProductsTable.vue
@@ -64,11 +64,8 @@ const table = useAppTable({
         :is="table.TableToolbar"
         title="Products Table"
         :onRefresh="refreshData"
+        :onStressTest="stressTest"
       />
-      <div style="margin-bottom: 8px">
-        <button @click="refreshData">Regenerate Data</button>
-        <button @click="stressTest">Stress Test (200k rows)</button>
-      </div>
 
       <table>
         <thead>

--- a/examples/vue/composable-tables/src/components/UsersTable.vue
+++ b/examples/vue/composable-tables/src/components/UsersTable.vue
@@ -82,11 +82,8 @@ function tableSelector(state: ReturnType<typeof table.store.get>) {
         :is="table.TableToolbar"
         title="Users Table"
         :onRefresh="refreshData"
+        :onStressTest="stressTest"
       />
-      <div style="margin-bottom: 8px">
-        <button @click="refreshData">Regenerate Data</button>
-        <button @click="stressTest">Stress Test (200k rows)</button>
-      </div>
 
       <table>
         <thead>

--- a/examples/vue/composable-tables/src/components/table-components.ts
+++ b/examples/vue/composable-tables/src/components/table-components.ts
@@ -122,19 +122,17 @@ export const TableToolbar = defineComponent({
       type: Function as PropType<() => void>,
       default: undefined,
     },
+    onStressTest: {
+      type: Function as PropType<() => void>,
+      default: undefined,
+    },
   },
   setup(props) {
     const table = useTableContext()
     return () =>
       h('div', { class: 'table-toolbar' }, [
         h('h2', props.title),
-        h('div', [
-          h(
-            'button',
-            { onClick: () => table.resetColumnFilters() },
-            'Clear Filters',
-          ),
-          h('button', { onClick: () => table.resetSorting() }, 'Clear Sorting'),
+        h('div', { class: 'table-toolbar-actions' }, [
           props.onRefresh
             ? h(
                 'button',
@@ -142,6 +140,19 @@ export const TableToolbar = defineComponent({
                 'Regenerate Data',
               )
             : null,
+          props.onStressTest
+            ? h(
+                'button',
+                { onClick: () => props.onStressTest?.() },
+                'Stress Test (200k rows)',
+              )
+            : null,
+          h(
+            'button',
+            { onClick: () => table.resetColumnFilters() },
+            'Clear Filters',
+          ),
+          h('button', { onClick: () => table.resetSorting() }, 'Clear Sorting'),
         ]),
       ])
   },

--- a/examples/vue/composable-tables/src/index.css
+++ b/examples/vue/composable-tables/src/index.css
@@ -174,6 +174,12 @@ tfoot th {
   border-spacing: 0;
 }
 
+.table-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .table-toolbar button {
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/packages/angular-table/src/helpers/createTableHook.ts
+++ b/packages/angular-table/src/helpers/createTableHook.ts
@@ -404,7 +404,10 @@ export function createTableHook<
     return injectFlexRenderContext<CellContext<TFeatures, TData, TValue>>()
   }
 
-  function injectAppTable<TData extends RowData, TSelected = {}>(
+  function injectAppTable<
+    TData extends RowData,
+    TSelected = TableState<TFeatures>,
+  >(
     tableOptions: () => Omit<
       TableOptions<TFeatures, TData>,
       '_features' | '_rowModels'

--- a/packages/angular-table/src/injectTable.ts
+++ b/packages/angular-table/src/injectTable.ts
@@ -136,8 +136,7 @@ export function injectTable<
   TSelected = TableState<TFeatures>,
 >(
   options: () => TableOptions<TFeatures, TData>,
-  selector: (state: TableState<TFeatures>) => TSelected = (state) =>
-    state as TSelected,
+  selector?: (state: TableState<TFeatures>) => TSelected,
 ): AngularTable<TFeatures, TData, TSelected> {
   assertInInjectionContext(injectTable)
   const injector = inject(Injector)
@@ -175,18 +174,14 @@ export function injectTable<
       equal?: ValueEqualityFn<unknown>
     }) {
       const source = props.source ?? table.store
-      return injectSelector(
-        source,
-        props.selector ?? ((state: unknown) => state),
-        {
-          compare: props.equal ?? shallow,
-          injector,
-        },
-      )
+      return injectSelector(source, props.selector as never, {
+        compare: props.equal ?? shallow,
+        injector,
+      })
     } as AngularTableComputed<TFeatures>
 
     Object.defineProperty(table, 'state', {
-      value: computed(() => selector(table.store.get())),
+      value: computed(() => selector?.(table.store.get()) ?? table.store.get()),
     })
 
     Object.defineProperty(table, 'value', {

--- a/packages/lit-table/src/TableController.ts
+++ b/packages/lit-table/src/TableController.ts
@@ -30,7 +30,7 @@ export type SubscribeSource<TValue> =
 export type LitTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 > = Table<TFeatures, TData> & {
   /**
    * Subscribe to a selected slice of table state, or to a single source (atom or store).
@@ -144,10 +144,9 @@ export class TableController<
     ;(this.host = host).addController(this)
   }
 
-  public table<TSelected = {}>(
+  public table<TSelected = TableState<TFeatures>>(
     tableOptions: TableOptions<TFeatures, TData>,
-    selector: (state: TableState<TFeatures>) => TSelected = () =>
-      ({}) as TSelected,
+    selector?: (state: TableState<TFeatures>) => TSelected,
   ): LitTable<TFeatures, TData, TSelected> {
     if (!this._table) {
       const mergedOptions: TableOptions<TFeatures, TData> = {
@@ -206,7 +205,8 @@ export class TableController<
       Subscribe,
       FlexRender,
       get state() {
-        return selector(tableInstance.store.state)
+        return (selector?.(tableInstance.store.state) ??
+          tableInstance.store.state) as TSelected
       },
     }
   }

--- a/packages/lit-table/src/createTableHook.ts
+++ b/packages/lit-table/src/createTableHook.ts
@@ -612,7 +612,10 @@ export function createTableHook<
    * }
    * ```
    */
-  function useAppTable<TData extends RowData, TSelected = {}>(
+  function useAppTable<
+    TData extends RowData,
+    TSelected = TableState<TFeatures>,
+  >(
     host: ReactiveControllerHost & HTMLElement,
     tableOptions: Omit<
       TableOptions<TFeatures, TData>,

--- a/packages/preact-table/src/Subscribe.ts
+++ b/packages/preact-table/src/Subscribe.ts
@@ -92,11 +92,9 @@ export function Subscribe<
 >(
   props: SubscribeProps<TFeatures, TSelected, TSourceValue>,
 ): ComponentChildren {
-  const selectFn = props.selector ?? ((x: unknown) => x)
-
   const selected = useSelector(
     props.source as never,
-    selectFn as Parameters<typeof useSelector>[1],
+    props.selector as Parameters<typeof useSelector>[1],
     {
       compare: shallow,
     },

--- a/packages/preact-table/src/createTableHook.tsx
+++ b/packages/preact-table/src/createTableHook.tsx
@@ -796,7 +796,10 @@ export function createTableHook<
    *
    * TFeatures is already known from the createTableHook call; TData is inferred from the data prop.
    */
-  function useAppTable<TData extends RowData, TSelected = {}>(
+  function useAppTable<
+    TData extends RowData,
+    TSelected = TableState<TFeatures>,
+  >(
     tableOptions: Omit<
       TableOptions<TFeatures, TData>,
       '_features' | '_rowModels'

--- a/packages/preact-table/src/useTable.ts
+++ b/packages/preact-table/src/useTable.ts
@@ -19,7 +19,7 @@ import type { SubscribePropsWithStore, SubscribeSource } from './Subscribe'
 export type PreactTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 > = Table<TFeatures, TData> & {
   /**
    * A Preact HOC (Higher Order Component) that allows you to subscribe to the table state.
@@ -79,11 +79,10 @@ export type PreactTable<
 export function useTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 >(
   tableOptions: TableOptions<TFeatures, TData>,
-  selector: (state: TableState<TFeatures>) => TSelected = () =>
-    ({}) as TSelected,
+  selector?: (state: TableState<TFeatures>) => TSelected,
 ): PreactTable<TFeatures, TData, TSelected> {
   const [table] = useState(() => {
     const tableInstance = constructTable({

--- a/packages/react-table/src/Subscribe.ts
+++ b/packages/react-table/src/Subscribe.ts
@@ -138,12 +138,10 @@ export function Subscribe<
 >(
   props: SubscribeProps<TFeatures, TSelected, TSourceValue>,
 ): ReturnType<FunctionComponent> {
-  const selectFn = props.selector ?? ((x: unknown) => x)
-
   const selected = useSelector(
     // Atom and store share the same selection protocol; union args need a widen for TS.
     props.source,
-    selectFn as Parameters<typeof useSelector>[1],
+    props.selector as Parameters<typeof useSelector>[1],
     {
       compare: shallow,
     },

--- a/packages/react-table/src/createTableHook.tsx
+++ b/packages/react-table/src/createTableHook.tsx
@@ -800,7 +800,10 @@ export function createTableHook<
    *
    * TFeatures is already known from the createTableHook call; TData is inferred from the data prop.
    */
-  function useAppTable<TData extends RowData, TSelected = {}>(
+  function useAppTable<
+    TData extends RowData,
+    TSelected = TableState<TFeatures>,
+  >(
     tableOptions: Omit<
       TableOptions<TFeatures, TData>,
       '_features' | '_rowModels'

--- a/packages/react-table/src/useTable.ts
+++ b/packages/react-table/src/useTable.ts
@@ -21,7 +21,7 @@ import type { FunctionComponent, ReactNode } from 'react'
 export type ReactTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 > = Table<TFeatures, TData> & {
   /**
    * A React HOC (Higher Order Component) that allows you to subscribe to the table state.
@@ -108,11 +108,10 @@ export type ReactTable<
 export function useTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 >(
   tableOptions: TableOptions<TFeatures, TData>,
-  selector: (state: TableState<TFeatures>) => TSelected = () =>
-    ({}) as TSelected,
+  selector?: (state: TableState<TFeatures>) => TSelected,
 ): ReactTable<TFeatures, TData, TSelected> {
   const [table] = useState(() => {
     const tableInstance = constructTable({

--- a/packages/solid-table/src/createTable.ts
+++ b/packages/solid-table/src/createTable.ts
@@ -27,7 +27,7 @@ export type SubscribeSource<TValue> =
 export type SolidTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 > = Table<TFeatures, TData> & {
   /**
    * Subscribe to the store (selector required) or a single source (atom or store).
@@ -76,11 +76,10 @@ export type SolidTable<
 export function createTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 >(
   tableOptions: TableOptions<TFeatures, TData>,
-  selector: (state: TableState<TFeatures>) => TSelected = () =>
-    ({}) as TSelected,
+  selector?: (state: TableState<TFeatures>) => TSelected,
 ): SolidTable<TFeatures, TData, TSelected> {
   const owner = getOwner()!
 
@@ -130,8 +129,7 @@ export function createTable<
     children: ((state: Accessor<unknown>) => JSX.Element) | JSX.Element
   }) => {
     const source = props.source ?? table.store
-    const selectFn = props.selector ?? ((x: unknown) => x)
-    const selected = useSelector(source as never, selectFn, {
+    const selected = useSelector(source as never, props.selector as never, {
       compare: shallow,
     })
     return typeof props.children === 'function'

--- a/packages/solid-table/src/createTableHook.tsx
+++ b/packages/solid-table/src/createTableHook.tsx
@@ -820,7 +820,10 @@ export function createTableHook<
    *
    * TFeatures is already known from the createTableHook call; TData is inferred from the data prop.
    */
-  function createAppTable<TData extends RowData, TSelected = {}>(
+  function createAppTable<
+    TData extends RowData,
+    TSelected = TableState<TFeatures>,
+  >(
     tableOptions: Omit<
       TableOptions<TFeatures, TData>,
       '_features' | '_rowModels'

--- a/packages/svelte-table/src/createTable.svelte.ts
+++ b/packages/svelte-table/src/createTable.svelte.ts
@@ -14,7 +14,7 @@ import type {
 export type SvelteTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 > = Table<TFeatures, TData> & {
   /**
    * The selected state of the table. This state may not match the structure of `table.store.state` because it is selected by the `selector` function that you pass as the 2nd argument to `createTable`.
@@ -30,11 +30,10 @@ export type SvelteTable<
 export function createTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 >(
   tableOptions: TableOptions<TFeatures, TData>,
-  selector: (state: TableState<TFeatures>) => TSelected = () =>
-    ({}) as TSelected,
+  selector?: (state: TableState<TFeatures>) => TSelected,
 ): SvelteTable<TFeatures, TData, TSelected> {
   // 1. Merge reactivity into options using mergeObjects (preserves getters)
   const mergedOptions = mergeObjects(tableOptions, {

--- a/packages/svelte-table/src/createTableHook.svelte.ts
+++ b/packages/svelte-table/src/createTableHook.svelte.ts
@@ -523,7 +523,10 @@ export function createTableHook<
    *
    * TFeatures is already known from the createTableHook call; TData is inferred from the data prop.
    */
-  function createAppTable<TData extends RowData, TSelected = {}>(
+  function createAppTable<
+    TData extends RowData,
+    TSelected = TableState<TFeatures>,
+  >(
     tableOptions: Omit<
       TableOptions<TFeatures, TData>,
       '_features' | '_rowModels'

--- a/packages/vue-table/src/createTableHook.ts
+++ b/packages/vue-table/src/createTableHook.ts
@@ -392,7 +392,10 @@ export function createTableHook<
     },
   })
 
-  function useAppTable<TData extends RowData, TSelected = {}>(
+  function useAppTable<
+    TData extends RowData,
+    TSelected = TableState<TFeatures>,
+  >(
     tableOptions: Omit<
       TableOptionsWithReactiveData<TFeatures, TData>,
       '_features' | '_rowModels'

--- a/packages/vue-table/src/useTable.ts
+++ b/packages/vue-table/src/useTable.ts
@@ -61,7 +61,7 @@ function getReactiveOptionDeps<
 export type VueTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 > = Table<TFeatures, TData> & {
   /**
    * Store mode: `selector` required. Source mode: pass `source` (atom or store); omit
@@ -107,13 +107,12 @@ export type VueTable<
 export function useTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
-  TSelected = {},
+  TSelected = TableState<TFeatures>,
 >(
   tableOptions:
     | TableOptions<TFeatures, TData>
     | TableOptionsWithReactiveData<TFeatures, TData>,
-  selector: (state: TableState<TFeatures>) => TSelected = () =>
-    ({}) as TSelected,
+  selector?: (state: TableState<TFeatures>) => TSelected,
 ): VueTable<TFeatures, TData, TSelected> {
   const syncTableOptions = (
     table: Table<TFeatures, TData>,
@@ -209,8 +208,7 @@ export function useTable<
       | Array<VNode>
   }) => {
     const source = props.source ?? table.store
-    const selectFn = props.selector ?? ((x: unknown) => x)
-    const selected = useSelector(source as never, selectFn as never, {
+    const selected = useSelector(source as never, props.selector as never, {
       compare: shallow,
     })
     if (typeof props.children === 'function') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1660,6 +1660,37 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
 
+  examples/preact/basic-subscribe:
+    dependencies:
+      '@faker-js/faker':
+        specifier: ^10.4.0
+        version: 10.4.0
+      '@tanstack/preact-store':
+        specifier: ^0.13.0
+        version: 0.13.0(preact@10.29.1)
+      '@tanstack/preact-table':
+        specifier: ^9.0.0-alpha.44
+        version: link:../../../packages/preact-table
+      preact:
+        specifier: ^10.29.1
+        version: 10.29.1
+    devDependencies:
+      '@preact/preset-vite':
+        specifier: ^2.10.5
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+      '@tanstack/preact-devtools':
+        specifier: ^0.10.2
+        version: 0.10.2(preact@10.29.1)(solid-js@1.9.12)
+      '@tanstack/preact-table-devtools':
+        specifier: ^9.0.0-alpha.43
+        version: link:../../../packages/preact-table-devtools
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
+
   examples/preact/basic-use-app-table:
     dependencies:
       '@tanstack/preact-table':
@@ -2285,6 +2316,55 @@ importers:
       '@rollup/plugin-replace':
         specifier: ^6.0.3
         version: 6.0.3(rollup@4.60.2)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0))(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3)
+
+  examples/react/basic-subscribe:
+    dependencies:
+      '@faker-js/faker':
+        specifier: ^10.4.0
+        version: 10.4.0
+      '@tanstack/react-store':
+        specifier: ^0.11.0
+        version: 0.11.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-table':
+        specifier: ^9.0.0-alpha.44
+        version: link:../../../packages/react-table
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.0)(@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0))(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(sugarss@5.0.1(postcss@8.5.13))(terser@5.46.0)(yaml@2.8.3))
+      '@rollup/plugin-replace':
+        specifier: ^6.0.3
+        version: 6.0.3(rollup@4.60.2)
+      '@tanstack/react-devtools':
+        specifier: ^0.10.2
+        version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)
+      '@tanstack/react-table-devtools':
+        specifier: ^9.0.0-alpha.43
+        version: link:../../../packages/react-table-devtools
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table toolbars gain a "Stress Test (200k rows)" action and unified regenerate/stress controls.

* **Improvements**
  * Toolbar controls consolidated into reusable components across examples.
  * Example apps now read table state directly for simpler, more predictable debug displays.
  * Toolbar action layout and styling improved for consistent spacing.

* **Documentation**
  * Added/updated example and reference docs to reflect new toolbar and state behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->