### PR TITLE
fix(table-core): scan rows for first non-nullish value in getColumnCanGlobalFilter

### DIFF
--- a/packages/table-core/src/features/global-filtering/globalFilteringFeature.ts
+++ b/packages/table-core/src/features/global-filtering/globalFilteringFeature.ts
@@ -53,10 +53,11 @@ export function constructGlobalFilteringFeature<
         onGlobalFilterChange: makeStateUpdater('globalFilter', table),
         globalFilterFn: 'auto',
         getColumnCanGlobalFilter: (column) => {
-          const value = table
-            .getCoreRowModel()
-            .flatRows[0]?.getAllCellsByColumnId()
-            [column.id]?.getValue()
+          let value: unknown
+          for (const row of table.getCoreRowModel().flatRows) {
+            value = row.getAllCellsByColumnId()[column.id]?.getValue()
+            if (value != null) break
+          }
 
           return typeof value === 'string' || typeof value === 'number'
         },

--- a/packages/table-core/tests/implementation/features/global-filtering/globalFilteringFeature.test.ts
+++ b/packages/table-core/tests/implementation/features/global-filtering/globalFilteringFeature.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  columnFilteringFeature,
+  constructTable,
+  coreFeatures,
+  createColumnHelper,
+  globalFilteringFeature,
+} from '../../../../src'
+import { storeReactivityBindings } from '../../../../src/store-reactivity-bindings'
+import type { ColumnDef } from '../../../../src'
+
+type Row = { name: string | null | undefined }
+
+const _features = {
+  ...coreFeatures,
+  columnFilteringFeature,
+  globalFilteringFeature,
+  coreReativityFeature: storeReactivityBindings(),
+}
+
+const columnHelper = createColumnHelper<typeof _features, Row>()
+const columns: Array<ColumnDef<typeof _features, Row, any>> = [
+  columnHelper.accessor('name', { id: 'name' }),
+]
+
+function makeTable(data: Array<Row>) {
+  return constructTable<typeof _features, Row>({
+    _features,
+    _rowModels: {},
+    renderFallbackValue: '',
+    data,
+    columns,
+  })
+}
+
+describe('globalFilteringFeature', () => {
+  it('getColumnCanGlobalFilter returns true when a later row has a string value even if the first row is nullish', () => {
+    const table = makeTable([{ name: undefined }, { name: 'second' }])
+    expect(table.getColumn('name')!.getCanGlobalFilter()).toBe(true)
+  })
+
+  it('getColumnCanGlobalFilter returns false when every row value is nullish', () => {
+    const table = makeTable([{ name: undefined }, { name: null }])
+    expect(table.getColumn('name')!.getCanGlobalFilter()).toBe(false)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

`getColumnCanGlobalFilter`'s default `getColumnCanGlobalFilter` only looked at the first row's cell value, so a column was wrongly marked non-filterable whenever the first row happened to hold `undefined`/`null` even though every other row had a string or number. It now scans rows for the first non-nullish value before deciding. Closes #4594.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.
