### PR TITLE
fix: release branch publishing not to commit to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ env:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   release:
@@ -40,11 +41,34 @@ jobs:
       - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents
+      - name: Prepare Release PR Branch
+        id: release-branch
+        run: |
+          branch="release/${GITHUB_REF_NAME}/version-bump-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git switch -c "$branch"
+          git push --set-upstream origin "$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
       - name: Publish
         run: |
-          git config --global user.name 'Tanner Linsley'
-          git config --global user.email 'tannerlinsley@users.noreply.github.com'
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           pnpm run cipublish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
           TAG: ${{ inputs.tag }}
+      - name: Open Version Bump Pull Request
+        run: |
+          if [[ "$(git rev-list --count "origin/${GITHUB_REF_NAME}..HEAD")" == "0" ]]; then
+            echo "No version bump commit was created; skipping pull request."
+            git push origin --delete "${{ steps.release-branch.outputs.branch }}"
+            exit 0
+          fi
+
+          gh pr create \
+            --base "$GITHUB_REF_NAME" \
+            --head "${{ steps.release-branch.outputs.branch }}" \
+            --title "release: version packages" \
+            --body "Automated version bump created after publishing packages."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,14 +61,15 @@ jobs:
         run: |
           if [[ "$(git rev-list --count "origin/${GITHUB_REF_NAME}..HEAD")" == "0" ]]; then
             echo "No version bump commit was created; skipping pull request."
-            git push origin --delete "${{ steps.release-branch.outputs.branch }}"
+            git push origin --delete "$RELEASE_BRANCH"
             exit 0
           fi
 
           gh pr create \
             --base "$GITHUB_REF_NAME" \
-            --head "${{ steps.release-branch.outputs.branch }}" \
+            --head "$RELEASE_BRANCH" \
             --title "release: version packages" \
             --body "Automated version bump created after publishing packages."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BRANCH: ${{ steps.release-branch.outputs.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 permissions:
@@ -54,7 +55,6 @@ jobs:
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           pnpm run cipublish
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.ref_name }}
           TAG: ${{ inputs.tag }}
       - name: Open Version Bump Pull Request
@@ -71,5 +71,4 @@ jobs:
             --title "release: version packages" \
             --body "Automated version bump created after publishing packages."
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCH: ${{ steps.release-branch.outputs.branch }}


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow: publishes from a dedicated release branch with authenticated publishing, attempts to open a version-bump pull request when a new version is produced, and automatically skips PR creation and deletes the temporary branch if no version bump is detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/table/pull/6275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->