### PR TITLE
fix(grouping): aggregate grouped columns at shallower group levels

### DIFF
--- a/.changeset/fix-grouped-column-aggregation.md
+++ b/.changeset/fix-grouped-column-aggregation.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+fix(grouping): aggregate grouped columns at shallower group levels instead of showing the first row's value

--- a/packages/table-core/src/utils/getGroupedRowModel.ts
+++ b/packages/table-core/src/utils/getGroupedRowModel.ts
@@ -92,8 +92,12 @@ export function getGroupedRowModel<TData extends RowData>(): (
                 subRows,
                 leafRows,
                 getValue: (columnId: string) => {
-                  // Don't aggregate columns that are in the grouping
-                  if (existingGrouping.includes(columnId)) {
+                  // Don't aggregate columns that group this row at the current
+                  // level or an ancestor level - their value is constant across
+                  // the group. Columns grouped at a deeper level still need to
+                  // be aggregated here.
+                  const groupingIndex = existingGrouping.indexOf(columnId)
+                  if (groupingIndex > -1 && groupingIndex <= depth) {
                     if (row._valuesCache.hasOwnProperty(columnId)) {
                       return row._valuesCache[columnId]
                     }

--- a/packages/table-core/tests/getGroupedRowModel.test.ts
+++ b/packages/table-core/tests/getGroupedRowModel.test.ts
@@ -5,6 +5,17 @@ import { createTable } from '../src/core/table'
 import { getGroupedRowModel } from '../src/utils/getGroupedRowModel'
 import { makeData, Person } from './makeTestData'
 
+function createPerson(firstName: string, age: number): Person {
+  return {
+    firstName,
+    lastName: 'Doe',
+    age,
+    visits: 0,
+    progress: 0,
+    status: 'single',
+  }
+}
+
 type personKeys = keyof Person
 type PersonColumn = ColumnDef<Person, string | number | Person[] | undefined>
 
@@ -48,5 +59,44 @@ describe('#getGroupedRowModel', () => {
       groupedById['firstName:Fixed>lastName:Name>age:123'].leafRows.length,
     ).toEqual(50000)
     expect(end.valueOf() - start.valueOf()).toBeLessThan(5000)
+  })
+
+  it('aggregates a secondary grouped column at parent group levels', () => {
+    const data: Person[] = [
+      // first Engineering row is intentionally not the min, so the bug
+      // (returning the first row's raw value) differs from the aggregate
+      createPerson('Engineering', 30),
+      createPerson('Engineering', 24),
+      createPerson('Sales', 40),
+    ]
+
+    const columnHelper = createColumnHelper<Person>()
+    const columns = [
+      columnHelper.accessor('firstName', { id: 'firstName' }),
+      columnHelper.accessor('age', { id: 'age', aggregationFn: 'min' }),
+    ]
+
+    const table = createTable<Person>({
+      onStateChange() {},
+      renderFallbackValue: '',
+      data,
+      state: { grouping: ['firstName', 'age'] },
+      columns,
+      getCoreRowModel: getCoreRowModel(),
+      getGroupedRowModel: getGroupedRowModel(),
+    })
+
+    const rowsById = table.getGroupedRowModel().rowsById
+    const engineering = rowsById['firstName:Engineering']
+
+    // `age` is grouped at a deeper level, so the Engineering group row should
+    // still expose the aggregated (min) age across its leaf rows.
+    expect(engineering?.getValue('age')).toBe(24)
+    expect(rowsById['firstName:Sales']?.getValue('age')).toBe(40)
+
+    // at the `age` group level the column is the grouping key, so it keeps the
+    // grouping value rather than aggregating
+    expect(rowsById['firstName:Engineering>age:24']?.getValue('age')).toBe(24)
+    expect(rowsById['firstName:Engineering>age:30']?.getValue('age')).toBe(30)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #6228 (also the long-standing #3232).

When grouping by more than one column, a grouped column was never aggregated on any group row, so it showed an empty/incorrect value at parent group levels.

### Bug

Group by `Department` then `Age`, with `aggregationFn: 'min'` on `Age`. At the top-level `Department` group row the `Age` cell does not show the aggregated (min) age across the department — it shows the first leaf row's raw value (and renders blank in the demo because the grouped cell isn't treated as an aggregated cell).

### Root cause

In `getGroupedRowModel`, the grouped row's `getValue` skips aggregation for any column that appears **anywhere** in the grouping state:

```ts
// Don't aggregate columns that are in the grouping
if (existingGrouping.includes(columnId)) {
  // return the group's own value instead of aggregating
}
```

A column's value is only constant across a group when that column groups the row at the **current depth or a shallower (ancestor) level**. A column grouped at a *deeper* level still varies within the current group and must be aggregated.

### Fix

Compare the column's position in the grouping order against the row's depth, so only ancestor/current grouping columns short-circuit aggregation:

```ts
const groupingIndex = existingGrouping.indexOf(columnId)
if (groupingIndex > -1 && groupingIndex <= depth) {
  // ...
}
```

Single-column grouping is unaffected (index `0` at depth `0`), so the common case behaves exactly as before.

## Testing

- Added a regression test in `getGroupedRowModel.test.ts` that groups by two columns and asserts the secondary grouped column is aggregated at the parent group level, while still keeping its grouping value at its own level. The test fails on `main` and passes with this change.
- `pnpm --filter @tanstack/table-core test:lib` — all green
- `pnpm --filter @tanstack/table-core test:types` — green
- `pnpm --filter @tanstack/table-core build` — green
- Added a changeset.