### PR TITLE
fix(table-core): clamp column size to minSize/maxSize during resize drag

### DIFF
--- a/packages/table-core/src/features/column-resizing/columnResizingFeature.utils.ts
+++ b/packages/table-core/src/features/column-resizing/columnResizingFeature.utils.ts
@@ -163,9 +163,8 @@ export function header_getResizeHandler<
           const minSize = constraints?.minSize ?? 0
           const maxSize = constraints?.maxSize ?? Number.MAX_SAFE_INTEGER
           newColumnSizing[columnId] =
-            Math.round(
-              Math.min(maxSize, Math.max(minSize, rawSize)) * 100,
-            ) / 100
+            Math.round(Math.min(maxSize, Math.max(minSize, rawSize)) * 100) /
+            100
         })
 
         return {

--- a/packages/table-core/src/features/column-resizing/columnResizingFeature.utils.ts
+++ b/packages/table-core/src/features/column-resizing/columnResizingFeature.utils.ts
@@ -1,5 +1,6 @@
 import {
   column_getSize,
+  getDefaultColumnSizingColumnDef,
   header_getSize,
   table_setColumnSizing,
 } from '../column-sizing/columnSizingFeature.utils'
@@ -119,6 +120,18 @@ export function header_getResizeHandler<
         column_getSize(leafHeader.column),
       ])
 
+    const defaultSizes = getDefaultColumnSizingColumnDef()
+    const columnSizingConstraints: Record<
+      string,
+      { minSize: number; maxSize: number }
+    > = {}
+    header.getLeafHeaders().forEach((leafHeader) => {
+      columnSizingConstraints[leafHeader.column.id] = {
+        minSize: leafHeader.column.columnDef.minSize ?? defaultSizes.minSize,
+        maxSize: leafHeader.column.columnDef.maxSize ?? defaultSizes.maxSize,
+      }
+    })
+
     const clientX = isTouchStartEvent(event)
       ? Math.round(event.touches[0]!.clientX)
       : (event as MouseEvent).clientX
@@ -142,14 +155,16 @@ export function header_getResizeHandler<
         )
 
         old.columnSizingStart.forEach(([columnId, headerSize]) => {
+          const rawSize =
+            headerSize > 0
+              ? headerSize + headerSize * deltaPercentage
+              : deltaOffset / old.columnSizingStart.length
+          const constraints = columnSizingConstraints[columnId]
+          const minSize = constraints?.minSize ?? 0
+          const maxSize = constraints?.maxSize ?? Number.MAX_SAFE_INTEGER
           newColumnSizing[columnId] =
             Math.round(
-              Math.max(
-                headerSize > 0
-                  ? headerSize + headerSize * deltaPercentage
-                  : deltaOffset / old.columnSizingStart.length,
-                0,
-              ) * 100,
+              Math.min(maxSize, Math.max(minSize, rawSize)) * 100,
             ) / 100
         })
 

--- a/packages/table-core/tests/unit/features/column-resizing/columnResizingFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/column-resizing/columnResizingFeature.utils.test.ts
@@ -422,6 +422,118 @@ describe('header_getResizeHandler', () => {
 
     removeEventListenerSpy.mockRestore()
   })
+
+  it('should not resize a column below its minSize', () => {
+    const table = generateTestTableWithData<TestFeatures>(1, {
+      columnResizeMode: 'onChange',
+    })
+
+    let resizingState = getDefaultColumnResizingState()
+    table.options.onColumnResizingChange = (updater: any) => {
+      resizingState =
+        typeof updater === 'function' ? updater(resizingState) : updater
+      ;(table.store.state as any).columnResizing = resizingState
+    }
+
+    const sizingUpdates: Record<string, number>[] = []
+    table.options.onColumnSizingChange = (updater: any) => {
+      if (typeof updater === 'function') {
+        const result = updater(table.atoms.columnSizing?.get() ?? {})
+        sizingUpdates.push(result)
+      } else {
+        sizingUpdates.push(updater)
+      }
+    }
+
+    // Column starts at 100px, minSize is 50px
+    const constrainedColumn = {
+      ...table.getAllColumns()[0],
+      id: 'firstName',
+      columnDef: { enableResizing: true, minSize: 50, size: 100 },
+      table,
+    }
+    const header = createTestResizeHeader(table, {
+      getSize: () => 100,
+      getLeafHeaders: () => [
+        {
+          column: constrainedColumn,
+          getSize: () => 100,
+          subHeaders: [],
+        },
+      ],
+    })
+
+    const handler = header_getResizeHandler(header as any, document)
+    handler({ type: 'mousedown', clientX: 200 })
+
+    // Drag far left — would put column at ~10px without the clamp
+    const moveEvent = new MouseEvent('mousemove', { clientX: 10 })
+    document.dispatchEvent(moveEvent)
+
+    const lastUpdate = sizingUpdates[sizingUpdates.length - 1]
+    expect(lastUpdate).toBeDefined()
+    const newSize = lastUpdate!['firstName']
+    expect(newSize).toBeGreaterThanOrEqual(50)
+
+    const upEvent = new MouseEvent('mouseup', { clientX: 10 })
+    document.dispatchEvent(upEvent)
+  })
+
+  it('should not resize a column above its maxSize', () => {
+    const table = generateTestTableWithData<TestFeatures>(1, {
+      columnResizeMode: 'onChange',
+    })
+
+    let resizingState = getDefaultColumnResizingState()
+    table.options.onColumnResizingChange = (updater: any) => {
+      resizingState =
+        typeof updater === 'function' ? updater(resizingState) : updater
+      ;(table.store.state as any).columnResizing = resizingState
+    }
+
+    const sizingUpdates: Record<string, number>[] = []
+    table.options.onColumnSizingChange = (updater: any) => {
+      if (typeof updater === 'function') {
+        const result = updater(table.atoms.columnSizing?.get() ?? {})
+        sizingUpdates.push(result)
+      } else {
+        sizingUpdates.push(updater)
+      }
+    }
+
+    // Column starts at 100px, maxSize is 150px
+    const constrainedColumn = {
+      ...table.getAllColumns()[0],
+      id: 'firstName',
+      columnDef: { enableResizing: true, maxSize: 150, size: 100 },
+      table,
+    }
+    const header = createTestResizeHeader(table, {
+      getSize: () => 100,
+      getLeafHeaders: () => [
+        {
+          column: constrainedColumn,
+          getSize: () => 100,
+          subHeaders: [],
+        },
+      ],
+    })
+
+    const handler = header_getResizeHandler(header as any, document)
+    handler({ type: 'mousedown', clientX: 100 })
+
+    // Drag far right — would put column at ~500px without the clamp
+    const moveEvent = new MouseEvent('mousemove', { clientX: 600 })
+    document.dispatchEvent(moveEvent)
+
+    const lastUpdate = sizingUpdates[sizingUpdates.length - 1]
+    expect(lastUpdate).toBeDefined()
+    const newSize = lastUpdate!['firstName']
+    expect(newSize).toBeLessThanOrEqual(150)
+
+    const upEvent = new MouseEvent('mouseup', { clientX: 600 })
+    document.dispatchEvent(upEvent)
+  })
 })
 
 describe('passiveEventSupported', () => {


### PR DESCRIPTION
Closes #5997

## What was wrong

When a user drags a resize handle, `header_getResizeHandler` computes new column widths inside a `forEach` over `columnSizingStart`. That computation never consulted `columnDef.minSize` or `columnDef.maxSize`, so dragging far enough in either direction would write a committed size that violated the bounds. `column_getSize` does clamp when reading committed state, but the value gets written into `columnSizing` unclamped, so any code that reads `state.columnSizing[id]` directly (e.g. performant resize examples that skip the full recalculation) sees the out-of-bounds number.

## What the fix does

At drag-start time the handler already iterates `header.getLeafHeaders()` to build `columnSizingStart`. This PR adds a second pass that records each leaf column's `minSize` and `maxSize` from its `columnDef` (falling back to the same defaults `column_getSize` uses) into a closure map called `columnSizingConstraints`. During each drag-move update that map is used to clamp the computed size before it is written into `newColumnSizing`:

```ts
Math.min(maxSize, Math.max(minSize, rawSize))
```

The existing `Math.max(..., 0)` floor is replaced by this — the default `minSize` of 20 is stricter than 0 anyway, and custom `minSize: 0` is preserved correctly.

## Tests

Two new tests in `columnResizingFeature.utils.test.ts`:

- dragging far left on a column with `minSize: 50` keeps the committed size at or above 50
- dragging far right on a column with `maxSize: 150` keeps the committed size at or below 150

Both tests failed against `main` before this change and pass after.

Full suite: 295 tests, 19 test files, all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Column resizing now clamps column widths to configured minimum and maximum size constraints.

* **Tests**
  * Added unit tests to verify min/max size constraint behavior during column resizing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->