### PR TITLE
fix(table-core): exclude non-numeric values from inNumberRange filter

### DIFF
--- a/packages/table-core/src/fns/filterFns.ts
+++ b/packages/table-core/src/fns/filterFns.ts
@@ -245,7 +245,8 @@ const filterFn_betweenInclusive = Object.assign(
  * Keeps rows whose numeric value is inside an inclusive `[min, max]` range.
  *
  * Filter values are normalized so blank endpoints become open-ended and
- * reversed endpoints are swapped.
+ * reversed endpoints are swapped. Non-numeric row values (such as `null`,
+ * `undefined`, empty strings or booleans) never fall inside the range.
  */
 export const filterFn_inNumberRange = Object.assign(
   <TFeatures extends TableFeatures, TData extends RowData>(
@@ -255,7 +256,13 @@ export const filterFn_inNumberRange = Object.assign(
   ) => {
     const [min, max] = filterValue
 
-    const rowValue: number = row.getValue(columnId)
+    const rowValue = row.getValue<number>(columnId)
+    // Guard against non-numeric values. Without this check JavaScript's loose
+    // relational coercion lets values such as `null`, `''` and booleans slip
+    // into a numeric range (e.g. `null >= 0 && null <= 20` evaluates to `true`).
+    if (typeof rowValue !== 'number' || Number.isNaN(rowValue)) {
+      return false
+    }
     return rowValue >= min && rowValue <= max
   },
   {

--- a/packages/table-core/tests/unit/fns/filterFns.test.ts
+++ b/packages/table-core/tests/unit/fns/filterFns.test.ts
@@ -7,6 +7,7 @@ import {
   filterFn_equalsStringSensitive,
   filterFn_greaterThan,
   filterFn_greaterThanOrEqualTo,
+  filterFn_inNumberRange,
   filterFn_includesString,
   filterFn_includesStringSensitive,
   filterFn_lessThan,
@@ -509,6 +510,91 @@ describe('Filter Functions', () => {
           filterValue,
         )
         expect(result).toBe(true)
+      })
+    })
+    describe('filterFn_inNumberRange', () => {
+      // Mirror the real filtering pipeline: the raw `[min, max]` the user sets
+      // is run through `resolveFilterValue` before being handed to the filter fn.
+      const resolve = filterFn_inNumberRange.resolveFilterValue
+      const makeRow = (value: unknown) => ({ getValue: () => value }) as any
+
+      it('should match numbers inside the range', () => {
+        const result = filterFn_inNumberRange(
+          makeRow(15),
+          'age',
+          resolve([0, 20]) as any,
+        )
+        expect(result).toBe(true)
+      })
+      it('should match numbers on the inclusive boundaries', () => {
+        expect(
+          filterFn_inNumberRange(makeRow(0), 'age', resolve([0, 20]) as any),
+        ).toBe(true)
+        expect(
+          filterFn_inNumberRange(makeRow(20), 'age', resolve([0, 20]) as any),
+        ).toBe(true)
+      })
+      it('should not match numbers outside the range', () => {
+        expect(
+          filterFn_inNumberRange(makeRow(25), 'age', resolve([0, 20]) as any),
+        ).toBe(false)
+        expect(
+          filterFn_inNumberRange(makeRow(-5), 'age', resolve([0, 20]) as any),
+        ).toBe(false)
+      })
+      it('should not match `null` values when the lower bound is 0', () => {
+        // `null >= 0 && null <= 20` coerces to `true` in JS, so a nullable
+        // numeric column would leak empty rows into a `[0, max]` range.
+        const result = filterFn_inNumberRange(
+          makeRow(null),
+          'age',
+          resolve([0, 20]) as any,
+        )
+        expect(result).toBe(false)
+      })
+      it('should not match `undefined` values when the lower bound is 0', () => {
+        const result = filterFn_inNumberRange(
+          makeRow(undefined),
+          'age',
+          resolve([0, 20]) as any,
+        )
+        expect(result).toBe(false)
+      })
+      it('should not match empty string values when the lower bound is 0', () => {
+        // `'' >= 0 && '' <= 20` also coerces to `true` in JS.
+        const result = filterFn_inNumberRange(
+          makeRow(''),
+          'age',
+          resolve([0, 20]) as any,
+        )
+        expect(result).toBe(false)
+      })
+      it('should not match boolean values that coerce into the range', () => {
+        // `true` coerces to 1 and `false` to 0, both of which fall inside [0, 20].
+        expect(
+          filterFn_inNumberRange(makeRow(true), 'age', resolve([0, 20]) as any),
+        ).toBe(false)
+        expect(
+          filterFn_inNumberRange(
+            makeRow(false),
+            'age',
+            resolve([0, 20]) as any,
+          ),
+        ).toBe(false)
+      })
+      it('should still match numbers when only an upper bound is provided', () => {
+        // A blank lower bound resolves to -Infinity, so real numbers below the
+        // max should still pass while empty values stay excluded.
+        expect(
+          filterFn_inNumberRange(makeRow(-5), 'age', resolve(['', 20]) as any),
+        ).toBe(true)
+        expect(
+          filterFn_inNumberRange(
+            makeRow(null),
+            'age',
+            resolve(['', 20]) as any,
+          ),
+        ).toBe(false)
       })
     })
   })


### PR DESCRIPTION
## Summary

`filterFn_inNumberRange` compares row values with `rowValue >= min && rowValue <= max`, relying on JavaScript's loose relational coercion. Non-numeric values coerce to numbers in that context, so they slip into the range:

- `null >= 0` → `true` and `null <= 20` → `true`
- `'' >= 0` → `true` and `'' <= 20` → `true`
- `false` → `0`, `true` → `1` (both inside `[0, 20]`)

As a result, a **nullable numeric column** leaks empty rows into a `[0, max]` range filter. This matches the report in #6007 (filtering `age` from 0–20 also returns rows where `age` is `null`). The bug only surfaces when the lower bound is `0` (or negative), because that's when `null`/`''` coerce inside the range — a lower bound of `1` already excludes them.

`inNumberRange` is the auto-assigned filter for numeric columns and is documented as *"Number range inclusion"*, so non-numeric values should never be considered in range.

## Fix

Guard the comparison so only finite numbers can fall inside the range:

```ts
const rowValue = row.getValue<number>(columnId)
if (typeof rowValue !== 'number' || Number.isNaN(rowValue)) {
  return false
}
return rowValue >= min && rowValue <= max
```

Genuine numbers (including `0`, negatives and the inclusive boundaries) and open-ended ranges (`['', 20]` → `[-Infinity, 20]`) keep working exactly as before; only `null`/`undefined`/`''`/booleans are now correctly excluded. The sibling `between`/`betweenInclusive` filters are unaffected — they delegate to `greaterThan`/`lessThan`, which use strict `>` on a `0`-coerced value and already exclude `null` at the lower boundary.

## Tests

Added a `filterFn_inNumberRange` test block in `packages/table-core/tests/unit/fns/filterFns.test.ts` that runs the user filter through `resolveFilterValue` (mirroring the real filtering pipeline) and asserts:

- numbers inside the range, on the inclusive boundaries, and out of range
- `null`, `undefined`, `''` and booleans are excluded from `[0, 20]`
- open-ended ranges still match real numbers while excluding empty values

The new tests fail on `beta` without the fix (4 failing) and pass with it. Full `@tanstack/table-core` suite (313 tests) passes; `tsc`, `eslint` and `prettier` are clean.

Closes #6007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number range filter robustness by fixing edge cases where non-numeric values (`null`, `undefined`, empty strings, booleans) could incorrectly pass filter checks due to JavaScript type coercion. The filter now explicitly validates numeric types and consistently excludes non-numeric values as intended.

* **Tests**
  * Added comprehensive test coverage for number range filtering, including edge cases with various data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->