### PR TITLE
fix: more typescript performance improvements

### DIFF
--- a/packages/angular-table/src/injectTable.ts
+++ b/packages/angular-table/src/injectTable.ts
@@ -110,7 +110,10 @@ export function injectTable<
 
   return ngZone.runOutsideAngular(() =>
     lazyInit(() => {
-      const table = constructTable({
+      // Explicit type arguments skip generic inference from the spread object
+      // (a type-check hot spot); the spread only adds the angular reactivity
+      // binding to `features`.
+      const table = constructTable<TFeatures, TData>({
         ...options(),
         features: {
           coreReactivityFeature: angularReactivity(injector),

--- a/packages/preact-table/src/useTable.ts
+++ b/packages/preact-table/src/useTable.ts
@@ -118,7 +118,10 @@ export function useTable<
   selector?: (state: TableState<TFeatures>) => TSelected,
 ): PreactTable<TFeatures, TData, TSelected> {
   const [table] = useState(() => {
-    const tableInstance = constructTable({
+    // Explicit type arguments skip generic inference from the spread object (a
+    // type-check hot spot); the spread only adds the preact reactivity binding
+    // to `features`.
+    const tableInstance = constructTable<TFeatures, TData>({
       ...tableOptions,
       features: {
         coreReactivityFeature: preactReactivity(),

--- a/packages/react-table/src/useTable.ts
+++ b/packages/react-table/src/useTable.ts
@@ -147,7 +147,10 @@ export function useTable<
   selector?: (state: TableState<TFeatures>) => TSelected,
 ): ReactTable<TFeatures, TData, TSelected> {
   const [table] = useState(() => {
-    const tableInstance = constructTable({
+    // Explicit type arguments skip generic inference from the spread object (a
+    // type-check hot spot); the spread only adds the react reactivity binding
+    // to `features`.
+    const tableInstance = constructTable<TFeatures, TData>({
       ...tableOptions,
       features: {
         coreReactivityFeature: reactReactivity(),

--- a/packages/table-core/src/core/cells/coreCellsFeature.types.ts
+++ b/packages/table-core/src/core/cells/coreCellsFeature.types.ts
@@ -6,8 +6,8 @@ import type { Cell } from '../../types/Cell'
 import type { Column } from '../../types/Column'
 
 export interface CellContext<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > {
   cell: Cell<TFeatures, TData, TValue>
@@ -19,8 +19,8 @@ export interface CellContext<
 }
 
 export interface Cell_CoreProperties<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > {
   /**
@@ -42,8 +42,8 @@ export interface Cell_CoreProperties<
 }
 
 export interface Cell_Cell<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > extends Cell_CoreProperties<TFeatures, TData, TValue> {
   /**

--- a/packages/table-core/src/core/columns/coreColumnsFeature.types.ts
+++ b/packages/table-core/src/core/columns/coreColumnsFeature.types.ts
@@ -5,8 +5,8 @@ import type { AccessorFn, ColumnDef } from '../../types/ColumnDef'
 import type { Column } from '../../types/Column'
 
 export interface Column_CoreProperties<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > {
   /**
@@ -43,8 +43,8 @@ export interface Column_CoreProperties<
 }
 
 export interface Column_Column<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > extends Column_CoreProperties<TFeatures, TData, TValue> {
   /**
@@ -59,8 +59,8 @@ export interface Column_Column<
 }
 
 export interface TableOptions_Columns<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > {
   /**
@@ -74,8 +74,8 @@ export interface TableOptions_Columns<
 }
 
 export interface Table_Columns<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Returns a map of all flat columns by their ID.

--- a/packages/table-core/src/core/headers/coreHeadersFeature.types.ts
+++ b/packages/table-core/src/core/headers/coreHeadersFeature.types.ts
@@ -6,8 +6,8 @@ import type { HeaderGroup } from '../../types/HeaderGroup'
 import type { Column } from '../../types/Column'
 
 export interface Table_Headers<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Builds the visible header groups for the current column tree, visibility,
@@ -30,8 +30,8 @@ export interface Table_Headers<
 }
 
 export interface HeaderContext<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > {
   /**
@@ -49,8 +49,8 @@ export interface HeaderContext<
 }
 
 export interface Header_CoreProperties<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > {
   /**
@@ -100,8 +100,8 @@ export interface Header_CoreProperties<
 }
 
 export interface Header_Header<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > extends Header_CoreProperties<TFeatures, TData, TValue> {
   /**
@@ -115,8 +115,8 @@ export interface Header_Header<
 }
 
 export interface HeaderGroup_Header<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > {
   depth: number

--- a/packages/table-core/src/core/row-models/coreRowModelsFeature.types.ts
+++ b/packages/table-core/src/core/row-models/coreRowModelsFeature.types.ts
@@ -10,8 +10,8 @@ import type { TableFeatures } from '../../types/TableFeatures'
 import type { RowData } from '../../types/type-utils'
 
 export interface RowModel<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   rows: Array<Row<TFeatures, TData>>
   flatRows: Array<Row<TFeatures, TData>>
@@ -19,15 +19,15 @@ export interface RowModel<
 }
 
 export interface CachedRowModel_Core<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   coreRowModel: () => RowModel<TFeatures, TData>
 }
 
 export interface Table_RowModels_Core<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Returns the core row model before any processing has been applied.

--- a/packages/table-core/src/core/row-models/createCoreRowModel.ts
+++ b/packages/table-core/src/core/row-models/createCoreRowModel.ts
@@ -1,7 +1,7 @@
 import { constructRow } from '../rows/constructRow'
 import { tableMemo } from '../../utils'
 import { table_autoResetPageIndex } from '../../features/row-pagination/rowPaginationFeature.utils'
-import type { Table, Table_Internal } from '../../types/Table'
+import type { Table_Internal } from '../../types/Table'
 import type { RowModel } from './coreRowModelsFeature.types'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { Row } from '../../types/Row'
@@ -15,9 +15,10 @@ import type { RowData } from '../../types/type-utils'
 export function createCoreRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
-  return (_table) => {
-    const table = _table as unknown as Table_Internal<TFeatures, TData>
+>(): (
+  table: Table_Internal<TFeatures, TData>,
+) => () => RowModel<TFeatures, TData> {
+  return (table) => {
     return tableMemo({
       feature: 'coreRowModelsFeature',
       table,

--- a/packages/table-core/src/core/rows/coreRowsFeature.types.ts
+++ b/packages/table-core/src/core/rows/coreRowsFeature.types.ts
@@ -5,8 +5,8 @@ import type { Row } from '../../types/Row'
 import type { Cell } from '../../types/Cell'
 
 export interface Row_CoreProperties<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   _uniqueValuesCache: Record<string, unknown>
   _valuesCache: Record<string, unknown>
@@ -45,8 +45,8 @@ export interface Row_CoreProperties<
 }
 
 export interface Row_Row<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > extends Row_CoreProperties<TFeatures, TData> {
   /**
    * Builds a lookup of this row's cells keyed by leaf column id.
@@ -83,8 +83,8 @@ export interface Row_Row<
 }
 
 export interface TableOptions_Rows<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * This optional function is used to derive a unique ID for any given row. If not provided the rows index is used (nested rows join together with `.` using their grandparents' index eg. `index.index.index`). If you need to identify individual rows that are originating from any server-side operations, it's suggested you use this function to return an ID that makes sense regardless of network IO/ambiguity eg. a userId, taskId, database ID field, etc.
@@ -106,8 +106,8 @@ export interface TableOptions_Rows<
 }
 
 export interface Table_Rows<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   getRowId: (_: TData, index: number, parent?: Row<TFeatures, TData>) => string
   /**

--- a/packages/table-core/src/core/table/constructTable.ts
+++ b/packages/table-core/src/core/table/constructTable.ts
@@ -202,5 +202,5 @@ export function constructTable<
     featuresList[i]!.constructTableAPIs?.(table)
   }
 
-  return table
+  return table as unknown as Table<TFeatures, TData>
 }

--- a/packages/table-core/src/core/table/coreTablesFeature.types.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.types.ts
@@ -13,8 +13,8 @@ import type { TableOptions } from '../../types/TableOptions'
 import type { TableState, TableState_All } from '../../types/TableState'
 
 export interface TableMeta<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {}
 
 /**
@@ -84,8 +84,8 @@ export type ExternalAtoms_All = Partial<{
 }>
 
 export interface TableOptions_Table<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * The feature modules registered on this table instance.
@@ -152,8 +152,8 @@ export interface TableOptions_Table<
 }
 
 export interface Table_CoreProperties<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Table reactivity bindings for interacting with TanStack Store.
@@ -220,8 +220,8 @@ export interface Table_CoreProperties<
 }
 
 export interface Table_Table<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > extends Table_CoreProperties<TFeatures, TData> {
   /**
    * Resets the table's internal base atoms to `table.initialState`.

--- a/packages/table-core/src/core/table/coreTablesFeature.utils.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.utils.ts
@@ -83,7 +83,10 @@ export function table_mergeOptions<
   newOptions: TableOptions<TFeatures, TData>,
 ) {
   if (table.options.mergeOptions) {
-    return table.options.mergeOptions(table.options, newOptions)
+    return table.options.mergeOptions(
+      table.options as TableOptions<TFeatures, TData>,
+      newOptions,
+    )
   }
 
   return {
@@ -110,7 +113,10 @@ export function table_setOptions<
   table: Table_Internal<TFeatures, TData>,
   updater: Updater<TableOptions<TFeatures, TData>>,
 ): void {
-  const newOptions = functionalUpdate(updater, table.options)
+  const newOptions = functionalUpdate(
+    updater,
+    table.options as TableOptions<TFeatures, TData>,
+  )
   // table static options that should never change after initialization
   const { features, atoms, initialState } = table.options
   const mergedOptions = Object.assign(table_mergeOptions(table, newOptions), {

--- a/packages/table-core/src/features/column-faceting/columnFacetingFeature.types.ts
+++ b/packages/table-core/src/features/column-faceting/columnFacetingFeature.types.ts
@@ -4,8 +4,8 @@ import type { TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 
 export interface Column_ColumnFaceting<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Computes min/max numeric facet values for this column.
@@ -25,8 +25,8 @@ export interface Column_ColumnFaceting<
 }
 
 export interface Table_RowModels_Faceted<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Computes min/max numeric facet values for the active faceting context.
@@ -49,8 +49,8 @@ export interface Table_RowModels_Faceted<
 }
 
 export interface CachedRowModel_Faceted<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   facetedRowModel?: (columnId: string) => () => RowModel<TFeatures, TData>
   facetedMinMaxValues?: (columnId: string) => [number, number]
@@ -58,8 +58,8 @@ export interface CachedRowModel_Faceted<
 }
 
 export interface Table_ColumnFaceting<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Returns the min and max values for the global filter.

--- a/packages/table-core/src/features/column-filtering/columnFilteringFeature.types.ts
+++ b/packages/table-core/src/features/column-filtering/columnFilteringFeature.types.ts
@@ -41,8 +41,8 @@ export interface ColumnFilter {
 }
 
 export interface ResolvedColumnFilter<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   filterFn: FilterFn<TFeatures, TData>
   id: string
@@ -50,15 +50,15 @@ export interface ResolvedColumnFilter<
 }
 
 export interface RowModelFns_ColumnFiltering<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   filterFns: Record<string, FilterFn<TFeatures, TData>>
 }
 
 export interface FilterFn<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   (
     row: Row<TFeatures, TData>,
@@ -110,8 +110,8 @@ export type FilterFnOption<
 > = 'auto' | ExtractFilterFnKeys<TFeatures> | FilterFn<TFeatures, TData>
 
 export interface ColumnDef_ColumnFiltering<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Enables this column to participate in column-specific filtering.
@@ -127,8 +127,8 @@ export interface ColumnDef_ColumnFiltering<
 }
 
 export interface Column_ColumnFiltering<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Returns an automatically calculated filter function for the column based off of the columns first known value.
@@ -164,8 +164,8 @@ export interface Column_ColumnFiltering<
 }
 
 export interface Row_ColumnFiltering<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * The column filters map for the row. This object tracks whether a row is passing/failing specific filters by their column ID.
@@ -178,8 +178,8 @@ export interface Row_ColumnFiltering<
 }
 
 export interface TableOptions_ColumnFiltering<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Enables column-specific filtering for all columns that also allow it.
@@ -227,8 +227,8 @@ export interface Table_ColumnFiltering {
 }
 
 export interface Table_RowModels_Filtered<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Resolves the row model after column and global filters have been applied.
@@ -241,8 +241,8 @@ export interface Table_RowModels_Filtered<
 }
 
 export interface CachedRowModel_Filtered<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   filteredRowModel: () => RowModel<TFeatures, TData>
 }

--- a/packages/table-core/src/features/column-grouping/columnGroupingFeature.types.ts
+++ b/packages/table-core/src/features/column-grouping/columnGroupingFeature.types.ts
@@ -18,8 +18,8 @@ export interface TableState_ColumnGrouping {
 }
 
 export interface RowModelFns_ColumnGrouping<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   aggregationFns: Record<string, AggregationFn<TFeatures, TData>>
 }
@@ -66,8 +66,8 @@ export type AggregationFnOption<
   | AggregationFn<TFeatures, TData>
 
 export interface ColumnDef_ColumnGrouping<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > {
   /**
@@ -93,8 +93,8 @@ export interface ColumnDef_ColumnGrouping<
 }
 
 export interface Column_ColumnGrouping<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Returns the aggregation function for the column.
@@ -190,8 +190,8 @@ export interface TableOptions_ColumnGrouping {
 export type GroupingColumnMode = false | 'reorder' | 'remove'
 
 export interface Table_ColumnGrouping<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Resets `grouping` to `initialState.grouping`.
@@ -206,8 +206,8 @@ export interface Table_ColumnGrouping<
 }
 
 export interface Table_RowModels_Grouped<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Resolves the row model after grouping and aggregation have been applied.
@@ -220,8 +220,8 @@ export interface Table_RowModels_Grouped<
 }
 
 export interface CachedRowModel_Grouped<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   groupedRowModel: () => RowModel<TFeatures, TData>
 }

--- a/packages/table-core/src/features/column-ordering/columnOrderingFeature.types.ts
+++ b/packages/table-core/src/features/column-ordering/columnOrderingFeature.types.ts
@@ -44,8 +44,8 @@ export interface ColumnOrderDefaultOptions {
 }
 
 export interface Table_ColumnOrdering<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Resets `columnOrder` to `initialState.columnOrder`.

--- a/packages/table-core/src/features/column-pinning/columnPinningFeature.types.ts
+++ b/packages/table-core/src/features/column-pinning/columnPinningFeature.types.ts
@@ -67,8 +67,8 @@ export interface Column_ColumnPinning {
 }
 
 export interface Row_ColumnPinning<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Gets visible row cells whose columns are not pinned left or right.
@@ -85,8 +85,8 @@ export interface Row_ColumnPinning<
 }
 
 export interface Table_ColumnPinning<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Builds flat center-region headers for columns that are not pinned,

--- a/packages/table-core/src/features/column-visibility/columnVisibilityFeature.types.ts
+++ b/packages/table-core/src/features/column-visibility/columnVisibilityFeature.types.ts
@@ -28,8 +28,8 @@ export type VisibilityDefaultOptions = Pick<
 >
 
 export interface Table_ColumnVisibility<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Checks whether every leaf column is currently visible.
@@ -76,8 +76,8 @@ export interface ColumnDef_ColumnVisibility {
 }
 
 export interface Row_ColumnVisibility<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Gets this row's cells for currently visible columns.

--- a/packages/table-core/src/features/global-filtering/globalFilteringFeature.types.ts
+++ b/packages/table-core/src/features/global-filtering/globalFilteringFeature.types.ts
@@ -33,8 +33,8 @@ export interface Column_GlobalFiltering {
 }
 
 export interface TableOptions_GlobalFiltering<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Enables global filtering across columns that allow it.
@@ -67,8 +67,8 @@ export interface TableOptions_GlobalFiltering<
 }
 
 export interface Table_GlobalFiltering<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Currently, this function returns the built-in `includesString` filter function. In future releases, it may return more dynamic filter functions based on the nature of the data provided.

--- a/packages/table-core/src/features/row-expanding/rowExpandingFeature.types.ts
+++ b/packages/table-core/src/features/row-expanding/rowExpandingFeature.types.ts
@@ -35,8 +35,8 @@ export interface Row_RowExpanding {
 }
 
 export interface TableOptions_RowExpanding<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Enables automatic expanded-state resets when page-altering table state changes.
@@ -71,8 +71,8 @@ export interface TableOptions_RowExpanding<
 }
 
 export interface Table_RowExpanding<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   autoResetExpanded: () => void
   /**
@@ -112,8 +112,8 @@ export interface Table_RowExpanding<
 }
 
 export interface Table_RowModels_Expanded<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Resolves the row model after expanded rows have been flattened into view.
@@ -126,8 +126,8 @@ export interface Table_RowModels_Expanded<
 }
 
 export interface CachedRowModel_Expanded<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   expandedRowModel: () => RowModel<TFeatures, TData>
 }

--- a/packages/table-core/src/features/row-pagination/rowPaginationFeature.types.ts
+++ b/packages/table-core/src/features/row-pagination/rowPaginationFeature.types.ts
@@ -42,8 +42,8 @@ export interface PaginationDefaultOptions {
 }
 
 export interface Table_RowPagination<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   _autoResetPageIndex: () => void
   /**
@@ -117,8 +117,8 @@ export interface Table_RowPagination<
 }
 
 export interface Table_RowModels_Paginated<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Resolves the row model after pagination has sliced the current page.
@@ -131,8 +131,8 @@ export interface Table_RowModels_Paginated<
 }
 
 export interface CachedRowModel_Paginated<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   paginatedRowModel: () => RowModel<TFeatures, TData>
 }

--- a/packages/table-core/src/features/row-pinning/rowPinningFeature.types.ts
+++ b/packages/table-core/src/features/row-pinning/rowPinningFeature.types.ts
@@ -14,8 +14,8 @@ export interface TableState_RowPinning {
 }
 
 export interface TableOptions_RowPinning<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Allows rows to be pinned to top or bottom regions.
@@ -63,8 +63,8 @@ export interface Row_RowPinning {
 }
 
 export interface Table_RowPinning<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Gets rows pinned to the bottom region.

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts
@@ -10,8 +10,8 @@ export interface TableState_RowSelection {
 }
 
 export interface TableOptions_RowSelection<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Allows rows to be selected alongside other rows.
@@ -87,8 +87,8 @@ export interface Row_RowSelection {
 }
 
 export interface Table_RowSelection<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Builds a selected-row model from rows after filtering.

--- a/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts
+++ b/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts
@@ -18,8 +18,8 @@ export interface TableState_RowSorting {
 }
 
 export interface RowModelFns_RowSorting<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   sortFns: Record<string, SortFn<TFeatures, TData>>
 }
@@ -27,8 +27,8 @@ export interface RowModelFns_RowSorting<
 export interface SortFns {}
 
 export interface SortFn<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   (
     rowA: Row<TFeatures, TData>,
@@ -64,8 +64,8 @@ export type SortFnOption<
 > = 'auto' | ExtractSortFnKeys<TFeatures> | SortFn<TFeatures, TData>
 
 export interface ColumnDef_RowSorting<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Enables/Disables multi-sorting for this column.
@@ -102,8 +102,8 @@ export interface ColumnDef_RowSorting<
 }
 
 export interface Column_RowSorting<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Removes this column from the table's sorting state
@@ -199,8 +199,8 @@ export interface TableOptions_RowSorting {
 }
 
 export interface Table_RowSorting<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Resets `sorting` to `initialState.sorting`.
@@ -215,8 +215,8 @@ export interface Table_RowSorting<
 }
 
 export interface Table_RowModels_Sorted<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   /**
    * Reads the row model immediately before sorting.
@@ -229,8 +229,8 @@ export interface Table_RowModels_Sorted<
 }
 
 export interface CachedRowModel_Sorted<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   sortedRowModel: () => RowModel<TFeatures, TData>
 }

--- a/packages/table-core/src/types/Cell.ts
+++ b/packages/table-core/src/types/Cell.ts
@@ -4,8 +4,8 @@ import type { ExtractFeatureMapTypes, TableFeatures } from './TableFeatures'
 import type { Cell_Cell } from '../core/cells/coreCellsFeature.types'
 
 export interface Cell_Core<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > extends Cell_Cell<TFeatures, TData, TValue> {}
 

--- a/packages/table-core/src/types/Column.ts
+++ b/packages/table-core/src/types/Column.ts
@@ -14,14 +14,14 @@ import type { ExtractFeatureMapTypes, TableFeatures } from './TableFeatures'
 import type { Column_Column } from '../core/columns/coreColumnsFeature.types'
 
 export interface Column_Core<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue = unknown,
 > extends Column_Column<TFeatures, TData, TValue> {}
 
 export interface Column_FeatureMap<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   columnFacetingFeature: Column_ColumnFaceting<TFeatures, TData>
   columnFilteringFeature: Column_ColumnFiltering<TFeatures, TData>

--- a/packages/table-core/src/types/ColumnDef.ts
+++ b/packages/table-core/src/types/ColumnDef.ts
@@ -16,8 +16,8 @@ import type { ColumnDef_GlobalFiltering } from '../features/global-filtering/glo
 import type { ColumnDef_RowSorting } from '../features/row-sorting/rowSortingFeature.types'
 
 export interface ColumnMeta<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > {}
 
@@ -79,8 +79,8 @@ export interface StringHeaderIdentifier {
 }
 
 export interface IdIdentifier<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > {
   /**
@@ -127,8 +127,8 @@ interface ColumnDefBase_Core<
 }
 
 export interface ColumnDef_FeatureMap<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData,
 > {
   columnVisibilityFeature: ColumnDef_ColumnVisibility

--- a/packages/table-core/src/types/Header.ts
+++ b/packages/table-core/src/types/Header.ts
@@ -5,8 +5,8 @@ import type { Header_Header } from '../core/headers/coreHeadersFeature.types'
 import type { Header_ColumnResizing } from '../features/column-resizing/columnResizingFeature.types'
 
 export interface Header_Core<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
   TValue extends CellData = CellData,
 > extends Header_Header<TFeatures, TData, TValue> {}
 

--- a/packages/table-core/src/types/HeaderGroup.ts
+++ b/packages/table-core/src/types/HeaderGroup.ts
@@ -3,8 +3,8 @@ import type { TableFeatures } from './TableFeatures'
 import type { RowData } from './type-utils'
 
 export interface HeaderGroup_Core<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > extends HeaderGroup_Header<TFeatures, TData> {}
 
 export type HeaderGroup<

--- a/packages/table-core/src/types/Row.ts
+++ b/packages/table-core/src/types/Row.ts
@@ -10,13 +10,13 @@ import type { ExtractFeatureMapTypes, TableFeatures } from './TableFeatures'
 import type { Row_Row } from '../core/rows/coreRowsFeature.types'
 
 export interface Row_Core<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > extends Row_Row<TFeatures, TData> {}
 
 export interface Row_FeatureMap<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   columnFilteringFeature: Row_ColumnFiltering<TFeatures, TData>
   columnGroupingFeature: Row_ColumnGrouping

--- a/packages/table-core/src/types/RowModel.ts
+++ b/packages/table-core/src/types/RowModel.ts
@@ -12,8 +12,8 @@ import type { RowData } from './type-utils'
 import type { ExtractFeatureMapTypes, TableFeatures } from './TableFeatures'
 
 export interface CachedRowModels_FeatureMap<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   columnFacetingFeature: CachedRowModel_Faceted<TFeatures, TData>
   columnFilteringFeature: CachedRowModel_Filtered<TFeatures, TData>

--- a/packages/table-core/src/types/RowModelFns.ts
+++ b/packages/table-core/src/types/RowModelFns.ts
@@ -7,8 +7,8 @@ import type { ExtractFeatureMapTypes, TableFeatures } from './TableFeatures'
 export interface RowModelFns_Core {}
 
 export interface RowModelFns_FeatureMap<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   columnFilteringFeature: RowModelFns_ColumnFiltering<TFeatures, TData>
   columnGroupingFeature: RowModelFns_ColumnGrouping<TFeatures, TData>

--- a/packages/table-core/src/types/Table.ts
+++ b/packages/table-core/src/types/Table.ts
@@ -16,19 +16,21 @@ import type { Table_RowSorting } from '../features/row-sorting/rowSortingFeature
 import type { Table_RowModels } from '../core/row-models/coreRowModelsFeature.types'
 import type { CachedRowModel_All } from './RowModel'
 import type { RowModelFns_All } from './RowModelFns'
-import type { TableState_All } from './TableState'
+import type { TableState, TableState_All } from './TableState'
 import type { RowData } from './type-utils'
 import type { ExtractFeatureMapTypes, TableFeatures } from './TableFeatures'
 import type { Table_Columns } from '../core/columns/coreColumnsFeature.types'
 import type { Table_Headers } from '../core/headers/coreHeadersFeature.types'
 import type { Table_Rows } from '../core/rows/coreRowsFeature.types'
 import type {
+  Atoms,
   Atoms_All,
+  BaseAtoms,
   BaseAtoms_All,
   ExternalAtoms_All,
   Table_Table,
 } from '../core/table/coreTablesFeature.types'
-import type { TableOptions_All } from './TableOptions'
+import type { DebugOptions, TableOptions_All } from './TableOptions'
 
 /**
  * The core table object that only includes the core table functionality such as column, header, row, and table APIS.
@@ -44,8 +46,8 @@ export type Table_Core<
   Table_Headers<TFeatures, TData>
 
 export interface Table_FeatureMap<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   columnFilteringFeature: Table_ColumnFiltering
   columnGroupingFeature: Table_ColumnGrouping<TFeatures, TData>
@@ -72,19 +74,64 @@ export type Table<
 > = Table_Core<TFeatures, TData> &
   ExtractFeatureMapTypes<TFeatures, Table_FeatureMap<TFeatures, TData>>
 
-export type Table_Internal<
-  TFeatures extends TableFeatures,
-  TData extends RowData = any,
-> = Table<TFeatures, TData> & {
+/**
+ * `Table_Table` members that `Table_Internal` re-declares with broadened
+ * (all-features) types so internal code can read any feature's slots and
+ * construction code can assign them.
+ */
+type Table_InternalBroadenedKeys =
+  | '_rowModels'
+  | '_rowModelFns'
+  | 'options'
+  | 'initialState'
+  | 'store'
+
+/**
+ * Internal broad table shape used by feature implementations.
+ *
+ * Declared as an interface extending every stock feature's table API (rather
+ * than the feature-conditional `Table` intersection) so that the compiler can
+ * relate `Table_Internal` instantiations nominally instead of structurally
+ * re-expanding the feature-map conditional for every internal call site.
+ * Mirrors the `*_All` convention used for options, state, and row models.
+ * Type parameters are annotated `in out` (invariant) so the checker can relate
+ * instantiations by their type arguments without measuring variance or falling
+ * back to member-by-member structural comparison.
+ */
+export interface Table_Internal<
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData = any,
+>
+  extends
+    Omit<Table_Table<TFeatures, TData>, Table_InternalBroadenedKeys>,
+    Table_Columns<TFeatures, TData>,
+    Table_Rows<TFeatures, TData>,
+    Table_RowModels<TFeatures, TData>,
+    Table_Headers<TFeatures, TData>,
+    Table_ColumnFiltering,
+    Table_ColumnGrouping<TFeatures, TData>,
+    Table_ColumnOrdering<TFeatures, TData>,
+    Table_ColumnPinning<TFeatures, TData>,
+    Table_ColumnResizing,
+    Table_ColumnSizing,
+    Table_ColumnVisibility<TFeatures, TData>,
+    Table_ColumnFaceting<TFeatures, TData>,
+    Table_GlobalFiltering<TFeatures, TData>,
+    Table_RowExpanding<TFeatures, TData>,
+    Table_RowPagination<TFeatures, TData>,
+    Table_RowPinning<TFeatures, TData>,
+    Table_RowSelection<TFeatures, TData>,
+    Table_RowSorting<TFeatures, TData> {
   _rowModels: CachedRowModel_All<TFeatures, TData>
   _rowModelFns: RowModelFns_All<TFeatures, TData>
-  options: TableOptions_All<TFeatures, TData> & {
-    state?: TableState_All
-    initialState?: TableState_All
-    atoms?: ExternalAtoms_All
-  }
-  initialState: TableState_All
-  baseAtoms: BaseAtoms_All
-  atoms: Atoms_All
-  store: ReadonlyStore<TableState_All>
+  options: DebugOptions<TableFeatures> &
+    TableOptions_All<TFeatures, TData> & {
+      state?: TableState_All
+      initialState?: TableState_All
+      atoms?: ExternalAtoms_All
+    }
+  initialState: TableState<TFeatures> & TableState_All
+  baseAtoms: BaseAtoms<TFeatures> & BaseAtoms_All
+  atoms: Atoms<TFeatures> & Atoms_All
+  store: ReadonlyStore<TableState<TFeatures>> & ReadonlyStore<TableState_All>
 }

--- a/packages/table-core/src/types/TableOptions.ts
+++ b/packages/table-core/src/types/TableOptions.ts
@@ -28,8 +28,8 @@ import type {
  * options are mixed in.
  */
 export interface TableOptions_Core<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 >
   extends
     TableOptions_Table<TFeatures, TData>,
@@ -55,8 +55,8 @@ export type DebugOptions<TFeatures extends TableFeatures> = {
 } & DebugKeysFor<CoreFeatures & TFeatures>
 
 export interface TableOptions_FeatureMap<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  in out TFeatures extends TableFeatures,
+  in out TData extends RowData,
 > {
   columnFilteringFeature: TableOptions_ColumnFiltering<TFeatures, TData>
   columnGroupingFeature: TableOptions_ColumnGrouping
@@ -73,15 +73,42 @@ export interface TableOptions_FeatureMap<
   rowSortingFeature: TableOptions_RowSorting
 }
 
-export type TableOptions_FeatureMap_All<
+type TableOptions_StockFeatureKeys =
+  | 'columnFilteringFeature'
+  | 'columnGroupingFeature'
+  | 'columnOrderingFeature'
+  | 'columnPinningFeature'
+  | 'columnResizingFeature'
+  | 'columnSizingFeature'
+  | 'columnVisibilityFeature'
+  | 'globalFilteringFeature'
+  | 'rowExpandingFeature'
+  | 'rowPaginationFeature'
+  | 'rowPinningFeature'
+  | 'rowSelectionFeature'
+  | 'rowSortingFeature'
+
+/**
+ * Plugin entries declaration-merged into `TableOptions_FeatureMap`, i.e. keys
+ * beyond the stock set. Resolves to `unknown` (an intersection no-op) when no
+ * plugins are merged so the common case skips the union-to-intersection work.
+ */
+type TableOptions_PluginFeatureMapTypes<
   TFeatures extends TableFeatures,
   TData extends RowData,
-> = UnionToIntersection<
-  TableOptions_FeatureMap<TFeatures, TData>[keyof TableOptions_FeatureMap<
-    TFeatures,
-    TData
-  >]
->
+> = [
+  Exclude<
+    keyof TableOptions_FeatureMap<TFeatures, TData>,
+    TableOptions_StockFeatureKeys
+  >,
+] extends [never]
+  ? unknown
+  : UnionToIntersection<
+      TableOptions_FeatureMap<TFeatures, TData>[Exclude<
+        keyof TableOptions_FeatureMap<TFeatures, TData>,
+        TableOptions_StockFeatureKeys
+      >]
+    >
 
 /**
  * Complete table options for a specific feature set.
@@ -105,4 +132,19 @@ export type TableOptions_All<
   TFeatures extends TableFeatures,
   TData extends RowData,
 > = TableOptions_Core<TFeatures, TData> &
-  Partial<TableOptions_FeatureMap_All<TFeatures, TData>>
+  Partial<
+    TableOptions_ColumnFiltering<TFeatures, TData> &
+      TableOptions_ColumnGrouping &
+      TableOptions_ColumnOrdering &
+      TableOptions_ColumnPinning &
+      TableOptions_ColumnResizing &
+      TableOptions_ColumnSizing &
+      TableOptions_ColumnVisibility &
+      TableOptions_GlobalFiltering<TFeatures, TData> &
+      TableOptions_RowExpanding<TFeatures, TData> &
+      TableOptions_RowPagination &
+      TableOptions_RowPinning<TFeatures, TData> &
+      TableOptions_RowSelection<TFeatures, TData> &
+      TableOptions_RowSorting &
+      TableOptions_PluginFeatureMapTypes<TFeatures, TData>
+  >

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Table, Table_Internal } from './types/Table'
+import type { Table_Internal } from './types/Table'
 import type { NoInfer, RowData, Updater } from './types/type-utils'
 import type { TableFeatures } from './types/TableFeatures'
 import type { TableState, TableState_All } from './types/TableState'
@@ -53,7 +53,16 @@ export function cloneState<T>(value: T): T {
 export function makeStateUpdater<
   TFeatures extends TableFeatures,
   K extends (string & {}) | keyof TableState_All | keyof TableState<TFeatures>,
->(key: K, instance: Table<TFeatures, any>) {
+>(
+  key: K,
+  // Minimal structural shape so any table view (public `Table`,
+  // `Table_Internal`, or a custom plugin table) can be passed without forcing
+  // the compiler to relate the full table types.
+  instance: {
+    readonly options: { readonly atoms?: object | undefined }
+    readonly baseAtoms: object
+  },
+) {
   return (updater: Updater<TableState<any>[K & keyof TableState<any>]>) => {
     const externalAtom = (instance.options as any).atoms?.[key]
     const targetAtom = externalAtom ?? (instance.baseAtoms as any)[key]

--- a/packages/table-core/tests/unit/core/columns/constructColumn.test.ts
+++ b/packages/table-core/tests/unit/core/columns/constructColumn.test.ts
@@ -4,6 +4,7 @@ import { constructColumn } from '../../../../src/core/columns/constructColumn'
 import { constructTable } from '../../../../src'
 import { storeReactivityBindings } from '../../../../src/store-reactivity-bindings'
 import type { ColumnDef } from '../../../../src/types/ColumnDef'
+import type { Table_Internal } from '../../../../src/types/Table'
 
 const features = {
   coreColumnsFeature,
@@ -20,7 +21,7 @@ describe('constructColumn', () => {
       features,
       columns: [],
       data: [],
-    })
+    }) as unknown as Table_Internal<typeof features, TestRow>
 
     const columnDef = {
       id: 'test-column',


### PR DESCRIPTION
# TanStack Table — TypeScript Type-Performance Report

Tracks TypeScript type-checking cost across the alpha branch, the beta branch as released (beta.10), and the optimized working tree (beta.11 candidate). Primary metric is `Instantiations` from `tsc --extendedDiagnostics` (deterministic — confirmed identical across repeated runs). Wall times and memory are supporting evidence only.

## Setup

| | Alpha | Beta |
| --- | --- | --- |
| Folder | `table-alpha/` | `table/` |
| Branch / commit | `alpha` @ `4f855fe4e` | `beta` @ `925358059` (+ uncommitted beta.11 work) |
| `@tanstack/table-core` version | 9.0.0-alpha.54 | 9.0.0-beta.10 |
| TypeScript | 6.0.3 | 6.0.3 |

- Dates: baseline 2026-06-12, beta.11 experiments same day. macOS (Darwin 25.4.0), one tsc at a time.
- **Rebuilt before measuring:** `pnpm build` (tsdown) for `table-core` and `react-table` in the measured repo before every consumer benchmark (react-table, kitchen-sink) so declarations are current.
- Every number below was measured at least twice; `Instantiations` was identical on every repeat.

## Benchmark commands

| Benchmark | Directory | Command |
| --- | --- | --- |
| table-core source | `packages/table-core` | `pnpm exec tsc --noEmit --extendedDiagnostics` |
| table-core declaration emit | `packages/table-core` | `pnpm exec tsc -p tests/tsconfig.declaration-emit.json --extendedDiagnostics` |
| react-table | `packages/react-table` | `pnpm exec tsc --noEmit --extendedDiagnostics` |
| kitchen-sink example | `examples/react/kitchen-sink` | `pnpm exec tsc --noEmit --extendedDiagnostics` |

These mirror the repo's own `test:types` script (`tsc && tsc -p tests/tsconfig.declaration-emit.json`).

## Results — Instantiations (primary metric)

| Benchmark | Alpha | beta.10 | beta.11 | Alpha → beta.11 |
| --- | ---: | ---: | ---: | ---: |
| `@tanstack/table-core` `tsc --noEmit` | 1,230,007 | 494,577 | 288,061 | **−941,946 (−76.6%)** |
| `@tanstack/table-core` declaration emit | 1,146,896 | 385,702 | 189,844 | **−957,052 (−83.4%)** |
| `@tanstack/react-table` `tsc --noEmit` | 235,498 | 73,690 | 54,732 | **−180,766 (−76.8%)** |
| `examples/react/kitchen-sink` `tsc --noEmit` | 221,006 | 85,839 | 74,797 | **−146,209 (−66.2%)** |

Per-step deltas: alpha → beta.10 was −59.8% / −66.4% / −68.7% / −61.2%; beta.10 → beta.11 adds another −41.8% / −50.8% / −25.7% / −12.9% (same benchmark order as the table).

## All framework adapters — Instantiations

`pnpm exec tsc --noEmit --extendedDiagnostics` per adapter package (src + tests), all packages rebuilt first in each repo. beta.11 includes the explicit-type-args fix applied to `angular-table` and `preact-table` (same `constructTable` spread-inference hot spot as react's `useTable`; lit/solid/svelte/vue already passed alias-typed variables and needed no change).

| Adapter package | Alpha | beta.11 | Alpha → beta.11 |
| --- | ---: | ---: | ---: |
| `@tanstack/angular-table` | 276,299 | 49,948 | **−81.9%** |
| `@tanstack/lit-table` | 192,656 | 44,165 | **−77.1%** |
| `@tanstack/preact-table` | 221,090 | 41,558 | **−81.2%** |
| `@tanstack/react-table` | 235,498 | 54,732 | **−76.8%** |
| `@tanstack/solid-table` | 198,164 | 28,654 | **−85.5%** |
| `@tanstack/svelte-table` | 168,534 | 29,298 | **−82.6%** |
| `@tanstack/vue-table` | 244,756 | 92,816 | **−62.1%** |

Within beta, the `constructTable` explicit-type-args fix alone took angular-table 59,190 → 49,948 (−15.6%) and preact-table 49,125 → 41,558 (−15.4%).

## All kitchen-sink examples — Instantiations

| Example | Alpha | beta.11 | Alpha → beta.11 |
| --- | ---: | ---: | ---: |
| `angular/kitchen-sink` | 148,203 | 31,294 | **−78.9%** |
| `lit/kitchen-sink` | 161,054 | 33,289 | **−79.3%** |
| `preact/kitchen-sink` | 216,291 | 70,104 | **−67.6%** |
| `react/kitchen-sink` | 221,006 | 74,797 | **−66.2%** |
| `solid/kitchen-sink` | 209,901 | 64,767 | **−69.1%** |
| `vue/kitchen-sink` (vue-tsc) | 256,813 | 114,634 | **−55.4%** |
| `react/kitchen-sink-hero-ui` | 373,851 | 219,955 | **−41.2%** |
| `react/kitchen-sink-mantine` | 305,513 | 150,697 | **−50.7%** |
| `react/kitchen-sink-material-ui` | 400,392 | 245,645 | **−38.6%** |
| `react/kitchen-sink-react-aria` | 251,945 | 98,030 | **−61.1%** |
| `react/kitchen-sink-shadcn-base` | 402,716 | 257,754 | **−36.0%** |
| `react/kitchen-sink-shadcn-radix` | 331,090 | 186,199 | **−43.8%** |

Measurement caveats:

- `svelte/kitchen-sink` is excluded: plain `tsc` does not check `.svelte` markup (it reports only ~2.2k instantiations from the loose `.ts` files in both repos); `svelte-check` does not expose `--extendedDiagnostics`. The svelte **adapter package** row above covers the svelte surface.
- `vue/kitchen-sink` is measured with `vue-tsc` (plain `tsc` skips `.vue` SFCs and returns an identical, meaningless number in both repos). The UI-kit react variants carry large third-party type surfaces (MUI, Mantine, etc.), which dilutes the percentage but the absolute deltas (−145k to −154k) match the plain kitchen-sink.
- `solid/kitchen-sink` has 3 pre-existing app-level JSX errors, byte-identical in alpha and beta — unrelated to table types.

Check times (secondary, two runs each): table-core 1.74s/1.83s → 1.07s/1.04s; declaration emit 1.58s/1.56s → 0.80s/0.87s; react-table 0.29s/0.26s → 0.21s/0.22s; kitchen-sink 0.53s/0.50s → 0.46s/0.50s.

### The react-table regression and the variance fix

Intermediate state (before variance annotations): the `Table_Internal` interface conversion alone regressed `react-table`'s package-internal check to 136,031 (+84.6%). Root cause: with type parameters flowing into conditional types, the compiler's *measured* variance for the interface was unreliable, so relating `Table_Internal<A>` to `Table_Internal<B>` across react's many fresh generic contexts fell back to member-by-member structural comparison, expanding the heavy members per pair. Adding explicit `in out` (invariant) variance annotations — the pattern used throughout `form` and `router` — tells the checker to relate instantiations by their type arguments directly: `Table_Internal` alone took react-table from 136,031 to 65,891, and annotating the rest of the generic interfaces took it to 54,732 — 26% **below** the beta.10 baseline, and turned kitchen-sink from neutral to −12.9%. Variance annotations don't cache anything; they short-circuit relation checks by eliminating both variance measurement and the unreliable-variance structural fallback.

## beta.11 kept changes

1. **`Table_Internal` → broad interface** (`types/Table.ts`). Was `Table<TF,TD> & {…}` — an intersection wrapping the deferred `ExtractFeatureMapTypes` conditional, re-expanded structurally at every internal call site. Now an interface extending `Omit<Table_Table, broadened-keys>` plus all four core API interfaces and all 14 stock feature `Table_*` interfaces, with the internal slots (`_rowModels`, `_rowModelFns`, `options`, `initialState`, `store`, `atoms`, `baseAtoms`) redeclared in their broad `*_All` forms (TData-bearing conditionals dropped; TFeatures-only conditionals kept — feature-set count is small, data-type count is large). Public `Table<TF,TD>` is untouched, so user-facing inference is unchanged.
2. **`TableOptions_All`'s feature-map intersection de-U2I'd** (`types/TableOptions.ts`). Was `UnionToIntersection<Map[keyof Map]>` (via a `TableOptions_FeatureMap_All` helper) — re-distributed 13 members per (features, data) pair. Now a direct intersection of the 13 named stock option interfaces (inlined into `TableOptions_All`; the helper type was removed as perf-neutral, see experiment 6) plus `TableOptions_PluginFeatureMapTypes`, which falls back to `UnionToIntersection` **only** for plugin keys declaration-merged beyond the stock set (`[Exclude<keyof Map, StockKeys>] extends [never]` guard). Plugin flow-through verified against the custom-plugin example (merges `TableOptions_FeatureMap` and reads `table.options.onDensityChange`).
3. **`makeStateUpdater` takes a minimal structural param** (`utils.ts`) — `{ options: { atoms?: object }, baseAtoms: object }` instead of `Table<TFeatures, any>`. It only reads those two slots; any table view (public, internal, plugin) now passes without relating full table types. Accepts strictly more than before — non-breaking.
4. **`in out` variance annotations on generic interfaces** (166 sites across `table-core/src`, applied to `TFeatures`/`TData` parameters of exported interfaces). Both parameters are structurally invariant already (used in parameter and return positions throughout), so the annotations change no assignability semantics — TypeScript verifies annotations against structure and reported no contradictions. The win: the checker relates two instantiations of the same interface by comparing type arguments directly instead of measuring variance (which came back unreliable due to conditional-type usage) and falling back to structural member expansion. Same pattern as TanStack `form` (`FieldApi`, `FormApi`) and `router` (`Router`, `Route`). This is what makes the `Table_Internal` interface conversion a win on *all* benchmarks instead of a core-vs-react trade-off.
5. **Supporting internal changes:** `createCoreRowModel` factory takes `Table_Internal` (removing an `as unknown as` cast); `constructTable` returns via one explicit cast; two `mergeOptions` call sites cast `table.options` down to `TableOptions`; one unit test casts its constructed table to `Table_Internal`.
6. **Explicit type args on adapter `constructTable` calls** — react `useTable`, angular `injectTable`, preact `useTable` all built `constructTable({ ...options, features: { <reactivity>, ...options.features } })`, forcing generic inference + structural relation of the anonymous spread type against `TableOptions` (react: ~740ms of traced check time). `constructTable<TFeatures, TData>(...)` skips inference. Saved ~12k (react), ~9.2k (angular), ~7.6k (preact). lit/solid/svelte/vue already passed alias-typed variables.

## Rejected / neutral experiments (with numbers)

| # | Hypothesis | Result vs beta.10 core (494,577) | Verdict |
| --- | --- | --- | --- |
| 1 | Split `ColumnDef_FeatureMap` into static/dynamic halves + plugin-residual extractor, so the TData-independent half caches per feature set | 522,934 (+28,357); without residual: 522,850 | **Rejected** — extra alias layers cost more than the smaller distribution saves |
| 2 | Type filter/sort/aggregation fn implementations' row params as `Row_Core` instead of `Row` (skip deferred-conditional apparent type) | 495,829 (+1,252) | **Rejected** — slightly negative, and changes public .d.ts surface |
| 3 | Split `ColumnHelper.accessor` conditional signature into two overloads (key-first) | core 491,830 (−2,747); react 74,014 (+324); kitchen-sink 84,569 (−1,270) | **Rejected** — mixed/marginal; not worth changing explicit-type-arg arity on a public API |
| 4a | `Table_Internal` as interface, members kept as `Inherited & All` intersections | core 355,207 (−28.2%), emit 256,270 (−33.6%), react 161,566 (+119%), KS −0.1% | Superseded by 4c |
| 4b | Same broad shape but as intersection **alias** (decompose interface-ness) | core 448,480 (−9.3%, +1 variance error) | **Rejected** — interface nominal relation is most of the win |
| 4c | Interface + `Omit`-extends + broad slot members + de-U2I'd options | core 299,155 (−39.5%), emit 200,928 (−47.9%), react 136,031 (+84.6%), KS −0.1% | **Kept**, react regression fixed by 5 |
| 5a | `in out` on `Table_Internal` only | core 298,360; react 65,891 (regression erased, −10.6% vs beta.10); KS unchanged | Superseded by 5b |
| 5b | `in out` on all generic interfaces, 166 sites (**kept**) | core 288,069 (−41.8%), emit 189,852 (−50.8%), react 54,732 (−25.7%), KS 74,797 (−12.9%) | **Kept** |
| 5c | `in out` on the public `Table` **alias** | TS2637 — alias variance annotations require object/function/mapped RHS; ours is an intersection with a conditional | **Not applicable** |
| 6 | Inline `TableOptions_FeatureMap_All` into `TableOptions_All` (its only internal user) | core 288,061 (−8), emit 189,844 (−8) — exactly one alias instantiation per distinct (TFeatures, TData) pair | **Neutral on perf** — kept inlined as an API-simplification (removes one public type); the named-alias indirection bought nothing |
| 7 | `in out` on `TValue extends CellData` params (16 interfaces) | core 286,003 (−2.1k) but breaks `TValue → unknown` covariant widening — `Header<TF,TD,TValue>` no longer assignable to `Header<TF,TD,unknown>` (buildHeaderGroups.ts:116) | **Rejected** — `TValue` is genuinely covariant in output-position types; invariance rejects valid library and user code for a marginal win |

## Validation

All re-run after the variance-annotation round:

- `packages/table-core`: `pnpm test:types` (tsc + declaration emit) ✓, `vitest run` 322/322 ✓, eslint ✓, publint ✓, build ✓ — run uncached via `nx --skip-nx-cache`.
- `packages/react-table`: tsc ✓, eslint ✓, build ✓ (no unit tests in package).
- All other adapters (`angular`, `vue`, `solid`, `svelte`, `lit`, `preact`): `test:types` ✓ uncached.
- `examples/react/kitchen-sink` ✓ and `examples/react/custom-plugin` ✓ (plugin declaration-merging exercises the rewritten options path).
- After the angular/preact adapter fixes: uncached eslint/lib/types/build for both packages ✓; all 13 kitchen-sink examples type-check with zero new errors (solid's 3 errors are pre-existing in alpha too).
- Residual risks:
  - `Table_Internal` no longer carries plugin-merged *table API* members (plugin options/state still flow). Core code doesn't use plugin APIs and the plugin example only reads merged options, so nothing observable broke; a plugin reading its own merged table APIs through `Table_Internal` (rather than the public `Table`) would now need a cast.
  - `in out` declares invariance. TypeScript verified the annotations against the measured structure with no contradictions, so today they change nothing semantically — but if a future interface edit makes a parameter genuinely covariant, the annotation would keep it invariant silently. Convention: annotate new generic interfaces and trust the compiler's TS2636 error to catch mistakes.

## Comparison to the beta.3 checkpoint

| Benchmark | Alpha baseline | beta.3 | beta.10 | beta.11 |
| --- | ---: | ---: | ---: | ---: |
| table-core `tsc --noEmit` | 1,233,254¹ | 841,237 | 494,577 | 288,061 |
| table-core declaration emit | 1,150,070¹ | 771,858 | 385,702 | 189,844 |
| react-table `tsc --noEmit` | 235,498 | 168,199 | 73,690 | 54,732 |
| kitchen-sink `tsc --noEmit` | 221,006 | 169,162 | 85,839 | 74,797 |

¹ The beta.3 report's alpha baselines differ from today's alpha measurement by ~0.3% (minor alpha commits since that snapshot). react-table and kitchen-sink baselines match exactly.

## Profiling notes (for future rounds)

- `tsc --generateTrace` + `types.json` aggregation by `firstDeclaration` is the fastest way to localize: top creator in every program is `UnionToIntersection`'s distributed function types (`type-utils.ts:15`), driven by `ExtractFeatureMapTypes`.
- table-core src alone is ~77% of the core benchmark (383k of 494k at beta.10) — the library's own generic-to-generic relations dominate, not the tests.
- Isolated single-file compiles overstate marginal cost (shared types get re-paid); only whole-program numbers are comparable.
- react-table's generic hook layer (`createTableHook.tsx`, `useTable`) is highly sensitive to relation-check cost on core types: it doubled the package's check when `Table_Internal` related structurally, and dropped 60% once variance annotations restored argument-level relation. Watch this benchmark whenever core's central generic types change shape.
- Variance annotations (`in out`) are only legal on interfaces/classes and on type aliases whose RHS is an object/function/mapped type — not on intersection-with-conditional aliases like `Table` (TS2637).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal TypeScript type system with improved generic variance annotations across table interfaces for more accurate type inference and better developer experience when working with custom table features and data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->