### PR TITLE
WIP: generic type inference in table for core/external plugins without *_All or *_Internal types

### DIFF
--- a/packages/table-core/src/core/cells/constructCell.ts
+++ b/packages/table-core/src/core/cells/constructCell.ts
@@ -1,4 +1,4 @@
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { CellData, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { Row } from '../../types/Row'
@@ -13,7 +13,7 @@ import type { Cell_CoreProperties } from './coreCellsFeature.types'
 function getCellPrototype<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): object {
+>(table: Table<TFeatures, TData>): object {
   if (!table._cellPrototype) {
     table._cellPrototype = { table }
     const features = Object.values(table._features)
@@ -36,7 +36,7 @@ export function constructCell<
 >(
   column: Column<TFeatures, TData, TValue>,
   row: Row<TFeatures, TData>,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ): Cell<TFeatures, TData, TValue> {
   // Create cell with shared prototype for memory efficiency
   const cellPrototype = getCellPrototype(table)

--- a/packages/table-core/src/core/cells/coreCellsFeature.types.ts
+++ b/packages/table-core/src/core/cells/coreCellsFeature.types.ts
@@ -1,6 +1,6 @@
 import type { CellData, Getter, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table, Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { Cell } from '../../types/Cell'
 import type { Column } from '../../types/Column'
@@ -38,7 +38,7 @@ export interface Cell_CoreProperties<
   /**
    * Reference to the parent table instance.
    */
-  table: Table_Internal<TFeatures, TData>
+  table: Table<TFeatures, TData>
 }
 
 export interface Cell_Cell<

--- a/packages/table-core/src/core/columns/constructColumn.ts
+++ b/packages/table-core/src/core/columns/constructColumn.ts
@@ -1,5 +1,5 @@
 import {} from '../../utils'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { CellData, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type {
@@ -17,7 +17,7 @@ import type { Column_CoreProperties } from './coreColumnsFeature.types'
 function getColumnPrototype<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): object {
+>(table: Table<TFeatures, TData>): object {
   if (!table._columnPrototype) {
     table._columnPrototype = { table }
     const features = Object.values(table._features)
@@ -38,7 +38,7 @@ export function constructColumn<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   columnDef: ColumnDef<TFeatures, TData, TValue>,
   depth: number,
   parent?: Column<TFeatures, TData, TValue>,

--- a/packages/table-core/src/core/columns/coreColumnsFeature.ts
+++ b/packages/table-core/src/core/columns/coreColumnsFeature.ts
@@ -11,11 +11,17 @@ import {
   table_getDefaultColumnDef,
 } from './coreColumnsFeature.utils'
 import type { TableFeature } from '../../types/TableFeatures'
+import type { CoreFeatures } from '../coreFeatures'
+
+type CoreColumnsFeature = {
+  coreColumnsFeature: TableFeature
+  columnOrderingFeature: TableFeature
+}
 
 /**
  * Core feature that builds the column tree and exposes table/column column APIs.
  */
-export const coreColumnsFeature: TableFeature = {
+export const coreColumnsFeature: TableFeature<CoreColumnsFeature> = {
   assignColumnPrototype: (prototype, table) => {
     assignPrototypeAPIs('coreColumnsFeature', prototype, table, {
       column_getFlatColumns: {

--- a/packages/table-core/src/core/columns/coreColumnsFeature.ts
+++ b/packages/table-core/src/core/columns/coreColumnsFeature.ts
@@ -11,12 +11,12 @@ import {
   table_getDefaultColumnDef,
 } from './coreColumnsFeature.utils'
 import type { TableFeature } from '../../types/TableFeatures'
-import type { CoreFeatures } from '../coreFeatures'
 
-type CoreColumnsFeature = {
+type CoreColumnsFeature = Partial<{
   coreColumnsFeature: TableFeature
   columnOrderingFeature: TableFeature
-}
+  columnGroupingFeature: TableFeature
+}>
 
 /**
  * Core feature that builds the column tree and exposes table/column column APIs.

--- a/packages/table-core/src/core/columns/coreColumnsFeature.types.ts
+++ b/packages/table-core/src/core/columns/coreColumnsFeature.types.ts
@@ -1,4 +1,4 @@
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { CellData, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { AccessorFn, ColumnDef } from '../../types/ColumnDef'
@@ -39,7 +39,7 @@ export interface Column_CoreProperties<
   /**
    * Reference to the parent table instance.
    */
-  table: Table_Internal<TFeatures, TData>
+  table: Table<TFeatures, TData>
 }
 
 export interface Column_Column<

--- a/packages/table-core/src/core/columns/coreColumnsFeature.utils.ts
+++ b/packages/table-core/src/core/columns/coreColumnsFeature.utils.ts
@@ -1,7 +1,7 @@
 import { callMemoOrStaticFn } from '../../utils'
 import { table_getOrderColumnsFn } from '../../features/column-ordering/columnOrderingFeature.utils'
 import { constructColumn } from './constructColumn'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { CellData, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type {
@@ -81,7 +81,7 @@ export function table_getDefaultColumnDef<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ): Partial<ColumnDef<TFeatures, TData, unknown>> {
   return {
     header: (props) => {
@@ -120,9 +120,7 @@ export function table_getDefaultColumnDef<
 export function table_getAllColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-): Array<Column<TFeatures, TData, unknown>> {
+>(table: Table<TFeatures, TData>): Array<Column<TFeatures, TData, unknown>> {
   const recurseColumns = (
     colDefs: ReadonlyArray<ColumnDef<TFeatures, TData, unknown>>,
     parent?: Column<TFeatures, TData, unknown>,
@@ -162,9 +160,7 @@ export function table_getAllColumns<
 export function table_getAllFlatColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-): Array<Column<TFeatures, TData, unknown>> {
+>(table: Table<TFeatures, TData>): Array<Column<TFeatures, TData, unknown>> {
   return table.getAllColumns().flatMap((column) => column.getFlatColumns())
 }
 
@@ -183,7 +179,7 @@ export function table_getAllFlatColumnsById<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ): Record<string, Column<TFeatures, TData, unknown>> {
   const result: Record<string, Column<TFeatures, TData, unknown>> = {}
   const flatColumns = table.getAllFlatColumns()
@@ -208,9 +204,7 @@ export function table_getAllFlatColumnsById<
 export function table_getAllLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-): Array<Column<TFeatures, TData, unknown>> {
+>(table: Table<TFeatures, TData>): Array<Column<TFeatures, TData, unknown>> {
   const leafColumns = table.getAllColumns().flatMap(
     (c) => c.getLeafColumns(), // recursive
   )
@@ -236,7 +230,7 @@ export function table_getAllLeafColumnsById<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ): Record<string, Column<TFeatures, TData, unknown>> {
   const result: Record<string, Column<TFeatures, TData, unknown>> = {}
   const leafColumns = table.getAllLeafColumns()
@@ -262,7 +256,7 @@ export function table_getColumn<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   columnId: string,
 ): Column<TFeatures, TData, unknown> | undefined {
   const column = table.getAllFlatColumnsById()[columnId]

--- a/packages/table-core/src/core/headers/buildHeaderGroups.ts
+++ b/packages/table-core/src/core/headers/buildHeaderGroups.ts
@@ -136,7 +136,7 @@ export function buildHeaderGroups<
   headerGroups.reverse()
 
   const recurseHeadersForSpans = (
-    headers: Array<Header<TFeatures, TData, TValue>>,
+    headers: Array<Header<TFeatures, TData, unknown>>,
   ): Array<{ colSpan: number; rowSpan: number }> => {
     const results: Array<{ colSpan: number; rowSpan: number }> = []
 

--- a/packages/table-core/src/core/headers/buildHeaderGroups.ts
+++ b/packages/table-core/src/core/headers/buildHeaderGroups.ts
@@ -1,7 +1,7 @@
 import { callMemoOrStaticFn } from '../../utils'
 import { column_getIsVisible } from '../../features/column-visibility/columnVisibilityFeature.utils'
 import { constructHeader } from './constructHeader'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { CellData, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { Header } from '../../types/Header'
@@ -20,7 +20,7 @@ export function buildHeaderGroups<
 >(
   allColumns: Array<Column<TFeatures, TData, TValue>>,
   columnsToGroup: Array<Column<TFeatures, TData, TValue>>,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   headerFamily?: 'center' | 'left' | 'right',
 ) {
   // Find the max depth of the columns:
@@ -113,9 +113,7 @@ export function buildHeaderGroups<
         pendingParentHeaders.push(header)
       }
 
-      headerGroup.headers.push(
-        headerToGroup as Header<TFeatures, TData, unknown>,
-      )
+      headerGroup.headers.push(headerToGroup)
       headerToGroup.headerGroup = headerGroup
     })
 
@@ -176,9 +174,7 @@ export function buildHeaderGroups<
     return results
   }
 
-  recurseHeadersForSpans(
-    (headerGroups[0]?.headers ?? []) as Array<Header<TFeatures, TData, TValue>>,
-  )
+  recurseHeadersForSpans(headerGroups[0]?.headers ?? [])
 
   return headerGroups
 }

--- a/packages/table-core/src/core/headers/constructHeader.ts
+++ b/packages/table-core/src/core/headers/constructHeader.ts
@@ -1,4 +1,4 @@
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { CellData, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { Header } from '../../types/Header'
@@ -12,7 +12,7 @@ import type { Header_CoreProperties } from './coreHeadersFeature.types'
 function getHeaderPrototype<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): object {
+>(table: Table<TFeatures, TData>): object {
   if (!table._headerPrototype) {
     table._headerPrototype = { table }
     const features = Object.values(table._features)
@@ -33,7 +33,7 @@ export function constructHeader<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   column: Column<TFeatures, TData, TValue>,
   options: {
     id?: string

--- a/packages/table-core/src/core/headers/coreHeadersFeature.ts
+++ b/packages/table-core/src/core/headers/coreHeadersFeature.ts
@@ -8,11 +8,19 @@ import {
   table_getLeafHeaders,
 } from './coreHeadersFeature.utils'
 import type { TableFeature } from '../../types/TableFeatures'
+import type { CoreFeatures } from '../coreFeatures'
+
+type CoreHeadersFeature = CoreFeatures & {
+  columnGroupingFeature: TableFeature
+  columnOrderingFeature: TableFeature
+  columnPinningFeature: TableFeature
+  columnVisibilityFeature: TableFeature
+}
 
 /**
  * Core feature that builds header groups and exposes header context APIs.
  */
-export const coreHeadersFeature: TableFeature = {
+export const coreHeadersFeature: TableFeature<CoreHeadersFeature> = {
   assignHeaderPrototype: (prototype, table) => {
     assignPrototypeAPIs('coreHeadersFeature', prototype, table, {
       header_getLeafHeaders: {

--- a/packages/table-core/src/core/headers/coreHeadersFeature.utils.ts
+++ b/packages/table-core/src/core/headers/coreHeadersFeature.utils.ts
@@ -5,7 +5,7 @@ import {
 } from '../../features/column-visibility/columnVisibilityFeature.utils'
 import { callMemoOrStaticFn } from '../../utils'
 import { buildHeaderGroups } from './buildHeaderGroups'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Header } from '../../types/Header'
 import type { RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
@@ -78,7 +78,7 @@ export function header_getContext<
 export function table_getHeaderGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const { left, right } =
     table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   const allColumns = table.getAllColumns()
@@ -142,7 +142,7 @@ export function table_getHeaderGroups<
 export function table_getFooterGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const headerGroups = table.getHeaderGroups()
   return [...headerGroups].reverse()
 }
@@ -161,13 +161,13 @@ export function table_getFooterGroups<
 export function table_getFlatHeaders<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const headerGroups = table.getHeaderGroups()
   const result: Array<Header<TFeatures, TData, unknown>> = []
   for (let i = 0; i < headerGroups.length; i++) {
     const headers = headerGroups[i]!.headers
     for (let j = 0; j < headers.length; j++) {
-      result.push(headers[j]!)
+      result.push(headers[j])
     }
   }
   return result
@@ -187,13 +187,13 @@ export function table_getFlatHeaders<
 export function table_getLeafHeaders<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const topHeaders = table.getHeaderGroups()[0]?.headers ?? []
   const result: Array<Header<TFeatures, TData, unknown>> = []
   for (let i = 0; i < topHeaders.length; i++) {
     const leafHeaders = topHeaders[i]!.getLeafHeaders()
     for (let j = 0; j < leafHeaders.length; j++) {
-      result.push(leafHeaders[j]!)
+      result.push(leafHeaders[j])
     }
   }
   return result

--- a/packages/table-core/src/core/headers/coreHeadersFeature.utils.ts
+++ b/packages/table-core/src/core/headers/coreHeadersFeature.utils.ts
@@ -171,7 +171,7 @@ export function table_getFlatHeaders<
   for (let i = 0; i < headerGroups.length; i++) {
     const headers = headerGroups[i]!.headers
     for (let j = 0; j < headers.length; j++) {
-      result.push(headers[j] as Header<TFeatures, TData, unknown>)
+      result.push(headers[j]!)
     }
   }
   return result

--- a/packages/table-core/src/core/headers/coreHeadersFeature.utils.ts
+++ b/packages/table-core/src/core/headers/coreHeadersFeature.utils.ts
@@ -8,9 +8,12 @@ import { buildHeaderGroups } from './buildHeaderGroups'
 import type { Table } from '../../types/Table'
 import type { Header } from '../../types/Header'
 import type { RowData } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Header_Header } from './coreHeadersFeature.types'
-import type { Column } from '../../types/Column'
+
+type HeaderFeatures = Partial<{
+  columnPinningFeature: TableFeature
+}>
 
 /**
  * Walks a header tree and collects all descendant leaf headers.
@@ -79,8 +82,9 @@ export function table_getHeaderGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<HeaderFeatures, TData>
   const { left, right } =
-    table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   const allColumns = table.getAllColumns()
   const leafColumns = callMemoOrStaticFn(
     table,
@@ -167,7 +171,7 @@ export function table_getFlatHeaders<
   for (let i = 0; i < headerGroups.length; i++) {
     const headers = headerGroups[i]!.headers
     for (let j = 0; j < headers.length; j++) {
-      result.push(headers[j])
+      result.push(headers[j] as Header<TFeatures, TData, unknown>)
     }
   }
   return result
@@ -193,7 +197,7 @@ export function table_getLeafHeaders<
   for (let i = 0; i < topHeaders.length; i++) {
     const leafHeaders = topHeaders[i]!.getLeafHeaders()
     for (let j = 0; j < leafHeaders.length; j++) {
-      result.push(leafHeaders[j])
+      result.push(leafHeaders[j] as Header<TFeatures, TData, unknown>)
     }
   }
   return result

--- a/packages/table-core/src/core/headers/coreHeadersFeature.utils.ts
+++ b/packages/table-core/src/core/headers/coreHeadersFeature.utils.ts
@@ -197,7 +197,7 @@ export function table_getLeafHeaders<
   for (let i = 0; i < topHeaders.length; i++) {
     const leafHeaders = topHeaders[i]!.getLeafHeaders()
     for (let j = 0; j < leafHeaders.length; j++) {
-      result.push(leafHeaders[j] as Header<TFeatures, TData, unknown>)
+      result.push(leafHeaders[j]!)
     }
   }
   return result

--- a/packages/table-core/src/core/row-models/coreRowModelsFeature.ts
+++ b/packages/table-core/src/core/row-models/coreRowModelsFeature.ts
@@ -14,11 +14,12 @@ import {
   table_getSortedRowModel,
 } from './coreRowModelsFeature.utils'
 import type { TableFeature } from '../../types/TableFeatures'
+import type { CoreFeatures } from '../coreFeatures'
 
 /**
  * Core feature that wires table row-model accessors and row-model caches.
  */
-export const coreRowModelsFeature: TableFeature = {
+export const coreRowModelsFeature: TableFeature<CoreFeatures> = {
   constructTableAPIs: (table) => {
     assignTableAPIs('coreRowModelsFeature', table, {
       table_getCoreRowModel: {

--- a/packages/table-core/src/core/row-models/coreRowModelsFeature.utils.ts
+++ b/packages/table-core/src/core/row-models/coreRowModelsFeature.utils.ts
@@ -32,13 +32,15 @@ export function table_getCoreRowModel<
   if (!featureTable._rowModels.coreRowModel) {
     featureTable._rowModels.coreRowModel =
       table.options.features.coreRowModel?.(table) ??
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       (createCoreRowModel<TFeatures, TData>()(
         table,
       ) as unknown as () => RowModel<RowModelFeatures, TData>)
   }
 
-  return featureTable._rowModels.coreRowModel()
+  return featureTable._rowModels.coreRowModel() as unknown as RowModel<
+    TFeatures,
+    TData
+  >
 }
 
 /**

--- a/packages/table-core/src/core/row-models/coreRowModelsFeature.utils.ts
+++ b/packages/table-core/src/core/row-models/coreRowModelsFeature.utils.ts
@@ -1,5 +1,5 @@
 import { createCoreRowModel } from './createCoreRowModel'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { RowData } from '../../types/type-utils'
 import type { RowModel } from './coreRowModelsFeature.types'
@@ -18,7 +18,7 @@ import type { RowModel } from './coreRowModelsFeature.types'
 export function table_getCoreRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   if (!table._rowModels.coreRowModel) {
     table._rowModels.coreRowModel =
       table.options.features.coreRowModel?.(table) ??
@@ -42,7 +42,7 @@ export function table_getCoreRowModel<
 export function table_getPreFilteredRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   return table.getCoreRowModel()
 }
 
@@ -61,7 +61,7 @@ export function table_getPreFilteredRowModel<
 export function table_getFilteredRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   if (!table._rowModels.filteredRowModel) {
     table._rowModels.filteredRowModel =
       table.options.features.filteredRowModel?.(table)
@@ -87,7 +87,7 @@ export function table_getFilteredRowModel<
 export function table_getPreGroupedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   return table.getFilteredRowModel()
 }
 
@@ -105,7 +105,7 @@ export function table_getPreGroupedRowModel<
 export function table_getGroupedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   if (!table._rowModels.groupedRowModel) {
     table._rowModels.groupedRowModel =
       table.options.features.groupedRowModel?.(table)
@@ -131,7 +131,7 @@ export function table_getGroupedRowModel<
 export function table_getPreSortedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   return table.getGroupedRowModel()
 }
 
@@ -150,7 +150,7 @@ export function table_getPreSortedRowModel<
 export function table_getSortedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   if (!table._rowModels.sortedRowModel) {
     table._rowModels.sortedRowModel =
       table.options.features.sortedRowModel?.(table)
@@ -176,7 +176,7 @@ export function table_getSortedRowModel<
 export function table_getPreExpandedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   return table.getSortedRowModel()
 }
 
@@ -194,7 +194,7 @@ export function table_getPreExpandedRowModel<
 export function table_getExpandedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   if (!table._rowModels.expandedRowModel) {
     table._rowModels.expandedRowModel =
       table.options.features.expandedRowModel?.(table)
@@ -221,7 +221,7 @@ export function table_getExpandedRowModel<
 export function table_getPrePaginatedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   return table.getExpandedRowModel()
 }
 
@@ -240,7 +240,7 @@ export function table_getPrePaginatedRowModel<
 export function table_getPaginatedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   if (!table._rowModels.paginatedRowModel) {
     table._rowModels.paginatedRowModel =
       table.options.features.paginatedRowModel?.(table)
@@ -267,6 +267,6 @@ export function table_getPaginatedRowModel<
 export function table_getRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   return table.getPaginatedRowModel()
 }

--- a/packages/table-core/src/core/row-models/coreRowModelsFeature.utils.ts
+++ b/packages/table-core/src/core/row-models/coreRowModelsFeature.utils.ts
@@ -32,14 +32,13 @@ export function table_getCoreRowModel<
   if (!featureTable._rowModels.coreRowModel) {
     featureTable._rowModels.coreRowModel =
       table.options.features.coreRowModel?.(table) ??
-      (createCoreRowModel<TFeatures, TData>()(table) as unknown as () =>
-        RowModel<RowModelFeatures, TData>)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      (createCoreRowModel<TFeatures, TData>()(
+        table,
+      ) as unknown as () => RowModel<RowModelFeatures, TData>)
   }
 
-  return featureTable._rowModels.coreRowModel() as unknown as RowModel<
-    TFeatures,
-    TData
-  >
+  return featureTable._rowModels.coreRowModel()
 }
 
 /**
@@ -73,13 +72,16 @@ export function table_getPreFilteredRowModel<
  * ```
  */
 export function table_getFilteredRowModel<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
+  TFeatures extends TableFeatures = any,
+  TData extends RowData = any,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   const featureTable = table as unknown as Table<RowModelFeatures, TData>
-  if (!featureTable._rowModels.filteredRowModel) {
-    ;(featureTable._rowModels as any).filteredRowModel =
-      table.options.features.filteredRowModel?.(table)
+  if (
+    !featureTable._rowModels.filteredRowModel &&
+    table.options.features.filteredRowModel
+  ) {
+    featureTable._rowModels.filteredRowModel =
+      table.options.features.filteredRowModel(table)
   }
 
   if (
@@ -128,9 +130,12 @@ export function table_getGroupedRowModel<
   TData extends RowData,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   const featureTable = table as unknown as Table<RowModelFeatures, TData>
-  if (!featureTable._rowModels.groupedRowModel) {
-    ;(featureTable._rowModels as any).groupedRowModel =
-      table.options.features.groupedRowModel?.(table)
+  if (
+    !featureTable._rowModels.groupedRowModel &&
+    table.options.features.groupedRowModel
+  ) {
+    featureTable._rowModels.groupedRowModel =
+      table.options.features.groupedRowModel(table)
   }
 
   if (
@@ -180,9 +185,12 @@ export function table_getSortedRowModel<
   TData extends RowData,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   const featureTable = table as unknown as Table<RowModelFeatures, TData>
-  if (!featureTable._rowModels.sortedRowModel) {
-    ;(featureTable._rowModels as any).sortedRowModel =
-      table.options.features.sortedRowModel?.(table)
+  if (
+    !featureTable._rowModels.sortedRowModel &&
+    table.options.features.sortedRowModel
+  ) {
+    featureTable._rowModels.sortedRowModel =
+      table.options.features.sortedRowModel(table)
   }
 
   if (
@@ -231,9 +239,12 @@ export function table_getExpandedRowModel<
   TData extends RowData,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   const featureTable = table as unknown as Table<RowModelFeatures, TData>
-  if (!featureTable._rowModels.expandedRowModel) {
-    ;(featureTable._rowModels as any).expandedRowModel =
-      table.options.features.expandedRowModel?.(table)
+  if (
+    !featureTable._rowModels.expandedRowModel &&
+    table.options.features.expandedRowModel
+  ) {
+    featureTable._rowModels.expandedRowModel =
+      table.options.features.expandedRowModel(table)
   }
 
   if (
@@ -284,9 +295,12 @@ export function table_getPaginatedRowModel<
   TData extends RowData,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   const featureTable = table as unknown as Table<RowModelFeatures, TData>
-  if (!featureTable._rowModels.paginatedRowModel) {
-    ;(featureTable._rowModels as any).paginatedRowModel =
-      table.options.features.paginatedRowModel?.(table)
+  if (
+    !featureTable._rowModels.paginatedRowModel &&
+    table.options.features.paginatedRowModel
+  ) {
+    featureTable._rowModels.paginatedRowModel =
+      table.options.features.paginatedRowModel(table)
   }
 
   if (

--- a/packages/table-core/src/core/row-models/coreRowModelsFeature.utils.ts
+++ b/packages/table-core/src/core/row-models/coreRowModelsFeature.utils.ts
@@ -1,8 +1,17 @@
 import { createCoreRowModel } from './createCoreRowModel'
 import type { Table } from '../../types/Table'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowData } from '../../types/type-utils'
 import type { RowModel } from './coreRowModelsFeature.types'
+
+type RowModelFeatures = Partial<{
+  coreRowModelsFeature: TableFeature
+  columnFilteringFeature: TableFeature
+  columnGroupingFeature: TableFeature
+  rowSortingFeature: TableFeature
+  rowExpandingFeature: TableFeature
+  rowPaginationFeature: TableFeature
+}>
 
 /**
  * Resolves the table's unmodified core row model.
@@ -19,13 +28,18 @@ export function table_getCoreRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
-  if (!table._rowModels.coreRowModel) {
-    table._rowModels.coreRowModel =
+  const featureTable = table as unknown as Table<RowModelFeatures, TData>
+  if (!featureTable._rowModels.coreRowModel) {
+    featureTable._rowModels.coreRowModel =
       table.options.features.coreRowModel?.(table) ??
-      createCoreRowModel<TFeatures, TData>()(table)
+      (createCoreRowModel<TFeatures, TData>()(table) as unknown as () =>
+        RowModel<RowModelFeatures, TData>)
   }
 
-  return table._rowModels.coreRowModel()
+  return featureTable._rowModels.coreRowModel() as unknown as RowModel<
+    TFeatures,
+    TData
+  >
 }
 
 /**
@@ -62,16 +76,23 @@ export function table_getFilteredRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
-  if (!table._rowModels.filteredRowModel) {
-    table._rowModels.filteredRowModel =
+  const featureTable = table as unknown as Table<RowModelFeatures, TData>
+  if (!featureTable._rowModels.filteredRowModel) {
+    ;(featureTable._rowModels as any).filteredRowModel =
       table.options.features.filteredRowModel?.(table)
   }
 
-  if (table.options.manualFiltering || !table._rowModels.filteredRowModel) {
+  if (
+    featureTable.options.manualFiltering ||
+    !featureTable._rowModels.filteredRowModel
+  ) {
     return table.getPreFilteredRowModel()
   }
 
-  return table._rowModels.filteredRowModel()
+  return featureTable._rowModels.filteredRowModel() as unknown as RowModel<
+    TFeatures,
+    TData
+  >
 }
 
 /**
@@ -106,16 +127,23 @@ export function table_getGroupedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
-  if (!table._rowModels.groupedRowModel) {
-    table._rowModels.groupedRowModel =
+  const featureTable = table as unknown as Table<RowModelFeatures, TData>
+  if (!featureTable._rowModels.groupedRowModel) {
+    ;(featureTable._rowModels as any).groupedRowModel =
       table.options.features.groupedRowModel?.(table)
   }
 
-  if (table.options.manualGrouping || !table._rowModels.groupedRowModel) {
+  if (
+    featureTable.options.manualGrouping ||
+    !featureTable._rowModels.groupedRowModel
+  ) {
     return table.getPreGroupedRowModel()
   }
 
-  return table._rowModels.groupedRowModel()
+  return featureTable._rowModels.groupedRowModel() as unknown as RowModel<
+    TFeatures,
+    TData
+  >
 }
 
 /**
@@ -151,16 +179,23 @@ export function table_getSortedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
-  if (!table._rowModels.sortedRowModel) {
-    table._rowModels.sortedRowModel =
+  const featureTable = table as unknown as Table<RowModelFeatures, TData>
+  if (!featureTable._rowModels.sortedRowModel) {
+    ;(featureTable._rowModels as any).sortedRowModel =
       table.options.features.sortedRowModel?.(table)
   }
 
-  if (table.options.manualSorting || !table._rowModels.sortedRowModel) {
+  if (
+    featureTable.options.manualSorting ||
+    !featureTable._rowModels.sortedRowModel
+  ) {
     return table.getPreSortedRowModel()
   }
 
-  return table._rowModels.sortedRowModel()
+  return featureTable._rowModels.sortedRowModel() as unknown as RowModel<
+    TFeatures,
+    TData
+  >
 }
 
 /**
@@ -195,16 +230,23 @@ export function table_getExpandedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
-  if (!table._rowModels.expandedRowModel) {
-    table._rowModels.expandedRowModel =
+  const featureTable = table as unknown as Table<RowModelFeatures, TData>
+  if (!featureTable._rowModels.expandedRowModel) {
+    ;(featureTable._rowModels as any).expandedRowModel =
       table.options.features.expandedRowModel?.(table)
   }
 
-  if (table.options.manualExpanding || !table._rowModels.expandedRowModel) {
+  if (
+    featureTable.options.manualExpanding ||
+    !featureTable._rowModels.expandedRowModel
+  ) {
     return table.getPreExpandedRowModel()
   }
 
-  return table._rowModels.expandedRowModel()
+  return featureTable._rowModels.expandedRowModel() as unknown as RowModel<
+    TFeatures,
+    TData
+  >
 }
 
 /**
@@ -241,16 +283,23 @@ export function table_getPaginatedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
-  if (!table._rowModels.paginatedRowModel) {
-    table._rowModels.paginatedRowModel =
+  const featureTable = table as unknown as Table<RowModelFeatures, TData>
+  if (!featureTable._rowModels.paginatedRowModel) {
+    ;(featureTable._rowModels as any).paginatedRowModel =
       table.options.features.paginatedRowModel?.(table)
   }
 
-  if (table.options.manualPagination || !table._rowModels.paginatedRowModel) {
+  if (
+    featureTable.options.manualPagination ||
+    !featureTable._rowModels.paginatedRowModel
+  ) {
     return table.getPrePaginatedRowModel()
   }
 
-  return table._rowModels.paginatedRowModel()
+  return featureTable._rowModels.paginatedRowModel() as unknown as RowModel<
+    TFeatures,
+    TData
+  >
 }
 
 /**

--- a/packages/table-core/src/core/row-models/createCoreRowModel.ts
+++ b/packages/table-core/src/core/row-models/createCoreRowModel.ts
@@ -1,7 +1,7 @@
 import { constructRow } from '../rows/constructRow'
 import { tableMemo } from '../../utils'
 import { table_autoResetPageIndex } from '../../features/row-pagination/rowPaginationFeature.utils'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { RowModel } from './coreRowModelsFeature.types'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { Row } from '../../types/Row'
@@ -15,9 +15,7 @@ import type { RowData } from '../../types/type-utils'
 export function createCoreRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(): (
-  table: Table_Internal<TFeatures, TData>,
-) => () => RowModel<TFeatures, TData> {
+>(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
   return (table) => {
     return tableMemo({
       feature: 'coreRowModelsFeature',
@@ -34,7 +32,7 @@ function _createCoreRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   data: ReadonlyArray<TData>,
 ): {
   rows: Array<Row<TFeatures, TData>>

--- a/packages/table-core/src/core/rows/constructRow.ts
+++ b/packages/table-core/src/core/rows/constructRow.ts
@@ -1,4 +1,4 @@
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { Row } from '../../types/Row'
@@ -11,7 +11,7 @@ import type { Row_CoreProperties } from './coreRowsFeature.types'
 function getRowPrototype<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): object {
+>(table: Table<TFeatures, TData>): object {
   if (!table._rowPrototype) {
     table._rowPrototype = { table }
     const features = Object.values(table._features)
@@ -31,7 +31,7 @@ export const constructRow = <
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   id: string,
   original: TData,
   rowIndex: number,

--- a/packages/table-core/src/core/rows/coreRowsFeature.ts
+++ b/packages/table-core/src/core/rows/coreRowsFeature.ts
@@ -12,11 +12,12 @@ import {
   table_getRowId,
 } from './coreRowsFeature.utils'
 import type { TableFeature } from '../../types/TableFeatures'
+import type { CoreFeatures } from '../coreFeatures'
 
 /**
  * Core feature that creates row APIs for values, cells, and tree traversal.
  */
-export const coreRowsFeature: TableFeature = {
+export const coreRowsFeature: TableFeature<CoreFeatures> = {
   assignRowPrototype: (prototype, table) => {
     assignPrototypeAPIs('coreRowsFeature', prototype, table, {
       row_getAllCellsByColumnId: {

--- a/packages/table-core/src/core/rows/coreRowsFeature.types.ts
+++ b/packages/table-core/src/core/rows/coreRowsFeature.types.ts
@@ -1,4 +1,4 @@
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { Row } from '../../types/Row'
@@ -41,7 +41,7 @@ export interface Row_CoreProperties<
   /**
    * Reference to the parent table instance.
    */
-  table: Table_Internal<TFeatures, TData>
+  table: Table<TFeatures, TData>
 }
 
 export interface Row_Row<

--- a/packages/table-core/src/core/rows/coreRowsFeature.utils.ts
+++ b/packages/table-core/src/core/rows/coreRowsFeature.utils.ts
@@ -173,7 +173,7 @@ export function row_getAllCells<
     columns.length,
   )
   for (let i = 0; i < columns.length; i++) {
-    cells[i] = constructCell(columns[i], row, row.table)
+    cells[i] = constructCell(columns[i]!, row, row.table)
   }
   return cells
 }

--- a/packages/table-core/src/core/rows/coreRowsFeature.utils.ts
+++ b/packages/table-core/src/core/rows/coreRowsFeature.utils.ts
@@ -1,6 +1,6 @@
 import { flattenBy } from '../../utils'
 import { constructCell } from '../cells/constructCell'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { Row } from '../../types/Row'
@@ -173,7 +173,7 @@ export function row_getAllCells<
     columns.length,
   )
   for (let i = 0; i < columns.length; i++) {
-    cells[i] = constructCell(columns[i]!, row, row.table)
+    cells[i] = constructCell(columns[i], row, row.table)
   }
   return cells
 }
@@ -217,7 +217,7 @@ export function table_getRowId<
   TData extends RowData,
 >(
   originalRow: TData,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   index: number,
   parent?: Row<TFeatures, TData>,
 ) {
@@ -242,7 +242,7 @@ export function table_getRow<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   rowId: string,
   searchAll?: boolean,
 ): Row<TFeatures, TData> {

--- a/packages/table-core/src/core/table/constructTable.ts
+++ b/packages/table-core/src/core/table/constructTable.ts
@@ -5,7 +5,7 @@ import { table_syncExternalStateToBaseAtoms } from './coreTablesFeature.utils'
 import type { Atom } from '@tanstack/store'
 import type { RowData } from '../../types/type-utils'
 import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
-import type { Table, Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { TableOptions } from '../../types/TableOptions'
 import type { TableState, TableState_All } from '../../types/TableState'
 
@@ -21,7 +21,7 @@ export function getInitialTableState<TFeatures extends TableFeatures>(
   Object.values(features).forEach((feature) => {
     initialState = feature.getInitialState?.(initialState) ?? initialState
   })
-  return cloneState(initialState) as TableState<TFeatures>
+  return cloneState(initialState)
 }
 
 /**
@@ -64,7 +64,7 @@ export function constructTable<
     _rowModelFns: { aggregationFns, filterFns, sortFns },
     baseAtoms: {},
     atoms: {},
-  } as unknown as Table_Internal<TFeatures, TData>
+  } as unknown as Table<TFeatures, TData>
 
   const featuresList: Array<TableFeature> = Object.values(table._features)
 
@@ -121,9 +121,7 @@ export function constructTable<
     table.options.initialState,
   )
 
-  const stateKeys = Object.keys(table.initialState) as Array<
-    string & keyof TableState_All
-  >
+  const stateKeys = Object.keys(table.initialState)
 
   for (let i = 0; i < stateKeys.length; i++) {
     const key = stateKeys[i]!
@@ -137,9 +135,7 @@ export function constructTable<
     // create readonly derived atom: on each get(), read either external atom or base atom
     ;(table.atoms as any)[key] = _reactivity.createReadonlyAtom(
       () => {
-        const externalAtoms = table.options.atoms as
-          | Partial<Record<keyof TableState_All, Atom<unknown>>>
-          | undefined
+        const externalAtoms = table.options.atoms
         const externalAtom = externalAtoms?.[key]
         if (externalAtom) {
           return externalAtom.get()

--- a/packages/table-core/src/core/table/constructTable.ts
+++ b/packages/table-core/src/core/table/constructTable.ts
@@ -7,7 +7,7 @@ import type { RowData } from '../../types/type-utils'
 import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
 import type { TableOptions } from '../../types/TableOptions'
-import type { TableState, TableState_All } from '../../types/TableState'
+import type { TableState } from '../../types/TableState'
 
 /**
  * Builds the initial table state from registered features and user initial state.
@@ -19,9 +19,11 @@ export function getInitialTableState<TFeatures extends TableFeatures>(
   initialState: Partial<TableState<TFeatures>> | undefined = {},
 ): TableState<TFeatures> {
   Object.values(features).forEach((feature) => {
-    initialState = feature.getInitialState?.(initialState) ?? initialState
+    initialState =
+      feature.getInitialState?.(initialState as Partial<TableState<any>>) ??
+      initialState
   })
-  return cloneState(initialState)
+  return cloneState(initialState) as TableState<TFeatures>
 }
 
 /**
@@ -65,11 +67,15 @@ export function constructTable<
     baseAtoms: {},
     atoms: {},
   } as unknown as Table<TFeatures, TData>
+  const mutableTable = table as any
 
   const featuresList: Array<TableFeature> = Object.values(table._features)
 
   const defaultOptions = featuresList.reduce((obj, feature) => {
-    return Object.assign(obj, feature.getDefaultTableOptions?.(table))
+    return Object.assign(
+      obj,
+      feature.getDefaultTableOptions?.(table as unknown as Table<any, any>),
+    )
   }, {}) as TableOptions<TFeatures, TData>
 
   const mergedOptions = { ...defaultOptions, ...tableOptions }
@@ -113,10 +119,10 @@ export function constructTable<
       },
     })
   } else {
-    table.options = mergedOptions
+    mutableTable.options = mergedOptions
   }
 
-  table.initialState = getInitialTableState(
+  mutableTable.initialState = getInitialTableState(
     table._features,
     table.options.initialState,
   )
@@ -125,22 +131,24 @@ export function constructTable<
 
   for (let i = 0; i < stateKeys.length; i++) {
     const key = stateKeys[i]!
-    table.baseAtoms[key] = _reactivity.createWritableAtom(
-      table.initialState[key],
+    mutableTable.baseAtoms[key] = _reactivity.createWritableAtom(
+      mutableTable.initialState[key],
       {
         debugName: `table/baseAtoms/${key}`,
       },
     ) as any
 
     // create readonly derived atom: on each get(), read either external atom or base atom
-    ;(table.atoms as any)[key] = _reactivity.createReadonlyAtom(
+    mutableTable.atoms[key] = _reactivity.createReadonlyAtom(
       () => {
         const externalAtoms = table.options.atoms
-        const externalAtom = externalAtoms?.[key]
+        const externalAtom = (externalAtoms as Record<string, Atom<any>> | undefined)?.[
+          key
+        ]
         if (externalAtom) {
           return externalAtom.get()
         }
-        return table.baseAtoms[key]!.get()
+        return mutableTable.baseAtoms[key]!.get()
       },
       { debugName: `table/atoms/${key}` },
     )
@@ -148,13 +156,15 @@ export function constructTable<
 
   table_syncExternalStateToBaseAtoms(table)
 
-  table.store = atomToStore(
+  mutableTable.store = atomToStore(
     _reactivity.createReadonlyAtom(
       () => {
-        const snapshot = {} as TableState<TFeatures> & TableState_All
+        const snapshot = {} as TableState<TFeatures>
         for (let i = 0; i < stateKeys.length; i++) {
           const key = stateKeys[i]!
-          ;(snapshot as Record<string, unknown>)[key] = table.atoms[key]!.get()
+          ;(snapshot as Record<string, unknown>)[key] = mutableTable.atoms[
+            key
+          ]!.get()
         }
         return snapshot
       },
@@ -195,7 +205,7 @@ export function constructTable<
   }
 
   for (let i = 0; i < featuresList.length; i++) {
-    featuresList[i]!.constructTableAPIs?.(table)
+    featuresList[i]!.constructTableAPIs?.(table as unknown as Table<any, any>)
   }
 
   return table as unknown as Table<TFeatures, TData>

--- a/packages/table-core/src/core/table/constructTable.ts
+++ b/packages/table-core/src/core/table/constructTable.ts
@@ -2,13 +2,18 @@ import { coreFeatures } from '../coreFeatures'
 import { cloneState } from '../../utils'
 import { atomToStore } from '../reactivity/coreReactivityFeature.utils'
 import { table_syncExternalStateToBaseAtoms } from './coreTablesFeature.utils'
-import type { Atom } from '@tanstack/store'
+import type { Atom, ReadonlyStore } from '@tanstack/store'
 import type { RowData } from '../../types/type-utils'
 import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
 import type { TableOptions } from '../../types/TableOptions'
 import type { TableState } from '../../types/TableState'
 
+type Writeable<T> = { -readonly [P in keyof T]: T[P] }
+type MutableTable<
+  TFeatures extends TableFeatures,
+  TRowData extends RowData,
+> = Writeable<Table<TFeatures, TRowData>>
 /**
  * Builds the initial table state from registered features and user initial state.
  *
@@ -19,9 +24,7 @@ export function getInitialTableState<TFeatures extends TableFeatures>(
   initialState: Partial<TableState<TFeatures>> | undefined = {},
 ): TableState<TFeatures> {
   Object.values(features).forEach((feature) => {
-    initialState =
-      feature.getInitialState?.(initialState as Partial<TableState<any>>) ??
-      initialState
+    initialState = feature.getInitialState?.(initialState) ?? initialState
   })
   return cloneState(initialState) as TableState<TFeatures>
 }
@@ -66,8 +69,7 @@ export function constructTable<
     _rowModelFns: { aggregationFns, filterFns, sortFns },
     baseAtoms: {},
     atoms: {},
-  } as unknown as Table<TFeatures, TData>
-  const mutableTable = table as any
+  } as unknown as MutableTable<any, TData>
 
   const featuresList: Array<TableFeature> = Object.values(table._features)
 
@@ -78,7 +80,10 @@ export function constructTable<
     )
   }, {}) as TableOptions<TFeatures, TData>
 
-  const mergedOptions = { ...defaultOptions, ...tableOptions }
+  const mergedOptions = { ...defaultOptions, ...tableOptions } as TableOptions<
+    TFeatures,
+    TData
+  >
 
   if (_reactivity.wrapExternalAtoms && mergedOptions.atoms) {
     for (const [atomKey, _atom] of Object.entries(mergedOptions.atoms)) {
@@ -119,10 +124,10 @@ export function constructTable<
       },
     })
   } else {
-    mutableTable.options = mergedOptions
+    table.options = mergedOptions as any
   }
 
-  mutableTable.initialState = getInitialTableState(
+  table.initialState = getInitialTableState(
     table._features,
     table.options.initialState,
   )
@@ -131,46 +136,49 @@ export function constructTable<
 
   for (let i = 0; i < stateKeys.length; i++) {
     const key = stateKeys[i]!
-    mutableTable.baseAtoms[key] = _reactivity.createWritableAtom(
-      mutableTable.initialState[key],
-      {
-        debugName: `table/baseAtoms/${key}`,
-      },
-    ) as any
+    table.baseAtoms[key as keyof typeof table.baseAtoms] =
+      _reactivity.createWritableAtom(
+        table.initialState[key as keyof typeof table.initialState],
+        {
+          debugName: `table/baseAtoms/${key}`,
+        },
+      ) as any
 
     // create readonly derived atom: on each get(), read either external atom or base atom
-    mutableTable.atoms[key] = _reactivity.createReadonlyAtom(
-      () => {
-        const externalAtoms = table.options.atoms
-        const externalAtom = (externalAtoms as Record<string, Atom<any>> | undefined)?.[
-          key
-        ]
-        if (externalAtom) {
-          return externalAtom.get()
-        }
-        return mutableTable.baseAtoms[key]!.get()
-      },
-      { debugName: `table/atoms/${key}` },
-    )
+    table.atoms[key as keyof typeof table.atoms] =
+      _reactivity.createReadonlyAtom(
+        () => {
+          const externalAtoms = table.options.atoms
+          const externalAtom = (
+            externalAtoms as Record<string, Atom<any>> | undefined
+          )?.[key]
+          if (externalAtom) {
+            return externalAtom.get()
+          }
+          return table.baseAtoms[key as keyof typeof table.baseAtoms].get()
+        },
+        { debugName: `table/atoms/${key}` },
+      )
   }
 
-  table_syncExternalStateToBaseAtoms(table)
+  table_syncExternalStateToBaseAtoms(
+    table as unknown as Table<TFeatures, TData>,
+  )
 
-  mutableTable.store = atomToStore(
+  table.store = atomToStore(
     _reactivity.createReadonlyAtom(
       () => {
         const snapshot = {} as TableState<TFeatures>
         for (let i = 0; i < stateKeys.length; i++) {
           const key = stateKeys[i]!
-          ;(snapshot as Record<string, unknown>)[key] = mutableTable.atoms[
-            key
-          ]!.get()
+          ;(snapshot as Record<string, unknown>)[key] =
+            table.atoms[key as keyof typeof table.atoms].get()
         }
         return snapshot
       },
       { debugName: 'table/store' },
     ),
-  )
+  ) as unknown as ReadonlyStore<TableState<any>>
 
   if (
     process.env.NODE_ENV === 'development' &&

--- a/packages/table-core/src/core/table/coreTablesFeature.types.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.types.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../types/TableFeatures'
 import type { CachedRowModels } from '../../types/RowModel'
 import type { TableOptions } from '../../types/TableOptions'
-import type { TableState, TableState_All } from '../../types/TableState'
+import type { TableState } from '../../types/TableState'
 
 export interface TableMeta<
   in out TFeatures extends TableFeatures,
@@ -61,26 +61,6 @@ export type Atoms<TFeatures extends TableFeatures> = {
  */
 export type ExternalAtoms<TFeatures extends TableFeatures> = Partial<{
   [K in keyof TableState<TFeatures>]: Atom<TableState<TFeatures>[K]>
-}>
-
-/**
- * Internal "all features" flat variants of the atom types. `Table_Internal`
- * uses these so feature code (written generically over `TFeatures`) can access
- * any slice atom (e.g. `table.atoms.columnPinning`) without TypeScript
- * narrowing away slices that aren't in the current `TFeatures` union.
- *
- * Keys are optional: feature code can read atoms from slices it doesn't own,
- * but those slices may not be registered on the current table. Consumers must
- * use optional chaining (`table.atoms.columnPinning?.get() ?? default`).
- */
-export type BaseAtoms_All = {
-  [K in keyof TableState_All]?: Atom<TableState_All[K]>
-}
-export type Atoms_All = {
-  [K in keyof TableState_All]?: ReadonlyAtom<TableState_All[K]>
-}
-export type ExternalAtoms_All = Partial<{
-  [K in keyof TableState_All]: Atom<TableState_All[K]>
 }>
 
 export interface TableOptions_Table<

--- a/packages/table-core/src/core/table/coreTablesFeature.utils.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.utils.ts
@@ -121,7 +121,7 @@ export function table_setOptions<
   if (table.optionsStore) {
     table.optionsStore.set(() => mergedOptions)
   } else {
-    table.options = mergedOptions
+    ;(table as any).options = mergedOptions
   }
   table_syncExternalStateToBaseAtoms(table)
 }

--- a/packages/table-core/src/core/table/coreTablesFeature.utils.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.utils.ts
@@ -1,7 +1,7 @@
 import { cloneState, functionalUpdate } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { TableOptions } from '../../types/TableOptions'
 
 /**
@@ -18,7 +18,7 @@ import type { TableOptions } from '../../types/TableOptions'
 export function table_syncExternalStateToBaseAtoms<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): void {
+>(table: Table<TFeatures, TData>): void {
   const state = table.options.state
   if (!state) {
     return
@@ -53,7 +53,7 @@ export function table_syncExternalStateToBaseAtoms<
 export function table_reset<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): void {
+>(table: Table<TFeatures, TData>): void {
   const snap = cloneState(table.initialState)
   table._reactivity.batch(() => {
     const keys = Object.keys(snap) as Array<keyof typeof snap>
@@ -78,15 +78,9 @@ export function table_reset<
 export function table_mergeOptions<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  newOptions: TableOptions<TFeatures, TData>,
-) {
+>(table: Table<TFeatures, TData>, newOptions: TableOptions<TFeatures, TData>) {
   if (table.options.mergeOptions) {
-    return table.options.mergeOptions(
-      table.options as TableOptions<TFeatures, TData>,
-      newOptions,
-    )
+    return table.options.mergeOptions(table.options, newOptions)
   }
 
   return {
@@ -110,13 +104,10 @@ export function table_setOptions<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   updater: Updater<TableOptions<TFeatures, TData>>,
 ): void {
-  const newOptions = functionalUpdate(
-    updater,
-    table.options as TableOptions<TFeatures, TData>,
-  )
+  const newOptions = functionalUpdate(updater, table.options)
   // table static options that should never change after initialization
   const { features, atoms, initialState } = table.options
   const mergedOptions = Object.assign(table_mergeOptions(table, newOptions), {

--- a/packages/table-core/src/features/column-faceting/columnFacetingFeature.ts
+++ b/packages/table-core/src/features/column-faceting/columnFacetingFeature.ts
@@ -13,10 +13,16 @@ import {
 } from './columnFacetingFeature.utils'
 import type { TableFeature } from '../../types/TableFeatures'
 
+type ColumnFacetingFeature = {
+  columnFacetingFeature: TableFeature
+  columnFilteringFeature: TableFeature
+  globalFilteringFeature: TableFeature
+}
+
 /**
  * Feature that derives faceted row models, unique values, and min/max values for filters.
  */
-export const columnFacetingFeature: TableFeature = {
+export const columnFacetingFeature: TableFeature<ColumnFacetingFeature> = {
   assignColumnPrototype: (prototype, table) => {
     assignPrototypeAPIs('columnFacetingFeature', prototype, table, {
       column_getFacetedRowModel: {

--- a/packages/table-core/src/features/column-faceting/columnFacetingFeature.utils.ts
+++ b/packages/table-core/src/features/column-faceting/columnFacetingFeature.utils.ts
@@ -1,7 +1,7 @@
 import type { CellData, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Column_Internal } from '../../types/Column'
 
 /**
@@ -21,7 +21,7 @@ export function column_getFacetedMinMaxValues<
   TValue extends CellData = CellData,
 >(
   column: Column_Internal<TFeatures, TData, TValue>,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ): [number, number] | undefined {
   const facetedMinMaxValuesFn =
     table.options.features.facetedMinMaxValues?.(table, column.id) ??
@@ -47,7 +47,7 @@ export function column_getFacetedRowModel<
   TValue extends CellData = CellData,
 >(
   column: Column_Internal<TFeatures, TData, TValue> | undefined,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ): RowModel<TFeatures, TData> {
   const facetedRowModelFn =
     table.options.features.facetedRowModel?.(table, column?.id ?? '') ??
@@ -72,7 +72,7 @@ export function column_getFacetedUniqueValues<
   TValue extends CellData = CellData,
 >(
   column: Column_Internal<TFeatures, TData, TValue>,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ): Map<any, number> {
   const facetedUniqueValuesFn =
     table.options.features.facetedUniqueValues?.(table, column.id) ??
@@ -94,7 +94,7 @@ export function column_getFacetedUniqueValues<
 export function table_getGlobalFacetedMinMaxValues<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): undefined | [number, number] {
+>(table: Table<TFeatures, TData>): undefined | [number, number] {
   const facetedMinMaxValuesFn =
     table.options.features.facetedMinMaxValues?.(table, '__global__') ??
     (() => undefined)
@@ -116,7 +116,7 @@ export function table_getGlobalFacetedMinMaxValues<
 export function table_getGlobalFacetedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   const facetedRowModelFn =
     table.options.features.facetedRowModel?.(table, '__global__') ??
     (() => table.getPreFilteredRowModel())
@@ -137,7 +137,7 @@ export function table_getGlobalFacetedRowModel<
 export function table_getGlobalFacetedUniqueValues<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): Map<any, number> {
+>(table: Table<TFeatures, TData>): Map<any, number> {
   const facetedUniqueValuesFn =
     table.options.features.facetedUniqueValues?.(table, '__global__') ??
     (() => new Map())

--- a/packages/table-core/src/features/column-faceting/columnFacetingFeature.utils.ts
+++ b/packages/table-core/src/features/column-faceting/columnFacetingFeature.utils.ts
@@ -2,7 +2,7 @@ import type { CellData, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 import type { Table } from '../../types/Table'
-import type { Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 
 /**
  * Computes min and max numeric facet values for one column.
@@ -20,7 +20,7 @@ export function column_getFacetedMinMaxValues<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  column: Column_Internal<TFeatures, TData, TValue>,
+  column: Column<TFeatures, TData, TValue>,
   table: Table<TFeatures, TData>,
 ): [number, number] | undefined {
   const facetedMinMaxValuesFn =
@@ -46,7 +46,7 @@ export function column_getFacetedRowModel<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  column: Column_Internal<TFeatures, TData, TValue> | undefined,
+  column: Column<TFeatures, TData, TValue> | undefined,
   table: Table<TFeatures, TData>,
 ): RowModel<TFeatures, TData> {
   const facetedRowModelFn =
@@ -71,7 +71,7 @@ export function column_getFacetedUniqueValues<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  column: Column_Internal<TFeatures, TData, TValue>,
+  column: Column<TFeatures, TData, TValue>,
   table: Table<TFeatures, TData>,
 ): Map<any, number> {
   const facetedUniqueValuesFn =

--- a/packages/table-core/src/features/column-faceting/createFacetedMinMaxValues.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedMinMaxValues.ts
@@ -31,7 +31,7 @@ export function createFacetedMinMaxValues<
             'getFacetedRowModel',
             column_getFacetedRowModel,
             table,
-          ).flatRows as Array<Row<TFeatures, TData>>,
+          ).flatRows,
         ]
       },
       table,

--- a/packages/table-core/src/features/column-faceting/createFacetedMinMaxValues.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedMinMaxValues.ts
@@ -1,8 +1,8 @@
 import { callMemoOrStaticFn, tableMemo } from '../../utils'
 import { column_getFacetedRowModel } from './columnFacetingFeature.utils'
 import type { Row } from '../../types/Row'
-import type { Table, Table_Internal } from '../../types/Table'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { Table } from '../../types/Table'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowData } from '../../types/type-utils'
 
 /**
@@ -17,21 +17,27 @@ export function createFacetedMinMaxValues<
   table: Table<TFeatures, TData>,
   columnId: string,
 ) => () => undefined | [number, number] {
-  return (_table, columnId) => {
-    const table = _table as unknown as Table_Internal<TFeatures, TData>
+  return (table, columnId) => {
+    const typedTable = table as unknown as Table<
+      {
+        columnFacetingFeature: TableFeature
+        columnFilteringFeature: TableFeature
+      },
+      TData
+    >
     return tableMemo({
       feature: 'columnFacetingFeature',
       fn: (flatRows) => _createFacetedMinMaxValues(columnId, flatRows),
       fnName: 'table.getFacetedMinMaxValues',
       memoDeps: () => {
-        const column = table.getColumn(columnId)
-        if (!column) return [table.getPreFilteredRowModel().flatRows]
+        const column = typedTable.getColumn(columnId)
+        if (!column) return [typedTable.getPreFilteredRowModel().flatRows]
         return [
           callMemoOrStaticFn(
             column,
             'getFacetedRowModel',
             column_getFacetedRowModel,
-            table,
+            typedTable,
           ).flatRows,
         ]
       },

--- a/packages/table-core/src/features/column-faceting/createFacetedMinMaxValues.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedMinMaxValues.ts
@@ -2,7 +2,7 @@ import { callMemoOrStaticFn, tableMemo } from '../../utils'
 import { column_getFacetedRowModel } from './columnFacetingFeature.utils'
 import type { Row } from '../../types/Row'
 import type { Table } from '../../types/Table'
-import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
+import type { TableFeatures } from '../../types/TableFeatures'
 import type { RowData } from '../../types/type-utils'
 
 /**
@@ -18,27 +18,20 @@ export function createFacetedMinMaxValues<
   columnId: string,
 ) => () => undefined | [number, number] {
   return (table, columnId) => {
-    const typedTable = table as unknown as Table<
-      {
-        columnFacetingFeature: TableFeature
-        columnFilteringFeature: TableFeature
-      },
-      TData
-    >
     return tableMemo({
       feature: 'columnFacetingFeature',
       fn: (flatRows) => _createFacetedMinMaxValues(columnId, flatRows),
       fnName: 'table.getFacetedMinMaxValues',
       memoDeps: () => {
-        const column = typedTable.getColumn(columnId)
-        if (!column) return [typedTable.getPreFilteredRowModel().flatRows]
+        const column = table.getColumn(columnId)
+        if (!column) return [table.getPreFilteredRowModel().flatRows]
         return [
           callMemoOrStaticFn(
             column,
             'getFacetedRowModel',
             column_getFacetedRowModel,
-            typedTable,
-          ).flatRows,
+            table,
+          ).flatRows as Array<Row<TFeatures, TData>>,
         ]
       },
       table,

--- a/packages/table-core/src/features/column-faceting/createFacetedRowModel.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedRowModel.ts
@@ -1,11 +1,11 @@
 import { tableMemo } from '../../utils'
 import { filterRows } from '../column-filtering/filterRowsUtils'
-import type { Table, Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type {
   ColumnFiltersState,
   Row_ColumnFiltering,
 } from '../column-filtering/columnFilteringFeature.types'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 import type { Row } from '../../types/Row'
 import type { RowData } from '../../types/type-utils'
@@ -22,17 +22,24 @@ export function createFacetedRowModel<
   table: Table<TFeatures, TData>,
   columnId: string,
 ) => () => RowModel<TFeatures, TData> {
-  return (_table, columnId) => {
-    const table = _table as unknown as Table_Internal<TFeatures, TData>
+  return (table, columnId) => {
+    const typedTable = table as unknown as Table<
+      {
+        columnFacetingFeature: TableFeature
+        columnFilteringFeature: TableFeature
+        globalFilteringFeature: TableFeature
+      },
+      TData
+    >
     return tableMemo({
       feature: 'columnFacetingFeature',
       table,
       fnName: 'createFacetedRowModel',
       memoDeps: () => [
-        table.getPreFilteredRowModel(),
-        table.atoms.columnFilters?.get(),
-        table.atoms.globalFilter?.get(),
-        table.getFilteredRowModel(),
+        typedTable.getPreFilteredRowModel(),
+        typedTable.atoms.columnFilters?.get(),
+        typedTable.atoms.globalFilter?.get(),
+        typedTable.getFilteredRowModel(),
       ],
       fn: (preRowModel, columnFilters, globalFilter) =>
         _createFacetedRowModel(
@@ -50,7 +57,7 @@ function _createFacetedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   columnId: string,
   preRowModel: RowModel<TFeatures, TData>,
   columnFilters?: ColumnFiltersState,

--- a/packages/table-core/src/features/column-faceting/createFacetedRowModel.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedRowModel.ts
@@ -10,6 +10,12 @@ import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 import type { Row } from '../../types/Row'
 import type { RowData } from '../../types/type-utils'
 
+type FacetedRowModelFeatures = Partial<{
+  columnFacetingFeature: TableFeature
+  columnFilteringFeature: TableFeature
+  globalFilteringFeature: TableFeature
+}>
+
 /**
  * Creates a memoized faceted row model factory.
  *
@@ -23,12 +29,8 @@ export function createFacetedRowModel<
   columnId: string,
 ) => () => RowModel<TFeatures, TData> {
   return (table, columnId) => {
-    const typedTable = table as unknown as Table<
-      {
-        columnFacetingFeature: TableFeature
-        columnFilteringFeature: TableFeature
-        globalFilteringFeature: TableFeature
-      },
+    const featureTable = table as unknown as Table<
+      FacetedRowModelFeatures,
       TData
     >
     return tableMemo({
@@ -36,10 +38,10 @@ export function createFacetedRowModel<
       table,
       fnName: 'createFacetedRowModel',
       memoDeps: () => [
-        typedTable.getPreFilteredRowModel(),
-        typedTable.atoms.columnFilters?.get(),
-        typedTable.atoms.globalFilter?.get(),
-        typedTable.getFilteredRowModel(),
+        table.getPreFilteredRowModel(),
+        featureTable.atoms.columnFilters?.get(),
+        featureTable.atoms.globalFilter?.get(),
+        table.getFilteredRowModel(),
       ],
       fn: (preRowModel, columnFilters, globalFilter) =>
         _createFacetedRowModel(
@@ -88,5 +90,8 @@ function _createFacetedRowModel<
     return true
   }
 
-  return filterRows(preRowModel.rows, filterRowsImpl, table)
+  return filterRows(preRowModel.rows, filterRowsImpl, table) as RowModel<
+    TFeatures,
+    TData
+  >
 }

--- a/packages/table-core/src/features/column-faceting/createFacetedRowModel.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedRowModel.ts
@@ -90,8 +90,5 @@ function _createFacetedRowModel<
     return true
   }
 
-  return filterRows(preRowModel.rows, filterRowsImpl, table) as RowModel<
-    TFeatures,
-    TData
-  >
+  return filterRows(preRowModel.rows, filterRowsImpl, table)
 }

--- a/packages/table-core/src/features/column-faceting/createFacetedUniqueValues.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedUniqueValues.ts
@@ -1,8 +1,8 @@
 import { callMemoOrStaticFn, tableMemo } from '../../utils'
 import { column_getFacetedRowModel } from './columnFacetingFeature.utils'
 import type { Row } from '../../types/Row'
-import type { Table, Table_Internal } from '../../types/Table'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { Table } from '../../types/Table'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowData } from '../../types/type-utils'
 
 /**
@@ -17,21 +17,27 @@ export function createFacetedUniqueValues<
   table: Table<TFeatures, TData>,
   columnId: string,
 ) => () => Map<any, number> {
-  return (_table, columnId) => {
-    const table = _table as unknown as Table_Internal<TFeatures, TData>
+  return (table, columnId) => {
+    const typedTable = table as unknown as Table<
+      {
+        columnFacetingFeature: TableFeature
+        columnFilteringFeature: TableFeature
+      },
+      TData
+    >
     return tableMemo({
       feature: 'columnFacetingFeature',
       table,
       fnName: 'table.getFacetedUniqueValues',
       memoDeps: () => {
-        const column = table.getColumn(columnId)
-        if (!column) return [table.getPreFilteredRowModel().flatRows]
+        const column = typedTable.getColumn(columnId)
+        if (!column) return [typedTable.getPreFilteredRowModel().flatRows]
         return [
           callMemoOrStaticFn(
             column,
             'getFacetedRowModel',
             column_getFacetedRowModel,
-            table,
+            typedTable,
           ).flatRows,
         ]
       },

--- a/packages/table-core/src/features/column-faceting/createFacetedUniqueValues.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedUniqueValues.ts
@@ -31,7 +31,7 @@ export function createFacetedUniqueValues<
             'getFacetedRowModel',
             column_getFacetedRowModel,
             table,
-          ).flatRows as Array<Row<TFeatures, TData>>,
+          ).flatRows,
         ]
       },
       fn: (flatRows) => _createFacetedUniqueValues(columnId, flatRows),

--- a/packages/table-core/src/features/column-faceting/createFacetedUniqueValues.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedUniqueValues.ts
@@ -2,7 +2,7 @@ import { callMemoOrStaticFn, tableMemo } from '../../utils'
 import { column_getFacetedRowModel } from './columnFacetingFeature.utils'
 import type { Row } from '../../types/Row'
 import type { Table } from '../../types/Table'
-import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
+import type { TableFeatures } from '../../types/TableFeatures'
 import type { RowData } from '../../types/type-utils'
 
 /**
@@ -18,27 +18,20 @@ export function createFacetedUniqueValues<
   columnId: string,
 ) => () => Map<any, number> {
   return (table, columnId) => {
-    const typedTable = table as unknown as Table<
-      {
-        columnFacetingFeature: TableFeature
-        columnFilteringFeature: TableFeature
-      },
-      TData
-    >
     return tableMemo({
       feature: 'columnFacetingFeature',
       table,
       fnName: 'table.getFacetedUniqueValues',
       memoDeps: () => {
-        const column = typedTable.getColumn(columnId)
-        if (!column) return [typedTable.getPreFilteredRowModel().flatRows]
+        const column = table.getColumn(columnId)
+        if (!column) return [table.getPreFilteredRowModel().flatRows]
         return [
           callMemoOrStaticFn(
             column,
             'getFacetedRowModel',
             column_getFacetedRowModel,
-            typedTable,
-          ).flatRows,
+            table,
+          ).flatRows as Array<Row<TFeatures, TData>>,
         ]
       },
       fn: (flatRows) => _createFacetedUniqueValues(columnId, flatRows),

--- a/packages/table-core/src/features/column-filtering/columnFilteringFeature.utils.ts
+++ b/packages/table-core/src/features/column-filtering/columnFilteringFeature.utils.ts
@@ -1,7 +1,7 @@
 import { cloneState, functionalUpdate, isFunction } from '../../utils'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Column_Internal } from '../../types/Column'
 import type {
   ColumnFiltersState,
@@ -255,10 +255,7 @@ export function column_setFilterValue<
 export function table_setColumnFilters<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  updater: Updater<ColumnFiltersState>,
-) {
+>(table: Table<TFeatures, TData>, updater: Updater<ColumnFiltersState>) {
   const leafColumnsById = table.getAllLeafColumnsById()
 
   const updateFn = (old: ColumnFiltersState) => {
@@ -295,7 +292,7 @@ export function table_setColumnFilters<
 export function table_resetColumnFilters<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setColumnFilters(
     table,
     defaultState ? [] : cloneState(table.initialState.columnFilters ?? []),

--- a/packages/table-core/src/features/column-filtering/columnFilteringFeature.utils.ts
+++ b/packages/table-core/src/features/column-filtering/columnFilteringFeature.utils.ts
@@ -1,12 +1,16 @@
 import { cloneState, functionalUpdate, isFunction } from '../../utils'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
-import type { Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 import type {
   ColumnFiltersState,
   FilterFn,
 } from './columnFilteringFeature.types'
+
+type ColumnFilteringFeatures = Partial<{
+  columnFilteringFeature: TableFeature
+}>
 
 /**
  * Creates the default column filter state.
@@ -39,9 +43,14 @@ export function column_getAutoFilterFn<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
-  const filterFns: Record<string, FilterFn<TFeatures, TData>> | undefined =
-    column.table._rowModelFns.filterFns
+>(column: Column<TFeatures, TData, TValue>) {
+  const featureTable = column.table as unknown as Table<
+    ColumnFilteringFeatures,
+    TData
+  >
+  const filterFns = featureTable._rowModelFns.filterFns as
+    | Record<string, FilterFn<TFeatures, TData>>
+    | undefined
 
   const firstRow = column.table.getCoreRowModel().flatRows[0]
 
@@ -87,16 +96,31 @@ export function column_getFilterFn<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  column: Column_Internal<TFeatures, TData, TValue>,
+  column: Column<TFeatures, TData, TValue>,
 ): FilterFn<TFeatures, TData> | undefined {
   let filterFn = null
-  const filterFns: Record<string, FilterFn<TFeatures, TData>> | undefined =
-    column.table._rowModelFns.filterFns
-  filterFn = isFunction(column.columnDef.filterFn)
-    ? column.columnDef.filterFn
-    : column.columnDef.filterFn === 'auto'
+  const featureTable = column.table as unknown as Table<
+    ColumnFilteringFeatures,
+    TData
+  >
+  const filterFns = featureTable._rowModelFns.filterFns as
+    | Record<string, FilterFn<TFeatures, TData>>
+    | undefined
+  const featureColumn = column as unknown as Column<
+    ColumnFilteringFeatures,
+    TData,
+    TValue
+  >
+  const columnFilterFn = featureColumn.columnDef.filterFn as unknown as
+    | FilterFn<TFeatures, TData>
+    | 'auto'
+    | string
+    | undefined
+  filterFn = isFunction(columnFilterFn)
+    ? columnFilterFn
+    : columnFilterFn === 'auto'
       ? column_getAutoFilterFn(column)
-      : filterFns?.[column.columnDef.filterFn as string]
+      : filterFns?.[columnFilterFn as unknown as string]
 
   if (process.env.NODE_ENV === 'development' && !filterFn) {
     console.warn(
@@ -122,11 +146,20 @@ export function column_getCanFilter<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
+  const featureTable = column.table as unknown as Table<
+    ColumnFilteringFeatures,
+    TData
+  >
+  const featureColumn = column as unknown as Column<
+    ColumnFilteringFeatures,
+    TData,
+    TValue
+  >
   return (
-    (column.columnDef.enableColumnFilter ?? true) &&
-    (column.table.options.enableColumnFilters ?? true) &&
-    (column.table.options.enableFilters ?? true) &&
+    (featureColumn.columnDef.enableColumnFilter ?? true) &&
+    (featureTable.options.enableColumnFilters ?? true) &&
+    (featureTable.options.enableFilters ?? true) &&
     !!column.accessorFn
   )
 }
@@ -146,7 +179,7 @@ export function column_getIsFiltered<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
   return column_getFilterIndex(column) > -1
 }
 
@@ -164,8 +197,12 @@ export function column_getFilterValue<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
-  return column.table.atoms.columnFilters
+>(column: Column<TFeatures, TData, TValue>) {
+  const featureTable = column.table as unknown as Table<
+    ColumnFilteringFeatures,
+    TData
+  >
+  return featureTable.atoms.columnFilters
     ?.get()
     ?.find((d) => d.id === column.id)?.value
 }
@@ -184,9 +221,13 @@ export function column_getFilterIndex<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): number {
+>(column: Column<TFeatures, TData, TValue>): number {
+  const featureTable = column.table as unknown as Table<
+    ColumnFilteringFeatures,
+    TData
+  >
   return (
-    column.table.atoms.columnFilters
+    featureTable.atoms.columnFilters
       ?.get()
       ?.findIndex((d) => d.id === column.id) ?? -1
   )
@@ -207,7 +248,7 @@ export function column_setFilterValue<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>, value: any) {
+>(column: Column<TFeatures, TData, TValue>, value: any) {
   table_setColumnFilters(column.table, (old) => {
     const filterFn = column_getFilterFn(column)
     const previousFilter = old.find((d) => d.id === column.id)
@@ -274,7 +315,8 @@ export function table_setColumnFilters<
     })
   }
 
-  table.options.onColumnFiltersChange?.(updateFn)
+  const featureTable = table as unknown as Table<ColumnFilteringFeatures, TData>
+  featureTable.options.onColumnFiltersChange?.(updateFn)
 }
 
 /**
@@ -293,9 +335,12 @@ export function table_resetColumnFilters<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<ColumnFilteringFeatures, TData>
   table_setColumnFilters(
     table,
-    defaultState ? [] : cloneState(table.initialState.columnFilters ?? []),
+    defaultState
+      ? []
+      : cloneState(featureTable.initialState.columnFilters ?? []),
   )
 }
 
@@ -316,7 +361,7 @@ export function shouldAutoRemoveFilter<
 >(
   filterFn?: FilterFn<TFeatures, TData>,
   value?: any,
-  column?: Column_Internal<TFeatures, TData, TValue>,
+  column?: Column<TFeatures, TData, TValue>,
 ) {
   return (
     (filterFn && filterFn.autoRemove

--- a/packages/table-core/src/features/column-filtering/createFilteredRowModel.ts
+++ b/packages/table-core/src/features/column-filtering/createFilteredRowModel.ts
@@ -8,9 +8,9 @@ import { table_autoResetPageIndex } from '../row-pagination/rowPaginationFeature
 import { filterRows } from './filterRowsUtils'
 import { column_getFilterFn } from './columnFilteringFeature.utils'
 import type { RowData } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
-import type { Table, Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type {
   ResolvedColumnFilter,
@@ -29,16 +29,22 @@ export function createFilteredRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
-  return (_table) => {
-    const table = _table as unknown as Table_Internal<TFeatures, TData>
+  return (table) => {
+    const typedTable = table as unknown as Table<
+      {
+        columnFilteringFeature: TableFeature
+        globalFilteringFeature: TableFeature
+      },
+      TData
+    >
     return tableMemo({
       feature: 'columnFilteringFeature',
       table,
       fnName: 'table.getFilteredRowModel',
       memoDeps: () => [
-        table.getPreFilteredRowModel(),
-        table.atoms.columnFilters?.get(),
-        table.atoms.globalFilter?.get(),
+        typedTable.getPreFilteredRowModel(),
+        typedTable.atoms.columnFilters?.get(),
+        typedTable.atoms.globalFilter?.get(),
       ],
       fn: () => _createFilteredRowModel(table),
       onAfterUpdate: () => table_autoResetPageIndex(table),
@@ -49,7 +55,7 @@ export function createFilteredRowModel<
 function _createFilteredRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   const rowModel = table.getPreFilteredRowModel()
   const columnFilters = table.atoms.columnFilters?.get()
   const globalFilter = table.atoms.globalFilter?.get()

--- a/packages/table-core/src/features/column-filtering/createFilteredRowModel.ts
+++ b/packages/table-core/src/features/column-filtering/createFilteredRowModel.ts
@@ -56,9 +56,16 @@ function _createFilteredRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
+  const typedTable = table as unknown as Table<
+    {
+      columnFilteringFeature: TableFeature
+      globalFilteringFeature: TableFeature
+    },
+    TData
+  >
   const rowModel = table.getPreFilteredRowModel()
-  const columnFilters = table.atoms.columnFilters?.get()
-  const globalFilter = table.atoms.globalFilter?.get()
+  const columnFilters = typedTable.atoms.columnFilters?.get()
+  const globalFilter = typedTable.atoms.globalFilter?.get()
 
   if (!rowModel.rows.length || (!columnFilters?.length && !globalFilter)) {
     const flatRows = rowModel.flatRows as Array<

--- a/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
+++ b/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
@@ -3,8 +3,12 @@ import type { Row_ColumnFiltering } from './columnFilteringFeature.types'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 import type { Row } from '../../types/Row'
 import type { Table } from '../../types/Table'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowData } from '../../types/type-utils'
+
+type ColumnFilteringFeatures = Partial<{
+  columnFilteringFeature: TableFeature
+}>
 
 /**
  * Filters a row model with the supplied row predicate.
@@ -19,7 +23,8 @@ export function filterRows<
   filterRowImpl: (row: Row<TFeatures, TData>) => any,
   table: Table<TFeatures, TData>,
 ) {
-  if (table.options.filterFromLeafRows) {
+  const featureTable = table as unknown as Table<ColumnFilteringFeatures, TData>
+  if (featureTable.options.filterFromLeafRows) {
     return filterRowModelFromLeafs(rows, filterRowImpl, table)
   }
 
@@ -38,7 +43,8 @@ function filterRowModelFromLeafs<
 ): RowModel<TFeatures, TData> {
   const newFilteredFlatRows: Array<Row<TFeatures, TData>> = []
   const newFilteredRowsById: Record<string, Row<TFeatures, TData>> = {}
-  const maxDepth = table.options.maxLeafRowFilterDepth ?? 100
+  const featureTable = table as unknown as Table<ColumnFilteringFeatures, TData>
+  const maxDepth = featureTable.options.maxLeafRowFilterDepth ?? 100
 
   const recurseFilterRows = (
     rowsToFilter: Array<
@@ -110,7 +116,8 @@ function filterRowModelFromRoot<
 ): RowModel<TFeatures, TData> {
   const newFilteredFlatRows: Array<Row<TFeatures, TData>> = []
   const newFilteredRowsById: Record<string, Row<TFeatures, TData>> = {}
-  const maxDepth = table.options.maxLeafRowFilterDepth ?? 100
+  const featureTable = table as unknown as Table<ColumnFilteringFeatures, TData>
+  const maxDepth = featureTable.options.maxLeafRowFilterDepth ?? 100
 
   // Filters top level and nested rows
   const recurseFilterRows = (

--- a/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
+++ b/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
@@ -2,7 +2,7 @@ import { constructRow } from '../../core/rows/constructRow'
 import type { Row_ColumnFiltering } from './columnFilteringFeature.types'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 import type { Row } from '../../types/Row'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { RowData } from '../../types/type-utils'
 
@@ -17,7 +17,7 @@ export function filterRows<
 >(
   rows: Array<Row<TFeatures, TData>>,
   filterRowImpl: (row: Row<TFeatures, TData>) => any,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ) {
   if (table.options.filterFromLeafRows) {
     return filterRowModelFromLeafs(rows, filterRowImpl, table)
@@ -34,7 +34,7 @@ function filterRowModelFromLeafs<
   filterRow: (
     row: Row<TFeatures, TData>,
   ) => Array<Row<TFeatures, TData>> | undefined,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ): RowModel<TFeatures, TData> {
   const newFilteredFlatRows: Array<Row<TFeatures, TData>> = []
   const newFilteredRowsById: Record<string, Row<TFeatures, TData>> = {}
@@ -106,7 +106,7 @@ function filterRowModelFromRoot<
 >(
   rowsToFilter: Array<Row<TFeatures, TData>>,
   filterRow: (row: Row<TFeatures, TData>) => any,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ): RowModel<TFeatures, TData> {
   const newFilteredFlatRows: Array<Row<TFeatures, TData>> = []
   const newFilteredRowsById: Record<string, Row<TFeatures, TData>> = {}

--- a/packages/table-core/src/features/column-grouping/columnGroupingFeature.utils.ts
+++ b/packages/table-core/src/features/column-grouping/columnGroupingFeature.utils.ts
@@ -2,7 +2,7 @@ import { cloneState, isFunction } from '../../utils'
 import type { Column_Internal } from '../../types/Column'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { Cell } from '../../types/Cell'
 import type {
@@ -210,7 +210,7 @@ export function column_getAggregationFn<
 export function table_setGrouping<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, updater: Updater<GroupingState>) {
+>(table: Table<TFeatures, TData>, updater: Updater<GroupingState>) {
   table.options.onGroupingChange?.(updater)
 }
 
@@ -229,7 +229,7 @@ export function table_setGrouping<
 export function table_resetGrouping<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setGrouping(
     table,
     defaultState ? [] : cloneState(table.initialState.grouping ?? []),
@@ -305,7 +305,7 @@ export function cell_getIsGrouped<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(cell: Cell<TFeatures, TData, TValue>) {
-  const row = cell.row as Row<TFeatures, TData> & Partial<Row_ColumnGrouping>
+  const row = cell.row
   return (
     column_getIsGrouped(cell.column) && cell.column.id === row.groupingColumnId
   )

--- a/packages/table-core/src/features/column-grouping/columnGroupingFeature.utils.ts
+++ b/packages/table-core/src/features/column-grouping/columnGroupingFeature.utils.ts
@@ -1,7 +1,7 @@
 import { cloneState, isFunction } from '../../utils'
-import type { Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { Cell } from '../../types/Cell'
@@ -10,6 +10,8 @@ import type {
   GroupingState,
   Row_ColumnGrouping,
 } from './columnGroupingFeature.types'
+
+type ColumnGroupingFeatures = Partial<{ columnGroupingFeature: TableFeature }>
 
 /**
  * Creates the default grouping state.
@@ -41,7 +43,7 @@ export function column_toggleGrouping<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
   table_setGrouping(column.table, (old) => {
     // Find any existing grouping for this column
     if (old.includes(column.id)) {
@@ -67,11 +69,16 @@ export function column_getCanGroup<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
+  const featureColumn = column as unknown as Column<
+    ColumnGroupingFeatures,
+    TData,
+    TValue
+  >
   return (
-    (column.columnDef.enableGrouping ?? true) &&
-    (column.table.options.enableGrouping ?? true) &&
-    (!!column.accessorFn || !!column.columnDef.getGroupingValue)
+    (featureColumn.columnDef.enableGrouping ?? true) &&
+    (featureColumn.table.options.enableGrouping ?? true) &&
+    (!!column.accessorFn || !!featureColumn.columnDef.getGroupingValue)
   )
 }
 
@@ -90,8 +97,12 @@ export function column_getIsGrouped<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): boolean {
-  return !!column.table.atoms.grouping?.get()?.includes(column.id)
+>(column: Column<TFeatures, TData, TValue>): boolean {
+  const featureTable = column.table as unknown as Table<
+    ColumnGroupingFeatures,
+    TData
+  >
+  return !!featureTable.atoms.grouping?.get()?.includes(column.id)
 }
 
 /**
@@ -108,8 +119,12 @@ export function column_getGroupedIndex<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): number {
-  return column.table.atoms.grouping?.get()?.indexOf(column.id) ?? -1
+>(column: Column<TFeatures, TData, TValue>): number {
+  const featureTable = column.table as unknown as Table<
+    ColumnGroupingFeatures,
+    TData
+  >
+  return featureTable.atoms.grouping?.get()?.indexOf(column.id) ?? -1
 }
 
 /**
@@ -126,7 +141,7 @@ export function column_getToggleGroupingHandler<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
   const canGroup = column_getCanGroup(column)
 
   return () => {
@@ -150,10 +165,18 @@ export function column_getAutoAggregationFn<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(
+  column: Column<TFeatures, TData, TValue>,
+): AggregationFn<TFeatures, TData> | undefined {
+  const featureTable = column.table as unknown as Table<
+    ColumnGroupingFeatures,
+    TData
+  >
   const aggregationFns:
     | Record<string, AggregationFn<TFeatures, TData>>
-    | undefined = column.table._rowModelFns.aggregationFns
+    | undefined = featureTable._rowModelFns.aggregationFns as
+    | Record<string, AggregationFn<TFeatures, TData>>
+    | undefined
 
   const firstRow = column.table.getCoreRowModel().flatRows[0]
 
@@ -184,16 +207,33 @@ export function column_getAggregationFn<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(
+  column: Column<TFeatures, TData, TValue>,
+): AggregationFn<TFeatures, TData> | undefined {
+  const featureColumn = column as unknown as Column<
+    ColumnGroupingFeatures,
+    TData,
+    TValue
+  >
+  const featureTable = column.table as unknown as Table<
+    ColumnGroupingFeatures,
+    TData
+  >
   const aggregationFns:
     | Record<string, AggregationFn<TFeatures, TData>>
-    | undefined = column.table._rowModelFns.aggregationFns
+    | undefined = featureTable._rowModelFns.aggregationFns as
+    | Record<string, AggregationFn<TFeatures, TData>>
+    | undefined
 
-  return isFunction(column.columnDef.aggregationFn)
-    ? column.columnDef.aggregationFn
-    : column.columnDef.aggregationFn === 'auto'
+  const aggregationFn = isFunction(featureColumn.columnDef.aggregationFn)
+    ? featureColumn.columnDef.aggregationFn
+    : featureColumn.columnDef.aggregationFn === 'auto'
       ? column_getAutoAggregationFn(column)
-      : aggregationFns?.[column.columnDef.aggregationFn as string]
+      : featureColumn.columnDef.aggregationFn
+        ? aggregationFns?.[featureColumn.columnDef.aggregationFn]
+        : undefined
+
+  return aggregationFn as AggregationFn<TFeatures, TData> | undefined
 }
 
 /**
@@ -211,7 +251,8 @@ export function table_setGrouping<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<GroupingState>) {
-  table.options.onGroupingChange?.(updater)
+  const featureTable = table as unknown as Table<ColumnGroupingFeatures, TData>
+  featureTable.options.onGroupingChange?.(updater)
 }
 
 /**
@@ -230,9 +271,10 @@ export function table_resetGrouping<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<ColumnGroupingFeatures, TData>
   table_setGrouping(
     table,
-    defaultState ? [] : cloneState(table.initialState.grouping ?? []),
+    defaultState ? [] : cloneState(featureTable.initialState.grouping ?? []),
   )
 }
 
@@ -272,19 +314,19 @@ export function row_getGroupingValue<
     return row._groupingValuesCache[columnId]
   }
 
-  const column = row.table.getColumn(columnId) as Column_Internal<
-    TFeatures,
+  const column = row.table.getColumn(columnId) as Column<TFeatures, TData>
+  const featureColumn = column as unknown as Column<
+    ColumnGroupingFeatures,
     TData
   >
 
-  if (!column.columnDef.getGroupingValue) {
+  if (!featureColumn.columnDef.getGroupingValue) {
     return row.getValue(columnId)
   }
 
   if (row._groupingValuesCache) {
-    row._groupingValuesCache[columnId] = column.columnDef.getGroupingValue(
-      row.original,
-    )
+    row._groupingValuesCache[columnId] =
+      featureColumn.columnDef.getGroupingValue(row.original)
   }
 
   return row._groupingValuesCache?.[columnId]
@@ -307,7 +349,9 @@ export function cell_getIsGrouped<
 >(cell: Cell<TFeatures, TData, TValue>) {
   const row = cell.row
   return (
-    column_getIsGrouped(cell.column) && cell.column.id === row.groupingColumnId
+    column_getIsGrouped(cell.column) &&
+    cell.column.id ===
+      (row as Row<TFeatures, TData> & Row_ColumnGrouping).groupingColumnId
   )
 }
 

--- a/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
+++ b/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
@@ -31,7 +31,10 @@ export function createGroupedRowModel<
   TData extends RowData = any,
 >(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
   return (table) => {
-    const featureTable = table as unknown as Table<GroupedRowModelFeatures, TData>
+    const featureTable = table as unknown as Table<
+      GroupedRowModelFeatures,
+      TData
+    >
     return tableMemo({
       feature: 'columnGroupingFeature',
       table,

--- a/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
+++ b/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
@@ -15,6 +15,8 @@ import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { RowData } from '../../types/type-utils'
 
+type GroupedRowModelFeatures = Partial<{ columnGroupingFeature: TableFeature }>
+
 /**
  * Creates a memoized grouped row model factory.
  *
@@ -29,17 +31,14 @@ export function createGroupedRowModel<
   TData extends RowData = any,
 >(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
   return (table) => {
-    const typedTable = table as unknown as Table<
-      { columnGroupingFeature: TableFeature },
-      TData
-    >
+    const featureTable = table as unknown as Table<GroupedRowModelFeatures, TData>
     return tableMemo({
       feature: 'columnGroupingFeature',
       table,
       fnName: 'table.getGroupedRowModel',
       memoDeps: () => [
-        typedTable.atoms.grouping?.get(),
-        typedTable.getPreGroupedRowModel(),
+        featureTable.atoms.grouping?.get(),
+        table.getPreGroupedRowModel(),
       ],
       fn: () => _createGroupedRowModel(table),
       onAfterUpdate: () => {
@@ -54,8 +53,9 @@ function _createGroupedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
+  const featureTable = table as unknown as Table<GroupedRowModelFeatures, TData>
   const rowModel = table.getPreGroupedRowModel()
-  const grouping = table.atoms.grouping?.get()
+  const grouping = featureTable.atoms.grouping?.get()
 
   if (!rowModel.rows.length || !grouping?.length) {
     rowModel.rows.forEach((row) => {
@@ -156,9 +156,11 @@ function _createGroupedRowModel<
 
             // Aggregate the values
             const column = table.getColumn(colId)
-            const aggregateFn = column_getAggregationFn(
-              column as Column<TFeatures, TData, unknown>,
-            )
+            const aggregateFn = column
+              ? column_getAggregationFn(
+                  column as Column<TFeatures, TData, unknown>,
+                )
+              : undefined
 
             if (!row._groupingValuesCache) row._groupingValuesCache = {}
 

--- a/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
+++ b/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
@@ -9,9 +9,9 @@ import {
 } from './columnGroupingFeature.utils'
 import type { Column } from '../../types/Column'
 import type { Row_ColumnGrouping } from './columnGroupingFeature.types'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
-import type { Table, Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { RowData } from '../../types/type-utils'
 
@@ -28,15 +28,18 @@ export function createGroupedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
-  return (_table) => {
-    const table = _table as unknown as Table_Internal<TFeatures, TData>
+  return (table) => {
+    const typedTable = table as unknown as Table<
+      { columnGroupingFeature: TableFeature },
+      TData
+    >
     return tableMemo({
       feature: 'columnGroupingFeature',
       table,
       fnName: 'table.getGroupedRowModel',
       memoDeps: () => [
-        table.atoms.grouping?.get(),
-        table.getPreGroupedRowModel(),
+        typedTable.atoms.grouping?.get(),
+        typedTable.getPreGroupedRowModel(),
       ],
       fn: () => _createGroupedRowModel(table),
       onAfterUpdate: () => {
@@ -50,7 +53,7 @@ export function createGroupedRowModel<
 function _createGroupedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   const rowModel = table.getPreGroupedRowModel()
   const grouping = table.atoms.grouping?.get()
 

--- a/packages/table-core/src/features/column-ordering/columnOrderingFeature.utils.ts
+++ b/packages/table-core/src/features/column-ordering/columnOrderingFeature.utils.ts
@@ -2,11 +2,16 @@ import { table_getPinnedVisibleLeafColumns } from '../column-pinning/columnPinni
 import { cloneState } from '../../utils'
 import type { GroupingState } from '../column-grouping/columnGroupingFeature.types'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
-import type { Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 import type { ColumnPinningPosition } from '../column-pinning/columnPinningFeature.types'
 import type { ColumnOrderState } from './columnOrderingFeature.types'
+
+type ColumnOrderingFeatures = Partial<{
+  columnOrderingFeature: TableFeature
+  columnGroupingFeature: TableFeature
+}>
 
 /**
  * Creates the default column order state.
@@ -39,7 +44,7 @@ export function column_getIndex<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  column: Column_Internal<TFeatures, TData, TValue>,
+  column: Column<TFeatures, TData, TValue>,
   position?: ColumnPinningPosition | 'center',
 ) {
   const columns = table_getPinnedVisibleLeafColumns(column.table, position)
@@ -61,7 +66,7 @@ export function column_getIsFirstColumn<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  column: Column_Internal<TFeatures, TData, TValue>,
+  column: Column<TFeatures, TData, TValue>,
   position?: ColumnPinningPosition | 'center',
 ) {
   const columns = table_getPinnedVisibleLeafColumns(column.table, position)
@@ -83,7 +88,7 @@ export function column_getIsLastColumn<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  column: Column_Internal<TFeatures, TData, TValue>,
+  column: Column<TFeatures, TData, TValue>,
   position?: ColumnPinningPosition | 'center',
 ) {
   const columns = table_getPinnedVisibleLeafColumns(column.table, position)
@@ -105,7 +110,8 @@ export function table_setColumnOrder<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<ColumnOrderState>) {
-  table.options.onColumnOrderChange?.(updater)
+  const featureTable = table as unknown as Table<ColumnOrderingFeatures, TData>
+  featureTable.options.onColumnOrderChange?.(updater)
 }
 
 /**
@@ -124,9 +130,10 @@ export function table_resetColumnOrder<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<ColumnOrderingFeatures, TData>
   table_setColumnOrder(
     table,
-    defaultState ? [] : cloneState(table.initialState.columnOrder ?? []),
+    defaultState ? [] : cloneState(featureTable.initialState.columnOrder ?? []),
   )
 }
 
@@ -145,22 +152,20 @@ export function table_getOrderColumnsFn<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
-  const columnOrder = table.atoms.columnOrder?.get()
+  const featureTable = table as unknown as Table<ColumnOrderingFeatures, TData>
+  const columnOrder = featureTable.atoms.columnOrder?.get()
 
-  return (columns: Array<Column_Internal<TFeatures, TData, unknown>>) => {
+  return (columns: Array<Column<TFeatures, TData, unknown>>) => {
     // Sort grouped columns to the start of the column list
     // before the headers are built
-    let orderedColumns: Array<Column_Internal<TFeatures, TData, unknown>> = []
+    let orderedColumns: Array<Column<TFeatures, TData, unknown>> = []
 
     // If there is no order, return the normal columns
     if (!columnOrder?.length) {
       orderedColumns = columns
     } else {
       // Index columns by id for O(1) lookup
-      const remaining = new Map<
-        string,
-        Column_Internal<TFeatures, TData, unknown>
-      >()
+      const remaining = new Map<string, Column<TFeatures, TData, unknown>>()
       for (let i = 0; i < columns.length; i++) {
         const column = columns[i]!
         remaining.set(column.id, column)
@@ -205,10 +210,11 @@ export function orderColumns<
   TData extends RowData,
 >(
   table: Table<TFeatures, TData>,
-  leafColumns: Array<Column_Internal<TFeatures, TData, unknown>>,
+  leafColumns: Array<Column<TFeatures, TData, unknown>>,
 ) {
-  const grouping = table.atoms.grouping?.get() ?? ([] as GroupingState)
-  const { groupedColumnMode } = table.options
+  const featureTable = table as unknown as Table<ColumnOrderingFeatures, TData>
+  const grouping = featureTable.atoms.grouping?.get() ?? ([] as GroupingState)
+  const { groupedColumnMode } = featureTable.options
 
   if (!grouping.length || !groupedColumnMode) {
     return leafColumns
@@ -222,18 +228,15 @@ export function orderColumns<
     return nonGroupingColumns
   }
 
-  const leafColumnsById = new Map<
-    string,
-    Column_Internal<TFeatures, TData, unknown>
-  >()
+  const leafColumnsById = new Map<string, Column<TFeatures, TData, unknown>>()
   for (let i = 0; i < leafColumns.length; i++) {
     const col = leafColumns[i]!
     leafColumnsById.set(col.id, col)
   }
 
-  const groupingColumns: Array<Column_Internal<TFeatures, TData, unknown>> = []
+  const groupingColumns: Array<Column<TFeatures, TData, unknown>> = []
   for (let i = 0; i < grouping.length; i++) {
-    const col = leafColumnsById.get(grouping[i])
+    const col = leafColumnsById.get(grouping[i]!)
     if (col) groupingColumns.push(col)
   }
 

--- a/packages/table-core/src/features/column-ordering/columnOrderingFeature.utils.ts
+++ b/packages/table-core/src/features/column-ordering/columnOrderingFeature.utils.ts
@@ -3,7 +3,7 @@ import { cloneState } from '../../utils'
 import type { GroupingState } from '../column-grouping/columnGroupingFeature.types'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Column_Internal } from '../../types/Column'
 import type { ColumnPinningPosition } from '../column-pinning/columnPinningFeature.types'
 import type { ColumnOrderState } from './columnOrderingFeature.types'
@@ -104,7 +104,7 @@ export function column_getIsLastColumn<
 export function table_setColumnOrder<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, updater: Updater<ColumnOrderState>) {
+>(table: Table<TFeatures, TData>, updater: Updater<ColumnOrderState>) {
   table.options.onColumnOrderChange?.(updater)
 }
 
@@ -123,7 +123,7 @@ export function table_setColumnOrder<
 export function table_resetColumnOrder<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setColumnOrder(
     table,
     defaultState ? [] : cloneState(table.initialState.columnOrder ?? []),
@@ -144,7 +144,7 @@ export function table_resetColumnOrder<
 export function table_getOrderColumnsFn<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const columnOrder = table.atoms.columnOrder?.get()
 
   return (columns: Array<Column_Internal<TFeatures, TData, unknown>>) => {
@@ -204,7 +204,7 @@ export function orderColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   leafColumns: Array<Column_Internal<TFeatures, TData, unknown>>,
 ) {
   const grouping = table.atoms.grouping?.get() ?? ([] as GroupingState)
@@ -233,7 +233,7 @@ export function orderColumns<
 
   const groupingColumns: Array<Column_Internal<TFeatures, TData, unknown>> = []
   for (let i = 0; i < grouping.length; i++) {
-    const col = leafColumnsById.get(grouping[i]!)
+    const col = leafColumnsById.get(grouping[i])
     if (col) groupingColumns.push(col)
   }
 

--- a/packages/table-core/src/features/column-pinning/columnPinningFeature.utils.ts
+++ b/packages/table-core/src/features/column-pinning/columnPinningFeature.utils.ts
@@ -12,7 +12,7 @@ import type { Cell } from '../../types/Cell'
 import type { Row } from '../../types/Row'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Column, Column_Internal } from '../../types/Column'
 import type {
   ColumnPinningPosition,
@@ -289,10 +289,7 @@ export function row_getRightVisibleCells<
 export function table_setColumnPinning<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  updater: Updater<ColumnPinningState>,
-) {
+>(table: Table<TFeatures, TData>, updater: Updater<ColumnPinningState>) {
   table.options.onColumnPinningChange?.(updater)
 }
 
@@ -312,7 +309,7 @@ export function table_setColumnPinning<
 export function table_resetColumnPinning<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setColumnPinning(
     table,
     defaultState
@@ -337,7 +334,7 @@ export function table_resetColumnPinning<
 export function table_getIsSomeColumnsPinned<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, position?: ColumnPinningPosition) {
+>(table: Table<TFeatures, TData>, position?: ColumnPinningPosition) {
   const pinningState = table.atoms.columnPinning?.get()
 
   if (!position) {
@@ -362,7 +359,7 @@ export function table_getIsSomeColumnsPinned<
 export function table_getLeftHeaderGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const allColumns = table.getAllColumns()
   const leafColumnsById = table.getAllLeafColumnsById()
   const { left } =
@@ -396,7 +393,7 @@ export function table_getLeftHeaderGroups<
 export function table_getRightHeaderGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const allColumns = table.getAllColumns()
   const leafColumnsById = table.getAllLeafColumnsById()
   const { right } =
@@ -430,9 +427,7 @@ export function table_getRightHeaderGroups<
 export function table_getCenterHeaderGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-): Array<HeaderGroup<TFeatures, TData>> {
+>(table: Table<TFeatures, TData>): Array<HeaderGroup<TFeatures, TData>> {
   const allColumns = table.getAllColumns()
   let leafColumns = callMemoOrStaticFn(
     table,
@@ -464,7 +459,7 @@ export function table_getCenterHeaderGroups<
 export function table_getLeftFooterGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const headerGroups = callMemoOrStaticFn(
     table,
     'getLeftHeaderGroups',
@@ -486,7 +481,7 @@ export function table_getLeftFooterGroups<
 export function table_getRightFooterGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const headerGroups = callMemoOrStaticFn(
     table,
     'getRightHeaderGroups',
@@ -508,7 +503,7 @@ export function table_getRightFooterGroups<
 export function table_getCenterFooterGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const headerGroups = callMemoOrStaticFn(
     table,
     'getCenterHeaderGroups',
@@ -532,7 +527,7 @@ export function table_getCenterFooterGroups<
 export function table_getLeftFlatHeaders<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const leftHeaderGroups = callMemoOrStaticFn(
     table,
     'getLeftHeaderGroups',
@@ -542,7 +537,7 @@ export function table_getLeftFlatHeaders<
   for (let i = 0; i < leftHeaderGroups.length; i++) {
     const headers = leftHeaderGroups[i]!.headers
     for (let j = 0; j < headers.length; j++) {
-      result.push(headers[j]!)
+      result.push(headers[j])
     }
   }
   return result
@@ -561,7 +556,7 @@ export function table_getLeftFlatHeaders<
 export function table_getRightFlatHeaders<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const rightHeaderGroups = callMemoOrStaticFn(
     table,
     'getRightHeaderGroups',
@@ -571,7 +566,7 @@ export function table_getRightFlatHeaders<
   for (let i = 0; i < rightHeaderGroups.length; i++) {
     const headers = rightHeaderGroups[i]!.headers
     for (let j = 0; j < headers.length; j++) {
-      result.push(headers[j]!)
+      result.push(headers[j])
     }
   }
   return result
@@ -590,7 +585,7 @@ export function table_getRightFlatHeaders<
 export function table_getCenterFlatHeaders<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const centerHeaderGroups = callMemoOrStaticFn(
     table,
     'getCenterHeaderGroups',
@@ -600,7 +595,7 @@ export function table_getCenterFlatHeaders<
   for (let i = 0; i < centerHeaderGroups.length; i++) {
     const headers = centerHeaderGroups[i]!.headers
     for (let j = 0; j < headers.length; j++) {
-      result.push(headers[j]!)
+      result.push(headers[j])
     }
   }
   return result
@@ -621,7 +616,7 @@ export function table_getCenterFlatHeaders<
 export function table_getLeftLeafHeaders<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return callMemoOrStaticFn(
     table,
     'getLeftFlatHeaders',
@@ -642,7 +637,7 @@ export function table_getLeftLeafHeaders<
 export function table_getRightLeafHeaders<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return callMemoOrStaticFn(
     table,
     'getRightFlatHeaders',
@@ -663,7 +658,7 @@ export function table_getRightLeafHeaders<
 export function table_getCenterLeafHeaders<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return callMemoOrStaticFn(
     table,
     'getCenterFlatHeaders',
@@ -687,7 +682,7 @@ export function table_getCenterLeafHeaders<
 export function table_getLeftLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const { left } =
     table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   const leafColumnsById = table.getAllLeafColumnsById()
@@ -713,7 +708,7 @@ export function table_getLeftLeafColumns<
 export function table_getRightLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const { right } =
     table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   const leafColumnsById = table.getAllLeafColumnsById()
@@ -738,7 +733,7 @@ export function table_getRightLeafColumns<
 export function table_getCenterLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const { left, right } =
     table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   const leftAndRight: Array<string> = [...left, ...right]
@@ -759,10 +754,7 @@ export function table_getCenterLeafColumns<
 export function table_getPinnedLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  position: ColumnPinningPosition | 'center',
-) {
+>(table: Table<TFeatures, TData>, position: ColumnPinningPosition | 'center') {
   return !position
     ? table.getAllLeafColumns()
     : position === 'left'
@@ -799,7 +791,7 @@ export function table_getPinnedLeafColumns<
 export function table_getLeftVisibleLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return callMemoOrStaticFn(
     table,
     'getLeftLeafColumns',
@@ -822,7 +814,7 @@ export function table_getLeftVisibleLeafColumns<
 export function table_getRightVisibleLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return callMemoOrStaticFn(
     table,
     'getRightLeafColumns',
@@ -846,7 +838,7 @@ export function table_getRightVisibleLeafColumns<
 export function table_getCenterVisibleLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return callMemoOrStaticFn(
     table,
     'getCenterLeafColumns',
@@ -870,10 +862,7 @@ export function table_getCenterVisibleLeafColumns<
 export function table_getPinnedVisibleLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  position?: ColumnPinningPosition | 'center',
-) {
+>(table: Table<TFeatures, TData>, position?: ColumnPinningPosition | 'center') {
   return !position
     ? callMemoOrStaticFn(
         table,

--- a/packages/table-core/src/features/column-pinning/columnPinningFeature.utils.ts
+++ b/packages/table-core/src/features/column-pinning/columnPinningFeature.utils.ts
@@ -11,13 +11,17 @@ import type { HeaderGroup } from '../../types/HeaderGroup'
 import type { Cell } from '../../types/Cell'
 import type { Row } from '../../types/Row'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
-import type { Column, Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 import type {
   ColumnPinningPosition,
   ColumnPinningState,
 } from './columnPinningFeature.types'
+
+type ColumnPinningFeatures = Partial<{
+  columnPinningFeature: TableFeature
+}>
 
 // State
 
@@ -57,10 +61,7 @@ export function column_pin<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(
-  column: Column_Internal<TFeatures, TData, TValue>,
-  position: ColumnPinningPosition,
-) {
+>(column: Column<TFeatures, TData, TValue>, position: ColumnPinningPosition) {
   // Single pass: collect non-empty leaf-column ids.
   const leafColumns = column.getLeafColumns()
   const columnIds: Array<string> = []
@@ -109,16 +110,24 @@ export function column_getCanPin<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
-  const leafColumns = column.getLeafColumns() as Array<
-    Column_Internal<TFeatures, TData, TValue>
+>(column: Column<TFeatures, TData, TValue>) {
+  const featureTable = column.table as unknown as Table<
+    ColumnPinningFeatures,
+    TData
   >
+  const leafColumns = column.getLeafColumns()
 
-  return leafColumns.some(
-    (leafColumn) =>
-      (leafColumn.columnDef.enablePinning ?? true) &&
-      (column.table.options.enableColumnPinning ?? true),
-  )
+  return leafColumns.some((leafColumn) => {
+    const featureColumn = leafColumn as unknown as Column<
+      ColumnPinningFeatures,
+      TData,
+      TValue
+    >
+    return (
+      (featureColumn.columnDef.enablePinning ?? true) &&
+      (featureTable.options.enableColumnPinning ?? true)
+    )
+  })
 }
 
 /**
@@ -136,13 +145,15 @@ export function column_getIsPinned<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(
-  column: Column_Internal<TFeatures, TData, TValue>,
-): ColumnPinningPosition | false {
+>(column: Column<TFeatures, TData, TValue>): ColumnPinningPosition | false {
+  const featureTable = column.table as unknown as Table<
+    ColumnPinningFeatures,
+    TData
+  >
   const leafColumnIds = column.getLeafColumns().map((d) => d.id)
 
   const { left, right } =
-    column.table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
 
   const isLeft = leafColumnIds.some((d) => left.includes(d))
   const isRight = leafColumnIds.some((d) => right.includes(d))
@@ -165,11 +176,15 @@ export function column_getPinnedIndex<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
+  const featureTable = column.table as unknown as Table<
+    ColumnPinningFeatures,
+    TData
+  >
   const position = column_getIsPinned(column)
 
   return position
-    ? (column.table.atoms.columnPinning?.get()?.[position].indexOf(column.id) ??
+    ? (featureTable.atoms.columnPinning?.get()?.[position].indexOf(column.id) ??
         -1)
     : 0
 }
@@ -190,13 +205,17 @@ export function row_getCenterVisibleCells<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
+  const featureTable = row.table as unknown as Table<
+    ColumnPinningFeatures,
+    TData
+  >
   const allCells = callMemoOrStaticFn(
     row,
     'getVisibleCells',
     row_getVisibleCells,
   )
   const { left, right } =
-    row.table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   const leftAndRight: Array<string> = [...left, ...right]
   return allCells.filter((d) => !leftAndRight.includes(d.column.id))
 }
@@ -216,8 +235,12 @@ export function row_getLeftVisibleCells<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>): Array<Cell<TFeatures, TData, unknown>> {
+  const featureTable = row.table as unknown as Table<
+    ColumnPinningFeatures,
+    TData
+  >
   const { left } =
-    row.table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   if (!left.length) return []
   const allVisibleCells = callMemoOrStaticFn(
     row,
@@ -252,8 +275,12 @@ export function row_getRightVisibleCells<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
+  const featureTable = row.table as unknown as Table<
+    ColumnPinningFeatures,
+    TData
+  >
   const { right } =
-    row.table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   if (!right.length) return [] as Array<Cell<TFeatures, TData, unknown>>
   const allVisibleCells = callMemoOrStaticFn(
     row,
@@ -290,7 +317,8 @@ export function table_setColumnPinning<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<ColumnPinningState>) {
-  table.options.onColumnPinningChange?.(updater)
+  const featureTable = table as unknown as Table<ColumnPinningFeatures, TData>
+  featureTable.options.onColumnPinningChange?.(updater)
 }
 
 /**
@@ -310,12 +338,14 @@ export function table_resetColumnPinning<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<ColumnPinningFeatures, TData>
   table_setColumnPinning(
     table,
     defaultState
       ? getDefaultColumnPinningState()
       : cloneState(
-          table.initialState.columnPinning ?? getDefaultColumnPinningState(),
+          featureTable.initialState.columnPinning ??
+            getDefaultColumnPinningState(),
         ),
   )
 }
@@ -335,7 +365,8 @@ export function table_getIsSomeColumnsPinned<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, position?: ColumnPinningPosition) {
-  const pinningState = table.atoms.columnPinning?.get()
+  const featureTable = table as unknown as Table<ColumnPinningFeatures, TData>
+  const pinningState = featureTable.atoms.columnPinning?.get()
 
   if (!position) {
     return Boolean(pinningState?.left.length || pinningState?.right.length)
@@ -360,10 +391,11 @@ export function table_getLeftHeaderGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<ColumnPinningFeatures, TData>
   const allColumns = table.getAllColumns()
   const leafColumnsById = table.getAllLeafColumnsById()
   const { left } =
-    table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
 
   const orderedLeafColumns: Array<Column<TFeatures, TData, unknown>> = []
   for (let i = 0; i < left.length; i++) {
@@ -394,10 +426,11 @@ export function table_getRightHeaderGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<ColumnPinningFeatures, TData>
   const allColumns = table.getAllColumns()
   const leafColumnsById = table.getAllLeafColumnsById()
   const { right } =
-    table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
 
   const orderedLeafColumns: Array<Column<TFeatures, TData, unknown>> = []
   for (let i = 0; i < right.length; i++) {
@@ -428,6 +461,7 @@ export function table_getCenterHeaderGroups<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>): Array<HeaderGroup<TFeatures, TData>> {
+  const featureTable = table as unknown as Table<ColumnPinningFeatures, TData>
   const allColumns = table.getAllColumns()
   let leafColumns = callMemoOrStaticFn(
     table,
@@ -435,7 +469,7 @@ export function table_getCenterHeaderGroups<
     table_getVisibleLeafColumns,
   )
   const { left, right } =
-    table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   const leftAndRight: Array<string> = [...left, ...right]
 
   leafColumns = leafColumns.filter(
@@ -537,7 +571,7 @@ export function table_getLeftFlatHeaders<
   for (let i = 0; i < leftHeaderGroups.length; i++) {
     const headers = leftHeaderGroups[i]!.headers
     for (let j = 0; j < headers.length; j++) {
-      result.push(headers[j])
+      result.push(headers[j] as Header<TFeatures, TData, unknown>)
     }
   }
   return result
@@ -566,7 +600,7 @@ export function table_getRightFlatHeaders<
   for (let i = 0; i < rightHeaderGroups.length; i++) {
     const headers = rightHeaderGroups[i]!.headers
     for (let j = 0; j < headers.length; j++) {
-      result.push(headers[j])
+      result.push(headers[j] as Header<TFeatures, TData, unknown>)
     }
   }
   return result
@@ -595,7 +629,7 @@ export function table_getCenterFlatHeaders<
   for (let i = 0; i < centerHeaderGroups.length; i++) {
     const headers = centerHeaderGroups[i]!.headers
     for (let j = 0; j < headers.length; j++) {
-      result.push(headers[j])
+      result.push(headers[j] as Header<TFeatures, TData, unknown>)
     }
   }
   return result
@@ -683,10 +717,11 @@ export function table_getLeftLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<ColumnPinningFeatures, TData>
   const { left } =
-    table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   const leafColumnsById = table.getAllLeafColumnsById()
-  const result: Array<Column_Internal<TFeatures, TData, unknown>> = []
+  const result: Array<Column<TFeatures, TData, unknown>> = []
   for (let i = 0; i < left.length; i++) {
     const column = leafColumnsById[left[i]!]
     if (column) result.push(column)
@@ -709,10 +744,11 @@ export function table_getRightLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<ColumnPinningFeatures, TData>
   const { right } =
-    table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   const leafColumnsById = table.getAllLeafColumnsById()
-  const result: Array<Column_Internal<TFeatures, TData, unknown>> = []
+  const result: Array<Column<TFeatures, TData, unknown>> = []
   for (let i = 0; i < right.length; i++) {
     const column = leafColumnsById[right[i]!]
     if (column) result.push(column)
@@ -734,8 +770,9 @@ export function table_getCenterLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<ColumnPinningFeatures, TData>
   const { left, right } =
-    table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   const leftAndRight: Array<string> = [...left, ...right]
   return table.getAllLeafColumns().filter((d) => !leftAndRight.includes(d.id))
 }

--- a/packages/table-core/src/features/column-resizing/columnResizingFeature.utils.ts
+++ b/packages/table-core/src/features/column-resizing/columnResizingFeature.utils.ts
@@ -5,12 +5,14 @@ import {
 } from '../column-sizing/columnSizingFeature.utils'
 import { cloneState } from '../../utils'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
 import type { Header } from '../../types/Header'
-import type { Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 import type { ColumnSizingState } from '../column-sizing/columnSizingFeature.types'
 import type { columnResizingState } from './columnResizingFeature.types'
+
+type ColumnResizingFeatures = Partial<{ columnResizingFeature: TableFeature }>
 
 /**
  * Creates the default transient column resizing state.
@@ -49,10 +51,15 @@ export function column_getCanResize<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
+  const featureColumn = column as unknown as Column<
+    ColumnResizingFeatures,
+    TData,
+    TValue
+  >
   return (
-    (column.columnDef.enableResizing ?? true) &&
-    (column.table.options.enableColumnResizing ?? true)
+    (featureColumn.columnDef.enableResizing ?? true) &&
+    (featureColumn.table.options.enableColumnResizing ?? true)
   )
 }
 
@@ -70,9 +77,13 @@ export function column_getIsResizing<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
+  const featureTable = column.table as unknown as Table<
+    ColumnResizingFeatures,
+    TData
+  >
   return (
-    column.table.atoms.columnResizing?.get()?.isResizingColumn === column.id
+    featureTable.atoms.columnResizing?.get()?.isResizingColumn === column.id
   )
 }
 
@@ -94,6 +105,10 @@ export function header_getResizeHandler<
   TValue extends CellData = CellData,
 >(header: Header<TFeatures, TData, TValue>, _contextDocument?: Document) {
   const column = header.table.getColumn(header.column.id)!
+  const featureTable = column.table as unknown as Table<
+    ColumnResizingFeatures,
+    TData
+  >
   const canResize = column_getCanResize(column)
 
   return (event: unknown) => {
@@ -132,7 +147,7 @@ export function header_getResizeHandler<
 
       table_setColumnResizing(column.table, (old) => {
         const deltaDirection =
-          column.table.options.columnResizeDirection === 'rtl' ? -1 : 1
+          featureTable.options.columnResizeDirection === 'rtl' ? -1 : 1
         const deltaOffset =
           (clientXPos - (old.startOffset ?? 0)) * deltaDirection
         const startSize = old.startSize ?? 0
@@ -161,7 +176,7 @@ export function header_getResizeHandler<
       })
 
       if (
-        column.table.options.columnResizeMode === 'onChange' ||
+        featureTable.options.columnResizeMode === 'onChange' ||
         eventType === 'end'
       ) {
         table_setColumnSizing(column.table, (old) => ({
@@ -280,7 +295,8 @@ export function table_setColumnResizing<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<columnResizingState>) {
-  table.options.onColumnResizingChange?.(updater)
+  const featureTable = table as unknown as Table<ColumnResizingFeatures, TData>
+  featureTable.options.onColumnResizingChange?.(updater)
 }
 
 /**
@@ -300,12 +316,14 @@ export function table_resetHeaderSizeInfo<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<ColumnResizingFeatures, TData>
   table_setColumnResizing(
     table,
     defaultState
       ? getDefaultColumnResizingState()
       : cloneState(
-          table.initialState.columnResizing ?? getDefaultColumnResizingState(),
+          featureTable.initialState.columnResizing ??
+            getDefaultColumnResizingState(),
         ),
   )
 }

--- a/packages/table-core/src/features/column-resizing/columnResizingFeature.utils.ts
+++ b/packages/table-core/src/features/column-resizing/columnResizingFeature.utils.ts
@@ -6,7 +6,7 @@ import {
 import { cloneState } from '../../utils'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Header } from '../../types/Header'
 import type { Column_Internal } from '../../types/Column'
 import type { ColumnSizingState } from '../column-sizing/columnSizingFeature.types'
@@ -279,10 +279,7 @@ export function header_getResizeHandler<
 export function table_setColumnResizing<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  updater: Updater<columnResizingState>,
-) {
+>(table: Table<TFeatures, TData>, updater: Updater<columnResizingState>) {
   table.options.onColumnResizingChange?.(updater)
 }
 
@@ -302,7 +299,7 @@ export function table_setColumnResizing<
 export function table_resetHeaderSizeInfo<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setColumnResizing(
     table,
     defaultState

--- a/packages/table-core/src/features/column-sizing/columnSizingFeature.utils.ts
+++ b/packages/table-core/src/features/column-sizing/columnSizingFeature.utils.ts
@@ -9,7 +9,7 @@ import { callMemoOrStaticFn, cloneState } from '../../utils'
 import type { ColumnPinningPosition } from '../column-pinning/columnPinningFeature.types'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Header } from '../../types/Header'
 import type { Column_Internal } from '../../types/Column'
 import type { ColumnSizingState } from './columnSizingFeature.types'
@@ -255,10 +255,7 @@ export function header_getStart<
 export function table_setColumnSizing<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  updater: Updater<ColumnSizingState>,
-) {
+>(table: Table<TFeatures, TData>, updater: Updater<ColumnSizingState>) {
   table.options.onColumnSizingChange?.(updater)
 }
 
@@ -277,7 +274,7 @@ export function table_setColumnSizing<
 export function table_resetColumnSizing<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setColumnSizing(
     table,
     defaultState ? {} : cloneState(table.initialState.columnSizing ?? {}),
@@ -297,7 +294,7 @@ export function table_resetColumnSizing<
 export function table_getTotalSize<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return (
     table.getHeaderGroups()[0]?.headers.reduce((sum, header) => {
       return sum + header_getSize(header)
@@ -318,7 +315,7 @@ export function table_getTotalSize<
 export function table_getLeftTotalSize<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return (
     callMemoOrStaticFn(
       table,
@@ -343,7 +340,7 @@ export function table_getLeftTotalSize<
 export function table_getCenterTotalSize<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return (
     callMemoOrStaticFn(
       table,
@@ -368,7 +365,7 @@ export function table_getCenterTotalSize<
 export function table_getRightTotalSize<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return (
     callMemoOrStaticFn(
       table,

--- a/packages/table-core/src/features/column-sizing/columnSizingFeature.utils.ts
+++ b/packages/table-core/src/features/column-sizing/columnSizingFeature.utils.ts
@@ -8,11 +8,13 @@ import { column_getIndex } from '../column-ordering/columnOrderingFeature.utils'
 import { callMemoOrStaticFn, cloneState } from '../../utils'
 import type { ColumnPinningPosition } from '../column-pinning/columnPinningFeature.types'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
 import type { Header } from '../../types/Header'
-import type { Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 import type { ColumnSizingState } from './columnSizingFeature.types'
+
+type ColumnSizingFeatures = Partial<{ columnSizingFeature: TableFeature }>
 
 /**
  * Creates the default committed column sizing state.
@@ -64,16 +66,21 @@ export function column_getSize<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): number {
+>(column: Column<TFeatures, TData, TValue>): number {
   const defaultSizes = getDefaultColumnSizingColumnDef()
-  const columnSize = column.table.atoms.columnSizing?.get()?.[column.id]
+  const featureColumn = column as unknown as Column<
+    ColumnSizingFeatures,
+    TData,
+    TValue
+  >
+  const columnSize = featureColumn.table.atoms.columnSizing?.get()?.[column.id]
 
   return Math.min(
     Math.max(
-      column.columnDef.minSize ?? defaultSizes.minSize,
-      columnSize ?? column.columnDef.size ?? defaultSizes.size,
+      featureColumn.columnDef.minSize ?? defaultSizes.minSize,
+      columnSize ?? featureColumn.columnDef.size ?? defaultSizes.size,
     ),
-    column.columnDef.maxSize ?? defaultSizes.maxSize,
+    featureColumn.columnDef.maxSize ?? defaultSizes.maxSize,
   )
 }
 
@@ -93,7 +100,7 @@ export function column_getStart<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  column: Column_Internal<TFeatures, TData, TValue>,
+  column: Column<TFeatures, TData, TValue>,
   position: ColumnPinningPosition | 'center',
 ): number {
   const index = callMemoOrStaticFn(
@@ -134,7 +141,7 @@ export function column_getAfter<
   TData extends RowData,
   TValue extends CellData = CellData,
 >(
-  column: Column_Internal<TFeatures, TData, TValue>,
+  column: Column<TFeatures, TData, TValue>,
   position: ColumnPinningPosition | 'center',
 ): number {
   const visibleLeafColumns = callMemoOrStaticFn(
@@ -173,7 +180,7 @@ export function column_resetSize<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
   table_setColumnSizing(column.table, ({ [column.id]: _, ...rest }) => {
     return rest
   })
@@ -256,7 +263,8 @@ export function table_setColumnSizing<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<ColumnSizingState>) {
-  table.options.onColumnSizingChange?.(updater)
+  const featureTable = table as unknown as Table<ColumnSizingFeatures, TData>
+  featureTable.options.onColumnSizingChange?.(updater)
 }
 
 /**
@@ -275,9 +283,12 @@ export function table_resetColumnSizing<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<ColumnSizingFeatures, TData>
   table_setColumnSizing(
     table,
-    defaultState ? {} : cloneState(table.initialState.columnSizing ?? {}),
+    defaultState
+      ? {}
+      : cloneState(featureTable.initialState.columnSizing ?? {}),
   )
 }
 

--- a/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts
+++ b/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts
@@ -2,7 +2,7 @@ import { callMemoOrStaticFn, cloneState } from '../../utils'
 import { getDefaultColumnPinningState } from '../column-pinning/columnPinningFeature.utils'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Cell } from '../../types/Cell'
 import type { Column_Internal } from '../../types/Column'
 import type { ColumnVisibilityState } from './columnVisibilityFeature.types'
@@ -217,7 +217,7 @@ export function row_getVisibleCellsByColumnId<
 export function table_getVisibleFlatColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return table
     .getAllFlatColumns()
     .filter((column) =>
@@ -239,7 +239,7 @@ export function table_getVisibleFlatColumns<
 export function table_getVisibleLeafColumns<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return table
     .getAllLeafColumns()
     .filter((column) =>
@@ -261,10 +261,7 @@ export function table_getVisibleLeafColumns<
 export function table_setColumnVisibility<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  updater: Updater<ColumnVisibilityState>,
-) {
+>(table: Table<TFeatures, TData>, updater: Updater<ColumnVisibilityState>) {
   table.options.onColumnVisibilityChange?.(updater)
 }
 
@@ -283,7 +280,7 @@ export function table_setColumnVisibility<
 export function table_resetColumnVisibility<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setColumnVisibility(
     table,
     defaultState ? {} : cloneState(table.initialState.columnVisibility ?? {}),
@@ -303,7 +300,7 @@ export function table_resetColumnVisibility<
 export function table_toggleAllColumnsVisible<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, value?: boolean) {
+>(table: Table<TFeatures, TData>, value?: boolean) {
   value = value ?? !table_getIsAllColumnsVisible(table)
 
   const visibility: Record<string, boolean> = {}
@@ -330,7 +327,7 @@ export function table_toggleAllColumnsVisible<
 export function table_getIsAllColumnsVisible<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return !table
     .getAllLeafColumns()
     .some(
@@ -352,7 +349,7 @@ export function table_getIsAllColumnsVisible<
 export function table_getIsSomeColumnsVisible<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return table
     .getAllLeafColumns()
     .some((column) =>
@@ -374,7 +371,7 @@ export function table_getIsSomeColumnsVisible<
 export function table_getToggleAllColumnsVisibilityHandler<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return (e: unknown) => {
     table_toggleAllColumnsVisible(
       table,

--- a/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts
+++ b/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts
@@ -1,12 +1,17 @@
 import { callMemoOrStaticFn, cloneState } from '../../utils'
 import { getDefaultColumnPinningState } from '../column-pinning/columnPinningFeature.utils'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
 import type { Cell } from '../../types/Cell'
-import type { Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 import type { ColumnVisibilityState } from './columnVisibilityFeature.types'
 import type { Row } from '../../types/Row'
+
+type ColumnVisibilityFeatures = Partial<{
+  columnVisibilityFeature: TableFeature
+  columnPinningFeature: TableFeature
+}>
 
 /**
  * Creates the default column visibility state.
@@ -38,7 +43,7 @@ export function column_toggleVisibility<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>, visible?: boolean): void {
+>(column: Column<TFeatures, TData, TValue>, visible?: boolean): void {
   if (column_getCanHide(column)) {
     table_setColumnVisibility(column.table, (old) => ({
       ...old,
@@ -65,14 +70,19 @@ export function column_getIsVisible<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): boolean {
+>(column: Column<TFeatures, TData, TValue>): boolean {
+  const featureColumn = column as unknown as Column<
+    ColumnVisibilityFeatures,
+    TData,
+    TValue
+  >
   const childColumns = column.columns
   return (
     (childColumns.length
       ? childColumns.some((childColumn) =>
           callMemoOrStaticFn(childColumn, 'getIsVisible', column_getIsVisible),
         )
-      : column.table.atoms.columnVisibility?.get()?.[column.id]) ?? true
+      : featureColumn.table.atoms.columnVisibility?.get()?.[column.id]) ?? true
   )
 }
 
@@ -90,10 +100,15 @@ export function column_getCanHide<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
+  const featureColumn = column as unknown as Column<
+    ColumnVisibilityFeatures,
+    TData,
+    TValue
+  >
   return (
-    (column.columnDef.enableHiding ?? true) &&
-    (column.table.options.enableHiding ?? true)
+    (featureColumn.columnDef.enableHiding ?? true) &&
+    (featureColumn.table.options.enableHiding ?? true)
   )
 }
 
@@ -112,7 +127,7 @@ export function column_getToggleVisibilityHandler<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
   return (e: unknown) => {
     column_toggleVisibility(
       column,
@@ -136,6 +151,10 @@ export function row_getVisibleCells<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>): Array<Cell<TFeatures, TData, unknown>> {
+  const featureTable = row.table as unknown as Table<
+    ColumnVisibilityFeatures,
+    TData
+  >
   const allCells = row.getAllCells()
   const visibleCells: Array<Cell<TFeatures, TData, unknown>> = []
   for (let i = 0; i < allCells.length; i++) {
@@ -146,7 +165,7 @@ export function row_getVisibleCells<
   }
 
   const { left, right } =
-    row.table.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
+    featureTable.atoms.columnPinning?.get() ?? getDefaultColumnPinningState()
   if (!left.length && !right.length) return visibleCells // no pinning, return early
 
   const visibleCellsByColumnId = callMemoOrStaticFn(
@@ -262,7 +281,11 @@ export function table_setColumnVisibility<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<ColumnVisibilityState>) {
-  table.options.onColumnVisibilityChange?.(updater)
+  const featureTable = table as unknown as Table<
+    ColumnVisibilityFeatures,
+    TData
+  >
+  featureTable.options.onColumnVisibilityChange?.(updater)
 }
 
 /**
@@ -281,9 +304,15 @@ export function table_resetColumnVisibility<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<
+    ColumnVisibilityFeatures,
+    TData
+  >
   table_setColumnVisibility(
     table,
-    defaultState ? {} : cloneState(table.initialState.columnVisibility ?? {}),
+    defaultState
+      ? {}
+      : cloneState(featureTable.initialState.columnVisibility ?? {}),
   )
 }
 

--- a/packages/table-core/src/features/global-filtering/globalFilteringFeature.ts
+++ b/packages/table-core/src/features/global-filtering/globalFilteringFeature.ts
@@ -27,7 +27,7 @@ export const globalFilteringFeature: TableFeature = {
     return {
       onGlobalFilterChange: makeStateUpdater('globalFilter', table),
       globalFilterFn: 'auto',
-      getColumnCanGlobalFilter: (column) => {
+      getColumnCanGlobalFilter: (column: any) => {
         const value = table
           .getCoreRowModel()
           .flatRows[0]?.getAllCellsByColumnId()

--- a/packages/table-core/src/features/global-filtering/globalFilteringFeature.utils.ts
+++ b/packages/table-core/src/features/global-filtering/globalFilteringFeature.utils.ts
@@ -1,10 +1,15 @@
 import { filterFn_includesString } from '../../fns/filterFns'
 import { cloneState, isFunction } from '../../utils'
-import type { Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 import type { FilterFn } from '../column-filtering/columnFilteringFeature.types'
 import type { CellData, RowData } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
+
+type GlobalFilteringFeatures = Partial<{
+  globalFilteringFeature: TableFeature
+  columnFilteringFeature: TableFeature
+}>
 
 /**
  * Checks whether this accessor column participates in global filtering.
@@ -21,12 +26,18 @@ export function column_getCanGlobalFilter<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): boolean {
+>(column: Column<TFeatures, TData, TValue>): boolean {
+  const featureColumn = column as unknown as Column<
+    GlobalFilteringFeatures,
+    TData,
+    TValue
+  >
   return (
-    (column.columnDef.enableGlobalFilter ?? true) &&
-    (column.table.options.enableGlobalFilter ?? true) &&
-    (column.table.options.enableFilters ?? true) &&
-    (column.table.options.getColumnCanGlobalFilter?.(column as any) ?? true) &&
+    (featureColumn.columnDef.enableGlobalFilter ?? true) &&
+    (featureColumn.table.options.enableGlobalFilter ?? true) &&
+    (featureColumn.table.options.enableFilters ?? true) &&
+    (featureColumn.table.options.getColumnCanGlobalFilter?.(column as any) ??
+      true) &&
     !!column.accessorFn
   )
 }
@@ -62,17 +73,22 @@ export function table_getGlobalFilterFn<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>): FilterFn<TFeatures, TData> | undefined {
-  const { globalFilterFn: globalFilterFn } = table.options
+  const featureTable = table as unknown as Table<GlobalFilteringFeatures, TData>
+  const { globalFilterFn: globalFilterFn } = featureTable.options
   const filterFns: Record<string, FilterFn<TFeatures, TData>> | undefined =
-    table._rowModelFns.filterFns
+    featureTable._rowModelFns.filterFns as
+      | Record<string, FilterFn<TFeatures, TData>>
+      | undefined
 
   const filterFn = isFunction(globalFilterFn)
     ? globalFilterFn
     : globalFilterFn === 'auto'
       ? table_getGlobalAutoFilterFn()
-      : filterFns?.[globalFilterFn as string]
+      : globalFilterFn
+        ? filterFns?.[globalFilterFn]
+        : undefined
 
-  return filterFn
+  return filterFn as FilterFn<TFeatures, TData> | undefined
 }
 
 /**
@@ -90,7 +106,8 @@ export function table_setGlobalFilter<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: any) {
-  table.options.onGlobalFilterChange?.(updater)
+  const featureTable = table as unknown as Table<GlobalFilteringFeatures, TData>
+  featureTable.options.onGlobalFilterChange?.(updater)
 }
 
 /**
@@ -109,8 +126,11 @@ export function table_resetGlobalFilter<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<GlobalFilteringFeatures, TData>
   table_setGlobalFilter(
     table,
-    defaultState ? undefined : cloneState(table.initialState.globalFilter),
+    defaultState
+      ? undefined
+      : cloneState(featureTable.initialState.globalFilter),
   )
 }

--- a/packages/table-core/src/features/global-filtering/globalFilteringFeature.utils.ts
+++ b/packages/table-core/src/features/global-filtering/globalFilteringFeature.utils.ts
@@ -4,7 +4,7 @@ import type { Column_Internal } from '../../types/Column'
 import type { FilterFn } from '../column-filtering/columnFilteringFeature.types'
 import type { CellData, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 
 /**
  * Checks whether this accessor column participates in global filtering.
@@ -61,9 +61,7 @@ export function table_getGlobalAutoFilterFn() {
 export function table_getGlobalFilterFn<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-): FilterFn<TFeatures, TData> | undefined {
+>(table: Table<TFeatures, TData>): FilterFn<TFeatures, TData> | undefined {
   const { globalFilterFn: globalFilterFn } = table.options
   const filterFns: Record<string, FilterFn<TFeatures, TData>> | undefined =
     table._rowModelFns.filterFns
@@ -91,7 +89,7 @@ export function table_getGlobalFilterFn<
 export function table_setGlobalFilter<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, updater: any) {
+>(table: Table<TFeatures, TData>, updater: any) {
   table.options.onGlobalFilterChange?.(updater)
 }
 
@@ -110,7 +108,7 @@ export function table_setGlobalFilter<
 export function table_resetGlobalFilter<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setGlobalFilter(
     table,
     defaultState ? undefined : cloneState(table.initialState.globalFilter),

--- a/packages/table-core/src/features/row-expanding/createExpandedRowModel.ts
+++ b/packages/table-core/src/features/row-expanding/createExpandedRowModel.ts
@@ -5,6 +5,7 @@ import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { RowData } from '../../types/type-utils'
+type ExpandedRowModelFeatures = Partial<{ rowExpandingFeature: TableFeature }>
 
 /**
  * Creates a memoized expanded row model factory.
@@ -16,8 +17,8 @@ export function createExpandedRowModel<
   TData extends RowData = any,
 >(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
   return (table) => {
-    const typedTable = table as unknown as Table<
-      { rowExpandingFeature: TableFeature },
+    const featureTable = table as unknown as Table<
+      ExpandedRowModelFeatures,
       TData
     >
     return tableMemo({
@@ -25,9 +26,9 @@ export function createExpandedRowModel<
       table,
       fnName: 'table.getExpandedRowModel',
       memoDeps: () => [
-        typedTable.atoms.expanded?.get(),
-        typedTable.getPreExpandedRowModel(),
-        typedTable.options.paginateExpandedRows,
+        featureTable.atoms.expanded?.get(),
+        table.getPreExpandedRowModel(),
+        featureTable.options.paginateExpandedRows,
       ],
       fn: () => _createExpandedRowModel(table),
     })
@@ -38,8 +39,9 @@ function _createExpandedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
+  const featureTable = table as unknown as Table<ExpandedRowModelFeatures, TData>
   const rowModel = table.getPreExpandedRowModel()
-  const expanded = table.atoms.expanded?.get()
+  const expanded = featureTable.atoms.expanded?.get()
 
   if (
     !rowModel.rows.length ||
@@ -48,7 +50,7 @@ function _createExpandedRowModel<
     return rowModel
   }
 
-  if (!table.options.paginateExpandedRows) {
+  if (!featureTable.options.paginateExpandedRows) {
     // Only expand rows at this point if they are being paginated
     return rowModel
   }

--- a/packages/table-core/src/features/row-expanding/createExpandedRowModel.ts
+++ b/packages/table-core/src/features/row-expanding/createExpandedRowModel.ts
@@ -1,8 +1,8 @@
 import { tableMemo } from '../../utils'
 import { row_getIsExpanded } from './rowExpandingFeature.utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
-import type { Table, Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { RowData } from '../../types/type-utils'
 
@@ -15,16 +15,19 @@ export function createExpandedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
-  return (_table) => {
-    const table = _table as unknown as Table_Internal<TFeatures, TData>
+  return (table) => {
+    const typedTable = table as unknown as Table<
+      { rowExpandingFeature: TableFeature },
+      TData
+    >
     return tableMemo({
       feature: 'rowExpandingFeature',
       table,
       fnName: 'table.getExpandedRowModel',
       memoDeps: () => [
-        table.atoms.expanded?.get(),
-        table.getPreExpandedRowModel(),
-        table.options.paginateExpandedRows,
+        typedTable.atoms.expanded?.get(),
+        typedTable.getPreExpandedRowModel(),
+        typedTable.options.paginateExpandedRows,
       ],
       fn: () => _createExpandedRowModel(table),
     })
@@ -34,7 +37,7 @@ export function createExpandedRowModel<
 function _createExpandedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   const rowModel = table.getPreExpandedRowModel()
   const expanded = table.atoms.expanded?.get()
 

--- a/packages/table-core/src/features/row-expanding/createExpandedRowModel.ts
+++ b/packages/table-core/src/features/row-expanding/createExpandedRowModel.ts
@@ -39,7 +39,10 @@ function _createExpandedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
-  const featureTable = table as unknown as Table<ExpandedRowModelFeatures, TData>
+  const featureTable = table as unknown as Table<
+    ExpandedRowModelFeatures,
+    TData
+  >
   const rowModel = table.getPreExpandedRowModel()
   const expanded = featureTable.atoms.expanded?.get()
 

--- a/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
+++ b/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
@@ -305,7 +305,10 @@ export function row_getIsExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
-  const featureTable = row.table as unknown as Table<RowExpandingFeatures, TData>
+  const featureTable = row.table as unknown as Table<
+    RowExpandingFeatures,
+    TData
+  >
   const expanded: ExpandedState = featureTable.atoms.expanded?.get() ?? {}
 
   return !!(
@@ -331,7 +334,10 @@ export function row_getCanExpand<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
-  const featureTable = row.table as unknown as Table<RowExpandingFeatures, TData>
+  const featureTable = row.table as unknown as Table<
+    RowExpandingFeatures,
+    TData
+  >
   return (
     featureTable.options.getRowCanExpand?.(
       row as unknown as Row<RowExpandingFeatures, TData>,

--- a/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
+++ b/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
@@ -1,12 +1,14 @@
 import { cloneState } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type {
   ExpandedState,
   ExpandedStateList,
 } from './rowExpandingFeature.types'
+
+type RowExpandingFeatures = Partial<{ rowExpandingFeature: TableFeature }>
 
 /**
  * Creates the default expanded state.
@@ -39,10 +41,11 @@ export function table_autoResetExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<RowExpandingFeatures, TData>
   if (
     table.options.autoResetAll ??
-    table.options.autoResetExpanded ??
-    !table.options.manualExpanding
+    featureTable.options.autoResetExpanded ??
+    !featureTable.options.manualExpanding
   ) {
     table._reactivity.schedule(() => table_resetExpanded(table))
   }
@@ -63,7 +66,8 @@ export function table_setExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<ExpandedState>) {
-  table.options.onExpandedChange?.(updater)
+  const featureTable = table as unknown as Table<RowExpandingFeatures, TData>
+  featureTable.options.onExpandedChange?.(updater)
 }
 
 /**
@@ -105,9 +109,10 @@ export function table_resetExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<RowExpandingFeatures, TData>
   table_setExpanded(
     table,
-    defaultState ? {} : cloneState(table.initialState.expanded ?? {}),
+    defaultState ? {} : cloneState(featureTable.initialState.expanded ?? {}),
   )
 }
 
@@ -166,7 +171,8 @@ export function table_getIsSomeRowsExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
-  const expanded = table.atoms.expanded?.get() ?? {}
+  const featureTable = table as unknown as Table<RowExpandingFeatures, TData>
+  const expanded = featureTable.atoms.expanded?.get() ?? {}
   return expanded === true || Object.values(expanded).some(Boolean)
 }
 
@@ -185,7 +191,8 @@ export function table_getIsAllRowsExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
-  const expanded = table.atoms.expanded?.get() ?? {}
+  const featureTable = table as unknown as Table<RowExpandingFeatures, TData>
+  const expanded = featureTable.atoms.expanded?.get() ?? {}
 
   // If expanded is true, save some cycles and return true
   if (expanded === true) {
@@ -220,12 +227,13 @@ export function table_getExpandedDepth<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<RowExpandingFeatures, TData>
   let maxDepth = 0
 
   const rowIds =
-    table.atoms.expanded?.get() === true
+    featureTable.atoms.expanded?.get() === true
       ? Object.keys(table.getRowModel().rowsById)
-      : Object.keys(table.atoms.expanded?.get() ?? {})
+      : Object.keys(featureTable.atoms.expanded?.get() ?? {})
 
   rowIds.forEach((id) => {
     const splitId = id.split('.')
@@ -297,10 +305,13 @@ export function row_getIsExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
-  const expanded: ExpandedState = row.table.atoms.expanded?.get() ?? {}
+  const featureTable = row.table as unknown as Table<RowExpandingFeatures, TData>
+  const expanded: ExpandedState = featureTable.atoms.expanded?.get() ?? {}
 
   return !!(
-    row.table.options.getIsRowExpanded?.(row) ??
+    featureTable.options.getIsRowExpanded?.(
+      row as unknown as Row<RowExpandingFeatures, TData>,
+    ) ??
     (expanded === true || expanded[row.id])
   )
 }
@@ -320,9 +331,12 @@ export function row_getCanExpand<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
+  const featureTable = row.table as unknown as Table<RowExpandingFeatures, TData>
   return (
-    row.table.options.getRowCanExpand?.(row) ??
-    ((row.table.options.enableExpanding ?? true) && !!row.subRows.length)
+    featureTable.options.getRowCanExpand?.(
+      row as unknown as Row<RowExpandingFeatures, TData>,
+    ) ??
+    ((featureTable.options.enableExpanding ?? true) && !!row.subRows.length)
   )
 }
 

--- a/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
+++ b/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
@@ -1,7 +1,7 @@
 import { cloneState } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type {
   ExpandedState,
@@ -38,7 +38,7 @@ export function getDefaultExpandedState(): ExpandedState {
 export function table_autoResetExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   if (
     table.options.autoResetAll ??
     table.options.autoResetExpanded ??
@@ -62,7 +62,7 @@ export function table_autoResetExpanded<
 export function table_setExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, updater: Updater<ExpandedState>) {
+>(table: Table<TFeatures, TData>, updater: Updater<ExpandedState>) {
   table.options.onExpandedChange?.(updater)
 }
 
@@ -81,7 +81,7 @@ export function table_setExpanded<
 export function table_toggleAllRowsExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, expanded?: boolean) {
+>(table: Table<TFeatures, TData>, expanded?: boolean) {
   if (expanded ?? !table_getIsAllRowsExpanded(table)) {
     table_setExpanded(table, true)
   } else {
@@ -104,7 +104,7 @@ export function table_toggleAllRowsExpanded<
 export function table_resetExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setExpanded(
     table,
     defaultState ? {} : cloneState(table.initialState.expanded ?? {}),
@@ -125,7 +125,7 @@ export function table_resetExpanded<
 export function table_getCanSomeRowsExpand<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return table
     .getPrePaginatedRowModel()
     .flatRows.some((row) => row_getCanExpand(row))
@@ -145,7 +145,7 @@ export function table_getCanSomeRowsExpand<
 export function table_getToggleAllRowsExpandedHandler<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return (e: unknown) => {
     ;(e as any).persist?.()
     table_toggleAllRowsExpanded(table)
@@ -165,7 +165,7 @@ export function table_getToggleAllRowsExpandedHandler<
 export function table_getIsSomeRowsExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const expanded = table.atoms.expanded?.get() ?? {}
   return expanded === true || Object.values(expanded).some(Boolean)
 }
@@ -184,7 +184,7 @@ export function table_getIsSomeRowsExpanded<
 export function table_getIsAllRowsExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const expanded = table.atoms.expanded?.get() ?? {}
 
   // If expanded is true, save some cycles and return true
@@ -219,7 +219,7 @@ export function table_getIsAllRowsExpanded<
 export function table_getExpandedDepth<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   let maxDepth = 0
 
   const rowIds =

--- a/packages/table-core/src/features/row-pagination/createPaginatedRowModel.ts
+++ b/packages/table-core/src/features/row-pagination/createPaginatedRowModel.ts
@@ -7,6 +7,11 @@ import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { RowData } from '../../types/type-utils'
 
+type PaginatedRowModelFeatures = Partial<{
+  rowPaginationFeature: TableFeature
+  rowExpandingFeature: TableFeature
+}>
+
 /**
  * Creates a memoized paginated row model factory.
  *
@@ -17,11 +22,8 @@ export function createPaginatedRowModel<
   TData extends RowData = any,
 >(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
   return (table) => {
-    const typedTable = table as unknown as Table<
-      {
-        rowExpandingFeature: TableFeature
-        rowPaginationFeature: TableFeature
-      },
+    const featureTable = table as unknown as Table<
+      PaginatedRowModelFeatures,
       TData
     >
     return tableMemo({
@@ -29,10 +31,10 @@ export function createPaginatedRowModel<
       table,
       fnName: 'table.getPaginatedRowModel',
       memoDeps: () => [
-        typedTable.getPrePaginatedRowModel(),
-        typedTable.atoms.pagination?.get(),
-        typedTable.options.paginateExpandedRows
-          ? typedTable.atoms.expanded?.get()
+        table.getPrePaginatedRowModel(),
+        featureTable.atoms.pagination?.get(),
+        featureTable.options.paginateExpandedRows
+          ? featureTable.atoms.expanded?.get()
           : undefined,
       ],
       fn: () => _createPaginatedRowModel(table),
@@ -44,8 +46,12 @@ function _createPaginatedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
+  const featureTable = table as unknown as Table<
+    PaginatedRowModelFeatures,
+    TData
+  >
   const prePaginatedRowModel = table.getPrePaginatedRowModel()
-  const pagination = table.atoms.pagination?.get()
+  const pagination = featureTable.atoms.pagination?.get()
 
   if (!prePaginatedRowModel.rows.length) {
     return prePaginatedRowModel
@@ -60,7 +66,7 @@ function _createPaginatedRowModel<
 
   let paginatedRowModel: RowModel<TFeatures, TData>
 
-  if (!table.options.paginateExpandedRows) {
+  if (!featureTable.options.paginateExpandedRows) {
     paginatedRowModel = expandRows({
       rows: paginatedRows,
       flatRows,

--- a/packages/table-core/src/features/row-pagination/createPaginatedRowModel.ts
+++ b/packages/table-core/src/features/row-pagination/createPaginatedRowModel.ts
@@ -1,9 +1,9 @@
 import { tableMemo } from '../../utils'
 import { expandRows } from '../row-expanding/createExpandedRowModel'
 import { getDefaultPaginationState } from './rowPaginationFeature.utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
-import type { Table, Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { RowData } from '../../types/type-utils'
 
@@ -16,17 +16,23 @@ export function createPaginatedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
-  return (_table) => {
-    const table = _table as unknown as Table_Internal<TFeatures, TData>
+  return (table) => {
+    const typedTable = table as unknown as Table<
+      {
+        rowExpandingFeature: TableFeature
+        rowPaginationFeature: TableFeature
+      },
+      TData
+    >
     return tableMemo({
       feature: 'rowPaginationFeature',
       table,
       fnName: 'table.getPaginatedRowModel',
       memoDeps: () => [
-        table.getPrePaginatedRowModel(),
-        table.atoms.pagination?.get(),
-        table.options.paginateExpandedRows
-          ? table.atoms.expanded?.get()
+        typedTable.getPrePaginatedRowModel(),
+        typedTable.atoms.pagination?.get(),
+        typedTable.options.paginateExpandedRows
+          ? typedTable.atoms.expanded?.get()
           : undefined,
       ],
       fn: () => _createPaginatedRowModel(table),
@@ -37,7 +43,7 @@ export function createPaginatedRowModel<
 function _createPaginatedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   const prePaginatedRowModel = table.getPrePaginatedRowModel()
   const pagination = table.atoms.pagination?.get()
 

--- a/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
+++ b/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
@@ -1,8 +1,10 @@
 import { cloneState, functionalUpdate } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
 import type { PaginationState } from './rowPaginationFeature.types'
+
+type RowPaginationFeatures = Partial<{ rowPaginationFeature: TableFeature }>
 
 const defaultPageIndex = 0
 const defaultPageSize = 10
@@ -41,10 +43,11 @@ export function table_autoResetPageIndex<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<RowPaginationFeatures, TData>
   if (
     table.options.autoResetAll ??
-    table.options.autoResetPageIndex ??
-    !table.options.manualPagination
+    featureTable.options.autoResetPageIndex ??
+    !featureTable.options.manualPagination
   ) {
     table_resetPageIndex(table)
   }
@@ -66,13 +69,14 @@ export function table_setPagination<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<PaginationState>) {
+  const featureTable = table as unknown as Table<RowPaginationFeatures, TData>
   const safeUpdater: Updater<PaginationState> = (old) => {
     const newState = functionalUpdate(updater, old)
 
     return newState
   }
 
-  return table.options.onPaginationChange?.(safeUpdater)
+  return featureTable.options.onPaginationChange?.(safeUpdater)
 }
 
 /**
@@ -92,12 +96,13 @@ export function table_resetPagination<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<RowPaginationFeatures, TData>
   table_setPagination(
     table,
     defaultState
       ? getDefaultPaginationState()
       : cloneState(
-          table.initialState.pagination ?? getDefaultPaginationState(),
+          featureTable.initialState.pagination ?? getDefaultPaginationState(),
         ),
   )
 }
@@ -117,14 +122,15 @@ export function table_setPageIndex<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<number>) {
+  const featureTable = table as unknown as Table<RowPaginationFeatures, TData>
   table_setPagination(table, (old) => {
     let pageIndex = functionalUpdate(updater, old.pageIndex)
 
     const maxPageIndex =
-      typeof table.options.pageCount === 'undefined' ||
-      table.options.pageCount === -1
+      typeof featureTable.options.pageCount === 'undefined' ||
+      featureTable.options.pageCount === -1
         ? Number.MAX_SAFE_INTEGER
-        : table.options.pageCount - 1
+        : featureTable.options.pageCount - 1
 
     pageIndex = Math.max(0, Math.min(pageIndex, maxPageIndex))
 
@@ -151,11 +157,12 @@ export function table_resetPageIndex<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<RowPaginationFeatures, TData>
   const currentPageIndex =
-    table.atoms.pagination?.get()?.pageIndex ?? defaultPageIndex
+    featureTable.atoms.pagination?.get()?.pageIndex ?? defaultPageIndex
   const newPageIndex = defaultState
     ? defaultPageIndex
-    : (table.initialState.pagination?.pageIndex ?? defaultPageIndex)
+    : (featureTable.initialState.pagination?.pageIndex ?? defaultPageIndex)
   if (newPageIndex === currentPageIndex) return
   table_setPageIndex(table, newPageIndex)
 }
@@ -176,11 +183,12 @@ export function table_resetPageSize<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<RowPaginationFeatures, TData>
   const currentPageSize =
-    table.atoms.pagination?.get()?.pageSize ?? defaultPageSize
+    featureTable.atoms.pagination?.get()?.pageSize ?? defaultPageSize
   const newPageSize = defaultState
     ? defaultPageSize
-    : (table.initialState.pagination?.pageSize ?? defaultPageSize)
+    : (featureTable.initialState.pagination?.pageSize ?? defaultPageSize)
   if (newPageSize === currentPageSize) return
   table_setPageSize(table, newPageSize)
 }
@@ -251,7 +259,8 @@ export function table_getCanPreviousPage<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
-  return (table.atoms.pagination?.get()?.pageIndex ?? 0) > 0
+  const featureTable = table as unknown as Table<RowPaginationFeatures, TData>
+  return (featureTable.atoms.pagination?.get()?.pageIndex ?? 0) > 0
 }
 
 /**
@@ -269,7 +278,9 @@ export function table_getCanNextPage<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
-  const pageIndex = table.atoms.pagination?.get()?.pageIndex ?? defaultPageIndex
+  const featureTable = table as unknown as Table<RowPaginationFeatures, TData>
+  const pageIndex =
+    featureTable.atoms.pagination?.get()?.pageIndex ?? defaultPageIndex
 
   const pageCount = table_getPageCount(table)
 
@@ -371,11 +382,12 @@ export function table_getPageCount<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<RowPaginationFeatures, TData>
   return (
-    table.options.pageCount ??
+    featureTable.options.pageCount ??
     Math.ceil(
       table_getRowCount(table) /
-        (table.atoms.pagination?.get()?.pageSize ?? defaultPageSize),
+        (featureTable.atoms.pagination?.get()?.pageSize ?? defaultPageSize),
     )
   )
 }
@@ -396,5 +408,8 @@ export function table_getRowCount<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
-  return table.options.rowCount ?? table.getPrePaginatedRowModel().rows.length
+  const featureTable = table as unknown as Table<RowPaginationFeatures, TData>
+  return (
+    featureTable.options.rowCount ?? table.getPrePaginatedRowModel().rows.length
+  )
 }

--- a/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
+++ b/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
@@ -1,7 +1,7 @@
 import { cloneState, functionalUpdate } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { PaginationState } from './rowPaginationFeature.types'
 
 const defaultPageIndex = 0
@@ -40,7 +40,7 @@ export function getDefaultPaginationState(): PaginationState {
 export function table_autoResetPageIndex<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   if (
     table.options.autoResetAll ??
     table.options.autoResetPageIndex ??
@@ -65,7 +65,7 @@ export function table_autoResetPageIndex<
 export function table_setPagination<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, updater: Updater<PaginationState>) {
+>(table: Table<TFeatures, TData>, updater: Updater<PaginationState>) {
   const safeUpdater: Updater<PaginationState> = (old) => {
     const newState = functionalUpdate(updater, old)
 
@@ -91,7 +91,7 @@ export function table_setPagination<
 export function table_resetPagination<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setPagination(
     table,
     defaultState
@@ -116,7 +116,7 @@ export function table_resetPagination<
 export function table_setPageIndex<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, updater: Updater<number>) {
+>(table: Table<TFeatures, TData>, updater: Updater<number>) {
   table_setPagination(table, (old) => {
     let pageIndex = functionalUpdate(updater, old.pageIndex)
 
@@ -150,7 +150,7 @@ export function table_setPageIndex<
 export function table_resetPageIndex<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   const currentPageIndex =
     table.atoms.pagination?.get()?.pageIndex ?? defaultPageIndex
   const newPageIndex = defaultState
@@ -175,7 +175,7 @@ export function table_resetPageIndex<
 export function table_resetPageSize<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   const currentPageSize =
     table.atoms.pagination?.get()?.pageSize ?? defaultPageSize
   const newPageSize = defaultState
@@ -199,7 +199,7 @@ export function table_resetPageSize<
 export function table_setPageSize<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, updater: Updater<number>) {
+>(table: Table<TFeatures, TData>, updater: Updater<number>) {
   table_setPagination(table, (old) => {
     const pageSize = Math.max(1, functionalUpdate(updater, old.pageSize))
     const topRowIndex = old.pageSize * old.pageIndex
@@ -227,7 +227,7 @@ export function table_setPageSize<
 export function table_getPageOptions<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const pageCount = table_getPageCount(table)
   let pageOptions: Array<number> = []
   if (pageCount && pageCount > 0) {
@@ -250,7 +250,7 @@ export function table_getPageOptions<
 export function table_getCanPreviousPage<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return (table.atoms.pagination?.get()?.pageIndex ?? 0) > 0
 }
 
@@ -268,7 +268,7 @@ export function table_getCanPreviousPage<
 export function table_getCanNextPage<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const pageIndex = table.atoms.pagination?.get()?.pageIndex ?? defaultPageIndex
 
   const pageCount = table_getPageCount(table)
@@ -298,7 +298,7 @@ export function table_getCanNextPage<
 export function table_previousPage<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return table_setPageIndex(table, (old) => old - 1)
 }
 
@@ -316,7 +316,7 @@ export function table_previousPage<
 export function table_nextPage<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return table_setPageIndex(table, (old) => {
     return old + 1
   })
@@ -335,7 +335,7 @@ export function table_nextPage<
 export function table_firstPage<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return table_setPageIndex(table, 0)
 }
 
@@ -352,7 +352,7 @@ export function table_firstPage<
 export function table_lastPage<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return table_setPageIndex(table, table_getPageCount(table) - 1)
 }
 
@@ -370,7 +370,7 @@ export function table_lastPage<
 export function table_getPageCount<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return (
     table.options.pageCount ??
     Math.ceil(
@@ -395,6 +395,6 @@ export function table_getPageCount<
 export function table_getRowCount<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return table.options.rowCount ?? table.getPrePaginatedRowModel().rows.length
 }

--- a/packages/table-core/src/features/row-pinning/rowPinningFeature.utils.ts
+++ b/packages/table-core/src/features/row-pinning/rowPinningFeature.utils.ts
@@ -2,7 +2,7 @@ import { row_getIsAllParentsExpanded } from '../row-expanding/rowExpandingFeatur
 import { callMemoOrStaticFn, cloneState } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type {
   RowPinningPosition,
@@ -43,10 +43,7 @@ export function getDefaultRowPinningState(): RowPinningState {
 export function table_setRowPinning<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  updater: Updater<RowPinningState>,
-): void {
+>(table: Table<TFeatures, TData>, updater: Updater<RowPinningState>): void {
   table.options.onRowPinningChange?.(updater)
 }
 
@@ -66,7 +63,7 @@ export function table_setRowPinning<
 export function table_resetRowPinning<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean): void {
+>(table: Table<TFeatures, TData>, defaultState?: boolean): void {
   table_setRowPinning(
     table,
     defaultState
@@ -93,10 +90,7 @@ export function table_resetRowPinning<
 export function table_getIsSomeRowsPinned<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  position?: RowPinningPosition,
-): boolean {
+>(table: Table<TFeatures, TData>, position?: RowPinningPosition): boolean {
   const rowPinning = table.atoms.rowPinning?.get()
 
   if (!position) {
@@ -109,7 +103,7 @@ function table_getPinnedRows<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   position: 'top' | 'bottom',
 ): Array<Row<TFeatures, TData>> {
   const visibleRows = table.getRowModel().rows
@@ -152,7 +146,7 @@ function table_getPinnedRows<
 export function table_getTopRows<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): Array<Row<TFeatures, TData>> {
+>(table: Table<TFeatures, TData>): Array<Row<TFeatures, TData>> {
   return table_getPinnedRows(table, 'top')
 }
 
@@ -170,7 +164,7 @@ export function table_getTopRows<
 export function table_getBottomRows<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): Array<Row<TFeatures, TData>> {
+>(table: Table<TFeatures, TData>): Array<Row<TFeatures, TData>> {
   return table_getPinnedRows(table, 'bottom')
 }
 
@@ -188,7 +182,7 @@ export function table_getBottomRows<
 export function table_getCenterRows<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): Array<Row<TFeatures, TData>> {
+>(table: Table<TFeatures, TData>): Array<Row<TFeatures, TData>> {
   const { top, bottom } =
     table.atoms.rowPinning?.get() ?? getDefaultRowPinningState()
   const allRows = table.getRowModel().rows

--- a/packages/table-core/src/features/row-pinning/rowPinningFeature.utils.ts
+++ b/packages/table-core/src/features/row-pinning/rowPinningFeature.utils.ts
@@ -1,13 +1,15 @@
 import { row_getIsAllParentsExpanded } from '../row-expanding/rowExpandingFeature.utils'
 import { callMemoOrStaticFn, cloneState } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type {
   RowPinningPosition,
   RowPinningState,
 } from './rowPinningFeature.types'
+
+type RowPinningFeatures = Partial<{ rowPinningFeature: TableFeature }>
 
 // State Utils
 
@@ -44,7 +46,8 @@ export function table_setRowPinning<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<RowPinningState>): void {
-  table.options.onRowPinningChange?.(updater)
+  const featureTable = table as unknown as Table<RowPinningFeatures, TData>
+  featureTable.options.onRowPinningChange?.(updater)
 }
 
 /**
@@ -64,12 +67,13 @@ export function table_resetRowPinning<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean): void {
+  const featureTable = table as unknown as Table<RowPinningFeatures, TData>
   table_setRowPinning(
     table,
     defaultState
       ? getDefaultRowPinningState()
       : cloneState(
-          table.initialState.rowPinning ?? getDefaultRowPinningState(),
+          featureTable.initialState.rowPinning ?? getDefaultRowPinningState(),
         ),
   )
 }
@@ -91,7 +95,8 @@ export function table_getIsSomeRowsPinned<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, position?: RowPinningPosition): boolean {
-  const rowPinning = table.atoms.rowPinning?.get()
+  const featureTable = table as unknown as Table<RowPinningFeatures, TData>
+  const rowPinning = featureTable.atoms.rowPinning?.get()
 
   if (!position) {
     return Boolean(rowPinning?.top.length || rowPinning?.bottom.length)
@@ -106,9 +111,10 @@ function table_getPinnedRows<
   table: Table<TFeatures, TData>,
   position: 'top' | 'bottom',
 ): Array<Row<TFeatures, TData>> {
+  const featureTable = table as unknown as Table<RowPinningFeatures, TData>
   const visibleRows = table.getRowModel().rows
-  const pinnedRowIds = table.atoms.rowPinning?.get()?.[position] ?? []
-  const keepPinnedRows = table.options.keepPinnedRows ?? true
+  const pinnedRowIds = featureTable.atoms.rowPinning?.get()?.[position] ?? []
+  const keepPinnedRows = featureTable.options.keepPinnedRows ?? true
 
   const result: Array<Row<TFeatures, TData>> = []
   for (let i = 0; i < pinnedRowIds.length; i++) {
@@ -183,8 +189,9 @@ export function table_getCenterRows<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>): Array<Row<TFeatures, TData>> {
+  const featureTable = table as unknown as Table<RowPinningFeatures, TData>
   const { top, bottom } =
-    table.atoms.rowPinning?.get() ?? getDefaultRowPinningState()
+    featureTable.atoms.rowPinning?.get() ?? getDefaultRowPinningState()
   const allRows = table.getRowModel().rows
 
   const topAndBottom = new Set([...top, ...bottom])
@@ -208,9 +215,10 @@ export function row_getCanPin<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>): boolean {
-  const { enableRowPinning } = row.table.options
+  const featureTable = row.table as unknown as Table<RowPinningFeatures, TData>
+  const { enableRowPinning } = featureTable.options
   if (typeof enableRowPinning === 'function') {
-    return enableRowPinning(row)
+    return enableRowPinning(row as unknown as Row<RowPinningFeatures, TData>)
   }
   return enableRowPinning ?? true
 }
@@ -230,8 +238,9 @@ export function row_getIsPinned<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>): RowPinningPosition {
+  const featureTable = row.table as unknown as Table<RowPinningFeatures, TData>
   const { top, bottom } =
-    row.table.atoms.rowPinning?.get() ?? getDefaultRowPinningState()
+    featureTable.atoms.rowPinning?.get() ?? getDefaultRowPinningState()
 
   return top.includes(row.id)
     ? 'top'

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.ts
@@ -29,11 +29,14 @@ import {
   table_toggleAllRowsSelected,
 } from './rowSelectionFeature.utils'
 import type { TableFeature } from '../../types/TableFeatures'
+import './rowSelectionFeature.types'
 
 /**
  * Feature that adds row selection state and APIs for row and page selection.
  */
-export const rowSelectionFeature: TableFeature = {
+export const rowSelectionFeature: TableFeature<{
+  rowSelectionFeature: TableFeature
+}> = {
   getInitialState: (initialState) => {
     return {
       rowSelection: getDefaultRowSelectionState(),

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts
@@ -1,5 +1,5 @@
 import type { OnChangeFn, RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 import type { Row } from '../../types/Row'
 

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
@@ -1,10 +1,12 @@
 import { cloneState } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { RowSelectionState } from './rowSelectionFeature.types'
+
+type RowSelectionFeatures = Partial<{ rowSelectionFeature: TableFeature }>
 
 // State APIs
 
@@ -38,7 +40,8 @@ export function table_setRowSelection<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<RowSelectionState>) {
-  table.options.onRowSelectionChange?.(updater)
+  const featureTable = table as unknown as Table<RowSelectionFeatures, TData>
+  featureTable.options.onRowSelectionChange?.(updater)
 }
 
 /**
@@ -57,9 +60,10 @@ export function table_resetRowSelection<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<RowSelectionFeatures, TData>
   table_setRowSelection(
     table,
-    defaultState ? {} : cloneState(table.initialState.rowSelection ?? {}),
+    defaultState ? {} : cloneState(featureTable.initialState.rowSelection ?? {}),
   )
 }
 
@@ -171,9 +175,10 @@ export function table_getSelectedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<RowSelectionFeatures, TData>
   const rowModel = table.getCoreRowModel()
 
-  if (!Object.keys(table.atoms.rowSelection?.get() ?? {}).length) {
+  if (!Object.keys(featureTable.atoms.rowSelection?.get() ?? {}).length) {
     return {
       rows: [],
       flatRows: [],
@@ -199,9 +204,10 @@ export function table_getFilteredSelectedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<RowSelectionFeatures, TData>
   const rowModel = table.getCoreRowModel()
 
-  if (!Object.keys(table.atoms.rowSelection?.get() ?? {}).length) {
+  if (!Object.keys(featureTable.atoms.rowSelection?.get() ?? {}).length) {
     return {
       rows: [],
       flatRows: [],
@@ -227,9 +233,10 @@ export function table_getGroupedSelectedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<RowSelectionFeatures, TData>
   const rowModel = table.getCoreRowModel()
 
-  if (!Object.keys(table.atoms.rowSelection?.get() ?? {}).length) {
+  if (!Object.keys(featureTable.atoms.rowSelection?.get() ?? {}).length) {
     return {
       rows: [],
       flatRows: [],
@@ -255,8 +262,10 @@ export function table_getIsAllRowsSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<RowSelectionFeatures, TData>
   const preGroupedFlatRows = table.getFilteredRowModel().flatRows
-  const rowSelection: RowSelectionState = table.atoms.rowSelection?.get() ?? {}
+  const rowSelection: RowSelectionState =
+    featureTable.atoms.rowSelection?.get() ?? {}
 
   let isAllRowsSelected = Boolean(
     preGroupedFlatRows.length && Object.keys(rowSelection).length,
@@ -289,10 +298,12 @@ export function table_getIsAllPageRowsSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<RowSelectionFeatures, TData>
   const paginationFlatRows = table
     .getPaginatedRowModel()
     .flatRows.filter((row) => row_getCanSelect(row))
-  const rowSelection: RowSelectionState = table.atoms.rowSelection?.get() ?? {}
+  const rowSelection: RowSelectionState =
+    featureTable.atoms.rowSelection?.get() ?? {}
 
   let isAllPageRowsSelected = !!paginationFlatRows.length
 
@@ -321,8 +332,9 @@ export function table_getIsSomeRowsSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>) {
+  const featureTable = table as unknown as Table<RowSelectionFeatures, TData>
   const totalSelected = Object.keys(
-    table.atoms.rowSelection?.get() ?? {},
+    featureTable.atoms.rowSelection?.get() ?? {},
   ).length
   return (
     totalSelected > 0 &&
@@ -511,9 +523,12 @@ export function row_getCanSelect<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
-  const options = row.table.options
+  const featureTable = row.table as unknown as Table<RowSelectionFeatures, TData>
+  const options = featureTable.options
   if (typeof options.enableRowSelection === 'function') {
-    return options.enableRowSelection(row)
+    return options.enableRowSelection(
+      row as unknown as Row<RowSelectionFeatures, TData>,
+    )
   }
 
   return options.enableRowSelection ?? true
@@ -534,9 +549,12 @@ export function row_getCanSelectSubRows<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
-  const options = row.table.options
+  const featureTable = row.table as unknown as Table<RowSelectionFeatures, TData>
+  const options = featureTable.options
   if (typeof options.enableSubRowSelection === 'function') {
-    return options.enableSubRowSelection(row)
+    return options.enableSubRowSelection(
+      row as unknown as Row<RowSelectionFeatures, TData>,
+    )
   }
 
   return options.enableSubRowSelection ?? true
@@ -557,9 +575,12 @@ export function row_getCanMultiSelect<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
-  const options = row.table.options
+  const featureTable = row.table as unknown as Table<RowSelectionFeatures, TData>
+  const options = featureTable.options
   if (typeof options.enableMultiRowSelection === 'function') {
-    return options.enableMultiRowSelection(row)
+    return options.enableMultiRowSelection(
+      row as unknown as Row<RowSelectionFeatures, TData>,
+    )
   }
 
   return options.enableMultiRowSelection ?? true
@@ -692,7 +713,8 @@ export function isRowSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>): boolean {
-  return (row.table.atoms.rowSelection?.get() ?? {})[row.id] ?? false
+  const featureTable = row.table as unknown as Table<RowSelectionFeatures, TData>
+  return (featureTable.atoms.rowSelection?.get() ?? {})[row.id] ?? false
 }
 
 /**

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
@@ -63,7 +63,9 @@ export function table_resetRowSelection<
   const featureTable = table as unknown as Table<RowSelectionFeatures, TData>
   table_setRowSelection(
     table,
-    defaultState ? {} : cloneState(featureTable.initialState.rowSelection ?? {}),
+    defaultState
+      ? {}
+      : cloneState(featureTable.initialState.rowSelection ?? {}),
   )
 }
 
@@ -523,7 +525,10 @@ export function row_getCanSelect<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
-  const featureTable = row.table as unknown as Table<RowSelectionFeatures, TData>
+  const featureTable = row.table as unknown as Table<
+    RowSelectionFeatures,
+    TData
+  >
   const options = featureTable.options
   if (typeof options.enableRowSelection === 'function') {
     return options.enableRowSelection(
@@ -549,7 +554,10 @@ export function row_getCanSelectSubRows<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
-  const featureTable = row.table as unknown as Table<RowSelectionFeatures, TData>
+  const featureTable = row.table as unknown as Table<
+    RowSelectionFeatures,
+    TData
+  >
   const options = featureTable.options
   if (typeof options.enableSubRowSelection === 'function') {
     return options.enableSubRowSelection(
@@ -575,7 +583,10 @@ export function row_getCanMultiSelect<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
-  const featureTable = row.table as unknown as Table<RowSelectionFeatures, TData>
+  const featureTable = row.table as unknown as Table<
+    RowSelectionFeatures,
+    TData
+  >
   const options = featureTable.options
   if (typeof options.enableMultiRowSelection === 'function') {
     return options.enableMultiRowSelection(
@@ -713,7 +724,10 @@ export function isRowSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>): boolean {
-  const featureTable = row.table as unknown as Table<RowSelectionFeatures, TData>
+  const featureTable = row.table as unknown as Table<
+    RowSelectionFeatures,
+    TData
+  >
   return (featureTable.atoms.rowSelection?.get() ?? {})[row.id] ?? false
 }
 

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
@@ -2,7 +2,7 @@ import { cloneState } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { RowSelectionState } from './rowSelectionFeature.types'
 
@@ -37,10 +37,7 @@ export function getDefaultRowSelectionState(): RowSelectionState {
 export function table_setRowSelection<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  table: Table_Internal<TFeatures, TData>,
-  updater: Updater<RowSelectionState>,
-) {
+>(table: Table<TFeatures, TData>, updater: Updater<RowSelectionState>) {
   table.options.onRowSelectionChange?.(updater)
 }
 
@@ -59,7 +56,7 @@ export function table_setRowSelection<
 export function table_resetRowSelection<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setRowSelection(
     table,
     defaultState ? {} : cloneState(table.initialState.rowSelection ?? {}),
@@ -82,7 +79,7 @@ export function table_resetRowSelection<
 export function table_toggleAllRowsSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, value?: boolean) {
+>(table: Table<TFeatures, TData>, value?: boolean) {
   table_setRowSelection(table, (old) => {
     value =
       typeof value !== 'undefined' ? value : !table_getIsAllRowsSelected(table)
@@ -124,7 +121,7 @@ export function table_toggleAllRowsSelected<
 export function table_toggleAllPageRowsSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, value?: boolean) {
+>(table: Table<TFeatures, TData>, value?: boolean) {
   table_setRowSelection(table, (old) => {
     const resolvedValue =
       typeof value !== 'undefined'
@@ -155,7 +152,7 @@ export function table_toggleAllPageRowsSelected<
 export function table_getPreSelectedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
   return table.getCoreRowModel()
 }
 
@@ -173,7 +170,7 @@ export function table_getPreSelectedRowModel<
 export function table_getSelectedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const rowModel = table.getCoreRowModel()
 
   if (!Object.keys(table.atoms.rowSelection?.get() ?? {}).length) {
@@ -201,7 +198,7 @@ export function table_getSelectedRowModel<
 export function table_getFilteredSelectedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const rowModel = table.getCoreRowModel()
 
   if (!Object.keys(table.atoms.rowSelection?.get() ?? {}).length) {
@@ -229,7 +226,7 @@ export function table_getFilteredSelectedRowModel<
 export function table_getGroupedSelectedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const rowModel = table.getCoreRowModel()
 
   if (!Object.keys(table.atoms.rowSelection?.get() ?? {}).length) {
@@ -257,7 +254,7 @@ export function table_getGroupedSelectedRowModel<
 export function table_getIsAllRowsSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const preGroupedFlatRows = table.getFilteredRowModel().flatRows
   const rowSelection: RowSelectionState = table.atoms.rowSelection?.get() ?? {}
 
@@ -291,7 +288,7 @@ export function table_getIsAllRowsSelected<
 export function table_getIsAllPageRowsSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const paginationFlatRows = table
     .getPaginatedRowModel()
     .flatRows.filter((row) => row_getCanSelect(row))
@@ -323,7 +320,7 @@ export function table_getIsAllPageRowsSelected<
 export function table_getIsSomeRowsSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const totalSelected = Object.keys(
     table.atoms.rowSelection?.get() ?? {},
   ).length
@@ -347,7 +344,7 @@ export function table_getIsSomeRowsSelected<
 export function table_getIsSomePageRowsSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   const paginationFlatRows = table.getPaginatedRowModel().flatRows
   return table_getIsAllPageRowsSelected(table)
     ? false
@@ -370,7 +367,7 @@ export function table_getIsSomePageRowsSelected<
 export function table_getToggleAllRowsSelectedHandler<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return (e: unknown) => {
     table_toggleAllRowsSelected(
       table,
@@ -393,7 +390,7 @@ export function table_getToggleAllRowsSelectedHandler<
 export function table_getToggleAllPageRowsSelectedHandler<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>) {
+>(table: Table<TFeatures, TData>) {
   return (e: unknown) => {
     table_toggleAllPageRowsSelected(
       table,
@@ -602,7 +599,7 @@ const mutateRowIsSelected = <
   rowId: string,
   value: boolean,
   includeChildren: boolean,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
 ) => {
   const row = table.getRow(rowId, true)
 

--- a/packages/table-core/src/features/row-sorting/createSortedRowModel.ts
+++ b/packages/table-core/src/features/row-sorting/createSortedRowModel.ts
@@ -2,9 +2,9 @@ import { tableMemo } from '../../utils'
 import { table_autoResetPageIndex } from '../row-pagination/rowPaginationFeature.utils'
 import { column_getCanSort, column_getSortFn } from './rowSortingFeature.utils'
 import type { Column_Internal } from '../../types/Column'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
-import type { Table, Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
 import type { SortFn } from './rowSortingFeature.types'
 import type { RowData } from '../../types/type-utils'
@@ -21,15 +21,18 @@ export function createSortedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
-  return (_table) => {
-    const table = _table as unknown as Table_Internal<TFeatures, TData>
+  return (table) => {
+    const typedTable = table as unknown as Table<
+      { rowSortingFeature: TableFeature },
+      TData
+    >
     return tableMemo({
       feature: 'rowSortingFeature',
-      table,
+      table: table,
       fnName: 'table.getSortedRowModel',
       memoDeps: () => [
-        table.atoms.sorting?.get(),
-        table.getPreSortedRowModel(),
+        typedTable.atoms.sorting?.get(),
+        typedTable.getPreSortedRowModel(),
       ],
       fn: () => _createSortedRowModel(table),
       onAfterUpdate: () => table_autoResetPageIndex(table),
@@ -40,9 +43,13 @@ export function createSortedRowModel<
 function _createSortedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
->(table: Table_Internal<TFeatures, TData>): RowModel<TFeatures, TData> {
+>(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
+  const typedTable = table as unknown as Table<
+    { rowSortingFeature: TableFeature },
+    TData
+  >
   const preSortedRowModel = table.getPreSortedRowModel()
-  const sorting = table.atoms.sorting?.get()
+  const sorting = typedTable.atoms.sorting?.get()
 
   if (!preSortedRowModel.rows.length || !sorting?.length) {
     return preSortedRowModel

--- a/packages/table-core/src/features/row-sorting/createSortedRowModel.ts
+++ b/packages/table-core/src/features/row-sorting/createSortedRowModel.ts
@@ -1,13 +1,15 @@
 import { tableMemo } from '../../utils'
 import { table_autoResetPageIndex } from '../row-pagination/rowPaginationFeature.utils'
 import { column_getCanSort, column_getSortFn } from './rowSortingFeature.utils'
-import type { Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 import type { Table } from '../../types/Table'
 import type { Row } from '../../types/Row'
-import type { SortFn } from './rowSortingFeature.types'
+import type { ColumnDef_RowSorting, SortFn } from './rowSortingFeature.types'
 import type { RowData } from '../../types/type-utils'
+
+type SortedRowModelFeatures = Partial<{ rowSortingFeature: TableFeature }>
 
 /**
  * Creates a memoized sorted row model factory.
@@ -22,8 +24,8 @@ export function createSortedRowModel<
   TData extends RowData,
 >(): (table: Table<TFeatures, TData>) => () => RowModel<TFeatures, TData> {
   return (table) => {
-    const typedTable = table as unknown as Table<
-      { rowSortingFeature: TableFeature },
+    const featureTable = table as unknown as Table<
+      SortedRowModelFeatures,
       TData
     >
     return tableMemo({
@@ -31,8 +33,8 @@ export function createSortedRowModel<
       table: table,
       fnName: 'table.getSortedRowModel',
       memoDeps: () => [
-        typedTable.atoms.sorting?.get(),
-        typedTable.getPreSortedRowModel(),
+        featureTable.atoms.sorting?.get(),
+        table.getPreSortedRowModel(),
       ],
       fn: () => _createSortedRowModel(table),
       onAfterUpdate: () => table_autoResetPageIndex(table),
@@ -44,12 +46,9 @@ function _createSortedRowModel<
   TFeatures extends TableFeatures,
   TData extends RowData = any,
 >(table: Table<TFeatures, TData>): RowModel<TFeatures, TData> {
-  const typedTable = table as unknown as Table<
-    { rowSortingFeature: TableFeature },
-    TData
-  >
+  const featureTable = table as unknown as Table<SortedRowModelFeatures, TData>
   const preSortedRowModel = table.getPreSortedRowModel()
-  const sorting = typedTable.atoms.sorting?.get()
+  const sorting = featureTable.atoms.sorting?.get()
 
   if (!preSortedRowModel.rows.length || !sorting?.length) {
     return preSortedRowModel
@@ -59,9 +58,7 @@ function _createSortedRowModel<
 
   // Filter out sortings that correspond to non existing columns
   const availableSorting = sorting.filter((sort) =>
-    column_getCanSort(
-      table.getColumn(sort.id) as Column_Internal<TFeatures, TData>,
-    ),
+    column_getCanSort(table.getColumn(sort.id) as Column<TFeatures, TData>),
   )
 
   const columnInfoById: Record<
@@ -74,13 +71,15 @@ function _createSortedRowModel<
   > = {}
 
   availableSorting.forEach((sortEntry) => {
-    const column: Column_Internal<TFeatures, TData> | undefined =
-      table.getColumn(sortEntry.id)
+    const column: Column<TFeatures, TData> | undefined = table.getColumn(
+      sortEntry.id,
+    )
     if (!column) return
+    const columnDef = column.columnDef as ColumnDef_RowSorting<TFeatures, TData>
 
     columnInfoById[sortEntry.id] = {
-      sortUndefined: column.columnDef.sortUndefined,
-      invertSorting: column.columnDef.invertSorting,
+      sortUndefined: columnDef.sortUndefined,
+      invertSorting: columnDef.invertSorting,
       sortFn: column_getSortFn(column),
     }
   })

--- a/packages/table-core/src/features/row-sorting/rowSortingFeature.utils.ts
+++ b/packages/table-core/src/features/row-sorting/rowSortingFeature.utils.ts
@@ -1,14 +1,17 @@
 import { reSplitAlphaNumeric, sortFn_basic } from '../../fns/sortFns'
 import { cloneState, isFunction } from '../../utils'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
-import type { TableFeatures } from '../../types/TableFeatures'
+import type { TableFeature, TableFeatures } from '../../types/TableFeatures'
 import type { Table } from '../../types/Table'
-import type { Column_Internal } from '../../types/Column'
+import type { Column } from '../../types/Column'
 import type {
+  ColumnDef_RowSorting,
   SortDirection,
   SortFn,
   SortingState,
 } from './rowSortingFeature.types'
+
+type RowSortingFeatures = Partial<{ rowSortingFeature: TableFeature }>
 
 // State Utils
 
@@ -42,7 +45,8 @@ export function table_setSorting<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, updater: Updater<SortingState>) {
-  table.options.onSortingChange?.(updater)
+  const featureTable = table as unknown as Table<RowSortingFeatures, TData>
+  featureTable.options.onSortingChange?.(updater)
 }
 
 /**
@@ -61,9 +65,10 @@ export function table_resetSorting<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table<TFeatures, TData>, defaultState?: boolean) {
+  const featureTable = table as unknown as Table<RowSortingFeatures, TData>
   table_setSorting(
     table,
-    defaultState ? [] : cloneState(table.initialState.sorting ?? []),
+    defaultState ? [] : cloneState(featureTable.initialState.sorting ?? []),
   )
 }
 
@@ -85,9 +90,16 @@ export function column_getAutoSortFn<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): SortFn<TFeatures, TData> {
+>(column: Column<TFeatures, TData, TValue>): SortFn<TFeatures, TData> {
+  const columnDef = column.columnDef as ColumnDef_RowSorting<TFeatures, TData>
+  const featureTable = column.table as unknown as Table<
+    RowSortingFeatures,
+    TData
+  >
   const sortFns: Record<string, SortFn<TFeatures, TData>> | undefined =
-    column.table._rowModelFns.sortFns
+    featureTable._rowModelFns.sortFns as
+      | Record<string, SortFn<TFeatures, TData>>
+      | undefined
 
   const firstRows = column.table.getFilteredRowModel().flatRows.slice(0, 10)
 
@@ -135,7 +147,7 @@ export function column_getAutoSortDir<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
   const firstRow = column.table.getFilteredRowModel().flatRows[0]
 
   const value = firstRow ? firstRow.getValue(column.id) : undefined
@@ -163,15 +175,22 @@ export function column_getSortFn<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): SortFn<TFeatures, TData> {
+>(column: Column<TFeatures, TData, TValue>): SortFn<TFeatures, TData> {
+  const columnDef = column.columnDef as ColumnDef_RowSorting<TFeatures, TData>
+  const featureTable = column.table as unknown as Table<
+    RowSortingFeatures,
+    TData
+  >
   const sortFns: Record<string, SortFn<TFeatures, TData>> | undefined =
-    column.table._rowModelFns.sortFns
+    featureTable._rowModelFns.sortFns as
+      | Record<string, SortFn<TFeatures, TData>>
+      | undefined
 
-  return isFunction(column.columnDef.sortFn)
-    ? column.columnDef.sortFn
-    : column.columnDef.sortFn === 'auto'
+  return isFunction(columnDef.sortFn)
+    ? columnDef.sortFn
+    : columnDef.sortFn === 'auto'
       ? column_getAutoSortFn(column)
-      : (sortFns?.[column.columnDef.sortFn as string] ?? sortFn_basic)
+      : (sortFns?.[columnDef.sortFn as string] ?? sortFn_basic)
 }
 
 /**
@@ -190,11 +209,11 @@ export function column_toggleSorting<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(
-  column: Column_Internal<TFeatures, TData, TValue>,
-  desc?: boolean,
-  multi?: boolean,
-) {
+>(column: Column<TFeatures, TData, TValue>, desc?: boolean, multi?: boolean) {
+  const featureTable = column.table as unknown as Table<
+    RowSortingFeatures,
+    TData
+  >
   // if (column.columns.length) {
   //   column.columns.forEach((c, i) => {
   //     if (c.id) {
@@ -260,7 +279,7 @@ export function column_toggleSorting<
       newSorting.splice(
         0,
         newSorting.length -
-          (column.table.options.maxMultiSortColCount ??
+          (featureTable.options.maxMultiSortColCount ??
             Number.MAX_SAFE_INTEGER),
       )
     } else if (sortAction === 'toggle') {
@@ -304,10 +323,15 @@ export function column_getFirstSortDir<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
+  const columnDef = column.columnDef as ColumnDef_RowSorting<TFeatures, TData>
+  const featureTable = column.table as unknown as Table<
+    RowSortingFeatures,
+    TData
+  >
   const sortDescFirst =
-    column.columnDef.sortDescFirst ??
-    column.table.options.sortDescFirst ??
+    columnDef.sortDescFirst ??
+    featureTable.options.sortDescFirst ??
     column_getAutoSortDir(column) === 'desc'
   return sortDescFirst ? 'desc' : 'asc'
 }
@@ -327,7 +351,11 @@ export function column_getNextSortingOrder<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>, multi?: boolean) {
+>(column: Column<TFeatures, TData, TValue>, multi?: boolean) {
+  const featureTable = column.table as unknown as Table<
+    RowSortingFeatures,
+    TData
+  >
   const firstSortDirection = column_getFirstSortDir(column)
   const isSorted = column_getIsSorted(column)
 
@@ -337,8 +365,8 @@ export function column_getNextSortingOrder<
 
   if (
     isSorted !== firstSortDirection &&
-    (column.table.options.enableSortingRemoval ?? true) && // If enableSortRemove, enable in general
-    (multi ? (column.table.options.enableMultiRemove ?? true) : true) // If multi, don't allow if enableMultiRemove))
+    (featureTable.options.enableSortingRemoval ?? true) && // If enableSortRemove, enable in general
+    (multi ? (featureTable.options.enableMultiRemove ?? true) : true) // If multi, don't allow if enableMultiRemove))
   ) {
     return false
   }
@@ -360,10 +388,15 @@ export function column_getCanSort<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
+  const columnDef = column.columnDef as ColumnDef_RowSorting<TFeatures, TData>
+  const featureTable = column.table as unknown as Table<
+    RowSortingFeatures,
+    TData
+  >
   return (
-    (column.columnDef.enableSorting ?? true) &&
-    (column.table.options.enableSorting ?? true) &&
+    (columnDef.enableSorting ?? true) &&
+    (featureTable.options.enableSorting ?? true) &&
     !!column.accessorFn
   )
 }
@@ -383,10 +416,15 @@ export function column_getCanMultiSort<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): boolean {
+>(column: Column<TFeatures, TData, TValue>): boolean {
+  const columnDef = column.columnDef as ColumnDef_RowSorting<TFeatures, TData>
+  const featureTable = column.table as unknown as Table<
+    RowSortingFeatures,
+    TData
+  >
   return (
-    column.columnDef.enableMultiSort ??
-    column.table.options.enableMultiSort ??
+    columnDef.enableMultiSort ??
+    featureTable.options.enableMultiSort ??
     !!column.accessorFn
   )
 }
@@ -406,8 +444,12 @@ export function column_getIsSorted<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): false | SortDirection {
-  const columnSort = column.table.atoms.sorting
+>(column: Column<TFeatures, TData, TValue>): false | SortDirection {
+  const featureTable = column.table as unknown as Table<
+    RowSortingFeatures,
+    TData
+  >
+  const columnSort = featureTable.atoms.sorting
     ?.get()
     ?.find((d) => d.id === column.id)
   return !columnSort ? false : columnSort.desc ? 'desc' : 'asc'
@@ -427,9 +469,13 @@ export function column_getSortIndex<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>): number {
+>(column: Column<TFeatures, TData, TValue>): number {
+  const featureTable = column.table as unknown as Table<
+    RowSortingFeatures,
+    TData
+  >
   return (
-    column.table.atoms.sorting?.get()?.findIndex((d) => d.id === column.id) ??
+    featureTable.atoms.sorting?.get()?.findIndex((d) => d.id === column.id) ??
     -1
   )
 }
@@ -448,7 +494,7 @@ export function column_clearSorting<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
   // clear sorting for just 1 column
   table_setSorting(column.table, (old) =>
     old.length ? old.filter((d) => d.id !== column.id) : [],
@@ -471,7 +517,11 @@ export function column_getToggleSortingHandler<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(column: Column_Internal<TFeatures, TData, TValue>) {
+>(column: Column<TFeatures, TData, TValue>) {
+  const featureTable = column.table as unknown as Table<
+    RowSortingFeatures,
+    TData
+  >
   const canSort = column_getCanSort(column)
 
   return (e: unknown) => {
@@ -482,7 +532,7 @@ export function column_getToggleSortingHandler<
 
       undefined,
       column_getCanMultiSort(column)
-        ? column.table.options.isMultiSortEvent?.(e)
+        ? featureTable.options.isMultiSortEvent?.(e)
         : false,
     )
   }

--- a/packages/table-core/src/features/row-sorting/rowSortingFeature.utils.ts
+++ b/packages/table-core/src/features/row-sorting/rowSortingFeature.utils.ts
@@ -2,7 +2,7 @@ import { reSplitAlphaNumeric, sortFn_basic } from '../../fns/sortFns'
 import { cloneState, isFunction } from '../../utils'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
-import type { Table_Internal } from '../../types/Table'
+import type { Table } from '../../types/Table'
 import type { Column_Internal } from '../../types/Column'
 import type {
   SortDirection,
@@ -41,7 +41,7 @@ export function getDefaultSortingState(): SortingState {
 export function table_setSorting<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, updater: Updater<SortingState>) {
+>(table: Table<TFeatures, TData>, updater: Updater<SortingState>) {
   table.options.onSortingChange?.(updater)
 }
 
@@ -60,7 +60,7 @@ export function table_setSorting<
 export function table_resetSorting<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+>(table: Table<TFeatures, TData>, defaultState?: boolean) {
   table_setSorting(
     table,
     defaultState ? [] : cloneState(table.initialState.sorting ?? []),

--- a/packages/table-core/src/features/stockFeatures.ts
+++ b/packages/table-core/src/features/stockFeatures.ts
@@ -12,6 +12,7 @@ import { rowPaginationFeature } from './row-pagination/rowPaginationFeature'
 import { rowPinningFeature } from './row-pinning/rowPinningFeature'
 import { rowSelectionFeature } from './row-selection/rowSelectionFeature'
 import { rowSortingFeature } from './row-sorting/rowSortingFeature'
+import type { TableFeature } from '../types/TableFeatures'
 
 export interface StockFeatures {
   columnFacetingFeature: typeof columnFacetingFeature
@@ -26,7 +27,7 @@ export interface StockFeatures {
   rowExpandingFeature: typeof rowExpandingFeature
   rowPaginationFeature: typeof rowPaginationFeature
   rowPinningFeature: typeof rowPinningFeature
-  rowSelectionFeature: typeof rowSelectionFeature
+  rowSelectionFeature: TableFeature
   rowSortingFeature: typeof rowSortingFeature
 }
 

--- a/packages/table-core/src/types/Column.ts
+++ b/packages/table-core/src/types/Column.ts
@@ -8,7 +8,6 @@ import type { Column_ColumnPinning } from '../features/column-pinning/columnPinn
 import type { Column_ColumnResizing } from '../features/column-resizing/columnResizingFeature.types'
 import type { Column_ColumnSizing } from '../features/column-sizing/columnSizingFeature.types'
 import type { Column_ColumnVisibility } from '../features/column-visibility/columnVisibilityFeature.types'
-import type { ColumnDefBase_All } from './ColumnDef'
 import type { RowData } from './type-utils'
 import type { ExtractFeatureMapTypes, TableFeatures } from './TableFeatures'
 import type { Column_Column } from '../core/columns/coreColumnsFeature.types'
@@ -41,11 +40,3 @@ export type Column<
   TValue = unknown,
 > = Column_Core<TFeatures, TData, TValue> &
   ExtractFeatureMapTypes<TFeatures, Column_FeatureMap<TFeatures, TData>>
-
-export interface Column_Internal<
-  in out TFeatures extends TableFeatures,
-  in out TData extends RowData,
-  TValue = unknown,
-> extends Omit<Column_Core<TFeatures, TData, TValue>, 'columnDef'> {
-  columnDef: ColumnDefBase_All<TFeatures, TData, TValue>
-}

--- a/packages/table-core/src/types/ColumnDef.ts
+++ b/packages/table-core/src/types/ColumnDef.ts
@@ -151,22 +151,6 @@ export type ColumnDefBase<
     ColumnDef_FeatureMap<TFeatures, TData, TValue>
   >
 
-export type ColumnDefBase_All<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
-  TValue extends CellData = CellData,
-> = ColumnDefBase_Core<TFeatures, TData, TValue> &
-  Partial<
-    ColumnDef_ColumnVisibility &
-      ColumnDef_ColumnPinning &
-      ColumnDef_ColumnFiltering<TFeatures, TData> &
-      ColumnDef_GlobalFiltering &
-      ColumnDef_RowSorting<TFeatures, TData> &
-      ColumnDef_ColumnGrouping<TFeatures, TData, TValue> &
-      ColumnDef_ColumnSizing &
-      ColumnDef_ColumnResizing
-  >
-
 export type IdentifiedColumnDef<
   TFeatures extends TableFeatures,
   TData extends RowData,

--- a/packages/table-core/src/types/RowModel.ts
+++ b/packages/table-core/src/types/RowModel.ts
@@ -1,10 +1,7 @@
 import type { CachedRowModel_Faceted } from '../features/column-faceting/columnFacetingFeature.types'
 import type { CachedRowModel_Grouped } from '../features/column-grouping/columnGroupingFeature.types'
 import type { CachedRowModel_Filtered } from '../features/column-filtering/columnFilteringFeature.types'
-import type {
-  CachedRowModel_Core,
-  RowModel,
-} from '../core/row-models/coreRowModelsFeature.types'
+import type { RowModel } from '../core/row-models/coreRowModelsFeature.types'
 import type { CachedRowModel_Expanded } from '../features/row-expanding/rowExpandingFeature.types'
 import type { CachedRowModel_Paginated } from '../features/row-pagination/rowPaginationFeature.types'
 import type { CachedRowModel_Sorted } from '../features/row-sorting/rowSortingFeature.types'
@@ -27,21 +24,8 @@ export type CachedRowModels<
   TFeatures extends TableFeatures,
   TData extends RowData,
 > = {
-  CachedRowModel_Core: () => RowModel<TFeatures, TData>
+  coreRowModel: () => RowModel<TFeatures, TData>
 } & ExtractFeatureMapTypes<
   TFeatures,
   CachedRowModels_FeatureMap<TFeatures, TData>
 >
-
-export interface CachedRowModel_All<
-  in out TFeatures extends TableFeatures,
-  in out TData extends RowData = any,
-> extends Partial<
-  CachedRowModel_Core<TFeatures, TData> &
-    CachedRowModel_Expanded<TFeatures, TData> &
-    CachedRowModel_Faceted<TFeatures, TData> &
-    CachedRowModel_Filtered<TFeatures, TData> &
-    CachedRowModel_Grouped<TFeatures, TData> &
-    CachedRowModel_Paginated<TFeatures, TData> &
-    CachedRowModel_Sorted<TFeatures, TData>
-> {}

--- a/packages/table-core/src/types/RowModelFns.ts
+++ b/packages/table-core/src/types/RowModelFns.ts
@@ -21,12 +21,3 @@ export type RowModelFns<
 > = Partial<
   ExtractFeatureMapTypes<TFeatures, RowModelFns_FeatureMap<TFeatures, TData>>
 >
-
-export interface RowModelFns_All<
-  in out TFeatures extends TableFeatures,
-  in out TData extends RowData,
-> extends Partial<
-  RowModelFns_ColumnFiltering<TFeatures, TData> &
-    RowModelFns_ColumnGrouping<TFeatures, TData> &
-    RowModelFns_RowSorting<TFeatures, TData>
-> {}

--- a/packages/table-core/src/types/Table.ts
+++ b/packages/table-core/src/types/Table.ts
@@ -14,23 +14,14 @@ import type { Table_RowPagination } from '../features/row-pagination/rowPaginati
 import type { Table_RowSelection } from '../features/row-selection/rowSelectionFeature.types'
 import type { Table_RowSorting } from '../features/row-sorting/rowSortingFeature.types'
 import type { Table_RowModels } from '../core/row-models/coreRowModelsFeature.types'
-import type { CachedRowModel_All } from './RowModel'
-import type { RowModelFns_All } from './RowModelFns'
-import type { TableState, TableState_All } from './TableState'
 import type { RowData } from './type-utils'
 import type { ExtractFeatureMapTypes, TableFeatures } from './TableFeatures'
 import type { Table_Columns } from '../core/columns/coreColumnsFeature.types'
 import type { Table_Headers } from '../core/headers/coreHeadersFeature.types'
 import type { Table_Rows } from '../core/rows/coreRowsFeature.types'
 import type {
-  Atoms,
-  Atoms_All,
-  BaseAtoms,
-  BaseAtoms_All,
-  ExternalAtoms_All,
   Table_Table,
 } from '../core/table/coreTablesFeature.types'
-import type { DebugOptions, TableOptions_All } from './TableOptions'
 
 /**
  * The core table object that only includes the core table functionality such as column, header, row, and table APIS.
@@ -75,15 +66,3 @@ export type Table<
   TData extends RowData,
 > = Table_Core<TFeatures, TData> &
   ExtractFeatureMapTypes<TFeatures, Table_FeatureMap<TFeatures, TData>>
-
-/**
- * `Table_Table` members that `Table_Internal` re-declares with broadened
- * (all-features) types so internal code can read any feature's slots and
- * construction code can assign them.
- */
-type Table_InternalBroadenedKeys =
-  | '_rowModels'
-  | '_rowModelFns'
-  | 'options'
-  | 'initialState'
-  | 'store'

--- a/packages/table-core/src/types/Table.ts
+++ b/packages/table-core/src/types/Table.ts
@@ -19,9 +19,7 @@ import type { ExtractFeatureMapTypes, TableFeatures } from './TableFeatures'
 import type { Table_Columns } from '../core/columns/coreColumnsFeature.types'
 import type { Table_Headers } from '../core/headers/coreHeadersFeature.types'
 import type { Table_Rows } from '../core/rows/coreRowsFeature.types'
-import type {
-  Table_Table,
-} from '../core/table/coreTablesFeature.types'
+import type { Table_Table } from '../core/table/coreTablesFeature.types'
 
 /**
  * The core table object that only includes the core table functionality such as column, header, row, and table APIS.

--- a/packages/table-core/src/types/Table.ts
+++ b/packages/table-core/src/types/Table.ts
@@ -87,30 +87,3 @@ type Table_InternalBroadenedKeys =
   | 'options'
   | 'initialState'
   | 'store'
-
-/**
- * Internal broad table shape used by feature implementations.
- */
-export interface Table_Internal<
-  in out TFeatures extends TableFeatures,
-  in out TData extends RowData = any,
->
-  extends
-    Omit<Table_Table<TFeatures, TData>, Table_InternalBroadenedKeys>,
-    Table_Columns<TFeatures, TData>,
-    Table_Rows<TFeatures, TData>,
-    Table_RowModels<TFeatures, TData>,
-    Table_Headers<TFeatures, TData> {
-  _rowModels: CachedRowModel_All<TFeatures, TData>
-  _rowModelFns: RowModelFns_All<TFeatures, TData>
-  options: DebugOptions<TableFeatures> &
-    TableOptions_All<TFeatures, TData> & {
-      state?: TableState_All
-      initialState?: TableState_All
-      atoms?: ExternalAtoms_All
-    }
-  initialState: TableState<TFeatures> & TableState_All
-  baseAtoms: BaseAtoms<TFeatures> & BaseAtoms_All
-  atoms: Atoms<TFeatures> & Atoms_All
-  store: ReadonlyStore<TableState<TFeatures>> & ReadonlyStore<TableState_All>
-}

--- a/packages/table-core/src/types/TableFeatures.ts
+++ b/packages/table-core/src/types/TableFeatures.ts
@@ -221,9 +221,7 @@ export interface TableFeatures
   tableMeta?: object
 }
 
-export interface TableFeature<
-  TFeatureContext extends TableFeatures = any,
-> {
+export interface TableFeature<TFeatureContext extends TableFeatures = any> {
   /**
    * Assigns Cell APIs to the cell prototype for memory-efficient method sharing.
    * This is called once per table to build a shared prototype for all cells.

--- a/packages/table-core/src/types/TableFeatures.ts
+++ b/packages/table-core/src/types/TableFeatures.ts
@@ -1,15 +1,15 @@
 import type { CoreFeatures } from '../core/coreFeatures'
 import type { CellData, RowData, UnionToIntersection } from './type-utils'
-import type { ColumnDefBase_All } from './ColumnDef'
 import type { Row } from './Row'
 import type { Table } from './Table'
-import type { TableOptions_All } from './TableOptions'
-import type { TableState_All } from './TableState'
+import type { TableOptions } from './TableOptions'
+import type { TableState } from './TableState'
 import type { StockFeatures } from '../features/stockFeatures'
 import type { RowModel } from '../core/row-models/coreRowModelsFeature.types'
 import type { FilterFn } from '../features/column-filtering/columnFilteringFeature.types'
 import type { SortFn } from '../features/row-sorting/rowSortingFeature.types'
 import type { AggregationFn } from '../features/column-grouping/columnGroupingFeature.types'
+import type { ColumnDefBase } from './ColumnDef'
 
 export type IsAny<T> = 0 extends 1 & T ? true : false
 type UnionToIntersectionOrEmpty<T> = [T] extends [never]
@@ -221,75 +221,63 @@ export interface TableFeatures
   tableMeta?: object
 }
 
-export interface TableFeature {
+export interface TableFeature<
+  TFeatureContext extends TableFeatures = any,
+> {
   /**
    * Assigns Cell APIs to the cell prototype for memory-efficient method sharing.
    * This is called once per table to build a shared prototype for all cells.
    */
-  assignCellPrototype?: <
-    TFeatures extends TableFeatures,
-    TData extends RowData,
-  >(
+  assignCellPrototype?: <TData extends RowData>(
     prototype: Record<string, any>,
-    table: Table<TFeatures, TData>,
+    table: Table<TFeatureContext, TData>,
   ) => void
   /**
    * Assigns Column APIs to the column prototype for memory-efficient method sharing.
    * This is called once per table to build a shared prototype for all columns.
    */
-  assignColumnPrototype?: <
-    TFeatures extends TableFeatures,
-    TData extends RowData,
-  >(
+  assignColumnPrototype?: <TData extends RowData>(
     prototype: Record<string, any>,
-    table: Table<TFeatures, TData>,
+    table: Table<TFeatureContext, TData>,
   ) => void
   /**
    * Assigns Header APIs to the header prototype for memory-efficient method sharing.
    * This is called once per table to build a shared prototype for all headers.
    */
-  assignHeaderPrototype?: <
-    TFeatures extends TableFeatures,
-    TData extends RowData,
-  >(
+  assignHeaderPrototype?: <TData extends RowData>(
     prototype: Record<string, any>,
-    table: Table<TFeatures, TData>,
+    table: Table<TFeatureContext, TData>,
   ) => void
   /**
    * Assigns Row APIs to the row prototype for memory-efficient method sharing.
    * This is called once per table to build a shared prototype for all rows.
    */
-  assignRowPrototype?: <TFeatures extends TableFeatures, TData extends RowData>(
+  assignRowPrototype?: <TData extends RowData>(
     prototype: Record<string, any>,
-    table: Table<TFeatures, TData>,
+    table: Table<TFeatureContext, TData>,
   ) => void
   /**
    * Assigns Table APIs to the table instance.
    * Unlike row/cell/column/header, the table is a singleton so methods are assigned directly.
    */
-  constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
-    table: Table<TFeatures, TData>,
+  constructTableAPIs?: <TData extends RowData>(
+    table: Table<TFeatureContext, TData>,
   ) => void
   getDefaultColumnDef?: <
-    TFeatures extends TableFeatures,
     TData extends RowData,
     TValue extends CellData = CellData,
-  >() => ColumnDefBase_All<TFeatures, TData, TValue>
-  getDefaultTableOptions?: <
-    TFeatures extends TableFeatures,
-    TData extends RowData,
-  >(
-    table: Table<TFeatures, TData>,
-  ) => Partial<TableOptions_All<TFeatures, TData>>
-  getInitialState?: (initialState: Partial<TableState_All>) => TableState_All
+  >() => ColumnDefBase<TFeatureContext, TData, TValue>
+  getDefaultTableOptions?: <TData extends RowData>(
+    table: Table<TFeatureContext, TData>,
+  ) => Partial<TableOptions<TFeatureContext, TData>>
+  getInitialState?: (
+    initialState: Partial<TableState<TFeatureContext>>,
+  ) => Partial<TableState<TFeatureContext>>
   /**
    * Initializes instance-specific data on each row (e.g., caches).
    * Methods should be assigned via assignRowPrototype instead.
    */
-  initRowInstanceData?: <
-    TFeatures extends TableFeatures,
-    TData extends RowData,
-  >(
-    row: Row<TFeatures, TData>,
+  initRowInstanceData?: <TData extends RowData>(
+    row: Row<TFeatureContext, TData>,
   ) => void
 }

--- a/packages/table-core/src/types/TableFeatures.ts
+++ b/packages/table-core/src/types/TableFeatures.ts
@@ -2,7 +2,7 @@ import type { CoreFeatures } from '../core/coreFeatures'
 import type { CellData, RowData, UnionToIntersection } from './type-utils'
 import type { ColumnDefBase_All } from './ColumnDef'
 import type { Row } from './Row'
-import type { Table_Internal } from './Table'
+import type { Table } from './Table'
 import type { TableOptions_All } from './TableOptions'
 import type { TableState_All } from './TableState'
 import type { StockFeatures } from '../features/stockFeatures'
@@ -231,7 +231,7 @@ export interface TableFeature {
     TData extends RowData,
   >(
     prototype: Record<string, any>,
-    table: Table_Internal<TFeatures, TData>,
+    table: Table<TFeatures, TData>,
   ) => void
   /**
    * Assigns Column APIs to the column prototype for memory-efficient method sharing.
@@ -242,7 +242,7 @@ export interface TableFeature {
     TData extends RowData,
   >(
     prototype: Record<string, any>,
-    table: Table_Internal<TFeatures, TData>,
+    table: Table<TFeatures, TData>,
   ) => void
   /**
    * Assigns Header APIs to the header prototype for memory-efficient method sharing.
@@ -253,7 +253,7 @@ export interface TableFeature {
     TData extends RowData,
   >(
     prototype: Record<string, any>,
-    table: Table_Internal<TFeatures, TData>,
+    table: Table<TFeatures, TData>,
   ) => void
   /**
    * Assigns Row APIs to the row prototype for memory-efficient method sharing.
@@ -261,14 +261,14 @@ export interface TableFeature {
    */
   assignRowPrototype?: <TFeatures extends TableFeatures, TData extends RowData>(
     prototype: Record<string, any>,
-    table: Table_Internal<TFeatures, TData>,
+    table: Table<TFeatures, TData>,
   ) => void
   /**
    * Assigns Table APIs to the table instance.
    * Unlike row/cell/column/header, the table is a singleton so methods are assigned directly.
    */
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
-    table: Table_Internal<TFeatures, TData>,
+    table: Table<TFeatures, TData>,
   ) => void
   getDefaultColumnDef?: <
     TFeatures extends TableFeatures,
@@ -279,7 +279,7 @@ export interface TableFeature {
     TFeatures extends TableFeatures,
     TData extends RowData,
   >(
-    table: Table_Internal<TFeatures, TData>,
+    table: Table<TFeatures, TData>,
   ) => Partial<TableOptions_All<TFeatures, TData>>
   getInitialState?: (initialState: Partial<TableState_All>) => TableState_All
   /**

--- a/packages/table-core/src/types/TableOptions.ts
+++ b/packages/table-core/src/types/TableOptions.ts
@@ -16,7 +16,7 @@ import type { TableOptions_RowPagination } from '../features/row-pagination/rowP
 import type { TableOptions_RowPinning } from '../features/row-pinning/rowPinningFeature.types'
 import type { TableOptions_RowSelection } from '../features/row-selection/rowSelectionFeature.types'
 import type { TableOptions_RowSorting } from '../features/row-sorting/rowSortingFeature.types'
-import type { RowData, UnionToIntersection } from './type-utils'
+import type { RowData } from './type-utils'
 import type {
   ExtractFeatureMapTypes,
   NonFeatureKeys,
@@ -73,43 +73,6 @@ export interface TableOptions_FeatureMap<
   rowSortingFeature: TableOptions_RowSorting
 }
 
-type TableOptions_StockFeatureKeys =
-  | 'columnFilteringFeature'
-  | 'columnGroupingFeature'
-  | 'columnOrderingFeature'
-  | 'columnPinningFeature'
-  | 'columnResizingFeature'
-  | 'columnSizingFeature'
-  | 'columnVisibilityFeature'
-  | 'globalFilteringFeature'
-  | 'rowExpandingFeature'
-  | 'rowPaginationFeature'
-  | 'rowPinningFeature'
-  | 'rowSelectionFeature'
-  | 'rowSortingFeature'
-
-/**
- * Plugin entries declaration-merged into `TableOptions_FeatureMap`, i.e. keys
- * beyond the stock set. Resolves to `unknown` (an intersection no-op) when no
- * plugins are merged so the common case skips the union-to-intersection work.
- */
-type TableOptions_PluginFeatureMapTypes<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
-> = [
-  Exclude<
-    keyof TableOptions_FeatureMap<TFeatures, TData>,
-    TableOptions_StockFeatureKeys
-  >,
-] extends [never]
-  ? unknown
-  : UnionToIntersection<
-      TableOptions_FeatureMap<TFeatures, TData>[Exclude<
-        keyof TableOptions_FeatureMap<TFeatures, TData>,
-        TableOptions_StockFeatureKeys
-      >]
-    >
-
 /**
  * Complete table options for a specific feature set.
  *
@@ -123,28 +86,3 @@ export type TableOptions<
 > = TableOptions_Core<TFeatures, TData> &
   ExtractFeatureMapTypes<TFeatures, TableOptions_FeatureMap<TFeatures, TData>> &
   DebugOptions<TFeatures>
-
-/**
- * Internal broad option shape used where feature code may need to read options
- * from features that are not present in the current generic feature set.
- */
-export type TableOptions_All<
-  TFeatures extends TableFeatures,
-  TData extends RowData,
-> = TableOptions_Core<TFeatures, TData> &
-  Partial<
-    TableOptions_ColumnFiltering<TFeatures, TData> &
-      TableOptions_ColumnGrouping &
-      TableOptions_ColumnOrdering &
-      TableOptions_ColumnPinning &
-      TableOptions_ColumnResizing &
-      TableOptions_ColumnSizing &
-      TableOptions_ColumnVisibility &
-      TableOptions_GlobalFiltering<TFeatures, TData> &
-      TableOptions_RowExpanding<TFeatures, TData> &
-      TableOptions_RowPagination &
-      TableOptions_RowPinning<TFeatures, TData> &
-      TableOptions_RowSelection<TFeatures, TData> &
-      TableOptions_RowSorting &
-      TableOptions_PluginFeatureMapTypes<TFeatures, TData>
-  >

--- a/packages/table-core/src/types/TableState.ts
+++ b/packages/table-core/src/types/TableState.ts
@@ -37,25 +37,3 @@ export interface TableState_FeatureMap {
  */
 export type TableState<TFeatures extends TableFeatures> =
   ExtractFeatureMapTypes<TFeatures, TableState_FeatureMap>
-
-/**
- * Internal broad state shape containing every registered feature state slice.
- *
- * Feature internals use this when they may need to inspect optional slices owned
- * by other features.
- */
-export interface TableState_All extends Partial<
-  TableState_ColumnFiltering &
-    TableState_ColumnGrouping &
-    TableState_ColumnOrdering &
-    TableState_ColumnPinning &
-    TableState_ColumnResizing &
-    TableState_ColumnSizing &
-    TableState_ColumnVisibility &
-    TableState_GlobalFiltering &
-    TableState_RowExpanding &
-    TableState_RowPagination &
-    TableState_RowPinning &
-    TableState_RowSelection &
-    TableState_RowSorting
-> {}

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Table } from './types/Table'
 import type { NoInfer, RowData, Updater } from './types/type-utils'
 import type { TableFeatures } from './types/TableFeatures'
-import type { TableState, TableState_All } from './types/TableState'
+import type { TableState } from './types/TableState'
 
 /**
  * Applies a TanStack updater to a value.
@@ -52,12 +52,11 @@ export function cloneState<T>(value: T): T {
  */
 export function makeStateUpdater<
   TFeatures extends TableFeatures,
-  K extends (string & {}) | keyof TableState_All | keyof TableState<TFeatures>,
+  K extends (string & {}) | keyof TableState<TFeatures>,
 >(
   key: K,
-  // Minimal structural shape so any table view (public `Table`,
-  // `Table_Internal`, or a custom plugin table) can be passed without forcing
-  // the compiler to relate the full table types.
+  // Minimal structural shape so public tables and custom plugin tables can be
+  // passed without forcing the compiler to relate the full table types.
   instance: {
     readonly options: { readonly atoms?: object | undefined }
     readonly baseAtoms: object

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Table_Internal } from './types/Table'
+import type { Table } from './types/Table'
 import type { NoInfer, RowData, Updater } from './types/type-utils'
 import type { TableFeatures } from './types/TableFeatures'
 import type { TableState, TableState_All } from './types/TableState'
@@ -172,7 +172,7 @@ interface TableMemoOptions<
   fnName: string
   objectId?: string
   onAfterUpdate?: () => void
-  table: Table_Internal<TFeatures, any>
+  table: Table<TFeatures, any>
 }
 
 const pad = (str: number | string, num: number) => {
@@ -353,7 +353,7 @@ export function assignTableAPIs<
   TDepArgs,
 >(
   feature: keyof TFeatures & string,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   apis: APIObject<TDeps, NoInfer<TDepArgs>>,
 ): void {
   for (const [staticFnName, { fn, memoDeps }] of Object.entries(apis)) {
@@ -396,7 +396,7 @@ export function assignPrototypeAPIs<
 >(
   feature: keyof TFeatures & string,
   prototype: Record<string, any>,
-  table: Table_Internal<TFeatures, TData>,
+  table: Table<TFeatures, TData>,
   apis: PrototypeAPIObject<TDeps, NoInfer<TDepArgs>>,
 ): void {
   for (const [staticFnName, { fn, memoDeps }] of Object.entries(apis)) {

--- a/packages/table-core/tests/declaration-emit/tableOptions.ts
+++ b/packages/table-core/tests/declaration-emit/tableOptions.ts
@@ -12,21 +12,21 @@ const features = tableFeatures({
 })
 
 export const optionsWithFeaturesOnly = tableOptions({
-  features,
+  features: features,
 })
 
 export const optionsWithFeaturesAndData = tableOptions({
-  features,
+  features: features,
   data: [] as Array<Person>,
 })
 
 export const optionsWithFeaturesAndColumns = tableOptions({
-  features,
+  features: features,
   columns: [],
 })
 
 export const optionsWithFeaturesDataAndColumns = tableOptions({
-  features,
+  features: features,
   data: [] as Array<Person>,
   columns: [],
 })

--- a/packages/table-core/tests/helpers/generateTestTable.ts
+++ b/packages/table-core/tests/helpers/generateTestTable.ts
@@ -4,10 +4,10 @@ import { generateTestData } from '../fixtures/data/generateTestData'
 import { storeReactivityBindings } from '../../src/store-reactivity-bindings'
 import type {
   Row,
+  Table,
   TableFeatures,
   TableOptions,
   TableState,
-  Table_Internal,
 } from '../../src'
 import type { Person } from '../fixtures/data/types'
 
@@ -19,7 +19,7 @@ export function generateTestTableWithData<TFeatures extends TableFeatures>(
   > & {
     features?: TFeatures
   },
-): Table_Internal<TFeatures, Person> {
+): Table<TFeatures, Person> {
   const lengthsArray = Array.isArray(lengths) ? lengths : [lengths]
   const data = generateTestData(...lengthsArray)
   const columns = generateTestColumnDefs<TFeatures>(data)
@@ -34,13 +34,13 @@ export function generateTestTableWithData<TFeatures extends TableFeatures>(
       ...options?.features,
       coreReactivityFeature: storeReactivityBindings(),
     },
-  } as any) as unknown as Table_Internal<TFeatures, Person>
+  } as any)
 }
 
 export function generateTestTableFromData<TFeatures extends TableFeatures>(
   data: Array<Person>,
   options?: Omit<TableOptions<TFeatures, Person>, 'data' | 'columns'>,
-): Table_Internal<TFeatures, Person> {
+): Table<TFeatures, Person> {
   const columns = generateTestColumnDefs<TFeatures>(data)
   return constructTable<TFeatures, Person>({
     data,
@@ -51,7 +51,7 @@ export function generateTestTableFromData<TFeatures extends TableFeatures>(
       ...options?.features,
       coreReactivityFeature: storeReactivityBindings(),
     },
-  } as any) as unknown as Table_Internal<TFeatures, Person>
+  } as any)
 }
 
 export function generateTestTableWithDataAndState<
@@ -62,7 +62,7 @@ export function generateTestTableWithDataAndState<
     TableOptions<TFeatures, Person>,
     'data' | 'columns' | 'onStateChange'
   >,
-): Table_Internal<TFeatures, Person> {
+): Table<TFeatures, Person> {
   const lengthsArray = Array.isArray(lengths) ? lengths : [lengths]
   const data = generateTestData(...lengthsArray)
   const columns = generateTestColumnDefs<TFeatures>(data)
@@ -98,7 +98,7 @@ export function generateTestTableWithStateFromData<
     TableOptions<TFeatures, Person>,
     'data' | 'columns' | 'onStateChange'
   >,
-): Table_Internal<TFeatures, Person> {
+): Table<TFeatures, Person> {
   const columns = generateTestColumnDefs<TFeatures>(data)
   let state = { ...options?.initialState } as TableState<TFeatures>
 

--- a/packages/table-core/tests/helpers/rowPinningHelpers.ts
+++ b/packages/table-core/tests/helpers/rowPinningHelpers.ts
@@ -17,8 +17,8 @@ import type {
   ColumnDef,
   RowPinningState,
   StockFeatures,
+  Table,
   TableOptions,
-  Table_Internal,
   Table_RowPinning,
 } from '../../src'
 import type { Person } from '../fixtures/data/types'
@@ -63,8 +63,7 @@ export function createTableWithPinningState(
 }
 
 export function createTableWithMockOnPinningChange(rowCount = 10): {
-  table: Table_Internal<StockFeatures, Person> &
-    Table_RowPinning<StockFeatures, Person>
+  table: Table<StockFeatures, Person> & Table_RowPinning<StockFeatures, Person>
   onRowPinningChangeMock: ReturnType<typeof vi.fn>
 } {
   const onRowPinningChangeMock = vi.fn()
@@ -72,7 +71,7 @@ export function createTableWithMockOnPinningChange(rowCount = 10): {
     features: {
       rowPinning: rowPinningFeature,
     },
-  } as any) as Table_Internal<StockFeatures, Person> &
+  } as any) as Table<StockFeatures, Person> &
     Table_RowPinning<StockFeatures, Person>
   table.options.onRowPinningChange = onRowPinningChangeMock
   return { table, onRowPinningChangeMock }

--- a/packages/table-core/tests/unit/core/cells/constructCell.test.ts
+++ b/packages/table-core/tests/unit/core/cells/constructCell.test.ts
@@ -3,7 +3,7 @@ import { constructCell } from '../../../../src/core/cells/constructCell'
 import { coreCellsFeature } from '../../../../src/core/cells/coreCellsFeature'
 import type { Row } from '../../../../src/types/Row'
 import type { Column } from '../../../../src/types/Column'
-import type { Table_Internal } from '../../../../src/types/Table'
+import type { Table } from '../../../../src/types/Table'
 
 type TestData = Record<string, unknown>
 type TestFeatures = {
@@ -20,7 +20,7 @@ describe('constructCell', () => {
     const table = {
       _features: { coreCellsFeature },
       options: {},
-    } as unknown as Table_Internal<TestFeatures, TestData>
+    } as unknown as Table<TestFeatures, TestData>
     const coreCell = constructCell(column, row, table)
 
     expect(coreCell).toBeDefined()

--- a/packages/table-core/tests/unit/core/columns/constructColumn.test.ts
+++ b/packages/table-core/tests/unit/core/columns/constructColumn.test.ts
@@ -4,7 +4,7 @@ import { constructColumn } from '../../../../src/core/columns/constructColumn'
 import { constructTable } from '../../../../src'
 import { storeReactivityBindings } from '../../../../src/store-reactivity-bindings'
 import type { ColumnDef } from '../../../../src/types/ColumnDef'
-import type { Table_Internal } from '../../../../src/types/Table'
+import type { Table } from '../../../../src/types/Table'
 
 const features = {
   coreColumnsFeature,
@@ -21,7 +21,7 @@ describe('constructColumn', () => {
       features,
       columns: [],
       data: [],
-    }) as unknown as Table_Internal<typeof features, TestRow>
+    })
 
     const columnDef = {
       id: 'test-column',

--- a/packages/table-core/tests/unit/core/headers/constructHeader.test.ts
+++ b/packages/table-core/tests/unit/core/headers/constructHeader.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { coreHeadersFeature } from '../../../../src/core/headers/coreHeadersFeature'
 import { constructHeader } from '../../../../src/core/headers/constructHeader'
 import type { Column } from '../../../../src/types/Column'
-import type { Table_Internal } from '../../../../src/types/Table'
+import type { Table } from '../../../../src/types/Table'
 
 type TestData = Record<string, unknown>
 type TestFeatures = {
@@ -14,7 +14,7 @@ describe('constructHeader', () => {
     const table = {
       _features: { coreHeadersFeature },
       options: {},
-    } as unknown as Table_Internal<TestFeatures, TestData>
+    } as unknown as Table<TestFeatures, TestData>
     const column = {
       id: 'test-column',
       columnDef: { id: 'test-column-def' },

--- a/packages/table-core/tests/unit/core/rows/constructRow.test.ts
+++ b/packages/table-core/tests/unit/core/rows/constructRow.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { coreRowsFeature } from '../../../../src/core/rows/coreRowsFeature'
 import { constructRow } from '../../../../src/core/rows/constructRow'
-import type { Table_Internal } from '../../../../src/types/Table'
+import type { Table } from '../../../../src/types/Table'
 import type { Row } from '../../../../src/types/Row'
 
 type TestFeatures = {
@@ -17,7 +17,7 @@ describe('constructRow', () => {
     const table = {
       _features: { coreRowsFeature },
       options: {},
-    } as unknown as Table_Internal<TestFeatures, Person>
+    } as unknown as Table<TestFeatures, Person>
     const id = 'test-row'
     const original = { firstName: 'Tanner' }
     const rowIndex = 0

--- a/packages/table-core/tests/unit/core/tableAtoms.test.ts
+++ b/packages/table-core/tests/unit/core/tableAtoms.test.ts
@@ -11,8 +11,8 @@ import { storeReactivityBindings } from '../../../src/store-reactivity-bindings'
 import type {
   PaginationState,
   SortingState,
+  Table,
   TableFeatures,
-  Table_Internal,
   Table_RowPagination,
   Table_RowSorting,
 } from '../../../src'
@@ -25,7 +25,7 @@ const features = {
 
 function makeTable<TFeatures extends TableFeatures>(
   options: any = {},
-): Table_Internal<TFeatures, any> &
+): Table<TFeatures, any> &
   Table_RowSorting<TFeatures, any> &
   Table_RowPagination<TFeatures, any> {
   return constructTable({
@@ -37,7 +37,7 @@ function makeTable<TFeatures extends TableFeatures>(
     columns: [],
     data: [],
     ...options,
-  }) as unknown as Table_Internal<TFeatures, any> &
+  }) as unknown as Table<TFeatures, any> &
     Table_RowSorting<TFeatures, any> &
     Table_RowPagination<TFeatures, any>
 }

--- a/packages/table-core/tests/unit/features/column-pinning/columnPinningFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/column-pinning/columnPinningFeature.utils.test.ts
@@ -37,9 +37,9 @@ import type { Person } from '../../../fixtures/data/types'
 import type {
   Header,
   StockFeatures,
+  Table,
   Table_ColumnOrdering,
   Table_ColumnPinning,
-  Table_Internal,
 } from '../../../../src'
 
 describe('getDefaultColumnPinningState', () => {
@@ -557,7 +557,7 @@ describe('table_getPinnedLeafColumns', () => {
           right: [],
         },
       },
-    }) as Table_Internal<StockFeatures, Person> &
+    }) as Table<StockFeatures, Person> &
       Table_ColumnPinning<StockFeatures, Person>
 
     const leafColumns = table_getPinnedLeafColumns(table, 'left')
@@ -652,7 +652,7 @@ describe('column pinning table instance APIs', () => {
           age: false,
         },
       },
-    }) as Table_Internal<StockFeatures, Person> &
+    }) as Table<StockFeatures, Person> &
       Table_ColumnPinning<StockFeatures, Person>
 
     expect(
@@ -682,7 +682,7 @@ describe('column pinning table instance APIs', () => {
   it('should update center visible columns when column order changes', () => {
     const table = generateTestTableWithDataAndState(1, {
       features: stockFeatures,
-    }) as Table_Internal<StockFeatures, Person> &
+    }) as Table<StockFeatures, Person> &
       Table_ColumnPinning<StockFeatures, Person> &
       Table_ColumnOrdering<StockFeatures, Person>
 

--- a/packages/table-core/tsconfig.json
+++ b/packages/table-core/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@tanstack/table-core": ["./src/index.ts"]
+    }
+  },
   "include": ["src", "eslint.config.js", "vite.config.ts", "tests"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated type definitions to consistently use the public table and column APIs across core and feature utilities.
  * Removed deprecated internal type exports and “all-features” typing variants (including internal table/column/options/state/column-def bases).
  * Updated feature typings to use feature-composed generics for stronger end-to-end type safety; runtime behavior remains unchanged.
* **Tests**
  * Updated TypeScript fixtures, helpers, and mocks to align with the public table types, including declaration-emit coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->