### PR TITLE
fix: enhance table option merging to preserve static properties

### DIFF
--- a/packages/table-core/src/core/table/coreTablesFeature.utils.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.utils.ts
@@ -68,7 +68,9 @@ export function table_reset<
  * Merges new table options with the current resolved options.
  *
  * If `options.mergeOptions` is provided, it owns the merge behavior; otherwise
- * options are shallow-merged.
+ * options are shallow-merged. Static options that should never change after
+ * initialization are restored on a fresh object so framework merge helpers may
+ * return readonly getter/proxy objects.
  *
  * @example
  * ```ts
@@ -82,17 +84,44 @@ export function table_mergeOptions<
   table: Table_Internal<TFeatures, TData>,
   newOptions: TableOptions<TFeatures, TData>,
 ) {
-  if (table.options.mergeOptions) {
-    return table.options.mergeOptions(
-      table.options as TableOptions<TFeatures, TData>,
-      newOptions,
-    )
+  const { features, atoms, initialState } = table.options
+  const mergedOptions = table.options.mergeOptions
+    ? table.options.mergeOptions(
+        table.options as TableOptions<TFeatures, TData>,
+        newOptions,
+      )
+    : {
+        ...table.options,
+        ...newOptions,
+      }
+  const descriptors: PropertyDescriptorMap = {
+    ...Object.getOwnPropertyDescriptors(mergedOptions),
   }
 
-  return {
-    ...table.options,
-    ...newOptions,
-  }
+  return Object.defineProperties(
+    Object.create(Object.getPrototypeOf(mergedOptions)),
+    {
+      ...descriptors,
+      features: {
+        value: features,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      },
+      atoms: {
+        value: atoms,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      },
+      initialState: {
+        value: initialState,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      },
+    },
+  ) as TableOptions<TFeatures, TData>
 }
 
 /**
@@ -117,15 +146,7 @@ export function table_setOptions<
     updater,
     table.options as TableOptions<TFeatures, TData>,
   )
-  // table static options that should never change after initialization
-  const { features, atoms, initialState } = table.options
-  const mergedOptions = Object.assign(table_mergeOptions(table, newOptions), {
-    // Once the table instance is created those properties should never change after initialization,
-    // so we assign them back preserving the `table_mergeOptions` object reference
-    features,
-    atoms,
-    initialState,
-  })
+  const mergedOptions = table_mergeOptions(table, newOptions)
 
   if (table.optionsStore) {
     table.optionsStore.set(() => mergedOptions)

--- a/packages/table-core/src/core/table/coreTablesFeature.utils.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.utils.ts
@@ -85,15 +85,23 @@ export function table_mergeOptions<
   newOptions: TableOptions<TFeatures, TData>,
 ) {
   const { features, atoms, initialState } = table.options
-  const mergedOptions = table.options.mergeOptions
-    ? table.options.mergeOptions(
-        table.options as TableOptions<TFeatures, TData>,
-        newOptions,
-      )
-    : {
-        ...table.options,
-        ...newOptions,
-      }
+
+  // simple merge if no mergeOptions is provided - performant
+  if (!table.options.mergeOptions) {
+    return {
+      ...table.options,
+      ...newOptions,
+      features,
+      atoms,
+      initialState,
+    }
+  }
+
+  // else use the mergeOptions function and preserve getters/setters
+  const mergedOptions = table.options.mergeOptions(
+    table.options as TableOptions<TFeatures, TData>,
+    newOptions,
+  )
   const descriptors: PropertyDescriptorMap = {
     ...Object.getOwnPropertyDescriptors(mergedOptions),
   }

--- a/packages/table-core/tests/unit/core/table/constructTable.test.ts
+++ b/packages/table-core/tests/unit/core/table/constructTable.test.ts
@@ -2,6 +2,36 @@ import { describe, expect, it } from 'vitest'
 import { constructTable, coreFeatures } from '../../../../src'
 import { storeReactivityBindings } from '../../../../src/store-reactivity-bindings'
 
+function getterOnlyMerge(...sources: Array<any>) {
+  const target = {}
+
+  for (const source of sources) {
+    if (!source) {
+      continue
+    }
+
+    for (const key of Reflect.ownKeys(source)) {
+      if (key in target) {
+        continue
+      }
+
+      Object.defineProperty(target, key, {
+        enumerable: true,
+        get() {
+          for (let i = sources.length - 1; i >= 0; i--) {
+            const value = sources[i]?.[key]
+            if (value !== undefined) {
+              return value
+            }
+          }
+        },
+      })
+    }
+  }
+
+  return target
+}
+
 describe('constructTable', () => {
   it('should create a table with all core table APIs and properties', () => {
     const table = constructTable({
@@ -45,5 +75,47 @@ describe('constructTable', () => {
     expect(table).toHaveProperty('reset')
     expect(table).toHaveProperty('setOptions')
     expect(table).toHaveProperty('store') // state is managed via store in v9
+  })
+
+  it('preserves static options without mutating mergeOptions results', () => {
+    const features = {
+      ...coreFeatures,
+      coreReactivityFeature: storeReactivityBindings(),
+    }
+    const atoms = {}
+    const initialState = {}
+    const data: Array<{ id: number }> = []
+    const nextData = [{ id: 1 }]
+    const nextFeatures = {
+      ...coreFeatures,
+      coreReactivityFeature: storeReactivityBindings(),
+    }
+    const nextAtoms = {}
+    const nextInitialState = {}
+
+    const table = constructTable<typeof features, { id: number }>({
+      features,
+      atoms,
+      initialState,
+      columns: [],
+      data,
+      mergeOptions: (defaultOptions, options) =>
+        getterOnlyMerge(defaultOptions, options) as any,
+    })
+
+    expect(() => {
+      table.setOptions((prev) => ({
+        ...prev,
+        data: nextData,
+        features: nextFeatures,
+        atoms: nextAtoms,
+        initialState: nextInitialState,
+      }))
+    }).not.toThrow()
+
+    expect(table.options.data).toBe(nextData)
+    expect(table.options.features).toBe(features)
+    expect(table.options.atoms).toBe(atoms)
+    expect(table.options.initialState).toBe(initialState)
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Updated the table_mergeOptions function to ensure that static options (features, atoms, initialState) are preserved without mutation when merging new options. Added a test to verify that static options remain unchanged after invoking setOptions.

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked internal table option merging to reliably preserve static configuration (including data, features, atoms, and initial state) when options are updated.
* **Tests**
  * Added unit tests covering option updates, including scenarios involving getter-based merge behavior and checks for correct object identity.
* **Documentation**
  * Updated documentation to clarify how merged option objects restore and preserve static options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->