### PR TITLE
fix(table-core): filterFn_between/betweenInclusive autoRemove never removes array filter values

### DIFF
--- a/packages/table-core/src/fns/filterFns.ts
+++ b/packages/table-core/src/fns/filterFns.ts
@@ -217,7 +217,10 @@ const filterFn_between = Object.assign(
       Number(filterValues[0]) > Number(filterValues[1])) ||
       (['', undefined] as Array<any>).includes(filterValues[1]) ||
       filterFn_lessThan(row, columnId, filterValues[1])),
-  { autoRemove: (val: any) => !val },
+  {
+    autoRemove: (val: any) =>
+      testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1])),
+  },
 )
 
 /**
@@ -238,7 +241,10 @@ const filterFn_betweenInclusive = Object.assign(
       Number(filterValues[0]) > Number(filterValues[1])) ||
       (['', undefined] as Array<any>).includes(filterValues[1]) ||
       filterFn_lessThanOrEqualTo(row, columnId, filterValues[1])),
-  { autoRemove: (val: any) => !val },
+  {
+    autoRemove: (val: any) =>
+      testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1])),
+  },
 )
 
 /**

--- a/packages/table-core/tests/unit/fns/filterFns.test.ts
+++ b/packages/table-core/tests/unit/fns/filterFns.test.ts
@@ -12,6 +12,7 @@ import {
   filterFn_lessThan,
   filterFn_lessThanOrEqualTo,
   filterFn_weakEquals,
+  filterFns,
 } from '../../../src'
 import { getStaticTestData } from '../../fixtures/data/generateTestData'
 
@@ -509,6 +510,56 @@ describe('Filter Functions', () => {
           filterValue,
         )
         expect(result).toBe(true)
+      })
+    })
+  })
+
+  describe('Range Filters', () => {
+    describe('filterFns.between.autoRemove', () => {
+      const autoRemove = filterFns.between.autoRemove!
+
+      it('should auto-remove when both endpoints are undefined', () => {
+        expect(autoRemove([undefined, undefined])).toBe(true)
+      })
+      it('should auto-remove when both endpoints are null', () => {
+        expect(autoRemove([null, null])).toBe(true)
+      })
+      it('should auto-remove when both endpoints are empty strings', () => {
+        expect(autoRemove(['', ''])).toBe(true)
+      })
+      it('should NOT auto-remove when both endpoints are valid numbers', () => {
+        expect(autoRemove([5, 10])).toBe(false)
+      })
+      it('should NOT auto-remove when lower bound is 0 (falsy number)', () => {
+        expect(autoRemove([0, 10])).toBe(false)
+      })
+      it('should NOT auto-remove when only one endpoint is provided', () => {
+        expect(autoRemove([undefined, 10])).toBe(false)
+        expect(autoRemove([5, undefined])).toBe(false)
+      })
+    })
+
+    describe('filterFns.betweenInclusive.autoRemove', () => {
+      const autoRemove = filterFns.betweenInclusive.autoRemove!
+
+      it('should auto-remove when both endpoints are undefined', () => {
+        expect(autoRemove([undefined, undefined])).toBe(true)
+      })
+      it('should auto-remove when both endpoints are null', () => {
+        expect(autoRemove([null, null])).toBe(true)
+      })
+      it('should auto-remove when both endpoints are empty strings', () => {
+        expect(autoRemove(['', ''])).toBe(true)
+      })
+      it('should NOT auto-remove when both endpoints are valid numbers', () => {
+        expect(autoRemove([5, 10])).toBe(false)
+      })
+      it('should NOT auto-remove when lower bound is 0 (falsy number)', () => {
+        expect(autoRemove([0, 10])).toBe(false)
+      })
+      it('should NOT auto-remove when only one endpoint is provided', () => {
+        expect(autoRemove([undefined, 10])).toBe(false)
+        expect(autoRemove([5, undefined])).toBe(false)
       })
     })
   })


### PR DESCRIPTION
## Bug

`filterFn_between` and `filterFn_betweenInclusive` have:

```ts
autoRemove: (val: any) => !val
```

Because the filter value for these functions is always a `[min, max]` tuple (an array), and **arrays are always truthy in JavaScript**, `!val` is always `false`. This means the filter is **never** auto-removed — even when both endpoints are cleared to `undefined`, `null`, or `''`.

**Effect:** A user who empties both range inputs ends up with an active filter that passes all rows but is never cleaned up from column filter state.

## Fix

Align the `autoRemove` predicate with the pattern already used by `filterFn_inNumberRange`:

```ts
// Before (never removes an array input)
autoRemove: (val: any) => !val

// After (removes when both endpoints are falsy; preserves 0 as valid)
autoRemove: (val: any) => testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1]))
```

`testFalsy` checks `undefined | null | ''`, so `0` is correctly preserved as a valid endpoint.

## Verification

```
pnpm vitest run packages/table-core/tests/unit/fns/filterFns.test.ts
```

Before fix: 6 new tests fail (autoRemove returns false for empty-endpoint arrays).
After fix: 63/63 tests pass (51 pre-existing + 12 new).

> This fix was developed with AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved range filter behavior to correctly remove filters when both endpoints are empty, rather than only when the entire filter value is empty. This provides better handling of incomplete range selections.

* **Tests**
  * Added comprehensive test coverage for range filter removal logic to ensure correct behavior across various endpoint scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->