### PR TITLE
chore: update pnpm to 11.9.0

### DIFF
--- a/examples/angular/basic-app-table/package.json
+++ b/examples/angular/basic-app-table/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/basic-external-atoms/package.json
+++ b/examples/angular/basic-external-atoms/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/basic-external-state/package.json
+++ b/examples/angular/basic-external-state/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/basic-inject-table/package.json
+++ b/examples/angular/basic-inject-table/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/column-groups/package.json
+++ b/examples/angular/column-groups/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/column-ordering/package.json
+++ b/examples/angular/column-ordering/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/column-pinning-split/package.json
+++ b/examples/angular/column-pinning-split/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/column-pinning-sticky/package.json
+++ b/examples/angular/column-pinning-sticky/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/column-pinning/package.json
+++ b/examples/angular/column-pinning/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/column-resizing-performant/package.json
+++ b/examples/angular/column-resizing-performant/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/column-resizing/package.json
+++ b/examples/angular/column-resizing/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/column-sizing/package.json
+++ b/examples/angular/column-sizing/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/column-visibility/package.json
+++ b/examples/angular/column-visibility/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/composable-tables/package.json
+++ b/examples/angular/composable-tables/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/custom-plugin/package.json
+++ b/examples/angular/custom-plugin/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/editable/package.json
+++ b/examples/angular/editable/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/expanding/package.json
+++ b/examples/angular/expanding/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/filters-faceted/package.json
+++ b/examples/angular/filters-faceted/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/filters-fuzzy/package.json
+++ b/examples/angular/filters-fuzzy/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/filters/package.json
+++ b/examples/angular/filters/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/grouping/package.json
+++ b/examples/angular/grouping/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/kitchen-sink/package.json
+++ b/examples/angular/kitchen-sink/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/pagination/package.json
+++ b/examples/angular/pagination/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/remote-data/package.json
+++ b/examples/angular/remote-data/package.json
@@ -12,7 +12,7 @@
     "serve:ssr:remote-data": "node dist/remote-data/server/server.mjs"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/row-dnd/package.json
+++ b/examples/angular/row-dnd/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",

--- a/examples/angular/row-pinning/package.json
+++ b/examples/angular/row-pinning/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/row-selection-signal/package.json
+++ b/examples/angular/row-selection-signal/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/animations": "^22.0.0",
     "@angular/common": "^22.0.0",

--- a/examples/angular/row-selection/package.json
+++ b/examples/angular/row-selection/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",

--- a/examples/angular/signal-input/package.json
+++ b/examples/angular/signal-input/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/cdk": "^22.0.0",
     "@angular/common": "^22.0.0",

--- a/examples/angular/sorting/package.json
+++ b/examples/angular/sorting/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/sub-components/package.json
+++ b/examples/angular/sub-components/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/virtualized-columns/package.json
+++ b/examples/angular/virtualized-columns/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/virtualized-infinite-scrolling/package.json
+++ b/examples/angular/virtualized-infinite-scrolling/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/virtualized-rows/package.json
+++ b/examples/angular/virtualized-rows/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/with-tanstack-form/package.json
+++ b/examples/angular/with-tanstack-form/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/examples/angular/with-tanstack-query/package.json
+++ b/examples/angular/with-tanstack-query/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ./src"
   },
   "private": true,
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@angular/common": "^22.0.0",
     "@angular/compiler": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "type": "git",
     "url": "git+https://github.com/TanStack/table.git"
   },
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.9.0",
   "engines": {
-    "pnpm": ">=11.0.0"
+    "pnpm": ">=11.9.0"
   },
   "type": "module",
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ allowBuilds:
   vue-demi: false # only required for vue 2 support
 
 cleanupUnusedCatalogs: true
-minimumReleaseAge: 1
+minimumReleaseAge: 1440
 
 linkWorkspacePackages: true
 preferWorkspacePackages: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,7 @@ allowBuilds:
   vue-demi: false # only required for vue 2 support
 
 cleanupUnusedCatalogs: true
+minimumReleaseAge: 1
 
 linkWorkspacePackages: true
 preferWorkspacePackages: true


### PR DESCRIPTION
Updates pnpm metadata to 11.9.0 and enables minimumReleaseAge for pnpm supply-chain policy verification.

Verification:
- pnpm install --lockfile-only --ignore-scripts --trust-lockfile=false
- pnpm install --frozen-lockfile --ignore-scripts --trust-lockfile=false
- git diff --check