### PR TITLE
fix: expanding and paginated row model memo

### DIFF
--- a/packages/table-core/src/features/row-pagination/createPaginatedRowModel.ts
+++ b/packages/table-core/src/features/row-pagination/createPaginatedRowModel.ts
@@ -25,7 +25,7 @@ export function createPaginatedRowModel<
       memoDeps: () => [
         table.getPrePaginatedRowModel(),
         table.atoms.pagination?.get(),
-        table.options.paginateExpandedRows
+        !table.options.paginateExpandedRows
           ? table.atoms.expanded?.get()
           : undefined,
       ],

--- a/packages/table-core/tests/implementation/features/row-expanding/rowExpandingFeature.test.ts
+++ b/packages/table-core/tests/implementation/features/row-expanding/rowExpandingFeature.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  constructTable,
+  coreFeatures,
+  createColumnHelper,
+  createExpandedRowModel,
+  createPaginatedRowModel,
+  rowExpandingFeature,
+  rowPaginationFeature,
+} from '../../../../src'
+import { storeReactivityBindings } from '../../../../src/store-reactivity-bindings'
+import type { ColumnDef } from '../../../../src'
+
+type Person = {
+  firstName: string
+  subRows?: Array<Person>
+}
+
+const features = {
+  ...coreFeatures,
+  rowExpandingFeature,
+  rowPaginationFeature,
+  coreReactivityFeature: storeReactivityBindings(),
+  expandedRowModel: createExpandedRowModel(),
+  paginatedRowModel: createPaginatedRowModel(),
+}
+
+function createTable(options?: { paginateExpandedRows?: boolean }) {
+  const data: Array<Person> = [
+    {
+      firstName: 'Parent 1',
+      subRows: [{ firstName: 'Child 1' }],
+    },
+    {
+      firstName: 'Parent 2',
+      subRows: [{ firstName: 'Child 2' }],
+    },
+  ]
+  const columnHelper = createColumnHelper<typeof features, Person>()
+  const columns: Array<ColumnDef<typeof features, Person, any>> = [
+    columnHelper.accessor('firstName', { id: 'firstName' }),
+  ]
+
+  return constructTable<typeof features, Person>({
+    features,
+    data,
+    columns,
+    getSubRows: (row) => row.subRows,
+    paginateExpandedRows: options?.paginateExpandedRows,
+    initialState: {
+      pagination: {
+        pageIndex: 0,
+        pageSize: 1,
+      },
+    },
+  })
+}
+
+describe('row expanding feature', () => {
+  it('updates the paginated row model when expanded state changes and expanded rows are not paginated', () => {
+    const table = createTable({ paginateExpandedRows: false })
+
+    expect(table.getRowModel().rows.map((row) => row.id)).toEqual(['0'])
+
+    table.getRow('0').toggleExpanded()
+
+    expect(table.atoms.expanded.get()).toEqual({ 0: true })
+    expect(table.getRowModel().rows.map((row) => row.id)).toEqual(['0', '0.0'])
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how paginated row views are recalculated, especially when expanded-row pagination is turned off or left unset.
  * Fixed expanded rows so they display correctly alongside pagination, including nested rows appearing after expansion.
* **Tests**
  * Added coverage for row expansion with pagination to verify the correct rows are shown before and after expanding a parent row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->