### PR TITLE
fix(table-core): guard Array.isArray before index access in range filter autoRemove

### DIFF
--- a/packages/table-core/src/fns/filterFns.ts
+++ b/packages/table-core/src/fns/filterFns.ts
@@ -219,7 +219,7 @@ const filterFn_between = Object.assign(
       filterFn_lessThan(row, columnId, filterValues[1])),
   {
     autoRemove: (val: any) =>
-      testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1])),
+      testFalsy(val) || (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
   },
 )
 
@@ -243,7 +243,7 @@ const filterFn_betweenInclusive = Object.assign(
       filterFn_lessThanOrEqualTo(row, columnId, filterValues[1])),
   {
     autoRemove: (val: any) =>
-      testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1])),
+      testFalsy(val) || (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
   },
 )
 
@@ -287,7 +287,7 @@ export const filterFn_inNumberRange = Object.assign(
       return [min, max] as const
     },
     autoRemove: (val: any) =>
-      testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1])),
+      testFalsy(val) || (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
   },
 )
 

--- a/packages/table-core/src/fns/filterFns.ts
+++ b/packages/table-core/src/fns/filterFns.ts
@@ -219,7 +219,8 @@ const filterFn_between = Object.assign(
       filterFn_lessThan(row, columnId, filterValues[1])),
   {
     autoRemove: (val: any) =>
-      testFalsy(val) || (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
+      testFalsy(val) ||
+      (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
   },
 )
 
@@ -243,7 +244,8 @@ const filterFn_betweenInclusive = Object.assign(
       filterFn_lessThanOrEqualTo(row, columnId, filterValues[1])),
   {
     autoRemove: (val: any) =>
-      testFalsy(val) || (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
+      testFalsy(val) ||
+      (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
   },
 )
 
@@ -287,7 +289,8 @@ export const filterFn_inNumberRange = Object.assign(
       return [min, max] as const
     },
     autoRemove: (val: any) =>
-      testFalsy(val) || (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
+      testFalsy(val) ||
+      (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
   },
 )
 

--- a/packages/table-core/tests/unit/fns/filterFns.test.ts
+++ b/packages/table-core/tests/unit/fns/filterFns.test.ts
@@ -563,4 +563,40 @@ describe('Filter Functions', () => {
       })
     })
   })
+    describe('filterFns.inNumberRange.autoRemove', () => {
+      const autoRemove = filterFns.inNumberRange.autoRemove!
+
+      it('should auto-remove when value is undefined', () => {
+        expect(autoRemove(undefined)).toBe(true)
+      })
+      it('should auto-remove when value is null', () => {
+        expect(autoRemove(null)).toBe(true)
+      })
+      it('should auto-remove when value is empty string', () => {
+        expect(autoRemove('')).toBe(true)
+      })
+      it('should auto-remove when both endpoints are undefined', () => {
+        expect(autoRemove([undefined, undefined])).toBe(true)
+      })
+      it('should auto-remove when both endpoints are null', () => {
+        expect(autoRemove([null, null])).toBe(true)
+      })
+      it('should NOT auto-remove when both endpoints are valid numbers', () => {
+        expect(autoRemove([5, 10])).toBe(false)
+      })
+      it('should NOT auto-remove when lower bound is 0 (falsy number)', () => {
+        expect(autoRemove([0, 10])).toBe(false)
+      })
+      it('should NOT auto-remove when only one endpoint is provided', () => {
+        expect(autoRemove([undefined, 10])).toBe(false)
+        expect(autoRemove([5, undefined])).toBe(false)
+      })
+      it('should NOT auto-remove a scalar number (issue #5949 — non-array value must not be silently dropped)', () => {
+        // Without Array.isArray guard: val[0] and val[1] are both undefined for
+        // a scalar, so testFalsy returns true for both, causing the filter to be
+        // incorrectly removed even though 99 is a perfectly valid filter value.
+        expect(autoRemove(99)).toBe(false)
+        expect(autoRemove(0)).toBe(false)
+      })
+    })
 })

--- a/packages/table-core/tests/unit/fns/filterFns.test.ts
+++ b/packages/table-core/tests/unit/fns/filterFns.test.ts
@@ -563,40 +563,40 @@ describe('Filter Functions', () => {
       })
     })
   })
-    describe('filterFns.inNumberRange.autoRemove', () => {
-      const autoRemove = filterFns.inNumberRange.autoRemove!
+  describe('filterFns.inNumberRange.autoRemove', () => {
+    const autoRemove = filterFns.inNumberRange.autoRemove!
 
-      it('should auto-remove when value is undefined', () => {
-        expect(autoRemove(undefined)).toBe(true)
-      })
-      it('should auto-remove when value is null', () => {
-        expect(autoRemove(null)).toBe(true)
-      })
-      it('should auto-remove when value is empty string', () => {
-        expect(autoRemove('')).toBe(true)
-      })
-      it('should auto-remove when both endpoints are undefined', () => {
-        expect(autoRemove([undefined, undefined])).toBe(true)
-      })
-      it('should auto-remove when both endpoints are null', () => {
-        expect(autoRemove([null, null])).toBe(true)
-      })
-      it('should NOT auto-remove when both endpoints are valid numbers', () => {
-        expect(autoRemove([5, 10])).toBe(false)
-      })
-      it('should NOT auto-remove when lower bound is 0 (falsy number)', () => {
-        expect(autoRemove([0, 10])).toBe(false)
-      })
-      it('should NOT auto-remove when only one endpoint is provided', () => {
-        expect(autoRemove([undefined, 10])).toBe(false)
-        expect(autoRemove([5, undefined])).toBe(false)
-      })
-      it('should NOT auto-remove a scalar number (issue #5949 — non-array value must not be silently dropped)', () => {
-        // Without Array.isArray guard: val[0] and val[1] are both undefined for
-        // a scalar, so testFalsy returns true for both, causing the filter to be
-        // incorrectly removed even though 99 is a perfectly valid filter value.
-        expect(autoRemove(99)).toBe(false)
-        expect(autoRemove(0)).toBe(false)
-      })
+    it('should auto-remove when value is undefined', () => {
+      expect(autoRemove(undefined)).toBe(true)
     })
+    it('should auto-remove when value is null', () => {
+      expect(autoRemove(null)).toBe(true)
+    })
+    it('should auto-remove when value is empty string', () => {
+      expect(autoRemove('')).toBe(true)
+    })
+    it('should auto-remove when both endpoints are undefined', () => {
+      expect(autoRemove([undefined, undefined])).toBe(true)
+    })
+    it('should auto-remove when both endpoints are null', () => {
+      expect(autoRemove([null, null])).toBe(true)
+    })
+    it('should NOT auto-remove when both endpoints are valid numbers', () => {
+      expect(autoRemove([5, 10])).toBe(false)
+    })
+    it('should NOT auto-remove when lower bound is 0 (falsy number)', () => {
+      expect(autoRemove([0, 10])).toBe(false)
+    })
+    it('should NOT auto-remove when only one endpoint is provided', () => {
+      expect(autoRemove([undefined, 10])).toBe(false)
+      expect(autoRemove([5, undefined])).toBe(false)
+    })
+    it('should NOT auto-remove a scalar number (issue #5949 — non-array value must not be silently dropped)', () => {
+      // Without Array.isArray guard: val[0] and val[1] are both undefined for
+      // a scalar, so testFalsy returns true for both, causing the filter to be
+      // incorrectly removed even though 99 is a perfectly valid filter value.
+      expect(autoRemove(99)).toBe(false)
+      expect(autoRemove(0)).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Bug

`filterFn_between`, `filterFn_betweenInclusive`, and `filterFn_inNumberRange` each contain:

```ts
autoRemove: (val: any) =>
  testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1]))
```

When a **scalar** (non-array) value such as `99` is passed, `val[0]` and `val[1]` are both `undefined`. `testFalsy(undefined) === true`, so the condition evaluates to `true && true` = `true` — the filter is immediately auto-removed even though `99` is a perfectly valid, non-empty filter value.

Numeric columns default to the `inNumberRange` filter function (auto-selected by `column_getAutoFilterFn`). Calling `col.setColumnFilter(99)` on a numeric column therefore silently discards the filter.

Closes #5949

## Fix

Add `Array.isArray(val) &&` before accessing `val[0]` / `val[1]`, so the index checks only execute when `val` is actually an array. The leading `testFalsy(val)` still handles `undefined`, `null`, and `''`.

```ts
// Before
autoRemove: (val: any) =>
  testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1]))

// After
autoRemove: (val: any) =>
  testFalsy(val) || (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1]))
```

The same pattern is applied identically to all three range filter functions that shared the bug.

## Verification

```
pnpm vitest run packages/table-core/tests/unit/fns/filterFns.test.ts
```

**Before fix:** 1 test fails — `filterFns.inNumberRange.autoRemove > should NOT auto-remove a scalar number` (`autoRemove(99)` returned `true`, expected `false`)

**After fix:** 358/358 tests pass (349 pre-existing + 9 new for `filterFns.inNumberRange.autoRemove`)

> This fix was developed with AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved range filter cleanup logic to safely handle non-array values without incorrectly treating them as invalid.
  * Preserved auto-removal for empty/missing range endpoints while keeping valid inputs (including `0`) and scalar values from being dropped.
* **Tests**
  * Added unit tests covering `inNumberRange` auto-removal behavior for undefined/null/empty strings, empty endpoint arrays, and valid numeric ranges (including regression checks for scalar `99` and `0`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->