### PR TITLE
fix(table-core): auto-remove empty arrHas filter values like the other array filters

### DIFF
--- a/examples/angular/with-tanstack-form/src/app/app.html
+++ b/examples/angular/with-tanstack-form/src/app/app.html
@@ -4,10 +4,16 @@
     <form (submit)="submitFullTable($event)">
       <div class="form-actions">
         <div class="form-status">
-          <span [class.warning-text]="fullFormState().isDirty" [class.muted-text]="!fullFormState().isDirty">
+          <span
+            [class.warning-text]="fullFormState().isDirty"
+            [class.muted-text]="!fullFormState().isDirty"
+          >
             {{ fullFormState().isDirty ? 'Modified' : 'Pristine' }}
           </span>
-          <span [class.success-text]="fullFormState().isValid" [class.error-text]="!fullFormState().isValid">
+          <span
+            [class.success-text]="fullFormState().isValid"
+            [class.error-text]="!fullFormState().isValid"
+          >
             {{ fullFormState().isValid ? 'Valid' : 'Invalid' }}
           </span>
         </div>
@@ -18,9 +24,7 @@
         >
           {{ fullFormState().isSubmitting ? 'Submitting...' : 'Save All Changes' }}
         </button>
-        <button class="demo-button success-action" type="button" (click)="addRow()">
-          Add Row
-        </button>
+        <button class="demo-button success-action" type="button" (click)="addRow()">Add Row</button>
         <button class="demo-button secondary-action" type="button" (click)="refreshData()">
           Regenerate Data
         </button>

--- a/examples/angular/with-tanstack-form/src/app/header-components.ts
+++ b/examples/angular/with-tanstack-form/src/app/header-components.ts
@@ -61,22 +61,28 @@ export class _ColumnFilter {
       .getPreFilteredRowModel()
       .flatRows[0]?.getValue(this.header().column.id),
   )
-  readonly isNumberColumn = computed(() => typeof this.firstValue() === 'number')
+  readonly isNumberColumn = computed(
+    () => typeof this.firstValue() === 'number',
+  )
   readonly filterValue = computed(() => this.header().column.getFilterValue())
   readonly numberFilterValue = computed(
     () => this.filterValue() as [number, number] | undefined,
   )
-  readonly textFilterValue = computed(() => (this.filterValue() ?? '') as string)
+  readonly textFilterValue = computed(
+    () => (this.filterValue() ?? '') as string,
+  )
 
   setMin(value: string | number) {
-    this.header().column.setFilterValue(
-      (old: [number, number] | undefined) => [value, old?.[1]],
-    )
+    this.header().column.setFilterValue((old: [number, number] | undefined) => [
+      value,
+      old?.[1],
+    ])
   }
 
   setMax(value: string | number) {
-    this.header().column.setFilterValue(
-      (old: [number, number] | undefined) => [old?.[0], value],
-    )
+    this.header().column.setFilterValue((old: [number, number] | undefined) => [
+      old?.[0],
+      value,
+    ])
   }
 }

--- a/examples/angular/with-tanstack-form/src/app/row-submit-table-row.ts
+++ b/examples/angular/with-tanstack-form/src/app/row-submit-table-row.ts
@@ -146,7 +146,9 @@ import type { Row } from '@tanstack/angular-table'
                 <button
                   type="button"
                   class="demo-button demo-button-sm primary-action"
-                  [disabled]="!formState().canSubmit || formState().isSubmitting"
+                  [disabled]="
+                    !formState().canSubmit || formState().isSubmitting
+                  "
                   (click)="form.handleSubmit()"
                 >
                   {{ formState().isSubmitting ? 'Saving...' : 'Save' }}

--- a/examples/angular/with-tanstack-form/src/app/table-components.ts
+++ b/examples/angular/with-tanstack-form/src/app/table-components.ts
@@ -85,18 +85,14 @@ export class PaginationControls {
   }
 
   onPageSizeChange(event: Event) {
-    this.table().setPageSize(
-      Number((event.target as HTMLSelectElement).value),
-    )
+    this.table().setPageSize(Number((event.target as HTMLSelectElement).value))
   }
 }
 
 @Component({
   selector: 'app-row-count',
   template: `
-    <div class="row-count">
-      Showing {{ length() }} of {{ rowCount() }} Rows
-    </div>
+    <div class="row-count">Showing {{ length() }} of {{ rowCount() }} Rows</div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/examples/preact/with-tanstack-form/src/form.tsx
+++ b/examples/preact/with-tanstack-form/src/form.tsx
@@ -1,7 +1,4 @@
-import {
-  createFormHook,
-  createFormHookContexts,
-} from '@tanstack/preact-form'
+import { createFormHook, createFormHookContexts } from '@tanstack/preact-form'
 
 // Create form and field contexts
 export const { fieldContext, useFieldContext, formContext, useFormContext } =

--- a/examples/react/with-tanstack-form/src/form.tsx
+++ b/examples/react/with-tanstack-form/src/form.tsx
@@ -1,7 +1,4 @@
-import {
-  createFormHook,
-  createFormHookContexts,
-} from '@tanstack/react-form'
+import { createFormHook, createFormHookContexts } from '@tanstack/react-form'
 
 // Create form and field contexts
 export const { fieldContext, useFieldContext, formContext, useFormContext } =

--- a/examples/solid/with-tanstack-form/src/App.tsx
+++ b/examples/solid/with-tanstack-form/src/App.tsx
@@ -394,9 +394,7 @@ function RowSubmitFormExample() {
             </thead>
             <tbody>
               <For each={table.getRowModel().rows}>
-                {(row) => (
-                  <RowSubmitTableRow row={row} onSave={saveRow} />
-                )}
+                {(row) => <RowSubmitTableRow row={row} onSave={saveRow} />}
               </For>
             </tbody>
           </table>

--- a/examples/solid/with-tanstack-form/src/index.tsx
+++ b/examples/solid/with-tanstack-form/src/index.tsx
@@ -10,7 +10,9 @@ render(
   () => (
     <>
       <App />
-      <TanStackDevtools plugins={[tableDevtoolsPlugin(), formDevtoolsPlugin()]} />
+      <TanStackDevtools
+        plugins={[tableDevtoolsPlugin(), formDevtoolsPlugin()]}
+      />
     </>
   ),
   document.getElementById('root') as HTMLElement,

--- a/examples/solid/with-tanstack-form/src/table.tsx
+++ b/examples/solid/with-tanstack-form/src/table.tsx
@@ -52,8 +52,7 @@ function ColumnFilter() {
             <DebouncedInput
               type="number"
               value={
-                (columnFilterValue() as [number, number] | undefined)?.[0] ??
-                ''
+                (columnFilterValue() as [number, number] | undefined)?.[0] ?? ''
               }
               onChange={(value) =>
                 header.column.setFilterValue(
@@ -66,8 +65,7 @@ function ColumnFilter() {
             <DebouncedInput
               type="number"
               value={
-                (columnFilterValue() as [number, number] | undefined)?.[1] ??
-                ''
+                (columnFilterValue() as [number, number] | undefined)?.[1] ?? ''
               }
               onChange={(value) =>
                 header.column.setFilterValue(

--- a/examples/vue/with-tanstack-form/src/App.vue
+++ b/examples/vue/with-tanstack-form/src/App.vue
@@ -156,7 +156,9 @@ function handleSubmit(event: Event) {
   fullTableForm.handleSubmit()
 }
 
-function getSortTitle(column: ReturnType<typeof fullTable.getAllColumns>[number]) {
+function getSortTitle(
+  column: ReturnType<typeof fullTable.getAllColumns>[number],
+) {
   if (!column.getCanSort()) return undefined
 
   const nextOrder = column.getNextSortingOrder()

--- a/examples/vue/with-tanstack-form/src/table.ts
+++ b/examples/vue/with-tanstack-form/src/table.ts
@@ -11,12 +11,7 @@ import {
   tableFeatures,
 } from '@tanstack/vue-table'
 import { computed, defineComponent, h } from 'vue'
-import type {
-  CellData,
-  Header,
-  RowData,
-  VueTable,
-} from '@tanstack/vue-table'
+import type { CellData, Header, RowData, VueTable } from '@tanstack/vue-table'
 
 const features = tableFeatures({
   rowPaginationFeature,
@@ -75,10 +70,7 @@ const ColumnFilter = defineComponent({
               onInput: (event: Event) => {
                 const nextValue = (event.target as HTMLInputElement).value
                 header.column.setFilterValue(
-                  (old: [number, number] | undefined) => [
-                    nextValue,
-                    old?.[1],
-                  ],
+                  (old: [number, number] | undefined) => [nextValue, old?.[1]],
                 )
               },
             }),
@@ -90,10 +82,7 @@ const ColumnFilter = defineComponent({
               onInput: (event: Event) => {
                 const nextValue = (event.target as HTMLInputElement).value
                 header.column.setFilterValue(
-                  (old: [number, number] | undefined) => [
-                    old?.[0],
-                    nextValue,
-                  ],
+                  (old: [number, number] | undefined) => [old?.[0], nextValue],
                 )
               },
             }),

--- a/packages/table-core/src/fns/filterFns.ts
+++ b/packages/table-core/src/fns/filterFns.ts
@@ -296,16 +296,16 @@ export const filterFn_inNumberRange = Object.assign(
 /**
  * Keeps rows whose scalar column value equals at least one filter value.
  */
-export const filterFn_arrHas = <
-  TFeatures extends TableFeatures,
-  TData extends RowData,
->(
-  row: Row<TFeatures, TData>,
-  columnId: string,
-  filterValue: Array<unknown>,
-) => {
-  return filterValue.some((val) => row.getValue<unknown>(columnId) === val)
-}
+export const filterFn_arrHas = Object.assign(
+  <TFeatures extends TableFeatures, TData extends RowData>(
+    row: Row<TFeatures, TData>,
+    columnId: string,
+    filterValue: Array<unknown>,
+  ) => {
+    return filterValue.some((val) => row.getValue<unknown>(columnId) === val)
+  },
+  { autoRemove: (val: any) => testFalsy(val) || !val?.length },
+)
 
 /**
  * Keeps rows whose array or string column value includes at least one filter value.

--- a/packages/table-core/tests/unit/fns/filterFns.test.ts
+++ b/packages/table-core/tests/unit/fns/filterFns.test.ts
@@ -563,4 +563,26 @@ describe('Filter Functions', () => {
       })
     })
   })
+
+  describe('Array Filters', () => {
+    describe('filterFns.arrHas.autoRemove', () => {
+      const autoRemove = filterFns.arrHas.autoRemove!
+
+      it('should auto-remove when the filter value is undefined', () => {
+        expect(autoRemove(undefined)).toBe(true)
+      })
+      it('should auto-remove when the filter value is null', () => {
+        expect(autoRemove(null)).toBe(true)
+      })
+      it('should auto-remove when the filter value is an empty string', () => {
+        expect(autoRemove('')).toBe(true)
+      })
+      it('should auto-remove when the filter value is an empty array', () => {
+        expect(autoRemove([])).toBe(true)
+      })
+      it('should NOT auto-remove when the filter value is a non-empty array', () => {
+        expect(autoRemove(['a'])).toBe(false)
+      })
+    })
+  })
 })


### PR DESCRIPTION
`arrHas` is the only one of the four array-valued filter functions that doesn't define an `autoRemove` handler. Its siblings `arrIncludes`, `arrIncludesAll` and `arrIncludesSome` all use the same one:

```ts
{ autoRemove: (val: any) => testFalsy(val) || !val?.length }
```

Because `arrHas` has none, `shouldAutoRemoveFilter` falls back to the built-in rules, which only drop a filter when the value is `undefined` or an empty string. An empty array (`[]`) gets through, so the filter stays active and `[].some(...)` returns `false` for every row. The column then hides everything instead of behaving like "no filter set". The other three array filters auto-remove an empty array and show all rows, and #6332 recently made the range filters (`between` / `betweenInclusive`) do the same for empty pairs.

This gives `arrHas` the same `autoRemove` as the rest of the array-filter family: empty or blank values are removed, a non-empty array keeps the filter active.

I added a regression test under a new `Array Filters` block, mirroring the existing `between` / `betweenInclusive` autoRemove tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved array-based filtering so empty or unset filter values (such as `undefined`, `null`, empty strings, and empty arrays) are automatically ignored.
  - Filtering behavior is now more consistent by automatically removing empty “arr has” filter selections to avoid unintended active filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->