### PR TITLE
fix: let parent rows unselect child rows when not itself selected

### DIFF
--- a/examples/alpine/expanding/index.html
+++ b/examples/alpine/expanding/index.html
@@ -97,7 +97,7 @@
                       <input
                         type="checkbox"
                         style="cursor: pointer"
-                        :checked="cell.row.getIsSelected()"
+                        :checked="cell.row.getIsSelected() || (cell.row.getCanSelectSubRows() && cell.row.getIsAllSubRowsSelected())"
                         x-effect="$el.indeterminate = !cell.row.getIsSelected() && cell.row.getIsSomeSelected()"
                         @change="cell.row.getToggleSelectedHandler()($event)"
                       />

--- a/examples/angular/expanding/src/app/expandable-cell/expandable-cell.ts
+++ b/examples/angular/expanding/src/app/expandable-cell/expandable-cell.ts
@@ -43,7 +43,10 @@ export class ExpandableHeaderCell<T extends RowData> {
         <input
           type="checkbox"
           [indeterminate]="row.getIsSomeSelected()"
-          [checked]="row.getIsSelected()"
+          [checked]="
+            row.getIsSelected() ||
+            (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
+          "
           (change)="row.getToggleSelectedHandler()($event)"
         />
         {{ ' ' }}

--- a/examples/lit/expanding/src/main.ts
+++ b/examples/lit/expanding/src/main.ts
@@ -123,7 +123,9 @@ const columns: Array<ColumnDef<typeof features, Person>> = [
     cell: ({ row, getValue }) => html`
       <div style="padding-left:${row.depth * 2}rem">
         ${indeterminateCheckbox({
-          checked: row.getIsSelected(),
+          checked:
+            row.getIsSelected() ||
+            (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected()),
           indeterminate: row.getIsSomeSelected(),
           onChange: row.getToggleSelectedHandler(),
         })}

--- a/examples/preact/expanding/src/main.tsx
+++ b/examples/preact/expanding/src/main.tsx
@@ -68,7 +68,10 @@ function App() {
             >
               <div>
                 <IndeterminateCheckbox
-                  checked={row.getIsSelected()}
+                  checked={
+                    row.getIsSelected() ||
+                    (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
+                  }
                   indeterminate={row.getIsSomeSelected()}
                   onChange={row.getToggleSelectedHandler()}
                 />{' '}

--- a/examples/react/expanding/src/main.tsx
+++ b/examples/react/expanding/src/main.tsx
@@ -69,7 +69,10 @@ function App() {
             >
               <div>
                 <IndeterminateCheckbox
-                  checked={row.getIsSelected()}
+                  checked={
+                    row.getIsSelected() ||
+                    (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
+                  }
                   indeterminate={row.getIsSomeSelected()}
                   onChange={row.getToggleSelectedHandler()}
                 />{' '}
@@ -129,6 +132,7 @@ function App() {
       // filterFromLeafRows: true,
       // maxLeafRowFilterDepth: 0,
       debugTable: true,
+      debugRows: true,
     },
     (state) => state, // default selector
   )
@@ -343,7 +347,7 @@ function IndeterminateCheckbox({
     if (typeof indeterminate === 'boolean') {
       ref.current.indeterminate = !rest.checked && indeterminate
     }
-  }, [ref, indeterminate])
+  }, [ref, indeterminate, rest.checked])
 
   return (
     <input

--- a/examples/solid/expanding/src/App.tsx
+++ b/examples/solid/expanding/src/App.tsx
@@ -59,7 +59,10 @@ function App() {
         <div style={{ 'padding-left': `${row.depth * 2}rem` }}>
           <div>
             <IndeterminateCheckbox
-              checked={row.getIsSelected()}
+              checked={
+                row.getIsSelected() ||
+                (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
+              }
               indeterminate={row.getIsSomeSelected()}
               onChange={row.getToggleSelectedHandler()}
             />{' '}

--- a/examples/svelte/expanding/src/App.svelte
+++ b/examples/svelte/expanding/src/App.svelte
@@ -156,7 +156,9 @@
                   <div>
                     <input
                       type="checkbox"
-                      checked={row.getIsSelected()}
+                      checked={row.getIsSelected() ||
+                        (row.getCanSelectSubRows() &&
+                          row.getIsAllSubRowsSelected())}
                       use:setIndeterminate={!row.getIsSelected() && row.getIsSomeSelected()}
                       onchange={row.getToggleSelectedHandler()}
                       class="sortable-header"

--- a/examples/vue/expanding/src/App.tsx
+++ b/examples/vue/expanding/src/App.tsx
@@ -156,7 +156,10 @@ export default defineComponent({
           <div style={{ paddingLeft: `${row.depth * 2}rem` }}>
             <div>
               <IndeterminateCheckbox
-                checked={row.getIsSelected()}
+                checked={
+                  row.getIsSelected() ||
+                  (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
+                }
                 indeterminate={row.getIsSomeSelected()}
                 onChange={row.getToggleSelectedHandler()}
               />{' '}

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.ts
@@ -61,9 +61,19 @@ export const rowSelectionFeature: TableFeature = {
       },
       row_getIsSomeSelected: {
         fn: (row) => row_getIsSomeSelected(row),
+        memoDeps: (row) => [
+          row.subRows,
+          row.table.atoms.rowSelection?.get(),
+          row.table.options.enableRowSelection,
+        ],
       },
       row_getIsAllSubRowsSelected: {
         fn: (row) => row_getIsAllSubRowsSelected(row),
+        memoDeps: (row) => [
+          row.subRows,
+          row.table.atoms.rowSelection?.get(),
+          row.table.options.enableRowSelection,
+        ],
       },
       row_getCanSelect: {
         fn: (row) => row_getCanSelect(row),

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
@@ -497,10 +497,6 @@ export function row_toggleSelected<
   table_setRowSelection(row.table, (old) => {
     value = typeof value !== 'undefined' ? value : !isSelected
 
-    if (row_getCanSelect(row) && isSelected === value) {
-      return old
-    }
-
     const rowSelection = Object.assign(makeObjectMap<true>(), old)
 
     mutateRowIsSelected(
@@ -787,13 +783,15 @@ export function isSubRowSelected<
 
   const rowSelection = row.table.atoms.rowSelection?.get() ?? {}
 
-  let allChildrenSelected = true
   let someSelected = false
+  let allChildrenSelected = true
 
-  row.subRows.forEach((subRow) => {
+  for (let i = 0; i < row.subRows.length; i++) {
+    const subRow = row.subRows[i]!
+
     // Bail out early if we know both of these
     if (someSelected && !allChildrenSelected) {
-      return
+      break
     }
 
     if (row_getCanSelect(subRow)) {
@@ -816,8 +814,7 @@ export function isSubRowSelected<
         allChildrenSelected = false
       }
     }
-  })
+  }
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return allChildrenSelected ? 'all' : someSelected ? 'some' : false
 }

--- a/perf-done.md
+++ b/perf-done.md
@@ -525,9 +525,7 @@ const results: Array<{ colSpan: number; rowSpan: number }> = []
 
 for (let i = 0; i < headers.length; i++) {
   const header = headers[i]!
-  if (
-    !callMemoOrStaticFn(header.column, 'getIsVisible', column_getIsVisible)
-  ) {
+  if (!callMemoOrStaticFn(header.column, 'getIsVisible', column_getIsVisible)) {
     continue
   }
 

--- a/perf-skipped.md
+++ b/perf-skipped.md
@@ -36,8 +36,7 @@ if (existingGrouping.includes(colId)) {
   }
 
   if (groupedRows[0]) {
-    row._valuesCache[colId] =
-      groupedRows[0].getValue(colId) ?? undefined
+    row._valuesCache[colId] = groupedRows[0].getValue(colId) ?? undefined
   }
 
   return row._valuesCache[colId]
@@ -134,9 +133,8 @@ Each call walks the `columnFilters` array. When a filter UI re-renders columns, 
 **Before**
 
 ```ts
-return column.table.atoms.columnFilters
-  ?.get()
-  ?.find((d) => d.id === column.id)?.value
+return column.table.atoms.columnFilters?.get()?.find((d) => d.id === column.id)
+  ?.value
 ```
 
 **After (new memoized table API)**


### PR DESCRIPTION
- Updated checkbox selection logic to account for sub-row selections in various examples (Alpine, Angular, React, Preact, Solid, Svelte, Vue).
- Refactored core row selection feature to include memoization for `getIsAllSubRowsSelected` and `getCanSelectSubRows` functions.
- Improved performance by optimizing selection checks in utility functions.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded row-selection behavior in expandable table examples so parent checkboxes now appear selected when all nested rows are selected.

* **Bug Fixes**
  * Improved consistency of selection state across supported examples, including indeterminate checkbox behavior.
  * Selection updates now refresh more reliably when row selection changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->