### PR TITLE
fix: prevent crash in createSortedRowModel for unknown sorting column ids

### DIFF
--- a/packages/table-core/src/features/row-sorting/createSortedRowModel.ts
+++ b/packages/table-core/src/features/row-sorting/createSortedRowModel.ts
@@ -51,11 +51,10 @@ function _createSortedRowModel<
   const sortedFlatRows: Array<Row<TFeatures, TData>> = []
 
   // Filter out sortings that correspond to non existing columns
-  const availableSorting = sorting.filter((sort) =>
-    column_getCanSort(
-      table.getColumn(sort.id) as Column_Internal<TFeatures, TData>,
-    ),
-  )
+  const availableSorting = sorting.filter((sort) => {
+    const column = table.getColumn(sort.id)
+    return column ? column_getCanSort(column) : false
+  })
 
   const resolvedSorting: Array<{
     id: string

--- a/packages/table-core/tests/unit/features/row-sorting/createSortedRowModel.test.ts
+++ b/packages/table-core/tests/unit/features/row-sorting/createSortedRowModel.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  constructTable,
+  coreFeatures,
+  createSortedRowModel,
+  rowSortingFeature,
+  tableFeatures,
+} from '../../../../src'
+import { storeReactivityBindings } from '../../../../src/store-reactivity-bindings'
+import type { ColumnDef } from '../../../../src'
+
+type Person = {
+  firstName: string
+  age: number
+}
+
+const features = tableFeatures({
+  ...coreFeatures,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+})
+
+const columns: Array<ColumnDef<typeof features, Person, any>> = [
+  { accessorKey: 'firstName', id: 'firstName' },
+  { accessorKey: 'age', id: 'age' },
+]
+
+const data: Array<Person> = [
+  { firstName: 'amy', age: 20 },
+  { firstName: 'bob', age: 40 },
+  { firstName: 'alice', age: 30 },
+]
+
+function makeTable(sorting: Array<{ id: string; desc: boolean }>) {
+  return constructTable<typeof features, Person>({
+    data,
+    columns,
+    features: {
+      ...features,
+      coreReactivityFeature: storeReactivityBindings(),
+    },
+    initialState: { sorting },
+  })
+}
+
+describe('createSortedRowModel', () => {
+  it('does not crash when the sorting state references a column that no longer exists', () => {
+    const table = makeTable([{ id: 'thisColumnDoesNotExist', desc: false }])
+
+    expect(() => table.getSortedRowModel()).not.toThrow()
+  })
+
+  it('falls back to the pre-sorted row order when only unknown columns are sorted', () => {
+    const table = makeTable([{ id: 'thisColumnDoesNotExist', desc: false }])
+
+    expect(
+      table.getSortedRowModel().rows.map((row) => row.original.firstName),
+    ).toEqual(['amy', 'bob', 'alice'])
+  })
+
+  it('still sorts by the remaining known columns when one sort entry is unknown', () => {
+    const table = makeTable([
+      { id: 'thisColumnDoesNotExist', desc: false },
+      { id: 'age', desc: false },
+    ])
+
+    expect(
+      table.getSortedRowModel().rows.map((row) => row.original.firstName),
+    ).toEqual(['amy', 'alice', 'bob'])
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

`createSortedRowModel`'s `sorting.filter(...)` force-cast `table.getColumn(sort.id)` to `Column_Internal` even when the lookup returned `undefined` (e.g. a column removed/renamed while its `sorting` state still references the old id). That `undefined` was then passed straight into `column_getCanSort`, which dereferences `column.columnDef.enableSorting` and throws a `TypeError`, crashing `getSortedRowModel()`.

This guards the lookup so an unknown sorting column id is simply treated as unsortable instead of crashing the whole row model.

Added `packages/table-core/tests/unit/features/row-sorting/createSortedRowModel.test.ts` covering:
- `getSortedRowModel()` no longer throws when `sorting` references a nonexistent column id
- the row order falls back to the pre-sorted order when only unknown columns are sorted
- sorting still works correctly on the remaining valid sort entries when one entry is unknown

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.