### PR TITLE
Feature: Allow Manual Override of Pagination canNextPage/canPreviousPage

### DIFF
--- a/docs/framework/react/guide/pagination.md
+++ b/docs/framework/react/guide/pagination.md
@@ -90,7 +90,7 @@ No pagination row model is needed for server-side pagination, but if you have pr
 
 #### Page Count and Row Count
 
-The table instance will have no way of knowing how many rows/pages there are in total in your back-end unless you tell it. Provide either the `rowCount` or `pageCount` table option to let the table instance know how many pages there are in total. If you provide a `rowCount`, the table instance will calculate the `pageCount` internally from `rowCount` and `pageSize`. Otherwise, you can directly provide the `pageCount` if you already have it. If you don't know the page count, you can just pass in `-1` for the `pageCount`, but the `getCanNextPage` and `getCanPreviousPage` row model functions will always return `true` in this case.
+The table instance will have no way of knowing how many rows/pages there are in total in your back-end unless you tell it. Provide either the `rowCount` or `pageCount` table option to let the table instance know how many pages there are in total. If you provide a `rowCount`, the table instance will calculate the `pageCount` internally from `rowCount` and `pageSize`. Otherwise, you can directly provide the `pageCount` if you already have it. If you don't know the page count, you can just pass in `-1` for the `pageCount`, but the `getCanNextPage` and `getCanPreviousPage` row model functions will always return `true` in this case. When you do know whether more pages are available (for example, a server response that says "has more"), you can override this by setting the optional `canNextPage`/`canPreviousPage` values on the [pagination state](#pagination-state) directly.
 
 ```tsx
 import {
@@ -121,6 +121,10 @@ The `pagination` state is an object that contains the following properties:
 
 - `pageIndex`: The current page index (zero-based).
 - `pageSize`: The current page size.
+- `canNextPage` _(optional)_: Explicitly overrides the value returned by `getCanNextPage()`. Useful for manual/server-side pagination (e.g. news feeds) where the total `pageCount`/`rowCount` is unknown.
+- `canPreviousPage` _(optional)_: Explicitly overrides the value returned by `getCanPreviousPage()`. Useful for manual/server-side pagination where the total `pageCount`/`rowCount` is unknown.
+
+> **Note**: The pagination navigation APIs (`setPageIndex`, `setPageSize`, `nextPage`, etc.) preserve `canNextPage`/`canPreviousPage` when they update the state. However, if you replace the whole `pagination` object yourself (for example inside `onPaginationChange`), you must re-supply these flags to keep the overrides in effect.
 
 For reactive reads that should re-render your UI, use `table.state.pagination`. In event handlers, you can read the current snapshot with `table.atoms.pagination.get()`, but this read does not subscribe the component to future changes.
 

--- a/packages/table-core/src/features/row-pagination/rowPaginationFeature.types.ts
+++ b/packages/table-core/src/features/row-pagination/rowPaginationFeature.types.ts
@@ -5,6 +5,14 @@ import type { TableFeatures } from '../../types/TableFeatures'
 export interface PaginationState {
   pageIndex: number
   pageSize: number
+  /**
+   * When manually controlling pagination, supply `canNextPage` explicitly to override the derived value. This is useful when working with news feeds or other server paginated data where `pageCount` or `rowCount` is unknown.
+   */
+  canNextPage?: boolean
+  /**
+   * When manually controlling pagination, supply `canPreviousPage` explicitly to override the derived value. This is useful when working with news feeds or other server paginated data where `pageCount` or `rowCount` is unknown.
+   */
+  canPreviousPage?: boolean
 }
 
 export interface TableState_RowPagination {

--- a/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
+++ b/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
@@ -251,7 +251,14 @@ export function table_getCanPreviousPage<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table_Internal<TFeatures, TData>) {
-  return (table.atoms.pagination?.get()?.pageIndex ?? 0) > 0
+  const pagination = table.atoms.pagination?.get()
+  const { canPreviousPage, pageIndex } = pagination ?? {}
+
+  if (canPreviousPage !== undefined) {
+    return canPreviousPage
+  }
+
+  return (pageIndex ?? defaultPageIndex) > 0
 }
 
 /**
@@ -269,9 +276,15 @@ export function table_getCanNextPage<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table_Internal<TFeatures, TData>) {
-  const pageIndex = table.atoms.pagination?.get()?.pageIndex ?? defaultPageIndex
-
+  const pagination = table.atoms.pagination?.get()
+  const pageIndex = pagination?.pageIndex ?? defaultPageIndex
+  // Read `pageCount` before any early return so the reactivity system always
+  // subscribes to its dependencies (pageSize atom + pre-paginated row model).
   const pageCount = table_getPageCount(table)
+
+  if (pagination?.canNextPage !== undefined) {
+    return pagination.canNextPage
+  }
 
   if (pageCount === -1) {
     return true

--- a/packages/table-core/tests/unit/features/row-pagination/rowPaginationFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/row-pagination/rowPaginationFeature.utils.test.ts
@@ -313,6 +313,26 @@ describe('table_getCanPreviousPage', () => {
 
     expect(table_getCanPreviousPage(table)).toBe(true)
   })
+
+  it('should honor an explicit canPreviousPage override on the first page', () => {
+    const table = makeTable(25, {
+      initialState: {
+        pagination: { pageIndex: 0, pageSize: 10, canPreviousPage: true },
+      },
+    })
+
+    expect(table_getCanPreviousPage(table)).toBe(true)
+  })
+
+  it('should honor an explicit canPreviousPage=false override past the first page', () => {
+    const table = makeTable(25, {
+      initialState: {
+        pagination: { pageIndex: 1, pageSize: 10, canPreviousPage: false },
+      },
+    })
+
+    expect(table_getCanPreviousPage(table)).toBe(false)
+  })
 })
 
 describe('table_getCanNextPage', () => {
@@ -344,6 +364,39 @@ describe('table_getCanNextPage', () => {
     const table = makeTable(0)
 
     expect(table_getCanNextPage(table)).toBe(false)
+  })
+
+  it('should return false for a manual page count of 0', () => {
+    const table = makeTable(25, {
+      manualPagination: true,
+      pageCount: 0,
+    })
+
+    expect(table_getCanNextPage(table)).toBe(false)
+  })
+
+  it('should honor a canNextPage=false override even when the page count is unknown (-1)', () => {
+    const table = makeTable(25, {
+      manualPagination: true,
+      pageCount: -1,
+      initialState: {
+        pagination: { pageIndex: 0, pageSize: 10, canNextPage: false },
+      },
+    })
+
+    expect(table_getCanNextPage(table)).toBe(false)
+  })
+
+  it('should honor a canNextPage=true override even when the page count is 0', () => {
+    const table = makeTable(25, {
+      manualPagination: true,
+      pageCount: 0,
+      initialState: {
+        pagination: { pageIndex: 0, pageSize: 10, canNextPage: true },
+      },
+    })
+
+    expect(table_getCanNextPage(table)).toBe(true)
   })
 })
 


### PR DESCRIPTION
## 🎯 Changes

This adds explicit `canNextPage` and `canPreviousPage` options to Pagination state.

In large data scale pagination (news feeds, financial, live updates, etc), counts may not be accurate to whether or not pages are available. In these cases it is common for [REST (JSON:API)](https://jsonapi.org/format/#fetching-pagination) or GraphQL requests to add information on how to navigate to next/previous pages and whether or not those pages exist.

## Alternative

For these cases consumers *could* use a separate store with fallback to Tanstack pagination atom/state. However this means having to manage two state objects and in cases of Frameworks where signal evaluation is lazy (Ember/Vue/Solid), it can be easy to return before all reactive state are evaluated and be in a situation where a value is not properly observed in the case of fallback behavior.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.
