### PR TITLE
fix: prevent sticky pinned column overlap

### DIFF
--- a/examples/angular/column-pinning-sticky/src/styles.css
+++ b/examples/angular/column-pinning-sticky/src/styles.css
@@ -17,13 +17,16 @@ table {
   /* box-shadow and borders will not work with position: sticky otherwise */
   border-collapse: collapse;
   border-spacing: 0;
+  table-layout: fixed;
 }
 
 th {
   background-color: lightgray;
   border-bottom: 1px solid lightgray;
+  box-sizing: border-box;
   font-weight: bold;
   height: 30px;
+  overflow: hidden;
   padding: 2px 4px;
   position: relative;
   text-align: center;
@@ -31,6 +34,8 @@ th {
 
 td {
   background-color: white;
+  box-sizing: border-box;
+  overflow: hidden;
   padding: 2px 4px;
 }
 
@@ -187,6 +192,8 @@ td {
 }
 
 .nowrap {
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/examples/lit/column-pinning-sticky/src/main.ts
+++ b/examples/lit/column-pinning-sticky/src/main.ts
@@ -349,13 +349,16 @@ class LitTableExample extends LitElement {
         }
 
         table {
+          table-layout: fixed;
         }
 
         th {
           background-color: lightgray;
           border-bottom: 1px solid lightgray;
+          box-sizing: border-box;
           font-weight: bold;
           height: 30px;
+          overflow: hidden;
           padding: 2px 4px;
           position: relative;
           text-align: center;
@@ -363,6 +366,8 @@ class LitTableExample extends LitElement {
 
         td {
           background-color: white;
+          box-sizing: border-box;
+          overflow: hidden;
           padding: 2px 4px;
         }
 
@@ -493,6 +498,8 @@ class LitTableExample extends LitElement {
           border-color: #000;
         }
         .nowrap {
+          overflow: hidden;
+          text-overflow: ellipsis;
           white-space: nowrap;
         }
         .demo-note {

--- a/examples/preact/column-pinning-sticky/src/index.css
+++ b/examples/preact/column-pinning-sticky/src/index.css
@@ -17,13 +17,16 @@ table {
   /* box-shadow and borders will not work with position: sticky otherwise */
   border-collapse: collapse;
   border-spacing: 0;
+  table-layout: fixed;
 }
 
 th {
   background-color: lightgray;
   border-bottom: 1px solid lightgray;
+  box-sizing: border-box;
   font-weight: bold;
   height: 30px;
+  overflow: hidden;
   padding: 2px 4px;
   position: relative;
   text-align: center;
@@ -31,6 +34,8 @@ th {
 
 td {
   background-color: white;
+  box-sizing: border-box;
+  overflow: hidden;
   padding: 2px 4px;
 }
 
@@ -187,6 +192,8 @@ td {
 }
 
 .nowrap {
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/examples/react/column-pinning-sticky/src/index.css
+++ b/examples/react/column-pinning-sticky/src/index.css
@@ -17,13 +17,16 @@ table {
   /* box-shadow and borders will not work with position: sticky otherwise */
   border-collapse: collapse;
   border-spacing: 0;
+  table-layout: fixed;
 }
 
 th {
   background-color: lightgray;
   border-bottom: 1px solid lightgray;
+  box-sizing: border-box;
   font-weight: bold;
   height: 30px;
+  overflow: hidden;
   padding: 2px 4px;
   position: relative;
   text-align: center;
@@ -31,6 +34,8 @@ th {
 
 td {
   background-color: white;
+  box-sizing: border-box;
+  overflow: hidden;
   padding: 2px 4px;
 }
 
@@ -187,6 +192,8 @@ td {
 }
 
 .nowrap {
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/examples/solid/column-pinning-sticky/src/index.css
+++ b/examples/solid/column-pinning-sticky/src/index.css
@@ -16,13 +16,16 @@ html {
 table {
   border-collapse: collapse;
   border-spacing: 0;
+  table-layout: fixed;
 }
 
 th {
   background-color: lightgray;
   border-bottom: 1px solid lightgray;
+  box-sizing: border-box;
   font-weight: bold;
   height: 30px;
+  overflow: hidden;
   padding: 2px 4px;
   position: relative;
   text-align: center;
@@ -30,6 +33,8 @@ th {
 
 td {
   background-color: white;
+  box-sizing: border-box;
+  overflow: hidden;
   padding: 2px 4px;
 }
 
@@ -186,6 +191,8 @@ td {
 }
 
 .nowrap {
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/examples/svelte/column-pinning-sticky/src/index.css
+++ b/examples/svelte/column-pinning-sticky/src/index.css
@@ -16,13 +16,16 @@ html {
 table {
   border-collapse: collapse;
   border-spacing: 0;
+  table-layout: fixed;
 }
 
 th {
   background-color: lightgray;
   border-bottom: 1px solid lightgray;
+  box-sizing: border-box;
   font-weight: bold;
   height: 30px;
+  overflow: hidden;
   padding: 2px 4px;
   position: relative;
   text-align: center;
@@ -30,6 +33,8 @@ th {
 
 td {
   background-color: white;
+  box-sizing: border-box;
+  overflow: hidden;
   padding: 2px 4px;
 }
 
@@ -186,6 +191,8 @@ td {
 }
 
 .nowrap {
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/examples/vue/column-pinning-sticky/src/index.css
+++ b/examples/vue/column-pinning-sticky/src/index.css
@@ -16,13 +16,16 @@ html {
 table {
   border-collapse: collapse;
   border-spacing: 0;
+  table-layout: fixed;
 }
 
 th {
   background-color: lightgray;
   border-bottom: 1px solid lightgray;
+  box-sizing: border-box;
   font-weight: bold;
   height: 30px;
+  overflow: hidden;
   padding: 2px 4px;
   position: relative;
   text-align: center;
@@ -30,6 +33,8 @@ th {
 
 td {
   background-color: white;
+  box-sizing: border-box;
+  overflow: hidden;
   padding: 2px 4px;
 }
 
@@ -186,6 +191,8 @@ td {
 }
 
 .nowrap {
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
 ## Changes

  Closes https://github.com/TanStack/table/issues/5392.

  This fixes the React `column-pinning-sticky` example so resized pinned columns do not overlap when horizontally scrolling.

  The example calculates sticky offsets from TanStack Table column sizes, but browser auto table layout could let rendered cell widths diverge from those calculated sizes after resizing. This change makes the rendered table cells respect the explicit column widths by using fixed table layout, border-box sizing, and clipped overflowing content.

  Changes made:

  - Add `table-layout: fixed` to the example table.
  - Add `box-sizing: border-box` to header and body cells.
  - Hide overflowing header and body cell content.
  - Add ellipsis behavior for nowrap text.

  ## Checklist

  - [x] I have tested this code locally with `pnpm test:pr`.

  ## Testing

  - `git diff --check`
  - `npm run build` from `examples/react/column-pinning-sticky`

  Manual visual testing:

  - Pinned multiple columns left and right.
  - Resized a pinned column wider.
  - Scrolled horizontally.
  - Confirmed pinned columns remain aligned and do not overlap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the pinned-columns table rendering by enforcing a fixed table layout.
  * Constrained header and body cell content using consistent box sizing and overflow clipping.
  * Enhanced the single-line “no-wrap” styling to truncate overflowing text with an ellipsis instead of letting it spill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->