### PR TITLE
fix(table-core): guard Array.isArray before index access in range filter autoRemove

### DIFF
--- a/packages/table-core/src/fns/filterFns.ts
+++ b/packages/table-core/src/fns/filterFns.ts
@@ -219,7 +219,8 @@ const filterFn_between = Object.assign(
       filterFn_lessThan(row, columnId, filterValues[1])),
   {
     autoRemove: (val: any) =>
-      testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1])),
+      testFalsy(val) ||
+      (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
   },
 )
 
@@ -243,7 +244,8 @@ const filterFn_betweenInclusive = Object.assign(
       filterFn_lessThanOrEqualTo(row, columnId, filterValues[1])),
   {
     autoRemove: (val: any) =>
-      testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1])),
+      testFalsy(val) ||
+      (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
   },
 )
 
@@ -287,7 +289,8 @@ export const filterFn_inNumberRange = Object.assign(
       return [min, max] as const
     },
     autoRemove: (val: any) =>
-      testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1])),
+      testFalsy(val) ||
+      (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1])),
   },
 )
 

--- a/packages/table-core/tests/unit/fns/filterFns.test.ts
+++ b/packages/table-core/tests/unit/fns/filterFns.test.ts
@@ -537,6 +537,12 @@ describe('Filter Functions', () => {
         expect(autoRemove([undefined, 10])).toBe(false)
         expect(autoRemove([5, undefined])).toBe(false)
       })
+      it('should NOT auto-remove a scalar value passed instead of a range tuple', () => {
+        // Regression test for #6353 - without the Array.isArray guard,
+        // `val[0]` and `val[1]` are undefined for a scalar and the index
+        // checks incorrectly auto-remove the filter.
+        expect(autoRemove(99 as any)).toBe(false)
+      })
     })
 
     describe('filterFns.betweenInclusive.autoRemove', () => {
@@ -560,6 +566,43 @@ describe('Filter Functions', () => {
       it('should NOT auto-remove when only one endpoint is provided', () => {
         expect(autoRemove([undefined, 10])).toBe(false)
         expect(autoRemove([5, undefined])).toBe(false)
+      })
+      it('should NOT auto-remove a scalar value passed instead of a range tuple', () => {
+        // Regression test for #6353 - same Array.isArray guard needed
+        // here as in `between` and `inNumberRange`.
+        expect(autoRemove(99 as any)).toBe(false)
+      })
+    })
+
+    describe('filterFns.inNumberRange.autoRemove', () => {
+      const autoRemove = filterFns.inNumberRange.autoRemove!
+
+      it('should auto-remove when both endpoints are undefined', () => {
+        expect(autoRemove([undefined, undefined])).toBe(true)
+      })
+      it('should auto-remove when both endpoints are null', () => {
+        expect(autoRemove([null, null])).toBe(true)
+      })
+      it('should auto-remove when both endpoints are empty strings', () => {
+        expect(autoRemove(['', ''])).toBe(true)
+      })
+      it('should NOT auto-remove when both endpoints are valid numbers', () => {
+        expect(autoRemove([5, 10])).toBe(false)
+      })
+      it('should NOT auto-remove when lower bound is 0 (falsy number)', () => {
+        expect(autoRemove([0, 10])).toBe(false)
+      })
+      it('should NOT auto-remove when only one endpoint is provided', () => {
+        expect(autoRemove([undefined, 10])).toBe(false)
+        expect(autoRemove([5, undefined])).toBe(false)
+      })
+      it('should NOT auto-remove a scalar number passed instead of a range tuple', () => {
+        // Regression test for #6353 - `val[0]` and `val[1]` were both
+        // undefined for a scalar, so the previous index checks produced
+        // true && true and the filter was discarded.
+        expect(autoRemove(99 as any)).toBe(false)
+        expect(autoRemove(0 as any)).toBe(false)
+        expect(autoRemove('' as any)).toBe(false)
       })
     })
   })

--- a/packages/table-core/tests/unit/fns/filterFns.test.ts
+++ b/packages/table-core/tests/unit/fns/filterFns.test.ts
@@ -596,13 +596,19 @@ describe('Filter Functions', () => {
         expect(autoRemove([undefined, 10])).toBe(false)
         expect(autoRemove([5, undefined])).toBe(false)
       })
-      it('should NOT auto-remove a scalar number passed instead of a range tuple', () => {
+      it('should NOT auto-remove a non-empty scalar number passed instead of a range tuple', () => {
         // Regression test for #6353 - `val[0]` and `val[1]` were both
-        // undefined for a scalar, so the previous index checks produced
-        // true && true and the filter was discarded.
+        // undefined for a non-array scalar, so the previous index checks
+        // produced true && true and the filter was discarded.
         expect(autoRemove(99 as any)).toBe(false)
         expect(autoRemove(0 as any)).toBe(false)
-        expect(autoRemove('' as any)).toBe(false)
+      })
+      it('should auto-remove an empty-string scalar (matches existing testFalsy behavior)', () => {
+        // `testFalsy` treats '' as falsy, and the leading `testFalsy(val)`
+        // branch short-circuits to true for an empty string. The new
+        // Array.isArray guard is intentionally additive and only kicks in
+        // when the value is not already caught by `testFalsy`.
+        expect(autoRemove('' as any)).toBe(true)
       })
     })
   })


### PR DESCRIPTION
Fixes #6353.

## Bug

`filterFn_between`, `filterFn_betweenInclusive`, and `filterFn_inNumberRange` share an `autoRemove`:

```ts
autoRemove: (val: any) =>
  testFalsy(val) || (testFalsy(val[0]) && testFalsy(val[1]))
```

When a scalar value such as `99` is passed instead of a `[min, max]` tuple, `val[0]` and `val[1]` are both `undefined`, so the condition evaluates to `true && true` and the filter is silently auto-removed.

Numeric columns default to `inNumberRange` via `column_getAutoFilterFn`, so `col.setColumnFilter(99)` on a numeric column discards the filter before the row scan even runs.

## Fix

Wrap the index checks in `Array.isArray(val) &&`:

```ts
autoRemove: (val: any) =>
  testFalsy(val) ||
  (Array.isArray(val) && testFalsy(val[0]) && testFalsy(val[1]))
```

The leading `testFalsy(val)` still handles `undefined`, `null`, `0`, and `''`. Behavior of the existing array-tuple cases is unchanged because `Array.isArray` is true and short-circuits to the same boolean.

## Tests

- New `filterFns.inNumberRange.autoRemove` describe block (the function had no direct unit tests previously).
- One regression test added to each of `between.autoRemove` and `betweenInclusive.autoRemove` covering `autoRemove(99)`.
- Existing array-tuple cases unchanged.

Local trace of all relevant cases:

| `val`              | before | after |
| ------------------ | ------ | ----- |
| `undefined`        | true   | true  |
| `[undefined, undefined]` | true | true |
| `[null, null]`     | true   | true  |
| `['', '']`         | true   | true  |
| `[5, 10]`          | false  | false |
| `[0, 10]`          | false  | false |
| `[undefined, 10]`  | false  | false |
| `99`               | true (BUG) | false |
| `''`               | true   | true  |

2 files changed, +49/-3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected auto-removal logic for range-based filters so non-array/scalar inputs are no longer treated as empty ranges.
  * Fixed range filter auto-removal behavior for between/between-inclusive and numeric range cases.
* **Tests**
  * Added regression tests to ensure scalar inputs don’t trigger auto-removal, and empty-string handling remains consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->