### PR TITLE
fix(column-filtering): include sub-rows in flatRows when maxLeafRowFilterDepth skips recursion

### DIFF
--- a/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
+++ b/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
@@ -113,6 +113,20 @@ function filterRowModelFromRoot<
   const newFilteredRowsById = makeObjectMap<Row<TFeatures, TData>>()
   const maxDepth = table.options.maxLeafRowFilterDepth ?? 100
 
+  // Recursively flatten a row's sub-rows into flatRows and rowsById.
+  // Used when a parent row passes the filter but recursion past
+  // maxLeafRowFilterDepth was skipped, so sub-rows would otherwise be
+  // missing from the flattened representation.
+  const addSubRowsToFlatArrays = (row: Row<TFeatures, TData>) => {
+    for (const subRow of row.subRows) {
+      newFilteredFlatRows.push(subRow)
+      newFilteredRowsById[subRow.id] = subRow
+      if (subRow.subRows.length) {
+        addSubRowsToFlatArrays(subRow)
+      }
+    }
+  }
+
   // Filters top level and nested rows
   const recurseFilterRows = (
     rowsToFilter: Array<Row<TFeatures, TData>>,
@@ -139,6 +153,12 @@ function filterRowModelFromRoot<
           )
           newRow.subRows = recurseFilterRows(row.subRows, depth + 1)
           row = newRow
+        } else if (row.subRows.length) {
+          // Parent passed but recursion past maxDepth was skipped;
+          // the sub-rows are still accessible via row.subRows, so
+          // mirror them into flatRows / rowsById to keep the
+          // flattened representation in sync with the visible tree.
+          addSubRowsToFlatArrays(row)
         }
 
         filteredRows.push(row)


### PR DESCRIPTION
Fixes #6361 (refs #5987).

## Bug

\`filterRowModelFromRoot\` discarded sub-rows when the parent passed the filter but recursion was skipped because \`depth >= maxLeafRowFilterDepth\`. The parent row was pushed into \`flatRows\` and \`rowsById\`, but the children stayed reachable only via \`row.subRows\`, leaving \`flatRows\` an incomplete view of the visible tree.

\`column.getFacetedUniqueValues()\` (which iterates \`flatRows\`) returned consistent counts before filtering but inconsistent counts after, because the pre-filter \`flatRows\` from the core row model includes sub-rows while the filtered \`flatRows\` did not.

## Fix

Add a small helper \`addSubRowsToFlatArrays\` that recursively pushes each surviving sub-row into \`flatRows\` and \`rowsById\`, and call it from the \`else if\` branch the parent-pass / depth-skipped case falls into. The branch is reached only when \`row.subRows.length\` is truthy, so the helper always has work to do.

\`flatRows\` and \`rowsById\` now contain the same set of rows that \`rows\` plus the surviving \`row.subRows\` paths cover, so faceted-unique counts and other flat-row consumers agree with the visible tree.

\`filterRowModelFromLeafs\` already pushed every passing leaf (including sub-rows that came from recursion) into \`flatRows\` via its own loop, so the bug was specific to \`filterRowModelFromRoot\`.

## Tests

Local test harness is not available in this environment (no \`node_modules\`), but the change is small and the cases are mechanical:

| scenario | before | after |
| --- | --- | --- |
| no filter | flatRows = all rows | flatRows = all rows |
| maxLeafRowFilterDepth = 100, normal filter | flatRows = passing rows at all depths | unchanged |
| maxLeafRowFilterDepth = 0, parent passes | flatRows = [parent only] | flatRows = [parent + subRows] |
| maxLeafRowFilterDepth = 0, parent passes, sub-rows also have subRows | subRows of subRows missing | included recursively |

A follow-up commit can add a regression test once the test harness is wired up locally; happy to do that in response to review feedback.

1 file changed, +20/-0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtered table results so nested rows stay consistent in the visible row list and row lookup data, even when filtering depth limits are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->