### PR TITLE
fix(vue): use noop batch in reactivity instead of tanstack store fn

### DIFF
--- a/packages/vue-table/src/reactivity.ts
+++ b/packages/vue-table/src/reactivity.ts
@@ -1,5 +1,4 @@
 import { computed, shallowRef, watch } from 'vue'
-import { batch } from '@tanstack/store'
 import type {
   TableAtomOptions,
   TableReactivityBindings,
@@ -84,6 +83,6 @@ export function vueReactivity(): TableReactivityBindings {
       return refToWritableAtom(shallowRef(value) as ShallowRef<T>)
     },
     untrack: (fn) => fn(),
-    batch,
+    batch: (fn) => fn(),
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue table reactivity to ensure updates are applied reliably without relying on external batching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->