### PR TITLE
feat: batch row selection

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,8 +35,10 @@ jobs:
         uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4.4.0
         with:
           main-branch-name: main
+      - name: Install Playwright Browsers
+        run: pnpm run test:e2e:install
       - name: Run Checks
-        run: pnpm run test:pr --parallel=3
+        run: pnpm run test:pr --parallel=8
       - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,8 +35,6 @@ jobs:
         uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4.4.0
         with:
           main-branch-name: main
-      - name: Install Playwright Browsers
-        run: pnpm run test:e2e:install
       - name: Run Checks
         run: pnpm run test:pr --parallel=8
       - name: Stop Nx Agents

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           main-branch-name: main
       - name: Run Checks
-        run: pnpm run test:pr --parallel=8
+        run: pnpm run test:pr --parallel4
       - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           main-branch-name: main
       - name: Run Checks
-        run: pnpm run test:pr --parallel4
+        run: pnpm run test:pr --parallel=4
       - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Tools
         uses: tanstack/config/.github/setup@e4b48f16568324f76f467aa4c2aac2f05db632c3 # main
       - name: Run Tests
-        run: pnpm run test:ci --parallel=3
+        run: pnpm run test:ci --parallel=8
       - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Tools
         uses: tanstack/config/.github/setup@e4b48f16568324f76f467aa4c2aac2f05db632c3 # main
       - name: Run Tests
-        run: pnpm run test:ci --parallel=8
+        run: pnpm run test:ci --parallel=4
       - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents

--- a/docs/framework/alpine/guide/custom-features.md
+++ b/docs/framework/alpine/guide/custom-features.md
@@ -52,6 +52,12 @@ export interface TableFeature {
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
     table: Table_Internal<TFeatures, TData>,
   ) => void
+  initTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
+  ) => void
   getDefaultColumnDef?: <
     TFeatures extends TableFeatures,
     TData extends RowData,
@@ -69,6 +75,12 @@ export interface TableFeature {
     TData extends RowData,
   >(
     row: Row<TFeatures, TData>,
+  ) => void
+  resetTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
   ) => void
 }
 ```
@@ -99,9 +111,19 @@ The `getInitialState` method in a table feature is responsible for setting the d
 
 <br />
 
+#### initTableInstanceData and resetTableInstanceData
+
+Use `initTableInstanceData` for mutable, non-reactive data that belongs to one table instance, such as an interaction anchor or an imperative cache. It runs once after table options, state atoms, and the store have been created. Every feature's initialization hook runs before any feature's `constructTableAPIs` hook.
+
+Use `resetTableInstanceData` to clear that transient data when `table.reset()` runs. Reset hooks run after internally owned table state atoms have been restored to `table.initialState`. They do not reset table state slices or externally controlled state, and `table.reset()` does not rerun `initTableInstanceData`.
+
+Keep API assignment in `constructTableAPIs`; initialization and reset hooks are for data owned by the feature.
+
+<br />
+
 #### constructTableAPIs
 
-The `constructTableAPIs` method in a table feature is responsible for adding methods to the `table` instance. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
+The `constructTableAPIs` method in a table feature is exclusively responsible for adding methods to the `table` instance. It runs after all feature-owned table instance data has been initialized. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
 
 <br />
 

--- a/docs/framework/alpine/guide/row-selection.md
+++ b/docs/framework/alpine/guide/row-selection.md
@@ -178,6 +178,35 @@ const table = createTable({
 })
 ```
 
+### Shift Range Selection
+
+`row.getToggleSelectedHandler()` supports Shift range selection by default. After an ordinary selectable-row interaction establishes an anchor, Shift-selecting another row selects or deselects the inclusive interval between them. The clicked checkbox's resulting checked value controls the whole range, and the clicked endpoint becomes the anchor for the next Shift interaction.
+
+The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
+
+```ts
+const table = createTable({
+  // ...
+  enableRowRangeSelection: false,
+
+  // For example, use the platform modifier instead of Shift:
+  // isRowRangeSelectionEvent: event =>
+  //   Boolean((event as { metaKey?: boolean }).metaKey),
+})
+```
+
+Range selection follows the table's current logical display order, including filtering, grouping, sorting, and expansion. With client-side pagination, ranges can cross pages because the complete pre-pagination order is used. With manual/server pagination, only rows loaded in the current `data` can participate.
+
+By default, a parent encountered in a range recursively toggles its selectable descendants when sub-row selection is enabled. Pass `selectChildren: false` when only rows explicitly present in the display-order interval should change:
+
+```ts
+const handler = row.getToggleSelectedHandler({
+  selectChildren: false,
+})
+```
+
+The interaction anchor is preserved across sorting, filtering, grouping, expansion, pagination, and data updates while its row id remains in the display order. If filtering or data replacement removes the anchor, the next Shift interaction falls back to an ordinary row toggle and establishes a new anchor. `resetRowSelection`, either select-all API, and `table.reset()` clear the anchor. Direct calls to `row.toggleSelected()` or `table.setRowSelection()`, and external controlled-state changes, do not establish or move it.
+
 ### Render Row Selection UI
 
 TanStack Table does not dictate how you should render your row selection UI. You can use checkboxes, radio buttons, or simply hook up click events to the row itself. The table instance provides a few APIs to help you render your row selection UI.

--- a/docs/framework/alpine/guide/row-selection.md
+++ b/docs/framework/alpine/guide/row-selection.md
@@ -184,6 +184,8 @@ const table = createTable({
 
 The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
 
+Bind an Alpine checkbox handler with `@click`, not `@change`, so the handler receives the click event and its `shiftKey` modifier.
+
 ```ts
 const table = createTable({
   // ...
@@ -260,7 +262,7 @@ const columns = [
     :checked="cell.row.getIsSelected()"
     :disabled="!cell.row.getCanSelect()"
     x-effect="$el.indeterminate = !cell.row.getIsSelected() && cell.row.getIsSomeSelected()"
-    @change="cell.row.getToggleSelectedHandler()($event)"
+    @click="cell.row.getToggleSelectedHandler()($event)"
   />
 </template>
 <!-- other cells -->

--- a/docs/framework/angular/guide/custom-features.md
+++ b/docs/framework/angular/guide/custom-features.md
@@ -58,6 +58,12 @@ export interface TableFeature {
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
     table: Table_Internal<TFeatures, TData>,
   ) => void
+  initTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
+  ) => void
   getDefaultColumnDef?: <
     TFeatures extends TableFeatures,
     TData extends RowData,
@@ -75,6 +81,12 @@ export interface TableFeature {
     TData extends RowData,
   >(
     row: Row<TFeatures, TData>,
+  ) => void
+  resetTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
   ) => void
 }
 ```
@@ -105,9 +117,19 @@ The `getInitialState` method in a table feature is responsible for setting the d
 
 <br />
 
+##### initTableInstanceData and resetTableInstanceData
+
+Use `initTableInstanceData` for mutable, non-reactive data that belongs to one table instance, such as an interaction anchor or an imperative cache. It runs once after table options, state atoms, and the store have been created. Every feature's initialization hook runs before any feature's `constructTableAPIs` hook.
+
+Use `resetTableInstanceData` to clear that transient data when `table.reset()` runs. Reset hooks run after internally owned table state atoms have been restored to `table.initialState`. They do not reset table state slices or externally controlled state, and `table.reset()` does not rerun `initTableInstanceData`.
+
+Keep API assignment in `constructTableAPIs`; initialization and reset hooks are for data owned by the feature.
+
+<br />
+
 ##### constructTableAPIs
 
-The `constructTableAPIs` method in a table feature is responsible for adding methods to the `table` instance. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
+The `constructTableAPIs` method in a table feature is exclusively responsible for adding methods to the `table` instance. It runs after all feature-owned table instance data has been initialized. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
 
 <br />
 

--- a/docs/framework/angular/guide/migrating.md
+++ b/docs/framework/angular/guide/migrating.md
@@ -753,6 +753,11 @@ Some row APIs have changed from private to public:
 
 ### Row Selection API Changes
 
+> [!WARNING]
+> **Minor breaking change:** `row.getToggleSelectedHandler()` now enables inclusive Shift range selection by default when `rowSelectionFeature` is enabled. Existing checkboxes or rows wired through this handler establish an anchor on an ordinary interaction and select or deselect the current display-order range on a Shift interaction. Direct `row.toggleSelected()` calls are unchanged.
+>
+> Set `enableRowRangeSelection: false` to preserve the previous non-range handler behavior. The handler must receive an event that exposes Shift directly or through `nativeEvent`; see [Shift Range Selection](./row-selection.md#shift-range-selection).
+
 The "some rows selected" checks were simplified to mean "at least one row is selected":
 
 | API                                 | v8                                                  | v9                                            |

--- a/docs/framework/angular/guide/row-selection.md
+++ b/docs/framework/angular/guide/row-selection.md
@@ -177,6 +177,35 @@ readonly table = injectTable(() => ({
 }))
 ```
 
+### Shift Range Selection
+
+`row.getToggleSelectedHandler()` supports Shift range selection by default. After an ordinary selectable-row interaction establishes an anchor, Shift-selecting another row selects or deselects the inclusive interval between them. The clicked checkbox's resulting checked value controls the whole range, and the clicked endpoint becomes the anchor for the next Shift interaction.
+
+The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
+
+```ts
+readonly table = injectTable(() => ({
+  // ...
+  enableRowRangeSelection: false,
+
+  // For example, use the platform modifier instead of Shift:
+  // isRowRangeSelectionEvent: event =>
+  //   Boolean((event as { metaKey?: boolean }).metaKey),
+}))
+```
+
+Range selection follows the table's current logical display order, including filtering, grouping, sorting, and expansion. With client-side pagination, ranges can cross pages because the complete pre-pagination order is used. With manual/server pagination, only rows loaded in the current `data` can participate.
+
+By default, a parent encountered in a range recursively toggles its selectable descendants when sub-row selection is enabled. Pass `selectChildren: false` when only rows explicitly present in the display-order interval should change:
+
+```ts
+const handler = row.getToggleSelectedHandler({
+  selectChildren: false,
+})
+```
+
+The interaction anchor is preserved across sorting, filtering, grouping, expansion, pagination, and data updates while its row id remains in the display order. If filtering or data replacement removes the anchor, the next Shift interaction falls back to an ordinary row toggle and establishes a new anchor. `resetRowSelection`, either select-all API, and `table.reset()` clear the anchor. Direct calls to `row.toggleSelected()` or `table.setRowSelection()`, and external controlled-state changes, do not establish or move it.
+
 ### Render Row Selection UI
 
 TanStack table does not dictate how you should render your row selection UI. You can use checkboxes, radio buttons, or simply hook up click events to the row itself. The table instance provides a few APIs to help you render your row selection UI.

--- a/docs/framework/angular/guide/row-selection.md
+++ b/docs/framework/angular/guide/row-selection.md
@@ -183,6 +183,8 @@ readonly table = injectTable(() => ({
 
 The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
 
+Bind an Angular checkbox handler with `(click)`, not `(change)`, so the handler receives the click event and its `shiftKey` modifier.
+
 ```ts
 readonly table = injectTable(() => ({
   // ...
@@ -233,7 +235,7 @@ If you need more granular control over these function handlers, you can always j
   [checked]="row.getIsSelected()"
   [disabled]="!row.getCanSelect()"
   [indeterminate]="row.getIsSomeSelected()"
-  (change)="row.getToggleSelectedHandler()?.($event)"
+  (click)="row.getToggleSelectedHandler()?.($event)"
 />
 ```
 

--- a/docs/framework/ember/guide/custom-features.md
+++ b/docs/framework/ember/guide/custom-features.md
@@ -58,6 +58,12 @@ export interface TableFeature {
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
     table: Table_Internal<TFeatures, TData>,
   ) => void
+  initTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
+  ) => void
   getDefaultColumnDef?: <
     TFeatures extends TableFeatures,
     TData extends RowData,
@@ -75,6 +81,12 @@ export interface TableFeature {
     TData extends RowData,
   >(
     row: Row<TFeatures, TData>,
+  ) => void
+  resetTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
   ) => void
 }
 ```
@@ -105,9 +117,19 @@ The `getInitialState` method in a table feature is responsible for setting the d
 
 <br />
 
+##### initTableInstanceData and resetTableInstanceData
+
+Use `initTableInstanceData` for mutable, non-reactive data that belongs to one table instance, such as an interaction anchor or an imperative cache. It runs once after table options, state atoms, and the store have been created. Every feature's initialization hook runs before any feature's `constructTableAPIs` hook.
+
+Use `resetTableInstanceData` to clear that transient data when `table.reset()` runs. Reset hooks run after internally owned table state atoms have been restored to `table.initialState`. They do not reset table state slices or externally controlled state, and `table.reset()` does not rerun `initTableInstanceData`.
+
+Keep API assignment in `constructTableAPIs`; initialization and reset hooks are for data owned by the feature.
+
+<br />
+
 ##### constructTableAPIs
 
-The `constructTableAPIs` method in a table feature is responsible for adding methods to the `table` instance. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
+The `constructTableAPIs` method in a table feature is exclusively responsible for adding methods to the `table` instance. It runs after all feature-owned table instance data has been initialized. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
 
 <br />
 

--- a/docs/framework/ember/guide/row-selection.md
+++ b/docs/framework/ember/guide/row-selection.md
@@ -169,6 +169,35 @@ const table = useTable(() => ({
 }))
 ```
 
+### Shift Range Selection
+
+`row.getToggleSelectedHandler()` supports Shift range selection by default. After an ordinary selectable-row interaction establishes an anchor, Shift-selecting another row selects or deselects the inclusive interval between them. The clicked checkbox's resulting checked value controls the whole range, and the clicked endpoint becomes the anchor for the next Shift interaction.
+
+The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
+
+```ts
+const table = useTable(() => ({
+  // ...
+  enableRowRangeSelection: false,
+
+  // For example, use the platform modifier instead of Shift:
+  // isRowRangeSelectionEvent: event =>
+  //   Boolean((event as { metaKey?: boolean }).metaKey),
+}))
+```
+
+Range selection follows the table's current logical display order, including filtering, grouping, sorting, and expansion. With client-side pagination, ranges can cross pages because the complete pre-pagination order is used. With manual/server pagination, only rows loaded in the current `data` can participate.
+
+By default, a parent encountered in a range recursively toggles its selectable descendants when sub-row selection is enabled. Pass `selectChildren: false` when only rows explicitly present in the display-order interval should change:
+
+```ts
+const handler = row.getToggleSelectedHandler({
+  selectChildren: false,
+})
+```
+
+The interaction anchor is preserved across sorting, filtering, grouping, expansion, pagination, and data updates while its row id remains in the display order. If filtering or data replacement removes the anchor, the next Shift interaction falls back to an ordinary row toggle and establishes a new anchor. `resetRowSelection`, either select-all API, and `table.reset()` clear the anchor. Direct calls to `row.toggleSelected()` or `table.setRowSelection()`, and external controlled-state changes, do not establish or move it.
+
 ### Render Row Selection UI
 
 TanStack table does not dictate how you should render your row selection UI. You can use checkboxes, radio buttons, or simply hook up click events to the row itself. The table instance provides a few APIs to help you render your row selection UI.

--- a/docs/framework/ember/guide/row-selection.md
+++ b/docs/framework/ember/guide/row-selection.md
@@ -175,6 +175,8 @@ const table = useTable(() => ({
 
 The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
 
+Bind an Ember checkbox handler to `click`, not `change`, so the handler receives the click event and its `shiftKey` modifier.
+
 ```ts
 const table = useTable(() => ({
   // ...
@@ -264,7 +266,7 @@ class SelectionRowCheckbox extends Component<
     return this.row.getIsSelected()
   }
 
-  handleChange = (event: Event) => {
+  handleClick = (event: Event) => {
     this.row.getToggleSelectedHandler()(event)
   }
 
@@ -272,7 +274,7 @@ class SelectionRowCheckbox extends Component<
     <Input
       @type='checkbox'
       @checked={{this.checked}}
-      {{on 'change' this.handleChange}}
+      {{on 'click' this.handleClick}}
     />
   </template>
 }

--- a/docs/framework/lit/guide/custom-features.md
+++ b/docs/framework/lit/guide/custom-features.md
@@ -50,6 +50,12 @@ export interface TableFeature {
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
     table: Table_Internal<TFeatures, TData>,
   ) => void
+  initTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
+  ) => void
   getDefaultColumnDef?: <
     TFeatures extends TableFeatures,
     TData extends RowData,
@@ -67,6 +73,12 @@ export interface TableFeature {
     TData extends RowData,
   >(
     row: Row<TFeatures, TData>,
+  ) => void
+  resetTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
   ) => void
 }
 ```
@@ -97,9 +109,19 @@ The `getInitialState` method in a table feature is responsible for setting the d
 
 <br />
 
+#### initTableInstanceData and resetTableInstanceData
+
+Use `initTableInstanceData` for mutable, non-reactive data that belongs to one table instance, such as an interaction anchor or an imperative cache. It runs once after table options, state atoms, and the store have been created. Every feature's initialization hook runs before any feature's `constructTableAPIs` hook.
+
+Use `resetTableInstanceData` to clear that transient data when `table.reset()` runs. Reset hooks run after internally owned table state atoms have been restored to `table.initialState`. They do not reset table state slices or externally controlled state, and `table.reset()` does not rerun `initTableInstanceData`.
+
+Keep API assignment in `constructTableAPIs`; initialization and reset hooks are for data owned by the feature.
+
+<br />
+
 #### constructTableAPIs
 
-The `constructTableAPIs` method in a table feature is responsible for adding methods to the `table` instance. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
+The `constructTableAPIs` method in a table feature is exclusively responsible for adding methods to the `table` instance. It runs after all feature-owned table instance data has been initialized. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
 
 <br />
 

--- a/docs/framework/lit/guide/migrating.md
+++ b/docs/framework/lit/guide/migrating.md
@@ -624,6 +624,11 @@ If you were accessing this internal API, you can now use it without the undersco
 
 ### Row Selection API Changes
 
+> [!WARNING]
+> **Minor breaking change:** `row.getToggleSelectedHandler()` now enables inclusive Shift range selection by default when `rowSelectionFeature` is enabled. Existing checkboxes or rows wired through this handler establish an anchor on an ordinary interaction and select or deselect the current display-order range on a Shift interaction. Direct `row.toggleSelected()` calls are unchanged.
+>
+> Set `enableRowRangeSelection: false` to preserve the previous non-range handler behavior. The handler must receive an event that exposes Shift directly or through `nativeEvent`; see [Shift Range Selection](./row-selection.md#shift-range-selection).
+
 The "some rows selected" checks were simplified to mean "at least one row is selected":
 
 | API                                 | v8                                                  | v9                                            |

--- a/docs/framework/lit/guide/row-selection.md
+++ b/docs/framework/lit/guide/row-selection.md
@@ -190,6 +190,8 @@ const table = this.tableController.table({
 
 The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
 
+Bind a Lit checkbox handler with `@click`, not `@change`, so the handler receives the click event and its `shiftKey` modifier.
+
 ```ts
 const table = this.tableController.table({
   // ...
@@ -241,7 +243,7 @@ html`
     .checked=${row.getIsSelected()}
     ?disabled=${!row.getCanSelect()}
     .indeterminate=${row.getIsSomeSelected()}
-    @change=${row.getToggleSelectedHandler()}
+    @click=${row.getToggleSelectedHandler()}
   />
 `
 ```

--- a/docs/framework/lit/guide/row-selection.md
+++ b/docs/framework/lit/guide/row-selection.md
@@ -184,6 +184,35 @@ const table = this.tableController.table({
 })
 ```
 
+### Shift Range Selection
+
+`row.getToggleSelectedHandler()` supports Shift range selection by default. After an ordinary selectable-row interaction establishes an anchor, Shift-selecting another row selects or deselects the inclusive interval between them. The clicked checkbox's resulting checked value controls the whole range, and the clicked endpoint becomes the anchor for the next Shift interaction.
+
+The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
+
+```ts
+const table = this.tableController.table({
+  // ...
+  enableRowRangeSelection: false,
+
+  // For example, use the platform modifier instead of Shift:
+  // isRowRangeSelectionEvent: event =>
+  //   Boolean((event as { metaKey?: boolean }).metaKey),
+})
+```
+
+Range selection follows the table's current logical display order, including filtering, grouping, sorting, and expansion. With client-side pagination, ranges can cross pages because the complete pre-pagination order is used. With manual/server pagination, only rows loaded in the current `data` can participate.
+
+By default, a parent encountered in a range recursively toggles its selectable descendants when sub-row selection is enabled. Pass `selectChildren: false` when only rows explicitly present in the display-order interval should change:
+
+```ts
+const handler = row.getToggleSelectedHandler({
+  selectChildren: false,
+})
+```
+
+The interaction anchor is preserved across sorting, filtering, grouping, expansion, pagination, and data updates while its row id remains in the display order. If filtering or data replacement removes the anchor, the next Shift interaction falls back to an ordinary row toggle and establishes a new anchor. `resetRowSelection`, either select-all API, and `table.reset()` clear the anchor. Direct calls to `row.toggleSelected()` or `table.setRowSelection()`, and external controlled-state changes, do not establish or move it.
+
 ### Render Row Selection UI
 
 TanStack table does not dictate how you should render your row selection UI. You can use checkboxes, radio buttons, or simply hook up click events to the row itself. The table instance provides a few APIs to help you render your row selection UI.

--- a/docs/framework/preact/guide/custom-features.md
+++ b/docs/framework/preact/guide/custom-features.md
@@ -58,6 +58,12 @@ export interface TableFeature {
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
     table: Table_Internal<TFeatures, TData>,
   ) => void
+  initTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
+  ) => void
   getDefaultColumnDef?: <
     TFeatures extends TableFeatures,
     TData extends RowData,
@@ -75,6 +81,12 @@ export interface TableFeature {
     TData extends RowData,
   >(
     row: Row<TFeatures, TData>,
+  ) => void
+  resetTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
   ) => void
 }
 ```
@@ -105,9 +117,19 @@ The `getInitialState` method in a table feature is responsible for setting the d
 
 <br />
 
+##### initTableInstanceData and resetTableInstanceData
+
+Use `initTableInstanceData` for mutable, non-reactive data that belongs to one table instance, such as an interaction anchor or an imperative cache. It runs once after table options, state atoms, and the store have been created. Every feature's initialization hook runs before any feature's `constructTableAPIs` hook.
+
+Use `resetTableInstanceData` to clear that transient data when `table.reset()` runs. Reset hooks run after internally owned table state atoms have been restored to `table.initialState`. They do not reset table state slices or externally controlled state, and `table.reset()` does not rerun `initTableInstanceData`.
+
+Keep API assignment in `constructTableAPIs`; initialization and reset hooks are for data owned by the feature.
+
+<br />
+
 ##### constructTableAPIs
 
-The `constructTableAPIs` method in a table feature is responsible for adding methods to the `table` instance. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
+The `constructTableAPIs` method in a table feature is exclusively responsible for adding methods to the `table` instance. It runs after all feature-owned table instance data has been initialized. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
 
 <br />
 

--- a/docs/framework/preact/guide/migrating.md
+++ b/docs/framework/preact/guide/migrating.md
@@ -608,6 +608,11 @@ If you were accessing this internal API, you can now use it without the undersco
 
 ### Row Selection API Changes
 
+> [!WARNING]
+> **Minor breaking change:** `row.getToggleSelectedHandler()` now enables inclusive Shift range selection by default when `rowSelectionFeature` is enabled. Existing checkboxes or rows wired through this handler establish an anchor on an ordinary interaction and select or deselect the current display-order range on a Shift interaction. Direct `row.toggleSelected()` calls are unchanged.
+>
+> Set `enableRowRangeSelection: false` to preserve the previous non-range handler behavior. The handler must receive an event that exposes Shift directly or through `nativeEvent`; see [Shift Range Selection](./row-selection.md#shift-range-selection).
+
 The "some rows selected" checks were simplified to mean "at least one row is selected":
 
 | API                                 | v8                                                  | v9                                            |

--- a/docs/framework/preact/guide/row-selection.md
+++ b/docs/framework/preact/guide/row-selection.md
@@ -173,6 +173,8 @@ const table = useTable({
 
 The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
 
+Bind a Preact checkbox handler with `onClick`, not `onChange`, so the handler receives the click event and its `shiftKey` modifier.
+
 ```ts
 const table = useTable({
   // ...
@@ -225,7 +227,7 @@ const columns = [
       <Checkbox
         checked={row.getIsSelected()}
         disabled={!row.getCanSelect()}
-        onChange={row.getToggleSelectedHandler()}
+        onClick={row.getToggleSelectedHandler()}
       />
     ),
   },

--- a/docs/framework/preact/guide/row-selection.md
+++ b/docs/framework/preact/guide/row-selection.md
@@ -167,6 +167,35 @@ const table = useTable({
 })
 ```
 
+### Shift Range Selection
+
+`row.getToggleSelectedHandler()` supports Shift range selection by default. After an ordinary selectable-row interaction establishes an anchor, Shift-selecting another row selects or deselects the inclusive interval between them. The clicked checkbox's resulting checked value controls the whole range, and the clicked endpoint becomes the anchor for the next Shift interaction.
+
+The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
+
+```ts
+const table = useTable({
+  // ...
+  enableRowRangeSelection: false,
+
+  // For example, use the platform modifier instead of Shift:
+  // isRowRangeSelectionEvent: event =>
+  //   Boolean((event as { metaKey?: boolean }).metaKey),
+})
+```
+
+Range selection follows the table's current logical display order, including filtering, grouping, sorting, and expansion. With client-side pagination, ranges can cross pages because the complete pre-pagination order is used. With manual/server pagination, only rows loaded in the current `data` can participate.
+
+By default, a parent encountered in a range recursively toggles its selectable descendants when sub-row selection is enabled. Pass `selectChildren: false` when only rows explicitly present in the display-order interval should change:
+
+```ts
+const handler = row.getToggleSelectedHandler({
+  selectChildren: false,
+})
+```
+
+The interaction anchor is preserved across sorting, filtering, grouping, expansion, pagination, and data updates while its row id remains in the display order. If filtering or data replacement removes the anchor, the next Shift interaction falls back to an ordinary row toggle and establishes a new anchor. `resetRowSelection`, either select-all API, and `table.reset()` clear the anchor. Direct calls to `row.toggleSelected()` or `table.setRowSelection()`, and external controlled-state changes, do not establish or move it.
+
 ### Render Row Selection UI
 
 TanStack table does not dictate how you should render your row selection UI. You can use checkboxes, radio buttons, or simply hook up click events to the row itself. The table instance provides a few APIs to help you render your row selection UI.

--- a/docs/framework/preact/guide/table-state.md
+++ b/docs/framework/preact/guide/table-state.md
@@ -175,7 +175,7 @@ You can also subscribe directly to a single atom and select one value from it:
     <input
       type="checkbox"
       checked={!!isSelected}
-      onChange={row.getToggleSelectedHandler()}
+      onClick={row.getToggleSelectedHandler()}
     />
   )}
 </table.Subscribe>

--- a/docs/framework/react/guide/custom-features.md
+++ b/docs/framework/react/guide/custom-features.md
@@ -58,6 +58,12 @@ export interface TableFeature {
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
     table: Table_Internal<TFeatures, TData>,
   ) => void
+  initTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
+  ) => void
   getDefaultColumnDef?: <
     TFeatures extends TableFeatures,
     TData extends RowData,
@@ -75,6 +81,12 @@ export interface TableFeature {
     TData extends RowData,
   >(
     row: Row<TFeatures, TData>,
+  ) => void
+  resetTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
   ) => void
 }
 ```
@@ -105,9 +117,19 @@ The `getInitialState` method in a table feature is responsible for setting the d
 
 <br />
 
+##### initTableInstanceData and resetTableInstanceData
+
+Use `initTableInstanceData` for mutable, non-reactive data that belongs to one table instance, such as an interaction anchor or an imperative cache. It runs once after table options, state atoms, and the store have been created. Every feature's initialization hook runs before any feature's `constructTableAPIs` hook.
+
+Use `resetTableInstanceData` to clear that transient data when `table.reset()` runs. Reset hooks run after internally owned table state atoms have been restored to `table.initialState`. They do not reset table state slices or externally controlled state, and `table.reset()` does not rerun `initTableInstanceData`.
+
+Keep API assignment in `constructTableAPIs`; initialization and reset hooks are for data owned by the feature.
+
+<br />
+
 ##### constructTableAPIs
 
-The `constructTableAPIs` method in a table feature is responsible for adding methods to the `table` instance. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
+The `constructTableAPIs` method in a table feature is exclusively responsible for adding methods to the `table` instance. It runs after all feature-owned table instance data has been initialized. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
 
 <br />
 

--- a/docs/framework/react/guide/migrating.md
+++ b/docs/framework/react/guide/migrating.md
@@ -940,6 +940,11 @@ If you were accessing this internal API, you can now use it without the undersco
 
 ### Row Selection API Changes
 
+> [!WARNING]
+> **Minor breaking change:** `row.getToggleSelectedHandler()` now enables inclusive Shift range selection by default when `rowSelectionFeature` is enabled. Existing checkboxes or rows wired through this handler establish an anchor on an ordinary interaction and select or deselect the current display-order range on a Shift interaction. Direct `row.toggleSelected()` calls are unchanged.
+>
+> Set `enableRowRangeSelection: false` to preserve the previous non-range handler behavior. The handler must receive an event that exposes Shift directly or through `nativeEvent`; see [Shift Range Selection](./row-selection.md#shift-range-selection).
+
 The "some rows selected" checks were simplified to mean "at least one row is selected":
 
 | API                                 | Table V8                                            | Table V9                                      |

--- a/docs/framework/react/guide/row-selection.md
+++ b/docs/framework/react/guide/row-selection.md
@@ -167,6 +167,36 @@ const table = useTable({
 })
 ```
 
+### Shift Range Selection
+
+`row.getToggleSelectedHandler()` supports Shift range selection by default. After an ordinary selectable-row interaction establishes an anchor, Shift-selecting another row selects or deselects the inclusive interval between them. The clicked checkbox's resulting checked value controls the whole range, and the clicked endpoint becomes the anchor for the next Shift interaction.
+
+The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
+
+```ts
+const table = useTable({
+  // ...
+  enableRowRangeSelection: false,
+
+  // For example, use the platform modifier instead of Shift:
+  // isRowRangeSelectionEvent: event =>
+  //   Boolean((event as React.MouseEvent).metaKey),
+})
+```
+
+Range selection follows the table's current logical display order, including filtering, grouping, sorting, and expansion. With client-side pagination, ranges can cross pages because the complete pre-pagination order is used. With manual/server pagination, only rows loaded in the current `data` can participate.
+
+By default, a parent encountered in a range recursively toggles its selectable descendants when sub-row selection is enabled. Pass `selectChildren: false` when only rows explicitly present in the display-order interval should change:
+
+```tsx
+<Checkbox
+  checked={row.getIsSelected()}
+  onChange={row.getToggleSelectedHandler({ selectChildren: false })}
+/>
+```
+
+The interaction anchor is preserved across sorting, filtering, grouping, expansion, pagination, and data updates while its row id remains in the display order. If filtering or data replacement removes the anchor, the next Shift interaction falls back to an ordinary row toggle and establishes a new anchor. `resetRowSelection`, either select-all API, and `table.reset()` clear the anchor. Direct calls to `row.toggleSelected()` or `table.setRowSelection()`, and external controlled-state changes, do not establish or move it.
+
 ### Render Row Selection UI
 
 TanStack table does not dictate how you should render your row selection UI. You can use checkboxes, radio buttons, or simply hook up click events to the row itself. The table instance provides a few APIs to help you render your row selection UI.

--- a/docs/framework/react/guide/row-selection.md
+++ b/docs/framework/react/guide/row-selection.md
@@ -173,6 +173,8 @@ const table = useTable({
 
 The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
 
+React checkbox `onChange` events expose the underlying click through `nativeEvent`, so the handler receives the Shift modifier in the examples below.
+
 ```ts
 const table = useTable({
   // ...

--- a/docs/framework/solid/guide/custom-features.md
+++ b/docs/framework/solid/guide/custom-features.md
@@ -52,6 +52,12 @@ export interface TableFeature {
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
     table: Table_Internal<TFeatures, TData>,
   ) => void
+  initTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
+  ) => void
   getDefaultColumnDef?: <
     TFeatures extends TableFeatures,
     TData extends RowData,
@@ -69,6 +75,12 @@ export interface TableFeature {
     TData extends RowData,
   >(
     row: Row<TFeatures, TData>,
+  ) => void
+  resetTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
   ) => void
 }
 ```
@@ -99,9 +111,19 @@ The `getInitialState` method in a table feature is responsible for setting the d
 
 <br />
 
+#### initTableInstanceData and resetTableInstanceData
+
+Use `initTableInstanceData` for mutable, non-reactive data that belongs to one table instance, such as an interaction anchor or an imperative cache. It runs once after table options, state atoms, and the store have been created. Every feature's initialization hook runs before any feature's `constructTableAPIs` hook.
+
+Use `resetTableInstanceData` to clear that transient data when `table.reset()` runs. Reset hooks run after internally owned table state atoms have been restored to `table.initialState`. They do not reset table state slices or externally controlled state, and `table.reset()` does not rerun `initTableInstanceData`.
+
+Keep API assignment in `constructTableAPIs`; initialization and reset hooks are for data owned by the feature.
+
+<br />
+
 #### constructTableAPIs
 
-The `constructTableAPIs` method in a table feature is responsible for adding methods to the `table` instance. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
+The `constructTableAPIs` method in a table feature is exclusively responsible for adding methods to the `table` instance. It runs after all feature-owned table instance data has been initialized. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
 
 <br />
 

--- a/docs/framework/solid/guide/migrating.md
+++ b/docs/framework/solid/guide/migrating.md
@@ -579,6 +579,11 @@ If you were accessing this internal API, you can now use it without the undersco
 
 ### Row Selection API Changes
 
+> [!WARNING]
+> **Minor breaking change:** `row.getToggleSelectedHandler()` now enables inclusive Shift range selection by default when `rowSelectionFeature` is enabled. Existing checkboxes or rows wired through this handler establish an anchor on an ordinary interaction and select or deselect the current display-order range on a Shift interaction. Direct `row.toggleSelected()` calls are unchanged.
+>
+> Set `enableRowRangeSelection: false` to preserve the previous non-range handler behavior. The handler must receive an event that exposes Shift directly or through `nativeEvent`; see [Shift Range Selection](./row-selection.md#shift-range-selection).
+
 The "some rows selected" checks were simplified to mean "at least one row is selected":
 
 | API                                 | v8                                                  | v9                                            |

--- a/docs/framework/solid/guide/row-selection.md
+++ b/docs/framework/solid/guide/row-selection.md
@@ -179,6 +179,8 @@ const table = createTable({
 
 The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
 
+Bind a Solid checkbox handler with `onClick`, not `onChange`, so the handler receives the click event and its `shiftKey` modifier.
+
 ```ts
 const table = createTable({
   // ...
@@ -231,7 +233,7 @@ const columns = [
       <Checkbox
         checked={row.getIsSelected()}
         disabled={!row.getCanSelect()}
-        onChange={row.getToggleSelectedHandler()}
+        onClick={row.getToggleSelectedHandler()}
       />
     ),
   },

--- a/docs/framework/solid/guide/row-selection.md
+++ b/docs/framework/solid/guide/row-selection.md
@@ -173,6 +173,35 @@ const table = createTable({
 })
 ```
 
+### Shift Range Selection
+
+`row.getToggleSelectedHandler()` supports Shift range selection by default. After an ordinary selectable-row interaction establishes an anchor, Shift-selecting another row selects or deselects the inclusive interval between them. The clicked checkbox's resulting checked value controls the whole range, and the clicked endpoint becomes the anchor for the next Shift interaction.
+
+The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
+
+```ts
+const table = createTable({
+  // ...
+  enableRowRangeSelection: false,
+
+  // For example, use the platform modifier instead of Shift:
+  // isRowRangeSelectionEvent: event =>
+  //   Boolean((event as { metaKey?: boolean }).metaKey),
+})
+```
+
+Range selection follows the table's current logical display order, including filtering, grouping, sorting, and expansion. With client-side pagination, ranges can cross pages because the complete pre-pagination order is used. With manual/server pagination, only rows loaded in the current `data` can participate.
+
+By default, a parent encountered in a range recursively toggles its selectable descendants when sub-row selection is enabled. Pass `selectChildren: false` when only rows explicitly present in the display-order interval should change:
+
+```ts
+const handler = row.getToggleSelectedHandler({
+  selectChildren: false,
+})
+```
+
+The interaction anchor is preserved across sorting, filtering, grouping, expansion, pagination, and data updates while its row id remains in the display order. If filtering or data replacement removes the anchor, the next Shift interaction falls back to an ordinary row toggle and establishes a new anchor. `resetRowSelection`, either select-all API, and `table.reset()` clear the anchor. Direct calls to `row.toggleSelected()` or `table.setRowSelection()`, and external controlled-state changes, do not establish or move it.
+
 ### Render Row Selection UI
 
 TanStack table does not dictate how you should render your row selection UI. You can use checkboxes, radio buttons, or simply hook up click events to the row itself. The table instance provides a few APIs to help you render your row selection UI.

--- a/docs/framework/solid/guide/table-state.md
+++ b/docs/framework/solid/guide/table-state.md
@@ -158,7 +158,7 @@ Use `table.Subscribe` when you want a specific part of the Solid tree to create 
                 <input
                   type="checkbox"
                   checked={!!isSelected()}
-                  onChange={row.getToggleSelectedHandler()}
+                  onClick={row.getToggleSelectedHandler()}
                 />
               </td>
             </tr>

--- a/docs/framework/svelte/guide/custom-features.md
+++ b/docs/framework/svelte/guide/custom-features.md
@@ -52,6 +52,12 @@ export interface TableFeature {
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
     table: Table_Internal<TFeatures, TData>,
   ) => void
+  initTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
+  ) => void
   getDefaultColumnDef?: <
     TFeatures extends TableFeatures,
     TData extends RowData,
@@ -69,6 +75,12 @@ export interface TableFeature {
     TData extends RowData,
   >(
     row: Row<TFeatures, TData>,
+  ) => void
+  resetTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
   ) => void
 }
 ```
@@ -99,9 +111,19 @@ The `getInitialState` method in a table feature is responsible for setting the d
 
 <br />
 
+#### initTableInstanceData and resetTableInstanceData
+
+Use `initTableInstanceData` for mutable, non-reactive data that belongs to one table instance, such as an interaction anchor or an imperative cache. It runs once after table options, state atoms, and the store have been created. Every feature's initialization hook runs before any feature's `constructTableAPIs` hook.
+
+Use `resetTableInstanceData` to clear that transient data when `table.reset()` runs. Reset hooks run after internally owned table state atoms have been restored to `table.initialState`. They do not reset table state slices or externally controlled state, and `table.reset()` does not rerun `initTableInstanceData`.
+
+Keep API assignment in `constructTableAPIs`; initialization and reset hooks are for data owned by the feature.
+
+<br />
+
 #### constructTableAPIs
 
-The `constructTableAPIs` method in a table feature is responsible for adding methods to the `table` instance. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
+The `constructTableAPIs` method in a table feature is exclusively responsible for adding methods to the `table` instance. It runs after all feature-owned table instance data has been initialized. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
 
 <br />
 

--- a/docs/framework/svelte/guide/migrating.md
+++ b/docs/framework/svelte/guide/migrating.md
@@ -657,6 +657,11 @@ If you were accessing this internal API, you can now use it without the undersco
 
 ### Row Selection API Changes
 
+> [!WARNING]
+> **Minor breaking change:** `row.getToggleSelectedHandler()` now enables inclusive Shift range selection by default when `rowSelectionFeature` is enabled. Existing checkboxes or rows wired through this handler establish an anchor on an ordinary interaction and select or deselect the current display-order range on a Shift interaction. Direct `row.toggleSelected()` calls are unchanged.
+>
+> Set `enableRowRangeSelection: false` to preserve the previous non-range handler behavior. The handler must receive an event that exposes Shift directly or through `nativeEvent`; see [Shift Range Selection](./row-selection.md#shift-range-selection).
+
 The "some rows selected" checks were simplified to mean "at least one row is selected":
 
 | API                                 | v8                                                  | v9                                            |

--- a/docs/framework/svelte/guide/row-selection.md
+++ b/docs/framework/svelte/guide/row-selection.md
@@ -181,6 +181,8 @@ const table = createTable({
 
 The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
 
+Bind a Svelte checkbox handler with `onclick`, not `onchange`, so the handler receives the click event and its `shiftKey` modifier.
+
 ```ts
 const table = createTable({
   // ...
@@ -246,7 +248,7 @@ The `indeterminate` checkbox property cannot be set from markup, so define a sma
   checked={row.getIsSelected()}
   disabled={!row.getCanSelect()}
   use:setIndeterminate={!row.getIsSelected() && row.getIsSomeSelected()}
-  onchange={row.getToggleSelectedHandler()}
+  onclick={row.getToggleSelectedHandler()}
 />
 ```
 

--- a/docs/framework/svelte/guide/row-selection.md
+++ b/docs/framework/svelte/guide/row-selection.md
@@ -175,6 +175,35 @@ const table = createTable({
 })
 ```
 
+### Shift Range Selection
+
+`row.getToggleSelectedHandler()` supports Shift range selection by default. After an ordinary selectable-row interaction establishes an anchor, Shift-selecting another row selects or deselects the inclusive interval between them. The clicked checkbox's resulting checked value controls the whole range, and the clicked endpoint becomes the anchor for the next Shift interaction.
+
+The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
+
+```ts
+const table = createTable({
+  // ...
+  enableRowRangeSelection: false,
+
+  // For example, use the platform modifier instead of Shift:
+  // isRowRangeSelectionEvent: event =>
+  //   Boolean((event as { metaKey?: boolean }).metaKey),
+})
+```
+
+Range selection follows the table's current logical display order, including filtering, grouping, sorting, and expansion. With client-side pagination, ranges can cross pages because the complete pre-pagination order is used. With manual/server pagination, only rows loaded in the current `data` can participate.
+
+By default, a parent encountered in a range recursively toggles its selectable descendants when sub-row selection is enabled. Pass `selectChildren: false` when only rows explicitly present in the display-order interval should change:
+
+```ts
+const handler = row.getToggleSelectedHandler({
+  selectChildren: false,
+})
+```
+
+The interaction anchor is preserved across sorting, filtering, grouping, expansion, pagination, and data updates while its row id remains in the display order. If filtering or data replacement removes the anchor, the next Shift interaction falls back to an ordinary row toggle and establishes a new anchor. `resetRowSelection`, either select-all API, and `table.reset()` clear the anchor. Direct calls to `row.toggleSelected()` or `table.setRowSelection()`, and external controlled-state changes, do not establish or move it.
+
 ### Render Row Selection UI
 
 TanStack table does not dictate how you should render your row selection UI. You can use checkboxes, radio buttons, or simply hook up click events to the row itself. The table instance provides a few APIs to help you render your row selection UI.

--- a/docs/framework/vue/guide/custom-features.md
+++ b/docs/framework/vue/guide/custom-features.md
@@ -52,6 +52,12 @@ export interface TableFeature {
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
     table: Table_Internal<TFeatures, TData>,
   ) => void
+  initTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
+  ) => void
   getDefaultColumnDef?: <
     TFeatures extends TableFeatures,
     TData extends RowData,
@@ -69,6 +75,12 @@ export interface TableFeature {
     TData extends RowData,
   >(
     row: Row<TFeatures, TData>,
+  ) => void
+  resetTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
   ) => void
 }
 ```
@@ -99,9 +111,19 @@ The `getInitialState` method in a table feature is responsible for setting the d
 
 <br />
 
+#### initTableInstanceData and resetTableInstanceData
+
+Use `initTableInstanceData` for mutable, non-reactive data that belongs to one table instance, such as an interaction anchor or an imperative cache. It runs once after table options, state atoms, and the store have been created. Every feature's initialization hook runs before any feature's `constructTableAPIs` hook.
+
+Use `resetTableInstanceData` to clear that transient data when `table.reset()` runs. Reset hooks run after internally owned table state atoms have been restored to `table.initialState`. They do not reset table state slices or externally controlled state, and `table.reset()` does not rerun `initTableInstanceData`.
+
+Keep API assignment in `constructTableAPIs`; initialization and reset hooks are for data owned by the feature.
+
+<br />
+
 #### constructTableAPIs
 
-The `constructTableAPIs` method in a table feature is responsible for adding methods to the `table` instance. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
+The `constructTableAPIs` method in a table feature is exclusively responsible for adding methods to the `table` instance. It runs after all feature-owned table instance data has been initialized. For example, in the [Row Selection](https://github.com/TanStack/table/blob/beta/packages/table-core/src/features/row-selection/rowSelectionFeature.ts) feature, the `constructTableAPIs` method adds many table instance API methods such as `toggleAllRowsSelected`, `getIsAllRowsSelected`, `getIsSomeRowsSelected`, etc. So then, when you call `table.toggleAllRowsSelected()`, you are calling a method that was added to the table instance by the `rowSelectionFeature` feature.
 
 <br />
 

--- a/docs/framework/vue/guide/migrating.md
+++ b/docs/framework/vue/guide/migrating.md
@@ -599,6 +599,11 @@ If you were accessing this internal API, you can now use it without the undersco
 
 ### Row Selection API Changes
 
+> [!WARNING]
+> **Minor breaking change:** `row.getToggleSelectedHandler()` now enables inclusive Shift range selection by default when `rowSelectionFeature` is enabled. Existing checkboxes or rows wired through this handler establish an anchor on an ordinary interaction and select or deselect the current display-order range on a Shift interaction. Direct `row.toggleSelected()` calls are unchanged.
+>
+> Set `enableRowRangeSelection: false` to preserve the previous non-range handler behavior. The handler must receive an event that exposes Shift directly or through `nativeEvent`; see [Shift Range Selection](./row-selection.md#shift-range-selection).
+
 The "some rows selected" checks were simplified to mean "at least one row is selected":
 
 | API                                 | v8                                                  | v9                                            |

--- a/docs/framework/vue/guide/row-selection.md
+++ b/docs/framework/vue/guide/row-selection.md
@@ -178,6 +178,8 @@ const table = useTable({
 
 The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
 
+Bind a Vue checkbox handler with `@click`, not `@change`, so the handler receives the click event and its `shiftKey` modifier.
+
 ```ts
 const table = useTable({
   // ...
@@ -228,7 +230,7 @@ If you need more granular control over these function handlers, you can always j
   :checked="row.getIsSelected()"
   :disabled="!row.getCanSelect()"
   :indeterminate="row.getIsSomeSelected()"
-  @change="row.getToggleSelectedHandler()?.($event)"
+  @click="row.getToggleSelectedHandler()?.($event)"
 />
 ```
 

--- a/docs/framework/vue/guide/row-selection.md
+++ b/docs/framework/vue/guide/row-selection.md
@@ -172,6 +172,35 @@ const table = useTable({
 })
 ```
 
+### Shift Range Selection
+
+`row.getToggleSelectedHandler()` supports Shift range selection by default. After an ordinary selectable-row interaction establishes an anchor, Shift-selecting another row selects or deselects the inclusive interval between them. The clicked checkbox's resulting checked value controls the whole range, and the clicked endpoint becomes the anchor for the next Shift interaction.
+
+The handler recognizes Shift when the event exposes either `event.shiftKey` or `event.nativeEvent.shiftKey`. You can disable range behavior or replace event detection:
+
+```ts
+const table = useTable({
+  // ...
+  enableRowRangeSelection: false,
+
+  // For example, use the platform modifier instead of Shift:
+  // isRowRangeSelectionEvent: event =>
+  //   Boolean((event as { metaKey?: boolean }).metaKey),
+})
+```
+
+Range selection follows the table's current logical display order, including filtering, grouping, sorting, and expansion. With client-side pagination, ranges can cross pages because the complete pre-pagination order is used. With manual/server pagination, only rows loaded in the current `data` can participate.
+
+By default, a parent encountered in a range recursively toggles its selectable descendants when sub-row selection is enabled. Pass `selectChildren: false` when only rows explicitly present in the display-order interval should change:
+
+```ts
+const handler = row.getToggleSelectedHandler({
+  selectChildren: false,
+})
+```
+
+The interaction anchor is preserved across sorting, filtering, grouping, expansion, pagination, and data updates while its row id remains in the display order. If filtering or data replacement removes the anchor, the next Shift interaction falls back to an ordinary row toggle and establishes a new anchor. `resetRowSelection`, either select-all API, and `table.reset()` clear the anchor. Direct calls to `row.toggleSelected()` or `table.setRowSelection()`, and external controlled-state changes, do not establish or move it.
+
 ### Render Row Selection UI
 
 TanStack table does not dictate how you should render your row selection UI. You can use checkboxes, radio buttons, or simply hook up click events to the row itself. The table instance provides a few APIs to help you render your row selection UI.

--- a/docs/framework/vue/guide/table-state.md
+++ b/docs/framework/vue/guide/table-state.md
@@ -157,7 +157,7 @@ You can also call it as a plain function inside a render function:
               <input
                 type="checkbox"
                 checked={!!atoms.rowSelection.get()[row.id]}
-                onChange={row.getToggleSelectedHandler()}
+                onClick={row.getToggleSelectedHandler()}
               />
             </td>
           </tr>

--- a/docs/guide/rows.md
+++ b/docs/guide/rows.md
@@ -55,6 +55,25 @@ const table = useTable({
 
 > Note: In some features like grouping and expanding, the `row.id` will have additional string appended to it.
 
+### Row Numbers and Display Indexes
+
+When displaying a row-number column, use `row.getDisplayIndex()` instead of `row.index`. The display index follows the table's current logical display order, including filtering, grouping, sorting, and expansion. `row.index` is the row's position within its parent array when the row is created, so it does not change to reflect the current display pipeline.
+
+```js
+const rowNumberColumn = columnHelper.display({
+  id: 'rowNumber',
+  header: '#',
+  cell: ({ row }) => {
+    const displayIndex = row.getDisplayIndex()
+    return displayIndex === -1 ? '' : displayIndex + 1
+  },
+})
+```
+
+`row.getDisplayIndex()` returns a zero-based index before pagination, or `-1` when the row is not present in the current display order.
+
+> Never read `row._displayIndexCache` directly. It is an internal implementation cache that can be stale until display order is recomputed. `row.getDisplayIndex()` refreshes and validates the cached position before returning it.
+
 ### Access Row Values
 
 The recommended way to access data values from a row is to use either the `row.getValue` or `row.renderValue` APIs. Using either of these APIs will cache the results of the accessor functions and keep rendering efficient. The only difference between the two is that `row.renderValue` will return either the value or the `renderFallbackValue` if the value is undefined, whereas `row.getValue` will return the value or `undefined` if the value is undefined.

--- a/docs/reference/index/index.md
+++ b/docs/reference/index/index.md
@@ -171,6 +171,7 @@ title: index
 - [TableState\_RowPinning](interfaces/TableState_RowPinning.md)
 - [TableState\_RowSelection](interfaces/TableState_RowSelection.md)
 - [TableState\_RowSorting](interfaces/TableState_RowSorting.md)
+- [ToggleSelectedOptions](interfaces/ToggleSelectedOptions.md)
 
 ## Type Aliases
 

--- a/docs/reference/index/interfaces/Row_Core.md
+++ b/docs/reference/index/interfaces/Row_Core.md
@@ -43,7 +43,15 @@ Defined in: [core/rows/coreRowsFeature.types.ts:12](https://github.com/TanStack/
 _displayIndexCache: number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:16](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L16)
+Defined in: [core/rows/coreRowsFeature.types.ts:25](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L25)
+
+**`Internal`**
+
+Internal cache used while resolving the current display order.
+
+This value may be stale until display order is recomputed. Use
+`row.getDisplayIndex()` instead; it refreshes and validates the cached
+position before returning it.
 
 #### Inherited from
 
@@ -57,7 +65,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:16](https://github.com/TanStack/
 _uniqueValuesCache: Record<string, unknown>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:17](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L17)
+Defined in: [core/rows/coreRowsFeature.types.ts:26](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L26)
 
 #### Inherited from
 
@@ -71,7 +79,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:17](https://github.com/TanStack/
 _valuesCache: Record<string, unknown>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:18](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L18)
+Defined in: [core/rows/coreRowsFeature.types.ts:27](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L27)
 
 #### Inherited from
 
@@ -85,7 +93,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:18](https://github.com/TanStack/
 depth: number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:22](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L22)
+Defined in: [core/rows/coreRowsFeature.types.ts:31](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L31)
 
 The depth of the row (if nested or grouped) relative to the root row array.
 
@@ -101,7 +109,7 @@ The depth of the row (if nested or grouped) relative to the root row array.
 getAllCells: () => Cell<TFeatures, TData, unknown>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:69](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L69)
+Defined in: [core/rows/coreRowsFeature.types.ts:80](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L80)
 
 Builds one cell for each leaf column, including cells for hidden columns.
 
@@ -121,7 +129,7 @@ Builds one cell for each leaf column, including cells for hidden columns.
 getAllCellsByColumnId: () => Record<string, Cell<TFeatures, TData, unknown>>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:65](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L65)
+Defined in: [core/rows/coreRowsFeature.types.ts:76](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L76)
 
 Builds a lookup of this row's cells keyed by leaf column id.
 
@@ -141,10 +149,12 @@ Builds a lookup of this row's cells keyed by leaf column id.
 getDisplayIndex: () => number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:61](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L61)
+Defined in: [core/rows/coreRowsFeature.types.ts:72](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L72)
 
 Returns the zero-based index of the row in the current display order
-before pagination, or `-1` if the row is not in that model.
+before pagination, or `-1` if the row is not in that model. Use this for
+display row-number columns instead of `row.index` or the internal
+`_displayIndexCache` field.
 
 #### Returns
 
@@ -162,7 +172,7 @@ before pagination, or `-1` if the row is not in that model.
 getLeafRows: () => Row<TFeatures, TData>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:73](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L73)
+Defined in: [core/rows/coreRowsFeature.types.ts:84](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L84)
 
 Returns the leaf rows for the row, not including any parent rows.
 
@@ -182,7 +192,7 @@ Returns the leaf rows for the row, not including any parent rows.
 getParentRow: () => Row<TFeatures, TData> | undefined;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:77](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L77)
+Defined in: [core/rows/coreRowsFeature.types.ts:88](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L88)
 
 Returns the parent row for the row, if it exists.
 
@@ -202,7 +212,7 @@ Returns the parent row for the row, if it exists.
 getParentRows: () => Row<TFeatures, TData>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:81](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L81)
+Defined in: [core/rows/coreRowsFeature.types.ts:92](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L92)
 
 Returns the parent rows for the row, all the way up to a root row.
 
@@ -222,7 +232,7 @@ Returns the parent rows for the row, all the way up to a root row.
 getUniqueValues: <TValue>(columnId) => TValue[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:85](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L85)
+Defined in: [core/rows/coreRowsFeature.types.ts:96](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L96)
 
 Reads the values this row contributes to faceting/grouping for a column.
 
@@ -254,7 +264,7 @@ Reads the values this row contributes to faceting/grouping for a column.
 getValue: <TValue>(columnId) => TValue;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:89](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L89)
+Defined in: [core/rows/coreRowsFeature.types.ts:100](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L100)
 
 Reads this row's accessor value for a column id and caches the result.
 
@@ -286,7 +296,7 @@ Reads this row's accessor value for a column id and caches the result.
 id: string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:26](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L26)
+Defined in: [core/rows/coreRowsFeature.types.ts:35](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L35)
 
 The resolved unique identifier for the row resolved via the `options.getRowId` option. Defaults to the row's index (or relative index if it is a subRow).
 
@@ -302,7 +312,7 @@ The resolved unique identifier for the row resolved via the `options.getRowId` o
 index: number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:30](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L30)
+Defined in: [core/rows/coreRowsFeature.types.ts:39](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L39)
 
 The index of the row within its parent array (or the root data array).
 
@@ -318,7 +328,7 @@ The index of the row within its parent array (or the root data array).
 original: TData;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:34](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L34)
+Defined in: [core/rows/coreRowsFeature.types.ts:43](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L43)
 
 The original row object provided to the table. If the row is a grouped row, the original row object will be the first original in the group.
 
@@ -334,7 +344,7 @@ The original row object provided to the table. If the row is a grouped row, the 
 optional originalSubRows: readonly TData[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:38](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L38)
+Defined in: [core/rows/coreRowsFeature.types.ts:47](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L47)
 
 An array of the original subRows as returned by the `options.getSubRows` option.
 
@@ -350,7 +360,7 @@ An array of the original subRows as returned by the `options.getSubRows` option.
 optional parentId: string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:42](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L42)
+Defined in: [core/rows/coreRowsFeature.types.ts:51](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L51)
 
 If nested, this row's parent row id.
 
@@ -366,7 +376,7 @@ If nested, this row's parent row id.
 renderValue: <TValue>(columnId) => TValue;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:93](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L93)
+Defined in: [core/rows/coreRowsFeature.types.ts:104](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L104)
 
 Renders the value for the row in a given columnId the same as `getValue`, but will return the `renderFallbackValue` if no value is found.
 
@@ -398,7 +408,7 @@ Renders the value for the row in a given columnId the same as `getValue`, but wi
 subRows: Row<TFeatures, TData>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:46](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L46)
+Defined in: [core/rows/coreRowsFeature.types.ts:55](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L55)
 
 An array of subRows for the row as returned and created by the `options.getSubRows` option.
 
@@ -414,7 +424,7 @@ An array of subRows for the row as returned and created by the `options.getSubRo
 table: Table_Internal<TFeatures, TData>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:50](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L50)
+Defined in: [core/rows/coreRowsFeature.types.ts:59](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L59)
 
 Reference to the parent table instance.
 

--- a/docs/reference/index/interfaces/Row_CoreProperties.md
+++ b/docs/reference/index/interfaces/Row_CoreProperties.md
@@ -39,7 +39,15 @@ Defined in: [core/rows/coreRowsFeature.types.ts:12](https://github.com/TanStack/
 _displayIndexCache: number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:16](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L16)
+Defined in: [core/rows/coreRowsFeature.types.ts:25](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L25)
+
+**`Internal`**
+
+Internal cache used while resolving the current display order.
+
+This value may be stale until display order is recomputed. Use
+`row.getDisplayIndex()` instead; it refreshes and validates the cached
+position before returning it.
 
 ***
 
@@ -49,7 +57,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:16](https://github.com/TanStack/
 _uniqueValuesCache: Record<string, unknown>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:17](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L17)
+Defined in: [core/rows/coreRowsFeature.types.ts:26](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L26)
 
 ***
 
@@ -59,7 +67,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:17](https://github.com/TanStack/
 _valuesCache: Record<string, unknown>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:18](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L18)
+Defined in: [core/rows/coreRowsFeature.types.ts:27](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L27)
 
 ***
 
@@ -69,7 +77,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:18](https://github.com/TanStack/
 depth: number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:22](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L22)
+Defined in: [core/rows/coreRowsFeature.types.ts:31](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L31)
 
 The depth of the row (if nested or grouped) relative to the root row array.
 
@@ -81,7 +89,7 @@ The depth of the row (if nested or grouped) relative to the root row array.
 id: string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:26](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L26)
+Defined in: [core/rows/coreRowsFeature.types.ts:35](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L35)
 
 The resolved unique identifier for the row resolved via the `options.getRowId` option. Defaults to the row's index (or relative index if it is a subRow).
 
@@ -93,7 +101,7 @@ The resolved unique identifier for the row resolved via the `options.getRowId` o
 index: number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:30](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L30)
+Defined in: [core/rows/coreRowsFeature.types.ts:39](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L39)
 
 The index of the row within its parent array (or the root data array).
 
@@ -105,7 +113,7 @@ The index of the row within its parent array (or the root data array).
 original: TData;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:34](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L34)
+Defined in: [core/rows/coreRowsFeature.types.ts:43](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L43)
 
 The original row object provided to the table. If the row is a grouped row, the original row object will be the first original in the group.
 
@@ -117,7 +125,7 @@ The original row object provided to the table. If the row is a grouped row, the 
 optional originalSubRows: readonly TData[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:38](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L38)
+Defined in: [core/rows/coreRowsFeature.types.ts:47](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L47)
 
 An array of the original subRows as returned by the `options.getSubRows` option.
 
@@ -129,7 +137,7 @@ An array of the original subRows as returned by the `options.getSubRows` option.
 optional parentId: string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:42](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L42)
+Defined in: [core/rows/coreRowsFeature.types.ts:51](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L51)
 
 If nested, this row's parent row id.
 
@@ -141,7 +149,7 @@ If nested, this row's parent row id.
 subRows: Row<TFeatures, TData>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:46](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L46)
+Defined in: [core/rows/coreRowsFeature.types.ts:55](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L55)
 
 An array of subRows for the row as returned and created by the `options.getSubRows` option.
 
@@ -153,6 +161,6 @@ An array of subRows for the row as returned and created by the `options.getSubRo
 table: Table_Internal<TFeatures, TData>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:50](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L50)
+Defined in: [core/rows/coreRowsFeature.types.ts:59](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L59)
 
 Reference to the parent table instance.

--- a/docs/reference/index/interfaces/Row_Row.md
+++ b/docs/reference/index/interfaces/Row_Row.md
@@ -5,7 +5,7 @@ title: Row_Row
 
 # Interface: Row\_Row\<TFeatures, TData\>
 
-Defined in: [core/rows/coreRowsFeature.types.ts:53](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L53)
+Defined in: [core/rows/coreRowsFeature.types.ts:62](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L62)
 
 ## Extends
 
@@ -47,7 +47,15 @@ Defined in: [core/rows/coreRowsFeature.types.ts:12](https://github.com/TanStack/
 _displayIndexCache: number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:16](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L16)
+Defined in: [core/rows/coreRowsFeature.types.ts:25](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L25)
+
+**`Internal`**
+
+Internal cache used while resolving the current display order.
+
+This value may be stale until display order is recomputed. Use
+`row.getDisplayIndex()` instead; it refreshes and validates the cached
+position before returning it.
 
 #### Inherited from
 
@@ -61,7 +69,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:16](https://github.com/TanStack/
 _uniqueValuesCache: Record<string, unknown>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:17](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L17)
+Defined in: [core/rows/coreRowsFeature.types.ts:26](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L26)
 
 #### Inherited from
 
@@ -75,7 +83,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:17](https://github.com/TanStack/
 _valuesCache: Record<string, unknown>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:18](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L18)
+Defined in: [core/rows/coreRowsFeature.types.ts:27](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L27)
 
 #### Inherited from
 
@@ -89,7 +97,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:18](https://github.com/TanStack/
 depth: number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:22](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L22)
+Defined in: [core/rows/coreRowsFeature.types.ts:31](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L31)
 
 The depth of the row (if nested or grouped) relative to the root row array.
 
@@ -105,7 +113,7 @@ The depth of the row (if nested or grouped) relative to the root row array.
 getAllCells: () => Cell<TFeatures, TData, unknown>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:69](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L69)
+Defined in: [core/rows/coreRowsFeature.types.ts:80](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L80)
 
 Builds one cell for each leaf column, including cells for hidden columns.
 
@@ -121,7 +129,7 @@ Builds one cell for each leaf column, including cells for hidden columns.
 getAllCellsByColumnId: () => Record<string, Cell<TFeatures, TData, unknown>>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:65](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L65)
+Defined in: [core/rows/coreRowsFeature.types.ts:76](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L76)
 
 Builds a lookup of this row's cells keyed by leaf column id.
 
@@ -137,10 +145,12 @@ Builds a lookup of this row's cells keyed by leaf column id.
 getDisplayIndex: () => number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:61](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L61)
+Defined in: [core/rows/coreRowsFeature.types.ts:72](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L72)
 
 Returns the zero-based index of the row in the current display order
-before pagination, or `-1` if the row is not in that model.
+before pagination, or `-1` if the row is not in that model. Use this for
+display row-number columns instead of `row.index` or the internal
+`_displayIndexCache` field.
 
 #### Returns
 
@@ -154,7 +164,7 @@ before pagination, or `-1` if the row is not in that model.
 getLeafRows: () => Row<TFeatures, TData>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:73](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L73)
+Defined in: [core/rows/coreRowsFeature.types.ts:84](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L84)
 
 Returns the leaf rows for the row, not including any parent rows.
 
@@ -170,7 +180,7 @@ Returns the leaf rows for the row, not including any parent rows.
 getParentRow: () => Row<TFeatures, TData> | undefined;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:77](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L77)
+Defined in: [core/rows/coreRowsFeature.types.ts:88](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L88)
 
 Returns the parent row for the row, if it exists.
 
@@ -186,7 +196,7 @@ Returns the parent row for the row, if it exists.
 getParentRows: () => Row<TFeatures, TData>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:81](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L81)
+Defined in: [core/rows/coreRowsFeature.types.ts:92](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L92)
 
 Returns the parent rows for the row, all the way up to a root row.
 
@@ -202,7 +212,7 @@ Returns the parent rows for the row, all the way up to a root row.
 getUniqueValues: <TValue>(columnId) => TValue[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:85](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L85)
+Defined in: [core/rows/coreRowsFeature.types.ts:96](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L96)
 
 Reads the values this row contributes to faceting/grouping for a column.
 
@@ -230,7 +240,7 @@ Reads the values this row contributes to faceting/grouping for a column.
 getValue: <TValue>(columnId) => TValue;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:89](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L89)
+Defined in: [core/rows/coreRowsFeature.types.ts:100](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L100)
 
 Reads this row's accessor value for a column id and caches the result.
 
@@ -258,7 +268,7 @@ Reads this row's accessor value for a column id and caches the result.
 id: string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:26](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L26)
+Defined in: [core/rows/coreRowsFeature.types.ts:35](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L35)
 
 The resolved unique identifier for the row resolved via the `options.getRowId` option. Defaults to the row's index (or relative index if it is a subRow).
 
@@ -274,7 +284,7 @@ The resolved unique identifier for the row resolved via the `options.getRowId` o
 index: number;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:30](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L30)
+Defined in: [core/rows/coreRowsFeature.types.ts:39](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L39)
 
 The index of the row within its parent array (or the root data array).
 
@@ -290,7 +300,7 @@ The index of the row within its parent array (or the root data array).
 original: TData;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:34](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L34)
+Defined in: [core/rows/coreRowsFeature.types.ts:43](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L43)
 
 The original row object provided to the table. If the row is a grouped row, the original row object will be the first original in the group.
 
@@ -306,7 +316,7 @@ The original row object provided to the table. If the row is a grouped row, the 
 optional originalSubRows: readonly TData[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:38](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L38)
+Defined in: [core/rows/coreRowsFeature.types.ts:47](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L47)
 
 An array of the original subRows as returned by the `options.getSubRows` option.
 
@@ -322,7 +332,7 @@ An array of the original subRows as returned by the `options.getSubRows` option.
 optional parentId: string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:42](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L42)
+Defined in: [core/rows/coreRowsFeature.types.ts:51](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L51)
 
 If nested, this row's parent row id.
 
@@ -338,7 +348,7 @@ If nested, this row's parent row id.
 renderValue: <TValue>(columnId) => TValue;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:93](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L93)
+Defined in: [core/rows/coreRowsFeature.types.ts:104](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L104)
 
 Renders the value for the row in a given columnId the same as `getValue`, but will return the `renderFallbackValue` if no value is found.
 
@@ -366,7 +376,7 @@ Renders the value for the row in a given columnId the same as `getValue`, but wi
 subRows: Row<TFeatures, TData>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:46](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L46)
+Defined in: [core/rows/coreRowsFeature.types.ts:55](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L55)
 
 An array of subRows for the row as returned and created by the `options.getSubRows` option.
 
@@ -382,7 +392,7 @@ An array of subRows for the row as returned and created by the `options.getSubRo
 table: Table_Internal<TFeatures, TData>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:50](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L50)
+Defined in: [core/rows/coreRowsFeature.types.ts:59](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L59)
 
 Reference to the parent table instance.
 

--- a/docs/reference/index/interfaces/Row_RowSelection.md
+++ b/docs/reference/index/interfaces/Row_RowSelection.md
@@ -5,7 +5,7 @@ title: Row_RowSelection
 
 # Interface: Row\_RowSelection
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:54](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L54)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:77](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L77)
 
 ## Properties
 
@@ -15,7 +15,7 @@ Defined in: [features/row-selection/rowSelectionFeature.types.ts:54](https://git
 getCanMultiSelect: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:58](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L58)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:81](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L81)
 
 Checks whether this row can be selected alongside other rows.
 
@@ -31,7 +31,7 @@ Checks whether this row can be selected alongside other rows.
 getCanSelect: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:62](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L62)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:85](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L85)
 
 Checks whether this row can currently be selected.
 
@@ -47,7 +47,7 @@ Checks whether this row can currently be selected.
 getCanSelectSubRows: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:66](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L66)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:89](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L89)
 
 Checks whether selecting this row should also select its subRows.
 
@@ -63,7 +63,7 @@ Checks whether selecting this row should also select its subRows.
 getIsAllSubRowsSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:70](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L70)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:93](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L93)
 
 Checks whether all selectable descendants are selected.
 
@@ -79,7 +79,7 @@ Checks whether all selectable descendants are selected.
 getIsSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:74](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L74)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:97](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L97)
 
 Checks whether this row id is selected.
 
@@ -95,7 +95,7 @@ Checks whether this row id is selected.
 getIsSomeSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:78](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L78)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:101](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L101)
 
 Checks whether some selectable descendants are selected.
 
@@ -108,12 +108,18 @@ Checks whether some selectable descendants are selected.
 ### getToggleSelectedHandler()
 
 ```ts
-getToggleSelectedHandler: () => (event) => void;
+getToggleSelectedHandler: (opts?) => (event) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:82](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L82)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:105](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L105)
 
 Creates a checkbox-style handler that toggles this row's selected state.
+
+#### Parameters
+
+##### opts?
+
+[`ToggleSelectedOptions`](ToggleSelectedOptions.md)
 
 #### Returns
 
@@ -139,7 +145,7 @@ Creates a checkbox-style handler that toggles this row's selected state.
 toggleSelected: (value?, opts?) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:86](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L86)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:111](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L111)
 
 Selects/deselects the row.
 
@@ -151,9 +157,7 @@ Selects/deselects the row.
 
 ##### opts?
 
-###### selectChildren?
-
-`boolean`
+[`ToggleSelectedOptions`](ToggleSelectedOptions.md)
 
 #### Returns
 

--- a/docs/reference/index/interfaces/Row_RowSelection.md
+++ b/docs/reference/index/interfaces/Row_RowSelection.md
@@ -111,9 +111,12 @@ Checks whether some selectable descendants are selected.
 getToggleSelectedHandler: (opts?) => (event) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:105](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L105)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:108](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L108)
 
 Creates a checkbox-style handler that toggles this row's selected state.
+Pass the original checkbox click event, or a framework event whose
+`nativeEvent` is that click, so Shift range selection can detect the
+modifier key.
 
 #### Parameters
 
@@ -145,7 +148,7 @@ Creates a checkbox-style handler that toggles this row's selected state.
 toggleSelected: (value?, opts?) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:111](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L111)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:114](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L114)
 
 Selects/deselects the row.
 

--- a/docs/reference/index/interfaces/TableFeature.md
+++ b/docs/reference/index/interfaces/TableFeature.md
@@ -186,14 +186,15 @@ mutable data.
 optional constructTableAPIs: <TFeatures, TData>(table) => void;
 ```
 
-Defined in: [types/TableFeatures.ts:374](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L374)
+Defined in: [types/TableFeatures.ts:375](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L375)
 
 Adds feature APIs directly to the table instance.
 
 The table is a singleton, unlike rows, columns, headers, and cells, so
 table APIs are assigned directly instead of through a shared prototype.
-This runs while the table is being constructed, after options and initial
-state have been resolved.
+This hook is exclusively for assigning table methods. It runs after
+options, state atoms, and the store have been created and after every
+feature's `initTableInstanceData` hook has completed.
 
 #### Type Parameters
 
@@ -223,7 +224,7 @@ state have been resolved.
 optional getDefaultColumnDef: <TFeatures, TData, TValue>() => ColumnDefBase_All<TFeatures, TData, TValue>;
 ```
 
-Defined in: [types/TableFeatures.ts:384](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L384)
+Defined in: [types/TableFeatures.ts:385](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L385)
 
 Returns default column definition options contributed by this feature.
 
@@ -257,7 +258,7 @@ resolved, so users can override values supplied here.
 optional getDefaultTableOptions: <TFeatures, TData>(table) => Partial<TableOptions_All<TFeatures, TData>>;
 ```
 
-Defined in: [types/TableFeatures.ts:397](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L397)
+Defined in: [types/TableFeatures.ts:398](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L398)
 
 Returns default table options contributed by this feature.
 
@@ -294,7 +295,7 @@ here.
 optional getInitialState: (initialState) => TableState_All;
 ```
 
-Defined in: [types/TableFeatures.ts:411](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L411)
+Defined in: [types/TableFeatures.ts:412](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L412)
 
 Returns this feature's initial table state.
 
@@ -321,7 +322,7 @@ override feature defaults.
 optional initColumnInstanceData: <TFeatures, TData, TValue>(column) => void;
 ```
 
-Defined in: [types/TableFeatures.ts:420](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L420)
+Defined in: [types/TableFeatures.ts:437](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L437)
 
 Initializes instance-specific data on each column.
 
@@ -362,7 +363,7 @@ methods should be assigned via `assignColumnPrototype` instead.
 optional initRowInstanceData: <TFeatures, TData>(row) => void;
 ```
 
-Defined in: [types/TableFeatures.ts:435](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L435)
+Defined in: [types/TableFeatures.ts:452](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L452)
 
 Initializes instance-specific data on each row.
 
@@ -386,6 +387,81 @@ should be assigned via `assignRowPrototype` instead.
 ##### row
 
 [`Row`](../type-aliases/Row.md)\<`TFeatures`, `TData`\>
+
+#### Returns
+
+`void`
+
+***
+
+### initTableInstanceData()?
+
+```ts
+optional initTableInstanceData: <TFeatures, TData>(table) => void;
+```
+
+Defined in: [types/TableFeatures.ts:423](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L423)
+
+Initializes mutable, non-reactive data owned by this feature on the table
+instance.
+
+This runs once during table construction after options, state atoms, and
+the store are available, and before any feature's `constructTableAPIs`
+hook runs. Use `constructTableAPIs` exclusively for assigning table
+methods. Table resets do not rerun this hook; use
+`resetTableInstanceData` to clear transient instance data instead.
+
+#### Type Parameters
+
+##### TFeatures
+
+`TFeatures` *extends* [`TableFeatures`](TableFeatures.md)
+
+##### TData
+
+`TData` *extends* [`RowData`](../type-aliases/RowData.md)
+
+#### Parameters
+
+##### table
+
+[`Table_Internal`](Table_Internal.md)\<`TFeatures`, `TData`\>
+
+#### Returns
+
+`void`
+
+***
+
+### resetTableInstanceData()?
+
+```ts
+optional resetTableInstanceData: <TFeatures, TData>(table) => void;
+```
+
+Defined in: [types/TableFeatures.ts:465](https://github.com/TanStack/table/blob/main/packages/table-core/src/types/TableFeatures.ts#L465)
+
+Resets mutable, non-reactive table-instance data owned by this feature.
+
+This runs after internally owned state atoms have been restored to
+`table.initialState` by `table.reset()`. It is intended for transient
+feature data, not table state slices or externally controlled state.
+
+#### Type Parameters
+
+##### TFeatures
+
+`TFeatures` *extends* [`TableFeatures`](TableFeatures.md)
+
+##### TData
+
+`TData` *extends* [`RowData`](../type-aliases/RowData.md)
+
+#### Parameters
+
+##### table
+
+[`Table_Internal`](Table_Internal.md)\<`TFeatures`, `TData`\>
 
 #### Returns
 

--- a/docs/reference/index/interfaces/TableOptions_Core.md
+++ b/docs/reference/index/interfaces/TableOptions_Core.md
@@ -138,7 +138,7 @@ slots (`tableMeta`, `columnMeta`).
 optional getRowId: (originalRow, index, parent?) => string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:104](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L104)
+Defined in: [core/rows/coreRowsFeature.types.ts:115](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L115)
 
 This optional function is used to derive a unique ID for any given row. If not provided the rows index is used (nested rows join together with `.` using their grandparents' index eg. `index.index.index`). If you need to identify individual rows that are originating from any server-side operations, it's suggested you use this function to return an ID that makes sense regardless of network IO/ambiguity eg. a userId, taskId, database ID field, etc.
 
@@ -178,7 +178,7 @@ getRowId: row => row.userId
 optional getSubRows: (originalRow, index) => readonly TData[] | undefined;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:113](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L113)
+Defined in: [core/rows/coreRowsFeature.types.ts:124](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L124)
 
 This optional function is used to access the sub rows for any given row. If you are using nested rows, you will need to use this function to return the sub rows object (or undefined) from the row.
 

--- a/docs/reference/index/interfaces/TableOptions_RowSelection.md
+++ b/docs/reference/index/interfaces/TableOptions_RowSelection.md
@@ -5,7 +5,7 @@ title: TableOptions_RowSelection
 
 # Interface: TableOptions\_RowSelection\<TFeatures, TData\>
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:12](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L12)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:23](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L23)
 
 ## Type Parameters
 
@@ -25,11 +25,24 @@ Defined in: [features/row-selection/rowSelectionFeature.types.ts:12](https://git
 optional enableMultiRowSelection: boolean | (row) => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:21](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L21)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:37](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L37)
 
 Allows rows to be selected alongside other rows.
 
 Provide a predicate to decide per row. Defaults to `true`.
+
+***
+
+### enableRowRangeSelection?
+
+```ts
+optional enableRowRangeSelection: boolean;
+```
+
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:31](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L31)
+
+Enables inclusive row range selection through
+`row.getToggleSelectedHandler()`. Defaults to `true`.
 
 ***
 
@@ -39,7 +52,7 @@ Provide a predicate to decide per row. Defaults to `true`.
 optional enableRowSelection: boolean | (row) => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:27](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L27)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:43](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L43)
 
 Allows rows to be selected.
 
@@ -53,12 +66,38 @@ Provide a predicate to decide per row. Defaults to `true`.
 optional enableSubRowSelection: boolean | (row) => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:34](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L34)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:50](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L50)
 
 Controls whether selecting a parent row also selects its subRows.
 
 Provide a predicate to decide per row. This is most useful with expanding or
 grouping features and defaults to `true`.
+
+***
+
+### isRowRangeSelectionEvent()?
+
+```ts
+optional isRowRangeSelectionEvent: (event) => boolean;
+```
+
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:58](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L58)
+
+Determines whether a row-selection handler event should select or
+deselect the inclusive range from the most recent handler interaction.
+
+By default, events with `shiftKey` directly on the event or on
+`event.nativeEvent` are treated as range-selection events.
+
+#### Parameters
+
+##### event
+
+`unknown`
+
+#### Returns
+
+`boolean`
 
 ***
 
@@ -68,7 +107,7 @@ grouping features and defaults to `true`.
 optional onRowSelectionChange: OnChangeFn<RowSelectionState>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:40](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L40)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:64](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L64)
 
 Called with an updater when row selection state changes. Pair this with
 `state.rowSelection` when using external state; external atoms can own the

--- a/docs/reference/index/interfaces/TableOptions_Rows.md
+++ b/docs/reference/index/interfaces/TableOptions_Rows.md
@@ -5,7 +5,7 @@ title: TableOptions_Rows
 
 # Interface: TableOptions\_Rows\<TFeatures, TData\>
 
-Defined in: [core/rows/coreRowsFeature.types.ts:96](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L96)
+Defined in: [core/rows/coreRowsFeature.types.ts:107](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L107)
 
 ## Extended by
 
@@ -29,7 +29,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:96](https://github.com/TanStack/
 optional getRowId: (originalRow, index, parent?) => string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:104](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L104)
+Defined in: [core/rows/coreRowsFeature.types.ts:115](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L115)
 
 This optional function is used to derive a unique ID for any given row. If not provided the rows index is used (nested rows join together with `.` using their grandparents' index eg. `index.index.index`). If you need to identify individual rows that are originating from any server-side operations, it's suggested you use this function to return an ID that makes sense regardless of network IO/ambiguity eg. a userId, taskId, database ID field, etc.
 
@@ -65,7 +65,7 @@ getRowId: row => row.userId
 optional getSubRows: (originalRow, index) => readonly TData[] | undefined;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:113](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L113)
+Defined in: [core/rows/coreRowsFeature.types.ts:124](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L124)
 
 This optional function is used to access the sub rows for any given row. If you are using nested rows, you will need to use this function to return the sub rows object (or undefined) from the row.
 

--- a/docs/reference/index/interfaces/TableState_All.md
+++ b/docs/reference/index/interfaces/TableState_All.md
@@ -178,7 +178,7 @@ Defined in: [features/row-pinning/rowPinningFeature.types.ts:13](https://github.
 optional rowSelection: RowSelectionState;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:9](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L9)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:20](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L20)
 
 #### Inherited from
 

--- a/docs/reference/index/interfaces/TableState_RowSelection.md
+++ b/docs/reference/index/interfaces/TableState_RowSelection.md
@@ -5,7 +5,7 @@ title: TableState_RowSelection
 
 # Interface: TableState\_RowSelection
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:8](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L8)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:19](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L19)
 
 ## Properties
 
@@ -15,4 +15,4 @@ Defined in: [features/row-selection/rowSelectionFeature.types.ts:8](https://gith
 rowSelection: RowSelectionState;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:9](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L9)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:20](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L20)

--- a/docs/reference/index/interfaces/Table_Core.md
+++ b/docs/reference/index/interfaces/Table_Core.md
@@ -718,7 +718,7 @@ Table_RowModels.getPreSortedRowModel
 getRow: (id, searchAll?) => Row<TFeatures, TData>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:134](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L134)
+Defined in: [core/rows/coreRowsFeature.types.ts:145](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L145)
 
 Returns the row with the given ID.
 
@@ -748,7 +748,7 @@ Returns the row with the given ID.
 getRowId: (_, index, parent?) => string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:130](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L130)
+Defined in: [core/rows/coreRowsFeature.types.ts:141](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L141)
 
 #### Parameters
 
@@ -802,7 +802,7 @@ Table_RowModels.getRowModel
 getRowsInDisplayOrder: () => Row<TFeatures, TData>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:129](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L129)
+Defined in: [core/rows/coreRowsFeature.types.ts:140](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L140)
 
 Returns the rows in the current display order and assigns their display
 indexes. When expanded rows bypass pagination, expanded descendants are
@@ -897,13 +897,14 @@ options as plain resolved data instead of backing them with an atom.
 reset: () => void;
 ```
 
-Defined in: [core/table/coreTablesFeature.types.ts:234](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L234)
+Defined in: [core/table/coreTablesFeature.types.ts:235](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L235)
 
 Resets the table's internal base atoms to `table.initialState`.
 
 Prefer feature-specific reset APIs, such as `resetPagination`, when a state
 slice may be owned by an external atom or needs that feature's blank/default
-reset behavior.
+reset behavior. After resetting internal atoms, this also invokes feature
+reset hooks for mutable, transient table-instance data.
 
 #### Returns
 
@@ -921,7 +922,7 @@ reset behavior.
 setOptions: (newOptions) => void;
 ```
 
-Defined in: [core/table/coreTablesFeature.types.ts:239](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L239)
+Defined in: [core/table/coreTablesFeature.types.ts:240](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L240)
 
 Updates the table options by applying a value or updater to the current
 resolved options and then merging them through `options.mergeOptions`.

--- a/docs/reference/index/interfaces/Table_Internal.md
+++ b/docs/reference/index/interfaces/Table_Internal.md
@@ -711,7 +711,7 @@ Table_RowModels.getPreSortedRowModel
 getRow: (id, searchAll?) => Row<TFeatures, TData>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:134](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L134)
+Defined in: [core/rows/coreRowsFeature.types.ts:145](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L145)
 
 Returns the row with the given ID.
 
@@ -741,7 +741,7 @@ Returns the row with the given ID.
 getRowId: (_, index, parent?) => string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:130](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L130)
+Defined in: [core/rows/coreRowsFeature.types.ts:141](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L141)
 
 #### Parameters
 
@@ -795,7 +795,7 @@ Table_RowModels.getRowModel
 getRowsInDisplayOrder: () => Row<TFeatures, TData>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:129](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L129)
+Defined in: [core/rows/coreRowsFeature.types.ts:140](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L140)
 
 Returns the rows in the current display order and assigns their display
 indexes. When expanded rows bypass pagination, expanded descendants are
@@ -958,13 +958,14 @@ Omit.optionsStore
 reset: () => void;
 ```
 
-Defined in: [core/table/coreTablesFeature.types.ts:234](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L234)
+Defined in: [core/table/coreTablesFeature.types.ts:235](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L235)
 
 Resets the table's internal base atoms to `table.initialState`.
 
 Prefer feature-specific reset APIs, such as `resetPagination`, when a state
 slice may be owned by an external atom or needs that feature's blank/default
-reset behavior.
+reset behavior. After resetting internal atoms, this also invokes feature
+reset hooks for mutable, transient table-instance data.
 
 #### Returns
 
@@ -984,7 +985,7 @@ Omit.reset
 setOptions: (newOptions) => void;
 ```
 
-Defined in: [core/table/coreTablesFeature.types.ts:239](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L239)
+Defined in: [core/table/coreTablesFeature.types.ts:240](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L240)
 
 Updates the table options by applying a value or updater to the current
 resolved options and then merging them through `options.mergeOptions`.

--- a/docs/reference/index/interfaces/Table_RowSelection.md
+++ b/docs/reference/index/interfaces/Table_RowSelection.md
@@ -5,7 +5,7 @@ title: Table_RowSelection
 
 # Interface: Table\_RowSelection\<TFeatures, TData\>
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:89](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L89)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:114](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L114)
 
 ## Type Parameters
 
@@ -19,13 +19,27 @@ Defined in: [features/row-selection/rowSelectionFeature.types.ts:89](https://git
 
 ## Properties
 
+### \_lastSelectedRowId
+
+```ts
+_lastSelectedRowId: string | null;
+```
+
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:123](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L123)
+
+**`Internal`**
+
+The most recent row interacted with through the row selection handler.
+
+***
+
 ### getFilteredSelectedRowModel()
 
 ```ts
 getFilteredSelectedRowModel: () => RowModel<TFeatures, TData>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:96](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L96)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:127](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L127)
 
 Builds a selected-row model from rows after filtering.
 
@@ -41,7 +55,7 @@ Builds a selected-row model from rows after filtering.
 getGroupedSelectedRowModel: () => RowModel<TFeatures, TData>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:100](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L100)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:131](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L131)
 
 Builds a selected-row model from rows after grouping.
 
@@ -57,7 +71,7 @@ Builds a selected-row model from rows after grouping.
 getIsAllPageRowsSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:108](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L108)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:139](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L139)
 
 Checks whether every selectable row on the current page is selected.
 
@@ -73,7 +87,7 @@ Checks whether every selectable row on the current page is selected.
 getIsAllRowsSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:112](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L112)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:143](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L143)
 
 Checks whether every selectable filtered row is selected.
 
@@ -89,7 +103,7 @@ Checks whether every selectable filtered row is selected.
 getIsSomePageRowsSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:116](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L116)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:147](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L147)
 
 Checks whether the current page has a partial row selection.
 
@@ -105,7 +119,7 @@ Checks whether the current page has a partial row selection.
 getIsSomeRowsSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:120](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L120)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:151](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L151)
 
 Checks whether filtered rows have a partial row selection.
 
@@ -121,7 +135,7 @@ Checks whether filtered rows have a partial row selection.
 getPreSelectedRowModel: () => RowModel<TFeatures, TData>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:124](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L124)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:155](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L155)
 
 Returns the core row model of all rows before row selection has been applied.
 
@@ -137,7 +151,7 @@ Returns the core row model of all rows before row selection has been applied.
 getSelectedRowIds: () => string[];
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:104](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L104)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:135](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L135)
 
 Returns the ids of all selected rows.
 
@@ -153,7 +167,7 @@ Returns the ids of all selected rows.
 getSelectedRowModel: () => RowModel<TFeatures, TData>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:128](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L128)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:159](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L159)
 
 Builds a selected-row model from the core row model.
 
@@ -169,7 +183,7 @@ Builds a selected-row model from the core row model.
 getToggleAllPageRowsSelectedHandler: () => (event) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:132](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L132)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:163](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L163)
 
 Creates a checkbox-style handler that toggles all current-page rows.
 
@@ -197,7 +211,7 @@ Creates a checkbox-style handler that toggles all current-page rows.
 getToggleAllRowsSelectedHandler: () => (event) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:136](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L136)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:167](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L167)
 
 Creates a checkbox-style handler that toggles all selectable rows.
 
@@ -225,7 +239,7 @@ Creates a checkbox-style handler that toggles all selectable rows.
 resetRowSelection: (defaultState?) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:142](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L142)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:173](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L173)
 
 Resets `rowSelection` to `initialState.rowSelection`.
 
@@ -249,7 +263,7 @@ Pass `true` to ignore initial state and reset to `{}`.
 setRowSelection: (updater) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:146](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L146)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:177](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L177)
 
 Updates row selection state with a next map or updater function.
 
@@ -271,7 +285,7 @@ Updates row selection state with a next map or updater function.
 toggleAllPageRowsSelected: (value?, opts?) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:150](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L150)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:181](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L181)
 
 Selects/deselects all rows on the current page.
 
@@ -299,7 +313,7 @@ Selects/deselects all rows on the current page.
 toggleAllRowsSelected: (value?, opts?) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:157](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L157)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:188](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L188)
 
 Selects/deselects all rows in the table.
 

--- a/docs/reference/index/interfaces/Table_RowSelection.md
+++ b/docs/reference/index/interfaces/Table_RowSelection.md
@@ -5,7 +5,7 @@ title: Table_RowSelection
 
 # Interface: Table\_RowSelection\<TFeatures, TData\>
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:114](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L114)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:117](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L117)
 
 ## Type Parameters
 
@@ -25,7 +25,7 @@ Defined in: [features/row-selection/rowSelectionFeature.types.ts:114](https://gi
 _lastSelectedRowId: string | null;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:123](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L123)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:126](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L126)
 
 **`Internal`**
 
@@ -39,7 +39,7 @@ The most recent row interacted with through the row selection handler.
 getFilteredSelectedRowModel: () => RowModel<TFeatures, TData>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:127](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L127)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:130](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L130)
 
 Builds a selected-row model from rows after filtering.
 
@@ -55,7 +55,7 @@ Builds a selected-row model from rows after filtering.
 getGroupedSelectedRowModel: () => RowModel<TFeatures, TData>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:131](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L131)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:134](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L134)
 
 Builds a selected-row model from rows after grouping.
 
@@ -71,7 +71,7 @@ Builds a selected-row model from rows after grouping.
 getIsAllPageRowsSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:139](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L139)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:142](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L142)
 
 Checks whether every selectable row on the current page is selected.
 
@@ -87,7 +87,7 @@ Checks whether every selectable row on the current page is selected.
 getIsAllRowsSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:143](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L143)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:146](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L146)
 
 Checks whether every selectable filtered row is selected.
 
@@ -103,7 +103,7 @@ Checks whether every selectable filtered row is selected.
 getIsSomePageRowsSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:147](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L147)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:150](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L150)
 
 Checks whether the current page has a partial row selection.
 
@@ -119,7 +119,7 @@ Checks whether the current page has a partial row selection.
 getIsSomeRowsSelected: () => boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:151](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L151)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:154](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L154)
 
 Checks whether filtered rows have a partial row selection.
 
@@ -135,7 +135,7 @@ Checks whether filtered rows have a partial row selection.
 getPreSelectedRowModel: () => RowModel<TFeatures, TData>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:155](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L155)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:158](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L158)
 
 Returns the core row model of all rows before row selection has been applied.
 
@@ -151,7 +151,7 @@ Returns the core row model of all rows before row selection has been applied.
 getSelectedRowIds: () => string[];
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:135](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L135)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:138](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L138)
 
 Returns the ids of all selected rows.
 
@@ -167,7 +167,7 @@ Returns the ids of all selected rows.
 getSelectedRowModel: () => RowModel<TFeatures, TData>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:159](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L159)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:162](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L162)
 
 Builds a selected-row model from the core row model.
 
@@ -183,7 +183,7 @@ Builds a selected-row model from the core row model.
 getToggleAllPageRowsSelectedHandler: () => (event) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:163](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L163)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:166](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L166)
 
 Creates a checkbox-style handler that toggles all current-page rows.
 
@@ -211,7 +211,7 @@ Creates a checkbox-style handler that toggles all current-page rows.
 getToggleAllRowsSelectedHandler: () => (event) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:167](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L167)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:170](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L170)
 
 Creates a checkbox-style handler that toggles all selectable rows.
 
@@ -239,7 +239,7 @@ Creates a checkbox-style handler that toggles all selectable rows.
 resetRowSelection: (defaultState?) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:173](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L173)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:176](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L176)
 
 Resets `rowSelection` to `initialState.rowSelection`.
 
@@ -263,7 +263,7 @@ Pass `true` to ignore initial state and reset to `{}`.
 setRowSelection: (updater) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:177](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L177)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:180](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L180)
 
 Updates row selection state with a next map or updater function.
 
@@ -285,7 +285,7 @@ Updates row selection state with a next map or updater function.
 toggleAllPageRowsSelected: (value?, opts?) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:181](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L181)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:184](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L184)
 
 Selects/deselects all rows on the current page.
 
@@ -313,7 +313,7 @@ Selects/deselects all rows on the current page.
 toggleAllRowsSelected: (value?, opts?) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.types.ts:188](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L188)
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:191](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L191)
 
 Selects/deselects all rows in the table.
 

--- a/docs/reference/index/interfaces/Table_Rows.md
+++ b/docs/reference/index/interfaces/Table_Rows.md
@@ -5,7 +5,7 @@ title: Table_Rows
 
 # Interface: Table\_Rows\<TFeatures, TData\>
 
-Defined in: [core/rows/coreRowsFeature.types.ts:119](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L119)
+Defined in: [core/rows/coreRowsFeature.types.ts:130](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L130)
 
 ## Extended by
 
@@ -30,7 +30,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:119](https://github.com/TanStack
 getRow: (id, searchAll?) => Row<TFeatures, TData>;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:134](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L134)
+Defined in: [core/rows/coreRowsFeature.types.ts:145](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L145)
 
 Returns the row with the given ID.
 
@@ -56,7 +56,7 @@ Returns the row with the given ID.
 getRowId: (_, index, parent?) => string;
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:130](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L130)
+Defined in: [core/rows/coreRowsFeature.types.ts:141](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L141)
 
 #### Parameters
 
@@ -84,7 +84,7 @@ Defined in: [core/rows/coreRowsFeature.types.ts:130](https://github.com/TanStack
 getRowsInDisplayOrder: () => Row<TFeatures, TData>[];
 ```
 
-Defined in: [core/rows/coreRowsFeature.types.ts:129](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L129)
+Defined in: [core/rows/coreRowsFeature.types.ts:140](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/rows/coreRowsFeature.types.ts#L140)
 
 Returns the rows in the current display order and assigns their display
 indexes. When expanded rows bypass pagination, expanded descendants are

--- a/docs/reference/index/interfaces/Table_Table.md
+++ b/docs/reference/index/interfaces/Table_Table.md
@@ -246,13 +246,14 @@ options as plain resolved data instead of backing them with an atom.
 reset: () => void;
 ```
 
-Defined in: [core/table/coreTablesFeature.types.ts:234](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L234)
+Defined in: [core/table/coreTablesFeature.types.ts:235](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L235)
 
 Resets the table's internal base atoms to `table.initialState`.
 
 Prefer feature-specific reset APIs, such as `resetPagination`, when a state
 slice may be owned by an external atom or needs that feature's blank/default
-reset behavior.
+reset behavior. After resetting internal atoms, this also invokes feature
+reset hooks for mutable, transient table-instance data.
 
 #### Returns
 
@@ -266,7 +267,7 @@ reset behavior.
 setOptions: (newOptions) => void;
 ```
 
-Defined in: [core/table/coreTablesFeature.types.ts:239](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L239)
+Defined in: [core/table/coreTablesFeature.types.ts:240](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.types.ts#L240)
 
 Updates the table options by applying a value or updater to the current
 resolved options and then merging them through `options.mergeOptions`.

--- a/docs/reference/index/interfaces/ToggleSelectedOptions.md
+++ b/docs/reference/index/interfaces/ToggleSelectedOptions.md
@@ -1,0 +1,23 @@
+---
+id: ToggleSelectedOptions
+title: ToggleSelectedOptions
+---
+
+# Interface: ToggleSelectedOptions
+
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:11](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L11)
+
+Controls how toggling a row affects its descendants.
+
+## Properties
+
+### selectChildren?
+
+```ts
+optional selectChildren: boolean;
+```
+
+Defined in: [features/row-selection/rowSelectionFeature.types.ts:16](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts#L16)
+
+Whether selectable child rows should be toggled recursively. Defaults to
+`true`.

--- a/docs/reference/static-functions/functions/getDefaultRowSelectionState.md
+++ b/docs/reference/static-functions/functions/getDefaultRowSelectionState.md
@@ -9,7 +9,7 @@ title: getDefaultRowSelectionState
 function getDefaultRowSelectionState(): RowSelectionState;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:28](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L28)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:31](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L31)
 
 Creates the default row selection state.
 

--- a/docs/reference/static-functions/functions/isRowSelected.md
+++ b/docs/reference/static-functions/functions/isRowSelected.md
@@ -9,7 +9,7 @@ title: isRowSelected
 function isRowSelected<TFeatures, TData>(row, rowSelection): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:768](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L768)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:868](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L868)
 
 Returns whether a row id is selected in the current row selection state.
 

--- a/docs/reference/static-functions/functions/isSubRowSelected.md
+++ b/docs/reference/static-functions/functions/isSubRowSelected.md
@@ -9,7 +9,7 @@ title: isSubRowSelected
 function isSubRowSelected<TFeatures, TData>(row): boolean | "some" | "all";
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:785](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L785)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:885](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L885)
 
 Returns whether all, some, or none of a row's selectable descendants are selected.
 

--- a/docs/reference/static-functions/functions/row_getCanMultiSelect.md
+++ b/docs/reference/static-functions/functions/row_getCanMultiSelect.md
@@ -9,7 +9,7 @@ title: row_getCanMultiSelect
 function row_getCanMultiSelect<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:630](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L630)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:633](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L633)
 
 Checks whether this row can be selected alongside other rows.
 

--- a/docs/reference/static-functions/functions/row_getCanSelect.md
+++ b/docs/reference/static-functions/functions/row_getCanSelect.md
@@ -9,7 +9,7 @@ title: row_getCanSelect
 function row_getCanSelect<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:584](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L584)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:587](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L587)
 
 Checks whether this row can be selected.
 

--- a/docs/reference/static-functions/functions/row_getCanSelectSubRows.md
+++ b/docs/reference/static-functions/functions/row_getCanSelectSubRows.md
@@ -9,7 +9,7 @@ title: row_getCanSelectSubRows
 function row_getCanSelectSubRows<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:607](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L607)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:610](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L610)
 
 Checks whether selecting this row should also select its subRows.
 

--- a/docs/reference/static-functions/functions/row_getIsAllSubRowsSelected.md
+++ b/docs/reference/static-functions/functions/row_getIsAllSubRowsSelected.md
@@ -9,7 +9,7 @@ title: row_getIsAllSubRowsSelected
 function row_getIsAllSubRowsSelected<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:566](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L566)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:569](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L569)
 
 Checks whether all selectable descendants are selected.
 

--- a/docs/reference/static-functions/functions/row_getIsSelected.md
+++ b/docs/reference/static-functions/functions/row_getIsSelected.md
@@ -9,7 +9,7 @@ title: row_getIsSelected
 function row_getIsSelected<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:531](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L531)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:534](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L534)
 
 Checks whether this row id is selected in `state.rowSelection`.
 

--- a/docs/reference/static-functions/functions/row_getIsSomeSelected.md
+++ b/docs/reference/static-functions/functions/row_getIsSomeSelected.md
@@ -9,7 +9,7 @@ title: row_getIsSomeSelected
 function row_getIsSomeSelected<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:549](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L549)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:552](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L552)
 
 Checks whether some, but not all, selectable descendants are selected.
 

--- a/docs/reference/static-functions/functions/row_getToggleSelectedHandler.md
+++ b/docs/reference/static-functions/functions/row_getToggleSelectedHandler.md
@@ -6,15 +6,19 @@ title: row_getToggleSelectedHandler
 # Function: row\_getToggleSelectedHandler()
 
 ```ts
-function row_getToggleSelectedHandler<TFeatures, TData>(row): (e) => void;
+function row_getToggleSelectedHandler<TFeatures, TData>(row, opts?): (e) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:653](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L653)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:660](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L660)
 
 Creates a checkbox-style handler that selects or deselects this row.
 
 The handler is a no-op when the row cannot be selected and reads
-`event.target.checked`.
+`event.target.checked`. Shift events select or deselect the inclusive range
+from the most recent selectable row handled by this table. The event's
+optional `persist()` method is called before it is read. Pass
+`selectChildren: false` to limit changes to rows explicitly present in the
+display-order interval.
 
 ## Type Parameters
 
@@ -31,6 +35,10 @@ The handler is a no-op when the row cannot be selected and reads
 ### row
 
 [`Row`](../../index/type-aliases/Row.md)\<`TFeatures`, `TData`\>
+
+### opts?
+
+[`ToggleSelectedOptions`](../../index/interfaces/ToggleSelectedOptions.md)
 
 ## Returns
 

--- a/docs/reference/static-functions/functions/row_toggleSelected.md
+++ b/docs/reference/static-functions/functions/row_toggleSelected.md
@@ -12,7 +12,7 @@ function row_toggleSelected<TFeatures, TData>(
    opts?): void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:492](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L492)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:501](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L501)
 
 Selects or deselects this row.
 
@@ -41,9 +41,7 @@ Omitting `value` toggles the row. Child rows are selected recursively unless
 
 ### opts?
 
-#### selectChildren?
-
-`boolean`
+[`ToggleSelectedOptions`](../../index/interfaces/ToggleSelectedOptions.md)
 
 ## Returns
 

--- a/docs/reference/static-functions/functions/selectRowsFn.md
+++ b/docs/reference/static-functions/functions/selectRowsFn.md
@@ -9,7 +9,7 @@ title: selectRowsFn
 function selectRowsFn<TFeatures, TData>(rowModel, table): RowModel<TFeatures, TData>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:709](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L709)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:809](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L809)
 
 Builds a row model containing rows selected by the current row selection state.
 

--- a/docs/reference/static-functions/functions/table_getFilteredSelectedRowModel.md
+++ b/docs/reference/static-functions/functions/table_getFilteredSelectedRowModel.md
@@ -15,7 +15,7 @@ function table_getFilteredSelectedRowModel<TFeatures, TData>(table):
 };
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:247](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L247)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:256](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L256)
 
 Builds a row model containing selected rows from the filtered row model.
 

--- a/docs/reference/static-functions/functions/table_getGroupedSelectedRowModel.md
+++ b/docs/reference/static-functions/functions/table_getGroupedSelectedRowModel.md
@@ -15,7 +15,7 @@ function table_getGroupedSelectedRowModel<TFeatures, TData>(table):
 };
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:281](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L281)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:290](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L290)
 
 Builds a row model containing selected rows from the grouped row model.
 

--- a/docs/reference/static-functions/functions/table_getIsAllPageRowsSelected.md
+++ b/docs/reference/static-functions/functions/table_getIsAllPageRowsSelected.md
@@ -9,7 +9,7 @@ title: table_getIsAllPageRowsSelected
 function table_getIsAllPageRowsSelected<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:366](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L366)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:375](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L375)
 
 Checks whether every selectable row on the current page is selected.
 

--- a/docs/reference/static-functions/functions/table_getIsAllRowsSelected.md
+++ b/docs/reference/static-functions/functions/table_getIsAllRowsSelected.md
@@ -9,7 +9,7 @@ title: table_getIsAllRowsSelected
 function table_getIsAllRowsSelected<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:332](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L332)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:341](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L341)
 
 Checks whether every selectable filtered row is selected.
 

--- a/docs/reference/static-functions/functions/table_getIsSomePageRowsSelected.md
+++ b/docs/reference/static-functions/functions/table_getIsSomePageRowsSelected.md
@@ -9,7 +9,7 @@ title: table_getIsSomePageRowsSelected
 function table_getIsSomePageRowsSelected<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:415](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L415)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:424](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L424)
 
 Checks whether the current page has a partial selection.
 

--- a/docs/reference/static-functions/functions/table_getIsSomeRowsSelected.md
+++ b/docs/reference/static-functions/functions/table_getIsSomeRowsSelected.md
@@ -9,7 +9,7 @@ title: table_getIsSomeRowsSelected
 function table_getIsSomeRowsSelected<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:397](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L397)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:406](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L406)
 
 Checks whether selection is partially applied across filtered rows.
 

--- a/docs/reference/static-functions/functions/table_getPreSelectedRowModel.md
+++ b/docs/reference/static-functions/functions/table_getPreSelectedRowModel.md
@@ -9,7 +9,7 @@ title: table_getPreSelectedRowModel
 function table_getPreSelectedRowModel<TFeatures, TData>(table): RowModel<TFeatures, TData>;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:195](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L195)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:204](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L204)
 
 Reads the row model before row selection is projected into selected rows.
 

--- a/docs/reference/static-functions/functions/table_getSelectedRowIds.md
+++ b/docs/reference/static-functions/functions/table_getSelectedRowIds.md
@@ -9,7 +9,7 @@ title: table_getSelectedRowIds
 function table_getSelectedRowIds<TFeatures, TData>(table): string[];
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:314](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L314)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:323](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L323)
 
 Returns the ids of all selected rows.
 

--- a/docs/reference/static-functions/functions/table_getSelectedRowModel.md
+++ b/docs/reference/static-functions/functions/table_getSelectedRowModel.md
@@ -15,7 +15,7 @@ function table_getSelectedRowModel<TFeatures, TData>(table):
 };
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:213](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L213)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:222](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L222)
 
 Builds a row model containing selected rows from the core row model.
 

--- a/docs/reference/static-functions/functions/table_getToggleAllPageRowsSelectedHandler.md
+++ b/docs/reference/static-functions/functions/table_getToggleAllPageRowsSelectedHandler.md
@@ -9,7 +9,7 @@ title: table_getToggleAllPageRowsSelectedHandler
 function table_getToggleAllPageRowsSelectedHandler<TFeatures, TData>(table): (e) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:463](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L463)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:472](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L472)
 
 Creates a checkbox-style handler that selects or deselects current page rows.
 

--- a/docs/reference/static-functions/functions/table_getToggleAllRowsSelectedHandler.md
+++ b/docs/reference/static-functions/functions/table_getToggleAllRowsSelectedHandler.md
@@ -9,7 +9,7 @@ title: table_getToggleAllRowsSelectedHandler
 function table_getToggleAllRowsSelectedHandler<TFeatures, TData>(table): (e) => void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:440](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L440)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:449](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L449)
 
 Creates a checkbox-style handler that selects or deselects all rows.
 

--- a/docs/reference/static-functions/functions/table_mergeOptions.md
+++ b/docs/reference/static-functions/functions/table_mergeOptions.md
@@ -9,7 +9,7 @@ title: table_mergeOptions
 function table_mergeOptions<TFeatures, TData>(table, newOptions): TableOptions<TFeatures, TData>;
 ```
 
-Defined in: [core/table/coreTablesFeature.utils.ts:80](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.utils.ts#L80)
+Defined in: [core/table/coreTablesFeature.utils.ts:86](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.utils.ts#L86)
 
 Merges new table options with the current resolved options.
 

--- a/docs/reference/static-functions/functions/table_reset.md
+++ b/docs/reference/static-functions/functions/table_reset.md
@@ -9,9 +9,10 @@ title: table_reset
 function table_reset<TFeatures, TData>(table): void;
 ```
 
-Defined in: [core/table/coreTablesFeature.utils.ts:53](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.utils.ts#L53)
+Defined in: [core/table/coreTablesFeature.utils.ts:54](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.utils.ts#L54)
 
-Resets all internal table base atoms to `table.initialState`.
+Resets all internal table base atoms to `table.initialState`, then clears
+transient instance data through registered feature reset hooks.
 
 This resets internally owned state slices in a single reactivity batch. Use
 feature-specific reset APIs when a slice may be externally owned.

--- a/docs/reference/static-functions/functions/table_resetRowSelection.md
+++ b/docs/reference/static-functions/functions/table_resetRowSelection.md
@@ -9,7 +9,7 @@ title: table_resetRowSelection
 function table_resetRowSelection<TFeatures, TData>(table, defaultState?): void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:65](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L65)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:68](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L68)
 
 Resets `rowSelection` to the configured initial state or feature default.
 

--- a/docs/reference/static-functions/functions/table_setOptions.md
+++ b/docs/reference/static-functions/functions/table_setOptions.md
@@ -9,7 +9,7 @@ title: table_setOptions
 function table_setOptions<TFeatures, TData>(table, updater): void;
 ```
 
-Defined in: [core/table/coreTablesFeature.utils.ts:146](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.utils.ts#L146)
+Defined in: [core/table/coreTablesFeature.utils.ts:152](https://github.com/TanStack/table/blob/main/packages/table-core/src/core/table/coreTablesFeature.utils.ts#L152)
 
 Updates the table options object.
 

--- a/docs/reference/static-functions/functions/table_setRowSelection.md
+++ b/docs/reference/static-functions/functions/table_setRowSelection.md
@@ -9,7 +9,7 @@ title: table_setRowSelection
 function table_setRowSelection<TFeatures, TData>(table, updater): void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:43](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L43)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:46](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L46)
 
 Routes a row selection updater through the table's selection change handler.
 

--- a/docs/reference/static-functions/functions/table_toggleAllPageRowsSelected.md
+++ b/docs/reference/static-functions/functions/table_toggleAllPageRowsSelected.md
@@ -12,7 +12,7 @@ function table_toggleAllPageRowsSelected<TFeatures, TData>(
    opts?): void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:148](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L148)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:155](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L155)
 
 Selects or deselects every selectable row on the current page.
 

--- a/docs/reference/static-functions/functions/table_toggleAllRowsSelected.md
+++ b/docs/reference/static-functions/functions/table_toggleAllRowsSelected.md
@@ -12,7 +12,7 @@ function table_toggleAllRowsSelected<TFeatures, TData>(
    opts?): void;
 ```
 
-Defined in: [features/row-selection/rowSelectionFeature.utils.ts:93](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L93)
+Defined in: [features/row-selection/rowSelectionFeature.utils.ts:98](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts#L98)
 
 Selects or deselects every selectable row before grouping.
 

--- a/examples/alpine/expanding/index.html
+++ b/examples/alpine/expanding/index.html
@@ -99,7 +99,7 @@
                         style="cursor: pointer"
                         :checked="cell.row.getIsSelected() || (cell.row.getCanSelectSubRows() && cell.row.getIsAllSubRowsSelected())"
                         x-effect="$el.indeterminate = !cell.row.getIsSelected() && cell.row.getIsSomeSelected()"
-                        @change="cell.row.getToggleSelectedHandler()($event)"
+                        @click="cell.row.getToggleSelectedHandler()($event)"
                       />
                       <button
                         x-show="cell.row.getCanExpand()"

--- a/examples/alpine/row-selection/index.html
+++ b/examples/alpine/row-selection/index.html
@@ -60,7 +60,7 @@
                       :checked="cell.row.getIsSelected()"
                       :disabled="!cell.row.getCanSelect()"
                       x-effect="$el.indeterminate = cell.row.getIsSomeSelected()"
-                      @change="cell.row.getToggleSelectedHandler()($event)"
+                      @click="cell.row.getToggleSelectedHandler()($event)"
                     />
                   </template>
                   <!-- other cells -->

--- a/examples/angular/basic-app-table/package.json
+++ b/examples/angular/basic-app-table/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/basic-dynamic-columns/package.json
+++ b/examples/angular/basic-dynamic-columns/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/basic-external-atoms/package.json
+++ b/examples/angular/basic-external-atoms/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/basic-external-state/package.json
+++ b/examples/angular/basic-external-state/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/basic-inject-table/package.json
+++ b/examples/angular/basic-inject-table/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/column-groups/package.json
+++ b/examples/angular/column-groups/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/column-ordering/package.json
+++ b/examples/angular/column-ordering/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/column-pinning-split/package.json
+++ b/examples/angular/column-pinning-split/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/column-pinning-sticky/package.json
+++ b/examples/angular/column-pinning-sticky/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/column-pinning/package.json
+++ b/examples/angular/column-pinning/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/column-resizing-performant/package.json
+++ b/examples/angular/column-resizing-performant/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/column-resizing/package.json
+++ b/examples/angular/column-resizing/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/column-sizing/package.json
+++ b/examples/angular/column-sizing/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/column-visibility/package.json
+++ b/examples/angular/column-visibility/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/composable-tables/package.json
+++ b/examples/angular/composable-tables/package.json
@@ -5,7 +5,7 @@
     "start": "ng serve --port 6565",
     "dev": "ng serve --port 6565",
     "build": "ng build",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "lint": "eslint ./src",
     "watch": "ng build --watch --configuration development"

--- a/examples/angular/composable-tables/src/app/components/cell-components.ts
+++ b/examples/angular/composable-tables/src/app/components/cell-components.ts
@@ -31,7 +31,7 @@ export class TextCell {
       [checked]="row().getIsSelected()"
       [disabled]="!row().getCanSelect()"
       [indeterminate]="row().getIsSomeSelected()"
-      (change)="row().getToggleSelectedHandler()($event)"
+      (click)="row().getToggleSelectedHandler()($event)"
     />
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/examples/angular/custom-plugin/package.json
+++ b/examples/angular/custom-plugin/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/editable/package.json
+++ b/examples/angular/editable/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/expanding/package.json
+++ b/examples/angular/expanding/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/expanding/src/app/expandable-cell/expandable-cell.ts
+++ b/examples/angular/expanding/src/app/expandable-cell/expandable-cell.ts
@@ -47,7 +47,7 @@ export class ExpandableHeaderCell<T extends RowData> {
             row.getIsSelected() ||
             (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
           "
-          (change)="row.getToggleSelectedHandler()($event)"
+          (change)="toggleSelected($event)"
         />
         {{ ' ' }}
 
@@ -78,5 +78,11 @@ export class ExpandableCell<T extends RowData> {
 
   get row() {
     return this.context().row
+  }
+
+  toggleSelected(event: Event) {
+    this.row.getToggleSelectedHandler({
+      // selectChildren: false
+    })(event)
   }
 }

--- a/examples/angular/expanding/src/app/expandable-cell/expandable-cell.ts
+++ b/examples/angular/expanding/src/app/expandable-cell/expandable-cell.ts
@@ -47,7 +47,7 @@ export class ExpandableHeaderCell<T extends RowData> {
             row.getIsSelected() ||
             (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
           "
-          (change)="toggleSelected($event)"
+          (click)="toggleSelected($event)"
         />
         {{ ' ' }}
 

--- a/examples/angular/filters-faceted/package.json
+++ b/examples/angular/filters-faceted/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/filters-fuzzy/package.json
+++ b/examples/angular/filters-fuzzy/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/filters/package.json
+++ b/examples/angular/filters/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/grouping/package.json
+++ b/examples/angular/grouping/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/kitchen-sink/package.json
+++ b/examples/angular/kitchen-sink/package.json
@@ -6,7 +6,7 @@
     "dev": "ng serve --port 6565",
     "build": "ng build",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "watch": "ng build --watch --configuration development"
   },

--- a/examples/angular/kitchen-sink/src/app/app.html
+++ b/examples/angular/kitchen-sink/src/app/app.html
@@ -183,7 +183,7 @@
                       [checked]="cell.row.getIsSelected()"
                       [disabled]="!cell.row.getCanSelect()"
                       [indeterminate]="cell.row.getIsSomeSelected()"
-                      (change)="cell.row.getToggleSelectedHandler()($event)"
+                      (click)="cell.row.getToggleSelectedHandler()($event)"
                     />
                     <button
                       class="pin-button"

--- a/examples/angular/pagination/package.json
+++ b/examples/angular/pagination/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/remote-data/package.json
+++ b/examples/angular/remote-data/package.json
@@ -10,7 +10,7 @@
     "test": "ng test",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "serve:ssr:remote-data": "node dist/remote-data/server/server.mjs"
   },
   "private": true,

--- a/examples/angular/row-dnd/package.json
+++ b/examples/angular/row-dnd/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/row-pinning/package.json
+++ b/examples/angular/row-pinning/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/row-selection-signal/package.json
+++ b/examples/angular/row-selection-signal/package.json
@@ -9,7 +9,7 @@
     "test": "ng test",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts",
     "lint": "eslint ./src",
-    "test:types": "ng build"
+    "test:types": "tsc -p tsconfig.app.json --noEmit"
   },
   "private": true,
   "packageManager": "pnpm@11.9.0",

--- a/examples/angular/row-selection-signal/src/app/selection-column.component.ts
+++ b/examples/angular/row-selection-signal/src/app/selection-column.component.ts
@@ -34,7 +34,7 @@ export class TableHeadSelectionComponent<T extends RowData> {
     <input
       type="checkbox"
       [checked]="row().getIsSelected()"
-      (change)="row().getToggleSelectedHandler()($event)"
+      (click)="row().getToggleSelectedHandler()($event)"
     />
   `,
   host: {

--- a/examples/angular/row-selection/package.json
+++ b/examples/angular/row-selection/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/row-selection/src/app/selection-column/selection-column.ts
+++ b/examples/angular/row-selection/src/app/selection-column/selection-column.ts
@@ -30,7 +30,7 @@ export class TableHeaderSelection {
       type="checkbox"
       [checked]="context.row.getIsSelected()"
       [disabled]="!context.row.getCanSelect()"
-      (change)="toggleSelected($event)"
+      (click)="toggleSelected($event)"
     />
   `,
   host: {

--- a/examples/angular/row-selection/src/app/selection-column/selection-column.ts
+++ b/examples/angular/row-selection/src/app/selection-column/selection-column.ts
@@ -30,7 +30,7 @@ export class TableHeaderSelection {
       type="checkbox"
       [checked]="context.row.getIsSelected()"
       [disabled]="!context.row.getCanSelect()"
-      (change)="context.row.getToggleSelectedHandler()($event)"
+      (change)="toggleSelected($event)"
     />
   `,
   host: {
@@ -43,4 +43,10 @@ export class TableRowSelection {
   readonly cell = injectTableCellContext()
   readonly row = computed(() => this.cell().row)
   readonly context = injectFlexRenderCellContext()
+
+  toggleSelected(event: Event) {
+    this.context.row.getToggleSelectedHandler({
+      // selectChildren: false
+    })(event)
+  }
 }

--- a/examples/angular/signal-input/package.json
+++ b/examples/angular/signal-input/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/sorting/package.json
+++ b/examples/angular/sorting/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/sub-components/package.json
+++ b/examples/angular/sub-components/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/virtualized-columns/package.json
+++ b/examples/angular/virtualized-columns/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/virtualized-infinite-scrolling/package.json
+++ b/examples/angular/virtualized-infinite-scrolling/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/virtualized-rows/package.json
+++ b/examples/angular/virtualized-rows/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/virtualized-rows/src/app/app.html
+++ b/examples/angular/virtualized-rows/src/app/app.html
@@ -60,7 +60,7 @@
                     [checked]="row.getIsSelected()"
                     [disabled]="!row.getCanSelect()"
                     [indeterminate]="row.getIsSomeSelected()"
-                    (change)="toggleSelected(row, $event)"
+                    (click)="toggleSelected(row, $event)"
                   />
                 } @else {
                   <ng-container *flexRenderCell="cell; let renderCell">

--- a/examples/angular/virtualized-rows/src/app/app.html
+++ b/examples/angular/virtualized-rows/src/app/app.html
@@ -4,6 +4,8 @@
     rendering performance will be slightly degraded until this application is built for production.
   </p>
   ({{ data().length.toLocaleString() }} rows)
+  <p>Hold Shift while selecting rows to select or deselect a range.</p>
+  <p>{{ table.getSelectedRowIds().length.toLocaleString() }} rows selected</p>
   <div>
     <button (click)="refreshData()">Regenerate Data</button>
     <button (click)="stressTest()">Stress Test (1M rows)</button>
@@ -19,7 +21,14 @@
                 style="align-items: center; display: flex; height: 34px"
                 [style.width.px]="header.getSize()"
               >
-                @if (!header.isPlaceholder) {
+                @if (header.column.id === 'select') {
+                  <input
+                    type="checkbox"
+                    [checked]="table.getIsAllRowsSelected()"
+                    [indeterminate]="table.getIsSomeRowsSelected()"
+                    (change)="table.getToggleAllRowsSelectedHandler()($event)"
+                  />
+                } @else if (!header.isPlaceholder) {
                   <div
                     [class.sortable-header]="header.column.getCanSort()"
                     (click)="header.column.getToggleSortingHandler()?.($event)"
@@ -45,9 +54,19 @@
           >
             @for (cell of row.getAllCells(); track cell.id) {
               <td style="display: flex" [style.width.px]="cell.column.getSize()">
-                <ng-container *flexRenderCell="cell; let renderCell">
-                  {{ renderCell }}
-                </ng-container>
+                @if (cell.column.id === 'select') {
+                  <input
+                    type="checkbox"
+                    [checked]="row.getIsSelected()"
+                    [disabled]="!row.getCanSelect()"
+                    [indeterminate]="row.getIsSomeSelected()"
+                    (change)="toggleSelected(row, $event)"
+                  />
+                } @else {
+                  <ng-container *flexRenderCell="cell; let renderCell">
+                    {{ renderCell }}
+                  </ng-container>
+                }
               </td>
             }
           </tr>
@@ -56,4 +75,3 @@
     </table>
   </div>
 </div>
-<pre>{{ stringifiedState() }}</pre>

--- a/examples/angular/virtualized-rows/src/app/app.ts
+++ b/examples/angular/virtualized-rows/src/app/app.ts
@@ -11,6 +11,7 @@ import {
   createColumnHelper,
   createSortedRowModel,
   injectTable,
+  rowSelectionFeature,
   rowSortingFeature,
   sortFns,
   tableFeatures,
@@ -19,9 +20,11 @@ import { injectVirtualizer } from '@tanstack/angular-virtual'
 import { makeData } from './makeData'
 import type { ElementRef } from '@angular/core'
 import type { Person } from './makeData'
+import type { Row } from '@tanstack/angular-table'
 
 const features = tableFeatures({
   columnSizingFeature,
+  rowSelectionFeature,
   rowSortingFeature,
   sortedRowModel: createSortedRowModel(),
   sortFns,
@@ -29,6 +32,12 @@ const features = tableFeatures({
 const columnHelper = createColumnHelper<typeof features, Person>()
 
 const columns = columnHelper.columns([
+  columnHelper.display({
+    id: 'select',
+    header: '',
+    cell: '',
+    size: 40,
+  }),
   columnHelper.accessor('id', {
     header: 'ID',
     size: 60,
@@ -83,6 +92,7 @@ export class App {
     features,
     columns,
     data: this.data(),
+    getRowId: (row) => String(row.id),
     debugTable: true,
   }))
 
@@ -106,14 +116,16 @@ export class App {
   readonly virtualRows = computed(() => this.rowVirtualizer.getVirtualItems())
   readonly totalSize = computed(() => this.rowVirtualizer.getTotalSize())
 
-  stringifiedState() {
-    return JSON.stringify(this.table.store.get(), null, 2)
-  }
-
   refreshData = () => this.data.set(makeData(200_000))
   stressTest = () => this.data.set(makeData(1_000_000))
 
   sortIndicator(sortDirection: false | 'asc' | 'desc') {
     return sortDirection ? sortIndicators[sortDirection] : null
+  }
+
+  toggleSelected(row: Row<typeof features, Person>, event: Event) {
+    row.getToggleSelectedHandler({
+      // selectChildren: false
+    })(event)
   }
 }

--- a/examples/angular/with-tanstack-form/package.json
+++ b/examples/angular/with-tanstack-form/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/angular/with-tanstack-query/package.json
+++ b/examples/angular/with-tanstack-query/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "lint": "eslint ./src",
-    "test:types": "ng build",
+    "test:types": "tsc -p tsconfig.app.json --noEmit",
     "test:e2e": "PLAYWRIGHT_TEST_DIR=$PWD/tests/e2e playwright test --config ../../../playwright.config.ts"
   },
   "private": true,

--- a/examples/ember/expanding/app/templates/application.gts
+++ b/examples/ember/expanding/app/templates/application.gts
@@ -95,7 +95,9 @@ const getCanFilter = (column: Column<typeof features, Person>): boolean =>
 const toggleExpanded = (row: Row<typeof features, Person>) => () =>
   row.toggleExpanded()
 const toggleSelected = (row: Row<typeof features, Person>) => (event: Event) =>
-  row.getToggleSelectedHandler()(event)
+  row.getToggleSelectedHandler({
+    // selectChildren: false
+  })(event)
 const toggleSort =
   (column: Column<typeof features, Person>) => (event: Event) =>
     column.getToggleSortingHandler()?.(event)

--- a/examples/ember/expanding/app/templates/application.gts
+++ b/examples/ember/expanding/app/templates/application.gts
@@ -364,7 +364,7 @@ export default class ExpandingTable extends Component {
                       type='checkbox'
                       checked={{getIsSelected row}}
                       indeterminate={{getIsSomeSelected row}}
-                      {{on 'change' (toggleSelected row)}}
+                      {{on 'click' (toggleSelected row)}}
                     />
                     {{#if (getCanExpand row)}}
                       <button {{on 'click' (toggleExpanded row)}}>

--- a/examples/ember/kitchen-sink/app/templates/application.gts
+++ b/examples/ember/kitchen-sink/app/templates/application.gts
@@ -743,7 +743,7 @@ export default class KitchenSinkTable extends Component {
                     <input
                       type='checkbox'
                       checked={{rowGetIsSelected cell.row}}
-                      {{on 'change' (toggleRowSelected cell.row)}}
+                      {{on 'click' (toggleRowSelected cell.row)}}
                     />
                   {{else if (cellIsFirstName cell)}}
                     <span style={{rowDepthPad cell.row}}>

--- a/examples/ember/row-selection/app/templates/application.gts
+++ b/examples/ember/row-selection/app/templates/application.gts
@@ -79,7 +79,9 @@ class SelectionRowCheckbox extends Component<
   }
 
   handleChange = (event: Event) => {
-    this.row.getToggleSelectedHandler()(event)
+    this.row.getToggleSelectedHandler({
+      // selectChildren: false
+    })(event)
   }
 
   <template>

--- a/examples/ember/row-selection/app/templates/application.gts
+++ b/examples/ember/row-selection/app/templates/application.gts
@@ -78,7 +78,7 @@ class SelectionRowCheckbox extends Component<
     return this.row.getIsSelected()
   }
 
-  handleChange = (event: Event) => {
+  handleClick = (event: Event) => {
     this.row.getToggleSelectedHandler({
       // selectChildren: false
     })(event)
@@ -88,7 +88,7 @@ class SelectionRowCheckbox extends Component<
     <Input
       @type='checkbox'
       @checked={{this.checked}}
-      {{on 'change' this.handleChange}}
+      {{on 'click' this.handleClick}}
     />
   </template>
 }

--- a/examples/lit/basic-subscribe/src/main.ts
+++ b/examples/lit/basic-subscribe/src/main.ts
@@ -75,7 +75,7 @@ const columns = columnHelper.columns([
             type="checkbox"
             .checked=${!!isRowSelected}
             ?disabled=${!row.getCanSelect()}
-            @change=${row.getToggleSelectedHandler()}
+            @click=${row.getToggleSelectedHandler()}
           />
         `,
       ),

--- a/examples/lit/composable-tables/src/components/products-table.ts
+++ b/examples/lit/composable-tables/src/components/products-table.ts
@@ -24,7 +24,7 @@ const columns = productColumnHelper.columns([
     cell: ({ row }) => html`
       <input
         type="checkbox"
-        @change=${row.getToggleSelectedHandler()}
+        @click=${row.getToggleSelectedHandler()}
         .checked=${row.getIsSelected()}
         ?disabled=${!row.getCanSelect()}
         .indeterminate=${row.getIsSomeSelected()}

--- a/examples/lit/composable-tables/src/components/users-table.ts
+++ b/examples/lit/composable-tables/src/components/users-table.ts
@@ -26,7 +26,7 @@ const columns = personColumnHelper.columns([
     cell: ({ row }) => html`
       <input
         type="checkbox"
-        @change=${row.getToggleSelectedHandler()}
+        @click=${row.getToggleSelectedHandler()}
         .checked=${row.getIsSelected()}
         ?disabled=${!row.getCanSelect()}
         .indeterminate=${row.getIsSomeSelected()}

--- a/examples/lit/expanding/src/main.ts
+++ b/examples/lit/expanding/src/main.ts
@@ -132,7 +132,9 @@ const columns: Array<ColumnDef<typeof features, Person>> = [
             row.getIsSelected() ||
             (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected()),
           indeterminate: row.getIsSomeSelected(),
-          onChange: row.getToggleSelectedHandler(),
+          onChange: row.getToggleSelectedHandler({
+            // selectChildren: false
+          }),
         })}
         ${row.getCanExpand()
           ? html`<button

--- a/examples/lit/expanding/src/main.ts
+++ b/examples/lit/expanding/src/main.ts
@@ -38,14 +38,14 @@ const features = tableFeatures({
 function indeterminateCheckbox(options: {
   checked: boolean
   indeterminate: boolean
-  onChange: (e: Event) => void
+  onClick: (e: Event) => void
 }) {
   return html`
     <input
       type="checkbox"
       .checked="${options.checked}"
       .indeterminate="${!options.checked && options.indeterminate}"
-      @change="${options.onChange}"
+      @click="${options.onClick}"
       style="cursor: pointer"
     />
   `
@@ -118,7 +118,7 @@ const columns: Array<ColumnDef<typeof features, Person>> = [
       ${indeterminateCheckbox({
         checked: table.getIsAllRowsSelected(),
         indeterminate: table.getIsSomeRowsSelected(),
-        onChange: table.getToggleAllRowsSelectedHandler(),
+        onClick: table.getToggleAllRowsSelectedHandler(),
       })}
       <button @click="${table.getToggleAllRowsExpandedHandler()}">
         ${table.getIsAllRowsExpanded() ? '👇' : '👉'}
@@ -132,7 +132,7 @@ const columns: Array<ColumnDef<typeof features, Person>> = [
             row.getIsSelected() ||
             (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected()),
           indeterminate: row.getIsSomeSelected(),
-          onChange: row.getToggleSelectedHandler({
+          onClick: row.getToggleSelectedHandler({
             // selectChildren: false
           }),
         })}

--- a/examples/lit/kitchen-sink/src/main.ts
+++ b/examples/lit/kitchen-sink/src/main.ts
@@ -611,7 +611,7 @@ class LitTableExample extends LitElement {
                 ?checked=${cell.row.getIsSelected()}
                 ?disabled=${!cell.row.getCanSelect()}
                 .indeterminate=${cell.row.getIsSomeSelected()}
-                @change=${cell.row.getToggleSelectedHandler()}
+                @click=${cell.row.getToggleSelectedHandler()}
               />
               <button
                 class="pin-button"

--- a/examples/lit/row-selection/src/main.ts
+++ b/examples/lit/row-selection/src/main.ts
@@ -39,7 +39,7 @@ const columns: Array<ColumnDef<typeof features, Person>> = [
     cell: ({ row }) => html`
       <input
         type="checkbox"
-        @change="${row.getToggleSelectedHandler({
+        @click="${row.getToggleSelectedHandler({
           // selectChildren: false
         })}"
         .checked="${row.getIsSelected()}"

--- a/examples/lit/row-selection/src/main.ts
+++ b/examples/lit/row-selection/src/main.ts
@@ -39,7 +39,9 @@ const columns: Array<ColumnDef<typeof features, Person>> = [
     cell: ({ row }) => html`
       <input
         type="checkbox"
-        @change="${row.getToggleSelectedHandler()}"
+        @change="${row.getToggleSelectedHandler({
+          // selectChildren: false
+        })}"
         .checked="${row.getIsSelected()}"
         ?disabled="${!row.getCanSelect()}"
         .indeterminate="${row.getIsSomeSelected()}"

--- a/examples/lit/virtualized-rows/src/main.ts
+++ b/examples/lit/virtualized-rows/src/main.ts
@@ -6,6 +6,7 @@ import {
   TableController,
   columnSizingFeature,
   createSortedRowModel,
+  rowSelectionFeature,
   rowSortingFeature,
   sortFns,
   tableFeatures,
@@ -18,12 +19,36 @@ import type { ColumnDef } from '@tanstack/lit-table'
 
 const features = tableFeatures({
   columnSizingFeature,
+  rowSelectionFeature,
   rowSortingFeature,
   sortedRowModel: createSortedRowModel(),
   sortFns,
 })
 
 const columns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    id: 'select',
+    header: ({ table }) => html`
+      <input
+        type="checkbox"
+        .checked=${table.getIsAllRowsSelected()}
+        .indeterminate=${table.getIsSomeRowsSelected()}
+        @change=${table.getToggleAllRowsSelectedHandler()}
+      />
+    `,
+    cell: ({ row }) => html`
+      <input
+        type="checkbox"
+        .checked=${row.getIsSelected()}
+        ?disabled=${!row.getCanSelect()}
+        .indeterminate=${row.getIsSomeSelected()}
+        @change=${row.getToggleSelectedHandler({
+          // selectChildren: false
+        })}
+      />
+    `,
+    size: 40,
+  },
   {
     accessorKey: 'id',
     header: 'ID',
@@ -92,8 +117,9 @@ class LitTableExample extends LitElement {
         features,
         columns,
         data: this._data,
+        getRowId: (row) => String(row.id),
       },
-      () => ({}), // selector - empty since we don't need any state
+      (state) => state.rowSelection,
     )
     const { rows } = table.getRowModel()
 
@@ -121,6 +147,10 @@ class LitTableExample extends LitElement {
           </button>
         </div>
         (${this._data.length.toLocaleString()} rows)
+        <p>Hold Shift while selecting rows to select or deselect a range.</p>
+        <p>
+          ${table.getSelectedRowIds().length.toLocaleString()} rows selected
+        </p>
         <div
           class="container"
           ${ref(this.tableContainerRef)}

--- a/examples/lit/virtualized-rows/src/main.ts
+++ b/examples/lit/virtualized-rows/src/main.ts
@@ -42,7 +42,7 @@ const columns: Array<ColumnDef<typeof features, Person>> = [
         .checked=${row.getIsSelected()}
         ?disabled=${!row.getCanSelect()}
         .indeterminate=${row.getIsSomeSelected()}
-        @change=${row.getToggleSelectedHandler({
+        @click=${row.getToggleSelectedHandler({
           // selectChildren: false
         })}
       />

--- a/examples/preact/basic-subscribe/src/main.tsx
+++ b/examples/preact/basic-subscribe/src/main.tsx
@@ -88,7 +88,7 @@ function App() {
                     checked={!!isRowSelected}
                     disabled={!row.getCanSelect()}
                     indeterminate={row.getIsSomeSelected()}
-                    onChange={row.getToggleSelectedHandler()}
+                    onClick={row.getToggleSelectedHandler()}
                   />
                 </div>
               )}

--- a/examples/preact/composable-tables/src/components/cell-components.tsx
+++ b/examples/preact/composable-tables/src/components/cell-components.tsx
@@ -24,7 +24,7 @@ export function SelectCell() {
       checked={row.getIsSelected()}
       disabled={!row.getCanSelect()}
       indeterminate={row.getIsSomeSelected()}
-      onChange={row.getToggleSelectedHandler()}
+      onClick={row.getToggleSelectedHandler()}
     />
   )
 }

--- a/examples/preact/expanding/src/main.tsx
+++ b/examples/preact/expanding/src/main.tsx
@@ -78,7 +78,9 @@ function App() {
                     (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
                   }
                   indeterminate={row.getIsSomeSelected()}
-                  onChange={row.getToggleSelectedHandler()}
+                  onChange={row.getToggleSelectedHandler({
+                    // selectChildren: false
+                  })}
                 />{' '}
                 {row.getCanExpand() ? (
                   <button

--- a/examples/preact/expanding/src/main.tsx
+++ b/examples/preact/expanding/src/main.tsx
@@ -78,7 +78,7 @@ function App() {
                     (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
                   }
                   indeterminate={row.getIsSomeSelected()}
-                  onChange={row.getToggleSelectedHandler({
+                  onClick={row.getToggleSelectedHandler({
                     // selectChildren: false
                   })}
                 />{' '}

--- a/examples/preact/kitchen-sink/src/main.tsx
+++ b/examples/preact/kitchen-sink/src/main.tsx
@@ -466,7 +466,7 @@ function App() {
               checked={row.getIsSelected()}
               disabled={!row.getCanSelect()}
               indeterminate={row.getIsSomeSelected()}
-              onChange={row.getToggleSelectedHandler()}
+              onClick={row.getToggleSelectedHandler()}
             />{' '}
             <button
               className="pin-button"

--- a/examples/preact/row-selection/src/main.tsx
+++ b/examples/preact/row-selection/src/main.tsx
@@ -62,7 +62,9 @@ function App() {
                 checked={row.getIsSelected()}
                 disabled={!row.getCanSelect()}
                 indeterminate={row.getIsSomeSelected()}
-                onChange={row.getToggleSelectedHandler()}
+                onChange={row.getToggleSelectedHandler({
+                  // selectChildren: false
+                })}
               />
             </div>
           ),

--- a/examples/preact/row-selection/src/main.tsx
+++ b/examples/preact/row-selection/src/main.tsx
@@ -62,7 +62,7 @@ function App() {
                 checked={row.getIsSelected()}
                 disabled={!row.getCanSelect()}
                 indeterminate={row.getIsSomeSelected()}
-                onChange={row.getToggleSelectedHandler({
+                onClick={row.getToggleSelectedHandler({
                   // selectChildren: false
                 })}
               />

--- a/examples/react/expanding/src/main.tsx
+++ b/examples/react/expanding/src/main.tsx
@@ -79,7 +79,9 @@ function App() {
                     (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
                   }
                   indeterminate={row.getIsSomeSelected()}
-                  onChange={row.getToggleSelectedHandler()}
+                  onChange={row.getToggleSelectedHandler({
+                    // selectChildren: false
+                  })}
                 />{' '}
                 {row.getCanExpand() ? (
                   <button

--- a/examples/react/row-selection/src/main.tsx
+++ b/examples/react/row-selection/src/main.tsx
@@ -58,7 +58,9 @@ function App() {
                 checked={row.getIsSelected()}
                 disabled={!row.getCanSelect()}
                 indeterminate={row.getIsSomeSelected()}
-                onChange={row.getToggleSelectedHandler()}
+                onChange={row.getToggleSelectedHandler({
+                  // selectChildren: false
+                })}
               />
             </div>
           ),
@@ -113,6 +115,8 @@ function App() {
       getRowId: (row) => row.id,
       enableRowSelection: true, // enable row selection for all rows
       // enableRowSelection: row => row.original.age > 18, // or enable row selection conditionally per row
+      // enableRowRangeSelection: false,
+      // isRowRangeSelectionEvent: event => Boolean((event as React.MouseEvent).metaKey),
       debugTable: true,
     },
     (state) => state, // default selector
@@ -146,6 +150,7 @@ function App() {
           />
         </div>
         <div className="spacer-sm" />
+        <p>Hold Shift while selecting rows to select or deselect a range.</p>
         <table>
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/examples/react/virtualized-rows/src/main.tsx
+++ b/examples/react/virtualized-rows/src/main.tsx
@@ -300,7 +300,7 @@ function IndeterminateCheckbox({
     if (typeof indeterminate === 'boolean') {
       ref.current.indeterminate = !rest.checked && indeterminate
     }
-  }, [ref, indeterminate])
+  }, [indeterminate, rest.checked])
 
   return (
     <input

--- a/examples/react/virtualized-rows/src/main.tsx
+++ b/examples/react/virtualized-rows/src/main.tsx
@@ -7,18 +7,21 @@ import {
   columnSizingFeature,
   createColumnHelper,
   createSortedRowModel,
+  rowSelectionFeature,
   rowSortingFeature,
   sortFns,
   useTable,
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { makeData } from './makeData'
+import type { HTMLProps } from 'react'
 import type { ReactTable, Row } from '@tanstack/react-table'
 import type { VirtualItem, Virtualizer } from '@tanstack/react-virtual'
 import type { Person } from './makeData'
 
 const features = {
   columnSizingFeature,
+  rowSelectionFeature,
   rowSortingFeature,
   sortedRowModel: createSortedRowModel(),
   sortFns,
@@ -31,6 +34,27 @@ function App() {
   const columns = React.useMemo(
     () =>
       columnHelper.columns([
+        columnHelper.display({
+          id: 'select',
+          header: ({ table }) => (
+            <IndeterminateCheckbox
+              checked={table.getIsAllRowsSelected()}
+              indeterminate={table.getIsSomeRowsSelected()}
+              onChange={table.getToggleAllRowsSelectedHandler()}
+            />
+          ),
+          cell: ({ row }) => (
+            <IndeterminateCheckbox
+              checked={row.getIsSelected()}
+              disabled={!row.getCanSelect()}
+              indeterminate={row.getIsSomeSelected()}
+              onChange={row.getToggleSelectedHandler({
+                // selectChildren: false
+              })}
+            />
+          ),
+          size: 40,
+        }),
         columnHelper.accessor('id', {
           header: 'ID',
           size: 60,
@@ -85,6 +109,7 @@ function App() {
       features,
       columns,
       data,
+      getRowId: (row) => String(row.id),
       debugTable: true,
     },
     (state) => state, // default selector
@@ -102,6 +127,8 @@ function App() {
           </p>
         ) : null}
         ({data.length.toLocaleString()} rows)
+        <p>Hold Shift while selecting rows to select or deselect a range.</p>
+        <p>{table.getSelectedRowIds().length.toLocaleString()} rows selected</p>
         <div>
           <button onClick={refreshData}>Regenerate Data</button>
           <button onClick={stressTest}>Stress Test (1M rows)</button>
@@ -166,7 +193,6 @@ function App() {
           </table>
         </div>
       </div>
-      <pre>{JSON.stringify(table.state, null, 2)}</pre>
     </>
   )
 }
@@ -260,6 +286,29 @@ function TableBodyRow({
         )
       })}
     </tr>
+  )
+}
+
+function IndeterminateCheckbox({
+  indeterminate,
+  className = '',
+  ...rest
+}: { indeterminate?: boolean } & HTMLProps<HTMLInputElement>) {
+  const ref = React.useRef<HTMLInputElement>(null!)
+
+  React.useEffect(() => {
+    if (typeof indeterminate === 'boolean') {
+      ref.current.indeterminate = !rest.checked && indeterminate
+    }
+  }, [ref, indeterminate])
+
+  return (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={className + ' sortable-header'}
+      {...rest}
+    />
   )
 }
 

--- a/examples/solid/composable-tables/src/components/cell-components.tsx
+++ b/examples/solid/composable-tables/src/components/cell-components.tsx
@@ -22,7 +22,7 @@ export function SelectCell() {
       checked={row.getIsSelected()}
       disabled={!row.getCanSelect()}
       indeterminate={row.getIsSomeSelected()}
-      onChange={row.getToggleSelectedHandler()}
+      onClick={row.getToggleSelectedHandler()}
     />
   )
 }

--- a/examples/solid/composable-tables/src/components/indeterminate-checkbox.tsx
+++ b/examples/solid/composable-tables/src/components/indeterminate-checkbox.tsx
@@ -14,6 +14,7 @@ export function IndeterminateCheckbox(props: {
   checked?: boolean
   disabled?: boolean
   onChange?: (event: Event) => void
+  onClick?: (event: MouseEvent) => void
 }) {
   let ref: HTMLInputElement | undefined
 
@@ -31,6 +32,7 @@ export function IndeterminateCheckbox(props: {
       checked={props.checked}
       disabled={props.disabled}
       onChange={props.onChange}
+      onClick={props.onClick}
     />
   )
 }

--- a/examples/solid/expanding/src/App.tsx
+++ b/examples/solid/expanding/src/App.tsx
@@ -69,7 +69,7 @@ function App() {
                 (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
               }
               indeterminate={row.getIsSomeSelected()}
-              onChange={row.getToggleSelectedHandler({
+              onClick={row.getToggleSelectedHandler({
                 // selectChildren: false
               })}
             />{' '}
@@ -298,6 +298,7 @@ function IndeterminateCheckbox(props: {
   checked?: boolean
   className?: string
   onChange?: (event: Event) => void
+  onClick?: (event: MouseEvent) => void
 }) {
   let ref: HTMLInputElement | undefined
 
@@ -314,6 +315,7 @@ function IndeterminateCheckbox(props: {
       class={`${props.className ?? ''} sortable-header`}
       checked={props.checked}
       onChange={props.onChange}
+      onClick={props.onClick}
     />
   )
 }

--- a/examples/solid/expanding/src/App.tsx
+++ b/examples/solid/expanding/src/App.tsx
@@ -69,7 +69,9 @@ function App() {
                 (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
               }
               indeterminate={row.getIsSomeSelected()}
-              onChange={row.getToggleSelectedHandler()}
+              onChange={row.getToggleSelectedHandler({
+                // selectChildren: false
+              })}
             />{' '}
             {row.getCanExpand() ? (
               <button

--- a/examples/solid/kitchen-sink/src/App.tsx
+++ b/examples/solid/kitchen-sink/src/App.tsx
@@ -454,7 +454,7 @@ const columns = columnHelper.columns([
           checked={row.getIsSelected()}
           disabled={!row.getCanSelect()}
           indeterminate={row.getIsSomeSelected()}
-          onChange={row.getToggleSelectedHandler()}
+          onClick={row.getToggleSelectedHandler()}
         />{' '}
         <button
           class="pin-button"

--- a/examples/solid/row-selection/src/App.tsx
+++ b/examples/solid/row-selection/src/App.tsx
@@ -57,7 +57,7 @@ function App() {
               checked={row.getIsSelected()}
               disabled={!row.getCanSelect()}
               indeterminate={row.getIsSomeSelected()}
-              onChange={row.getToggleSelectedHandler({
+              onClick={row.getToggleSelectedHandler({
                 // selectChildren: false
               })}
             />
@@ -346,6 +346,7 @@ function IndeterminateCheckbox(props: {
   checked?: boolean
   disabled?: boolean
   onChange?: (event: Event) => void
+  onClick?: (event: MouseEvent) => void
 }) {
   let ref: HTMLInputElement | undefined
 
@@ -363,6 +364,7 @@ function IndeterminateCheckbox(props: {
       checked={props.checked}
       disabled={props.disabled}
       onChange={props.onChange}
+      onClick={props.onClick}
     />
   )
 }

--- a/examples/solid/row-selection/src/App.tsx
+++ b/examples/solid/row-selection/src/App.tsx
@@ -57,7 +57,9 @@ function App() {
               checked={row.getIsSelected()}
               disabled={!row.getCanSelect()}
               indeterminate={row.getIsSomeSelected()}
-              onChange={row.getToggleSelectedHandler()}
+              onChange={row.getToggleSelectedHandler({
+                // selectChildren: false
+              })}
             />
           </div>
         )

--- a/examples/solid/virtualized-rows/src/App.tsx
+++ b/examples/solid/virtualized-rows/src/App.tsx
@@ -3,12 +3,13 @@ import {
   columnSizingFeature,
   createSortedRowModel,
   createTable,
+  rowSelectionFeature,
   rowSortingFeature,
   sortFns,
   tableFeatures,
 } from '@tanstack/solid-table'
 import { createVirtualizer } from '@tanstack/solid-virtual'
-import { For, createSignal } from 'solid-js'
+import { For, createEffect, createSignal } from 'solid-js'
 import { makeData } from './makeData'
 import type { Row, SolidTable } from '@tanstack/solid-table'
 import type { VirtualItem, Virtualizer } from '@tanstack/solid-virtual'
@@ -16,6 +17,7 @@ import type { Person } from './makeData'
 
 const features = tableFeatures({
   columnSizingFeature,
+  rowSelectionFeature,
   rowSortingFeature,
   sortedRowModel: createSortedRowModel(),
   sortFns,
@@ -25,6 +27,27 @@ const features = tableFeatures({
 // See https://tanstack.com/virtual/v3/docs/examples/solid/table for a simpler fixed row height example.
 function App() {
   const columns = [
+    {
+      id: 'select',
+      header: ({ table }: any) => (
+        <IndeterminateCheckbox
+          checked={table.getIsAllRowsSelected()}
+          indeterminate={table.getIsSomeRowsSelected()}
+          onChange={table.getToggleAllRowsSelectedHandler()}
+        />
+      ),
+      cell: ({ row }: any) => (
+        <IndeterminateCheckbox
+          checked={row.getIsSelected()}
+          disabled={!row.getCanSelect()}
+          indeterminate={row.getIsSomeSelected()}
+          onChange={row.getToggleSelectedHandler({
+            // selectChildren: false
+          })}
+        />
+      ),
+      size: 40,
+    },
     {
       accessorKey: 'id',
       header: 'ID',
@@ -78,8 +101,7 @@ function App() {
     get data() {
       return data()
     },
-    getRowId: (row) =>
-      `${row.id}-${row.firstName}-${row.lastName}-${row.createdAt.getTime()}`,
+    getRowId: (row) => String(row.id),
     debugTable: true,
   })
 
@@ -91,9 +113,10 @@ function App() {
           <button onClick={() => stressTest()}>Stress Test (1M rows)</button>
         </div>
         ({data().length.toLocaleString()} rows)
+        <p>Hold Shift while selecting rows to select or deselect a range.</p>
+        <p>{table.getSelectedRowIds().length.toLocaleString()} rows selected</p>
         <VirtualizedTable table={table} />
       </div>
-      <pre>{JSON.stringify(table.store.get(), null, 2)}</pre>
     </>
   )
 }
@@ -233,6 +256,33 @@ function TableBodyRow(props: {
         )}
       </For>
     </tr>
+  )
+}
+
+function IndeterminateCheckbox(props: {
+  indeterminate?: boolean
+  class?: string
+  checked?: boolean
+  disabled?: boolean
+  onChange?: (event: Event) => void
+}) {
+  let ref: HTMLInputElement | undefined
+
+  createEffect(() => {
+    if (typeof props.indeterminate === 'boolean' && ref) {
+      ref.indeterminate = !props.checked && props.indeterminate
+    }
+  })
+
+  return (
+    <input
+      type="checkbox"
+      ref={ref}
+      class={(props.class ?? '') + ' sortable-header'}
+      checked={props.checked}
+      disabled={props.disabled}
+      onChange={props.onChange}
+    />
   )
 }
 

--- a/examples/solid/virtualized-rows/src/App.tsx
+++ b/examples/solid/virtualized-rows/src/App.tsx
@@ -41,7 +41,7 @@ function App() {
           checked={row.getIsSelected()}
           disabled={!row.getCanSelect()}
           indeterminate={row.getIsSomeSelected()}
-          onChange={row.getToggleSelectedHandler({
+          onClick={row.getToggleSelectedHandler({
             // selectChildren: false
           })}
         />
@@ -265,6 +265,7 @@ function IndeterminateCheckbox(props: {
   checked?: boolean
   disabled?: boolean
   onChange?: (event: Event) => void
+  onClick?: (event: MouseEvent) => void
 }) {
   let ref: HTMLInputElement | undefined
 
@@ -278,10 +279,11 @@ function IndeterminateCheckbox(props: {
     <input
       type="checkbox"
       ref={ref}
-      class={(props.class ?? '') + ' sortable-header'}
+      class={props.class ?? ''}
       checked={props.checked}
       disabled={props.disabled}
       onChange={props.onChange}
+      onClick={props.onClick}
     />
   )
 }

--- a/examples/svelte/composable-tables/src/components/SelectCell.svelte
+++ b/examples/svelte/composable-tables/src/components/SelectCell.svelte
@@ -27,5 +27,5 @@
   checked={row.getIsSelected()}
   disabled={!row.getCanSelect()}
   use:setIndeterminate={!row.getIsSelected() && row.getIsSomeSelected()}
-  onchange={row.getToggleSelectedHandler()}
+  onclick={row.getToggleSelectedHandler()}
 />

--- a/examples/svelte/expanding/src/App.svelte
+++ b/examples/svelte/expanding/src/App.svelte
@@ -165,7 +165,9 @@
                         (row.getCanSelectSubRows() &&
                           row.getIsAllSubRowsSelected())}
                       use:setIndeterminate={!row.getIsSelected() && row.getIsSomeSelected()}
-                      onchange={row.getToggleSelectedHandler()}
+                      onchange={row.getToggleSelectedHandler({
+                        // selectChildren: false
+                      })}
                       class="sortable-header"
                     />
                     {' '}

--- a/examples/svelte/expanding/src/App.svelte
+++ b/examples/svelte/expanding/src/App.svelte
@@ -165,7 +165,7 @@
                         (row.getCanSelectSubRows() &&
                           row.getIsAllSubRowsSelected())}
                       use:setIndeterminate={!row.getIsSelected() && row.getIsSomeSelected()}
-                      onchange={row.getToggleSelectedHandler({
+                      onclick={row.getToggleSelectedHandler({
                         // selectChildren: false
                       })}
                       class="sortable-header"

--- a/examples/svelte/kitchen-sink/src/App.svelte
+++ b/examples/svelte/kitchen-sink/src/App.svelte
@@ -523,7 +523,7 @@
                       checked={cell.row.getIsSelected()}
                       disabled={!cell.row.getCanSelect()}
                       indeterminate={cell.row.getIsSomeSelected()}
-                      onchange={cell.row.getToggleSelectedHandler()}
+                      onclick={cell.row.getToggleSelectedHandler()}
                     />{' '}
                     <button
                       class="pin-button"

--- a/examples/svelte/row-selection/src/App.svelte
+++ b/examples/svelte/row-selection/src/App.svelte
@@ -174,7 +174,7 @@
                   checked={row.getIsSelected()}
                   disabled={!row.getCanSelect()}
                   use:setIndeterminate={!row.getIsSelected() && row.getIsSomeSelected()}
-                  onchange={row.getToggleSelectedHandler({
+                  onclick={row.getToggleSelectedHandler({
                     // selectChildren: false
                   })}
                   class="sortable-header"

--- a/examples/svelte/row-selection/src/App.svelte
+++ b/examples/svelte/row-selection/src/App.svelte
@@ -174,7 +174,9 @@
                   checked={row.getIsSelected()}
                   disabled={!row.getCanSelect()}
                   use:setIndeterminate={!row.getIsSelected() && row.getIsSomeSelected()}
-                  onchange={row.getToggleSelectedHandler()}
+                  onchange={row.getToggleSelectedHandler({
+                    // selectChildren: false
+                  })}
                   class="sortable-header"
                 />
               {:else}

--- a/examples/svelte/row-selection/tests/e2e/smoke.spec.ts
+++ b/examples/svelte/row-selection/tests/e2e/smoke.spec.ts
@@ -102,3 +102,25 @@ test('renders the table without crashing', async ({ page }) => {
     await server.close()
   }
 })
+
+test('selects an inclusive row range with Shift-click', async ({ page }) => {
+  const { errors, server } = await openExample(page)
+
+  try {
+    const table = getTable(page)
+    const rowCheckboxes = getBodyRows(table).locator('input[type="checkbox"]')
+
+    await expect(rowCheckboxes.nth(2)).toBeVisible()
+
+    await rowCheckboxes.nth(0).click()
+    await rowCheckboxes.nth(2).click({ modifiers: ['Shift'] })
+
+    await expect(rowCheckboxes.nth(0)).toBeChecked()
+    await expect(rowCheckboxes.nth(1)).toBeChecked()
+    await expect(rowCheckboxes.nth(2)).toBeChecked()
+    await expect(rowCheckboxes.nth(3)).not.toBeChecked()
+    expect(errors).toEqual([])
+  } finally {
+    await server.close()
+  }
+})

--- a/examples/svelte/virtualized-rows/src/App.svelte
+++ b/examples/svelte/virtualized-rows/src/App.svelte
@@ -4,6 +4,7 @@
     columnSizingFeature,
     createSortedRowModel,
     createTable,
+    rowSelectionFeature,
     rowSortingFeature,
     sortFns,
     tableFeatures,
@@ -17,6 +18,7 @@
 
   const features = tableFeatures({
     columnSizingFeature,
+    rowSelectionFeature,
     rowSortingFeature,
     sortedRowModel: createSortedRowModel(),
     sortFns,
@@ -25,6 +27,12 @@
   // This is a dynamic row height example, which is more complicated, but allows for a more realistic table.
   // See https://tanstack.com/virtual/v3/docs/examples/svelte/table for a simpler fixed row height example.
   const columns: Array<ColumnDef<typeof features, Person>> = [
+    {
+      id: 'select',
+      header: '',
+      cell: '',
+      size: 40,
+    },
     {
       accessorKey: 'id',
       header: 'ID',
@@ -71,12 +79,23 @@
   const refreshData = () => { data = makeData(200_000) }
   const stressTest = () => { data = makeData(1_000_000) }
 
+  // Svelte action to set indeterminate property on checkbox inputs
+  function setIndeterminate(node: HTMLInputElement, value: boolean) {
+    node.indeterminate = value
+    return {
+      update(newValue: boolean) {
+        node.indeterminate = newValue
+      },
+    }
+  }
+
   const table = createTable({
     features,
     columns,
     get data() {
       return data
     },
+    getRowId: (row) => String(row.id),
     debugTable: true,
   })
 
@@ -127,6 +146,8 @@
     <button onclick={() => stressTest()}>Stress Test (1M rows)</button>
   </div>
   ({data.length.toLocaleString()} rows)
+  <p>Hold Shift while selecting rows to select or deselect a range.</p>
+  <p>{table.getSelectedRowIds().length.toLocaleString()} rows selected</p>
   <div
     class="container"
     bind:this={tableContainerRef}
@@ -140,26 +161,35 @@
           <tr style="display: flex; width: 100%;">
             {#each headerGroup.headers as header (header.id)}
               <th style="display: flex; width: {header.getSize()}px;">
-                <div
-                  class={header.column.getCanSort()
-                    ? 'sortable-header'
-                    : ''}
-                  role="button"
-                  tabindex="0"
-                  onclick={header.column.getToggleSortingHandler()}
-                  onkeydown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      header.column.getToggleSortingHandler()?.(e)
-                    }
-                  }}
-                >
-                  <FlexRender header={header} />
-                  {#if header.column.getIsSorted() === 'asc'}
-                    {' '}🔼
-                  {:else if header.column.getIsSorted() === 'desc'}
-                    {' '}🔽
-                  {/if}
-                </div>
+                {#if header.column.id === 'select'}
+                  <input
+                    type="checkbox"
+                    checked={table.getIsAllRowsSelected()}
+                    use:setIndeterminate={!table.getIsAllRowsSelected() && table.getIsSomeRowsSelected()}
+                    onchange={table.getToggleAllRowsSelectedHandler()}
+                  />
+                {:else}
+                  <div
+                    class={header.column.getCanSort()
+                      ? 'sortable-header'
+                      : ''}
+                    role="button"
+                    tabindex="0"
+                    onclick={header.column.getToggleSortingHandler()}
+                    onkeydown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        header.column.getToggleSortingHandler()?.(e)
+                      }
+                    }}
+                  >
+                    <FlexRender header={header} />
+                    {#if header.column.getIsSorted() === 'asc'}
+                      {' '}🔼
+                    {:else if header.column.getIsSorted() === 'desc'}
+                      {' '}🔽
+                    {/if}
+                  </div>
+                {/if}
               </th>
             {/each}
           </tr>
@@ -177,7 +207,19 @@
           >
             {#each row.getAllCells() as cell (cell.id)}
               <td style="display: flex; width: {cell.column.getSize()}px;">
-                <FlexRender cell={cell} />
+                {#if cell.column.id === 'select'}
+                  <input
+                    type="checkbox"
+                    checked={row.getIsSelected()}
+                    disabled={!row.getCanSelect()}
+                    use:setIndeterminate={!row.getIsSelected() && row.getIsSomeSelected()}
+                    onchange={row.getToggleSelectedHandler({
+                      // selectChildren: false
+                    })}
+                  />
+                {:else}
+                  <FlexRender cell={cell} />
+                {/if}
               </td>
             {/each}
           </tr>

--- a/examples/svelte/virtualized-rows/src/App.svelte
+++ b/examples/svelte/virtualized-rows/src/App.svelte
@@ -213,7 +213,7 @@
                     checked={row.getIsSelected()}
                     disabled={!row.getCanSelect()}
                     use:setIndeterminate={!row.getIsSelected() && row.getIsSomeSelected()}
-                    onchange={row.getToggleSelectedHandler({
+                    onclick={row.getToggleSelectedHandler({
                       // selectChildren: false
                     })}
                   />

--- a/examples/vue/composable-tables/src/components/IndeterminateCheckbox.vue
+++ b/examples/vue/composable-tables/src/components/IndeterminateCheckbox.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   disabled?: boolean
   indeterminate?: boolean
   onChange?: (event: Event) => void
+  onClick?: (event: MouseEvent) => void
 }>()
 
 const inputRef = ref<HTMLInputElement | null>(null)
@@ -24,5 +25,6 @@ watchEffect(() => {
     :checked="props.checked"
     :disabled="props.disabled"
     @change="props.onChange"
+    @click="props.onClick"
   />
 </template>

--- a/examples/vue/composable-tables/src/components/cell-components.ts
+++ b/examples/vue/composable-tables/src/components/cell-components.ts
@@ -16,7 +16,7 @@ export const SelectCell = defineComponent({
           checked: row.getIsSelected(),
           disabled: !row.getCanSelect(),
           indeterminate: row.getIsSomeSelected(),
-          onChange: row.getToggleSelectedHandler(),
+          onClick: row.getToggleSelectedHandler(),
         }),
       ])
     }

--- a/examples/vue/expanding/src/App.tsx
+++ b/examples/vue/expanding/src/App.tsx
@@ -166,7 +166,9 @@ export default defineComponent({
                   (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
                 }
                 indeterminate={row.getIsSomeSelected()}
-                onChange={row.getToggleSelectedHandler()}
+                onChange={row.getToggleSelectedHandler({
+                  // selectChildren: false
+                })}
               />{' '}
               {row.getCanExpand() ? (
                 <button

--- a/examples/vue/expanding/src/App.tsx
+++ b/examples/vue/expanding/src/App.tsx
@@ -49,6 +49,7 @@ const IndeterminateCheckbox = defineComponent({
     checked: Boolean,
     indeterminate: Boolean,
     onChange: Function,
+    onClick: Function,
     className: String,
   },
   setup(props) {
@@ -67,6 +68,7 @@ const IndeterminateCheckbox = defineComponent({
         class={`${props.className ?? ''} sortable-header`}
         checked={props.checked}
         onChange={props.onChange as any}
+        onClick={props.onClick as any}
       />
     )
   },
@@ -166,7 +168,7 @@ export default defineComponent({
                   (row.getCanSelectSubRows() && row.getIsAllSubRowsSelected())
                 }
                 indeterminate={row.getIsSomeSelected()}
-                onChange={row.getToggleSelectedHandler({
+                onClick={row.getToggleSelectedHandler({
                   // selectChildren: false
                 })}
               />{' '}

--- a/examples/vue/kitchen-sink/src/App.vue
+++ b/examples/vue/kitchen-sink/src/App.vue
@@ -637,7 +637,7 @@ function shuffleColumns() {
                     :checked="cell.row.getIsSelected()"
                     :disabled="!cell.row.getCanSelect()"
                     :indeterminate="cell.row.getIsSomeSelected()"
-                    @change="cell.row.getToggleSelectedHandler()?.($event)"
+                    @click="cell.row.getToggleSelectedHandler()?.($event)"
                   />
                   <button
                     class="pin-button"

--- a/examples/vue/row-selection/src/App.vue
+++ b/examples/vue/row-selection/src/App.vue
@@ -37,7 +37,9 @@ const columns = columnHelper.columns([
             checked={row.getIsSelected()}
             disabled={!row.getCanSelect()}
             indeterminate={row.getIsSomeSelected()}
-            onChange={row.getToggleSelectedHandler()}
+            onChange={row.getToggleSelectedHandler({
+              // selectChildren: false
+            })}
           ></IndeterminateCheckbox>
           {/* @ts-ignore */}
         </div>

--- a/examples/vue/row-selection/src/App.vue
+++ b/examples/vue/row-selection/src/App.vue
@@ -37,7 +37,7 @@ const columns = columnHelper.columns([
             checked={row.getIsSelected()}
             disabled={!row.getCanSelect()}
             indeterminate={row.getIsSomeSelected()}
-            onChange={row.getToggleSelectedHandler({
+            onClick={row.getToggleSelectedHandler({
               // selectChildren: false
             })}
           ></IndeterminateCheckbox>

--- a/examples/vue/row-selection/src/IndeterminateCheckbox.vue
+++ b/examples/vue/row-selection/src/IndeterminateCheckbox.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   indeterminate: boolean
   className?: string
   onChange?: (event: Event) => void
+  onClick?: (event: MouseEvent) => void
 }>()
 
 const inputRef = ref<HTMLInputElement | null>(null)
@@ -26,6 +27,7 @@ watchEffect(() => {
     :checked="props.checked"
     :disabled="props.disabled"
     @change="props.onChange"
+    @click="props.onClick"
     v-bind="$attrs"
   />
 </template>

--- a/examples/vue/virtualized-rows/src/App.vue
+++ b/examples/vue/virtualized-rows/src/App.vue
@@ -5,19 +5,22 @@ import {
   FlexRender,
   columnSizingFeature,
   createSortedRowModel,
+  rowSelectionFeature,
   rowSortingFeature,
   sortFns,
   tableFeatures,
   useTable,
 } from '@tanstack/vue-table'
 import { useVirtualizer } from '@tanstack/vue-virtual'
+import IndeterminateCheckbox from './IndeterminateCheckbox.vue'
 import { makeData } from './makeData'
-import type { ColumnDef } from '@tanstack/vue-table'
+import type { ColumnDef, Row } from '@tanstack/vue-table'
 import type { ComponentPublicInstance } from 'vue'
 import type { Person } from './makeData'
 
 const features = tableFeatures({
   columnSizingFeature,
+  rowSelectionFeature,
   rowSortingFeature,
   sortedRowModel: createSortedRowModel(),
   sortFns,
@@ -65,6 +68,12 @@ function handleDebounceSearch(ev: Event) {
 
 const columns = computed<Array<ColumnDef<typeof features, Person>>>(() => [
   {
+    id: 'select',
+    header: '',
+    cell: '',
+    size: 40,
+  },
+  {
     accessorKey: 'id',
     header: 'ID',
   },
@@ -107,8 +116,15 @@ const table = useTable({
     return filteredData.value
   },
   columns: columns.value,
+  getRowId: (row: Person) => String(row.id),
   debugTable: false,
 })
+
+function toggleSelected(row: Row<typeof features, Person>, event: Event) {
+  row.getToggleSelectedHandler({
+    // selectChildren: false
+  })(event)
+}
 
 const rows = computed(() => table.getRowModel().rows)
 
@@ -146,6 +162,8 @@ function measureElement(el: Element | ComponentPublicInstance | null) {
       the translateY pixel count different and base it off the the index.
     </p>
     <h1 class="virtualized-title">Virtualized Rows</h1>
+    <p>Hold Shift while selecting rows to select or deselect a range.</p>
+    <p>{{ table.getSelectedRowIds().length.toLocaleString() }} rows selected</p>
     <div class="centered-button-row" style="margin-bottom: 8px">
       <button @click="refreshData" class="demo-button">Regenerate Data</button>
       <button @click="stressTest" class="demo-button">
@@ -193,8 +211,14 @@ function measureElement(el: Element | ComponentPublicInstance | null) {
               :colspan="header.colSpan"
               :style="{ width: `${header.getSize()}px` }"
             >
+              <IndeterminateCheckbox
+                v-if="header.column.id === 'select'"
+                :checked="table.getIsAllRowsSelected()"
+                :indeterminate="table.getIsSomeRowsSelected()"
+                :onChange="table.getToggleAllRowsSelectedHandler()"
+              />
               <div
-                v-if="!header.isPlaceholder"
+                v-else-if="!header.isPlaceholder"
                 :class="{
                   'sortable-header': header.column.getCanSort(),
                 }"
@@ -236,7 +260,14 @@ function measureElement(el: Element | ComponentPublicInstance | null) {
                 width: `${cell.column.getSize()}px`,
               }"
             >
-              <FlexRender :cell="cell" />
+              <IndeterminateCheckbox
+                v-if="cell.column.id === 'select'"
+                :checked="rows[vRow.index].getIsSelected()"
+                :disabled="!rows[vRow.index].getCanSelect()"
+                :indeterminate="rows[vRow.index].getIsSomeSelected()"
+                :onChange="(event) => toggleSelected(rows[vRow.index], event)"
+              />
+              <FlexRender v-else :cell="cell" />
             </td>
           </tr>
         </tbody>

--- a/examples/vue/virtualized-rows/src/App.vue
+++ b/examples/vue/virtualized-rows/src/App.vue
@@ -265,7 +265,7 @@ function measureElement(el: Element | ComponentPublicInstance | null) {
                 :checked="rows[vRow.index].getIsSelected()"
                 :disabled="!rows[vRow.index].getCanSelect()"
                 :indeterminate="rows[vRow.index].getIsSomeSelected()"
-                :onChange="(event) => toggleSelected(rows[vRow.index], event)"
+                :onClick="(event) => toggleSelected(rows[vRow.index], event)"
               />
               <FlexRender v-else :cell="cell" />
             </td>

--- a/examples/vue/virtualized-rows/src/IndeterminateCheckbox.vue
+++ b/examples/vue/virtualized-rows/src/IndeterminateCheckbox.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { ref, watchEffect } from 'vue'
+
+const props = defineProps<{
+  checked?: boolean
+  disabled?: boolean
+  indeterminate: boolean
+  className?: string
+  onChange?: (event: Event) => void
+}>()
+
+const inputRef = ref<HTMLInputElement | null>(null)
+
+watchEffect(() => {
+  if (inputRef.value) {
+    inputRef.value.indeterminate = !props.checked && !!props.indeterminate
+  }
+})
+</script>
+
+<template>
+  <input
+    type="checkbox"
+    ref="inputRef"
+    :class="`${props.className ?? ''} sortable-header`"
+    :checked="props.checked"
+    :disabled="props.disabled"
+    @change="props.onChange"
+    v-bind="$attrs"
+  />
+</template>

--- a/examples/vue/virtualized-rows/src/IndeterminateCheckbox.vue
+++ b/examples/vue/virtualized-rows/src/IndeterminateCheckbox.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   indeterminate: boolean
   className?: string
   onChange?: (event: Event) => void
+  onClick?: (event: MouseEvent) => void
 }>()
 
 const inputRef = ref<HTMLInputElement | null>(null)
@@ -26,6 +27,7 @@ watchEffect(() => {
     :checked="props.checked"
     :disabled="props.disabled"
     @change="props.onChange"
+    @click="props.onClick"
     v-bind="$attrs"
   />
 </template>

--- a/nx.json
+++ b/nx.json
@@ -29,23 +29,23 @@
   },
   "targetDefaults": {
     "test:lib": {
-      "dependsOn": ["^build", "build"],
+      "dependsOn": ["^build"],
       "inputs": ["default", "^public"],
       "outputs": ["{projectRoot}/coverage"],
       "cache": true
     },
     "test:eslint": {
-      "dependsOn": ["^build", "build"],
+      "dependsOn": ["^build"],
       "inputs": ["default", "^public"],
       "cache": true
     },
     "test:types": {
-      "dependsOn": ["^build", "build"],
+      "dependsOn": ["^build"],
       "inputs": ["default", "^public"],
       "cache": true
     },
     "test:e2e": {
-      "dependsOn": ["^build", "build"],
+      "dependsOn": ["^build"],
       "inputs": ["default", "^public"],
       "cache": true
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:knip": "NODE_OPTIONS='--max-old-space-size=4096' knip",
     "test:lib": "nx affected --targets=test:lib",
     "test:lib:dev": "pnpm test:lib && nx watch --all -- pnpm test:lib",
-    "test:pr": "nx affected --targets=test:eslint,test:sherif,test:knip,test:lib,test:types,test:build,build",
+    "test:pr": "nx affected --targets=test:eslint,test:sherif,test:knip,test:lib,test:e2e,test:types,test:build,build",
     "test:sherif": "sherif",
     "test:types": "nx affected --targets=test:types",
     "skills:versions:check": "node scripts/sync-skill-versions.mjs",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:knip": "NODE_OPTIONS='--max-old-space-size=4096' knip",
     "test:lib": "nx affected --targets=test:lib",
     "test:lib:dev": "pnpm test:lib && nx watch --all -- pnpm test:lib",
-    "test:pr": "nx affected --targets=test:eslint,test:sherif,test:knip,test:lib,test:e2e,test:types,test:build,build",
+    "test:pr": "nx affected --targets=test:eslint,test:sherif,test:knip,test:lib,test:types,test:build,build",
     "test:sherif": "sherif",
     "test:types": "nx affected --targets=test:types",
     "skills:versions:check": "node scripts/sync-skill-versions.mjs",

--- a/packages/table-core/skills/core/SKILL.md
+++ b/packages/table-core/skills/core/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: core
 description: >
-  Use TanStack Table v9 as a headless data-grid state and row-processing engine. Load for first-table architecture, stable data and columns, semantic rendering, framework adapter choice, or deciding what Table owns versus the renderer.
+  Use TanStack Table v9 as a headless data-grid state and row-processing engine. Load for first-table architecture, stable data and columns, row numbering with getDisplayIndex, semantic rendering, framework adapter choice, or deciding what Table owns versus the renderer.
 metadata:
   type: core
   library: '@tanstack/table-core'
@@ -10,6 +10,7 @@ sources:
   - 'TanStack/table:docs/overview.md'
   - 'TanStack/table:docs/guide/tables.md'
   - 'TanStack/table:docs/guide/data.md'
+  - 'TanStack/table:docs/guide/rows.md'
   - 'TanStack/table:packages/table-core/src/index.ts'
 ---
 
@@ -68,6 +69,21 @@ const columns = helper.columns([helper.accessor('name', { header: 'Name' })])
 ```
 
 Define static inputs once and preserve query/store references when data has not changed.
+
+### Number rows in current display order
+
+```ts
+const rowNumberColumn = helper.display({
+  id: 'rowNumber',
+  header: '#',
+  cell: ({ row }) => {
+    const displayIndex = row.getDisplayIndex()
+    return displayIndex === -1 ? '' : displayIndex + 1
+  },
+})
+```
+
+`row.getDisplayIndex()` follows the current filtering, grouping, sorting, and expansion order before pagination. `row.index` remains the row's creation-time position within its parent array.
 
 ## Common Mistakes
 
@@ -134,6 +150,25 @@ row.getValue('name')
 V9 row, cell, column, and header methods use their instance as `this`.
 
 Source: `docs/framework/react/guide/migrating.md#instance-methods-must-be-called-on-their-instance`
+
+### [HIGH] Reading the display-index cache directly
+
+Wrong:
+
+```ts
+const rowNumber = row._displayIndexCache + 1
+```
+
+Correct:
+
+```ts
+const displayIndex = row.getDisplayIndex()
+const rowNumber = displayIndex === -1 ? undefined : displayIndex + 1
+```
+
+`_displayIndexCache` is internal and may be stale until display order is recomputed. The public method refreshes display order, validates that the cached slot still contains the row, and returns `-1` when it does not.
+
+Source: `docs/guide/rows.md#row-numbers-and-display-indexes`, `packages/table-core/src/core/rows/coreRowsFeature.utils.ts`
 
 ## API Discovery
 

--- a/packages/table-core/skills/custom-features/SKILL.md
+++ b/packages/table-core/skills/custom-features/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: custom-features
 description: >
-  Author a TanStack Table v9 feature plugin across every FeatureMap and API installation surface: state, options, column definitions, table, column, row, cell, header, row-model functions/caches, defaults, prototypes, and instance data. Load only for reusable behavior not covered by built-ins, meta, or option composition.
+  Author a TanStack Table v9 feature plugin across every FeatureMap and API installation surface: state, options, column definitions, table, column, row, cell, header, row-model functions/caches, defaults, prototypes, and table/row/column instance data lifecycles. Load for initTableInstanceData, resetTableInstanceData, constructTableAPIs, or reusable behavior not covered by built-ins, meta, or option composition.
 metadata:
   type: sub-skill
   library: '@tanstack/table-core'
@@ -36,6 +36,32 @@ Declaration-merge `Plugins` to register the feature key, then merge only the map
 | `CachedRowModels_FeatureMap<TFeatures, TData>`   | Advanced `table._rowModels` cache getters |
 
 `assignTableAPIs` installs singleton table methods. Use `assignPrototypeAPIs` inside `assignColumnPrototype`, `assignRowPrototype`, `assignCellPrototype`, or `assignHeaderPrototype` for shared object methods. Use `initColumnInstanceData` and `initRowInstanceData` only for per-instance fields.
+
+Use `initTableInstanceData` for mutable, non-reactive data owned by one table. It runs once after options, state atoms, and the store exist, and every feature initialization finishes before any `constructTableAPIs` hook runs. Use `resetTableInstanceData` to clear transient instance data after internal atoms reset during `table.reset()`; it does not own state slices or externally controlled state. Keep `constructTableAPIs` exclusively for method assignment.
+
+## Table Instance Lifecycle
+
+```ts
+import type { TableFeature } from '@tanstack/table-core'
+
+interface InteractionData {
+  _interactionHistory: Set<string>
+}
+
+const interactionData = (table: object): InteractionData =>
+  table as unknown as InteractionData
+
+export const interactionFeature: TableFeature = {
+  initTableInstanceData: (table) => {
+    interactionData(table)._interactionHistory = new Set()
+  },
+  resetTableInstanceData: (table) => {
+    interactionData(table)._interactionHistory.clear()
+  },
+}
+```
+
+Initialization may allocate resources once while reset clears their transient contents. Do not rerun initialization during `table.reset()`.
 
 ## Complete Example
 
@@ -198,6 +224,8 @@ export const features = tableFeatures({ densityFeature })
 - Preserve incoming state in `getInitialState`; put user state after defaults.
 - Method keys use `table_`, `column_`, `row_`, `cell_`, or `header_`; the prefix is removed on installation.
 - Table API `fn` receives declared arguments. Prototype API `fn` receives the current object first.
+- Initialize table-owned mutable data in `initTableInstanceData`, not `constructTableAPIs`; all feature data is initialized before any table API is assigned.
+- Clear transient table-owned data in `resetTableInstanceData`. Reset state slices through atoms/updaters, and do not expect this hook to reset externally controlled state.
 - Add `memoDeps` only for a genuinely derived method. Prototype methods are shared and must not close over per-object mutable data.
 - There are no `assignColumnAPIs`, `assignRowAPIs`, `assignCellAPIs`, or `assignHeaderAPIs`; use `assignPrototypeAPIs` in the matching hook.
 - Do not mutate constructed instances ad hoc or use a feature for renderer-only callbacks that belong in meta.

--- a/packages/table-core/skills/row-selection/SKILL.md
+++ b/packages/table-core/skills/row-selection/SKILL.md
@@ -51,7 +51,9 @@ export function getSelectionHandler(row: Row<typeof features, Person>) {
 }
 ```
 
-The handler establishes a table-local anchor on ordinary interactions and applies the checked value to the inclusive current display-order range on Shift interactions. Direct `row.toggleSelected()` and `table.setRowSelection()` calls do not move that anchor.
+The handler establishes a table-local anchor on ordinary interactions and applies the checked value to the inclusive current display-order range on Shift interactions. Range behavior is enabled by default; set `enableRowRangeSelection: false` to preserve non-range handler behavior. Direct `row.toggleSelected()` and `table.setRowSelection()` calls do not move that anchor.
+
+Pass the original checkbox click event to this handler. DOM `change` events often omit modifier keys, so use the framework's click binding for row checkboxes unless its change event exposes the original click through `nativeEvent` (as React does).
 
 ### Limit a range to explicitly displayed rows
 
@@ -113,6 +115,24 @@ const onChange = row.getToggleSelectedHandler()
 Only successful interactions through `getToggleSelectedHandler()` establish or advance the Shift-range anchor. The handler also supports custom range-event detection through `isRowRangeSelectionEvent`.
 
 Source: `docs/framework/react/guide/row-selection.md#shift-range-selection`
+
+### [HIGH] Binding a DOM change event that drops Shift
+
+Wrong:
+
+```ts
+checkbox.addEventListener('change', row.getToggleSelectedHandler())
+```
+
+Correct:
+
+```ts
+checkbox.addEventListener('click', row.getToggleSelectedHandler())
+```
+
+The range modifier must be present on the event passed to the handler. Raw DOM `change` events do not reliably expose click modifier keys.
+
+Source: `docs/framework/svelte/guide/row-selection.md#shift-range-selection`
 
 ### [MEDIUM] Expecting ranges across unloaded server pages
 

--- a/packages/table-core/skills/row-selection/SKILL.md
+++ b/packages/table-core/skills/row-selection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: row-selection
 description: >
-  Maintain rowSelection ID state with stable getRowId, single, multi, and subrow rules, selected row models, and manual-pagination semantics. Load when selected IDs outlive loaded Row objects or data removal.
+  Maintain rowSelection ID state with stable getRowId, single, multi, subrow, and Shift-range rules, selected row models, handler anchors, and manual-pagination semantics. Load when implementing getToggleSelectedHandler, enableRowRangeSelection, selectChildren, or selected IDs that outlive loaded Row objects.
 metadata:
   {
     type: sub-skill,
@@ -20,7 +20,11 @@ This skill builds on `core` and `table-features`. Selection is independent ID st
 ## Setup
 
 ```ts
-import { rowSelectionFeature, tableFeatures } from '@tanstack/table-core'
+import {
+  rowSelectionFeature,
+  tableFeatures,
+  type Row,
+} from '@tanstack/table-core'
 
 type Person = { id: string; name: string }
 export const features = tableFeatures({ rowSelectionFeature })
@@ -38,6 +42,26 @@ const loadedSelectedRows = table.getSelectedRowModel().rows
 ```
 
 Use IDs for database-wide intent and row models for currently loaded objects.
+
+### Inclusive Shift ranges through the row handler
+
+```ts
+export function getSelectionHandler(row: Row<typeof features, Person>) {
+  return row.getToggleSelectedHandler()
+}
+```
+
+The handler establishes a table-local anchor on ordinary interactions and applies the checked value to the inclusive current display-order range on Shift interactions. Direct `row.toggleSelected()` and `table.setRowSelection()` calls do not move that anchor.
+
+### Limit a range to explicitly displayed rows
+
+```ts
+export function getDisplayedRowsOnlyHandler(row: Row<typeof features, Person>) {
+  return row.getToggleSelectedHandler({ selectChildren: false })
+}
+```
+
+The default `selectChildren: true` recursively changes selectable descendants of parents encountered in the range. Set it to `false` when collapsed descendants outside the display-order interval must remain unchanged.
 
 ## Common Mistakes
 
@@ -70,6 +94,50 @@ Correct: `const allSelectedIds = table.getSelectedRowIds()`
 Under manual pagination, unloaded selected IDs have no `Row` object in the current model.
 
 Source: `docs/framework/react/guide/row-selection.md#note-if-you-are-using-manualpagination`
+
+### [HIGH] Bypassing the range-selection handler
+
+Wrong:
+
+```ts
+const onChange = (event: { target: { checked: boolean } }) =>
+  row.toggleSelected(event.target.checked)
+```
+
+Correct:
+
+```ts
+const onChange = row.getToggleSelectedHandler()
+```
+
+Only successful interactions through `getToggleSelectedHandler()` establish or advance the Shift-range anchor. The handler also supports custom range-event detection through `isRowRangeSelectionEvent`.
+
+Source: `docs/framework/react/guide/row-selection.md#shift-range-selection`
+
+### [MEDIUM] Expecting ranges across unloaded server pages
+
+Wrong:
+
+```ts
+const options = {
+  manualPagination: true,
+  enableRowRangeSelection: true,
+}
+// Shift cannot select rows absent from data.
+```
+
+Correct:
+
+```ts
+const options = {
+  manualPagination: true,
+  getRowId: (row: Person) => row.id,
+}
+```
+
+Client-side ranges can cross pages because display order is pre-pagination. Manual/server pagination cannot include rows absent from the loaded `data`; select database-wide IDs in application state when that behavior is required.
+
+Source: `docs/framework/react/guide/row-selection.md#shift-range-selection`, `https://github.com/TanStack/table/issues/4781`
 
 ## API Discovery
 

--- a/packages/table-core/src/core/rows/coreRowsFeature.types.ts
+++ b/packages/table-core/src/core/rows/coreRowsFeature.types.ts
@@ -13,6 +13,15 @@ export interface Row_CoreProperties<
     Column<TFeatures, TData, unknown>,
     Cell<TFeatures, TData, unknown>
   >
+  /**
+   * Internal cache used while resolving the current display order.
+   *
+   * This value may be stale until display order is recomputed. Use
+   * `row.getDisplayIndex()` instead; it refreshes and validates the cached
+   * position before returning it.
+   *
+   * @internal
+   */
   _displayIndexCache: number
   _uniqueValuesCache: Record<string, unknown>
   _valuesCache: Record<string, unknown>
@@ -56,7 +65,9 @@ export interface Row_Row<
 > extends Row_CoreProperties<TFeatures, TData> {
   /**
    * Returns the zero-based index of the row in the current display order
-   * before pagination, or `-1` if the row is not in that model.
+   * before pagination, or `-1` if the row is not in that model. Use this for
+   * display row-number columns instead of `row.index` or the internal
+   * `_displayIndexCache` field.
    */
   getDisplayIndex: () => number
   /**

--- a/packages/table-core/src/core/table/constructTable.ts
+++ b/packages/table-core/src/core/table/constructTable.ts
@@ -166,6 +166,10 @@ export function constructTable<
     ),
   )
 
+  for (let i = 0; i < featuresList.length; i++) {
+    featuresList[i]!.initTableInstanceData?.(table)
+  }
+
   if (
     process.env.NODE_ENV === 'development' &&
     (tableOptions.debugAll || tableOptions.debugTable)

--- a/packages/table-core/src/core/table/coreTablesFeature.types.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.types.ts
@@ -229,7 +229,8 @@ export interface Table_Table<
    *
    * Prefer feature-specific reset APIs, such as `resetPagination`, when a state
    * slice may be owned by an external atom or needs that feature's blank/default
-   * reset behavior.
+   * reset behavior. After resetting internal atoms, this also invokes feature
+   * reset hooks for mutable, transient table-instance data.
    */
   reset: () => void
   /**

--- a/packages/table-core/src/core/table/coreTablesFeature.utils.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.utils.ts
@@ -40,7 +40,8 @@ export function table_syncExternalStateToBaseAtoms<
 }
 
 /**
- * Resets all internal table base atoms to `table.initialState`.
+ * Resets all internal table base atoms to `table.initialState`, then clears
+ * transient instance data through registered feature reset hooks.
  *
  * This resets internally owned state slices in a single reactivity batch. Use
  * feature-specific reset APIs when a slice may be externally owned.
@@ -62,6 +63,11 @@ export function table_reset<
       ;(table.baseAtoms as any)[key].set(snap[key])
     }
   })
+
+  const features = Object.values(table._features)
+  for (let i = 0; i < features.length; i++) {
+    features[i]!.resetTableInstanceData?.(table)
+  }
 }
 
 /**

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.ts
@@ -35,6 +35,16 @@ import type { TableFeature } from '../../types/TableFeatures'
  * Feature that adds row selection state and APIs for row and page selection.
  */
 export const rowSelectionFeature: TableFeature = {
+  initTableInstanceData: (table) => {
+    // @ts-expect-error - _lastSelectedRowId is a row selection table instance data
+    table._lastSelectedRowId = null
+  },
+
+  resetTableInstanceData: (table) => {
+    // @ts-expect-error - _lastSelectedRowId is a row selection table instance data
+    table._lastSelectedRowId = null
+  },
+
   getInitialState: (initialState) => {
     return {
       rowSelection: getDefaultRowSelectionState(),
@@ -47,7 +57,15 @@ export const rowSelectionFeature: TableFeature = {
       onRowSelectionChange: makeStateUpdater('rowSelection', table),
       enableRowSelection: true,
       enableMultiRowSelection: true,
+      enableRowRangeSelection: true,
       enableSubRowSelection: true,
+      isRowRangeSelectionEvent: (event) => {
+        const rangeEvent = event as {
+          shiftKey?: boolean
+          nativeEvent?: { shiftKey?: boolean }
+        }
+        return Boolean(rangeEvent.shiftKey || rangeEvent.nativeEvent?.shiftKey)
+      },
     }
   },
 
@@ -85,7 +103,7 @@ export const rowSelectionFeature: TableFeature = {
         fn: (row) => row_getCanMultiSelect(row),
       },
       row_getToggleSelectedHandler: {
-        fn: (row) => row_getToggleSelectedHandler(row),
+        fn: (row, opts) => row_getToggleSelectedHandler(row, opts),
       },
     })
   },

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.ts
@@ -36,12 +36,12 @@ import type { TableFeature } from '../../types/TableFeatures'
  */
 export const rowSelectionFeature: TableFeature = {
   initTableInstanceData: (table) => {
-    // @ts-expect-error - _lastSelectedRowId is a row selection table instance data
+    // @ts-ignore - _lastSelectedRowId is row selection table instance data
     table._lastSelectedRowId = null
   },
 
   resetTableInstanceData: (table) => {
-    // @ts-expect-error - _lastSelectedRowId is a row selection table instance data
+    // @ts-ignore - _lastSelectedRowId is row selection table instance data
     table._lastSelectedRowId = null
   },
 

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts
@@ -101,6 +101,9 @@ export interface Row_RowSelection {
   getIsSomeSelected: () => boolean
   /**
    * Creates a checkbox-style handler that toggles this row's selected state.
+   * Pass the original checkbox click event, or a framework event whose
+   * `nativeEvent` is that click, so Shift range selection can detect the
+   * modifier key.
    */
   getToggleSelectedHandler: (
     opts?: ToggleSelectedOptions,

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.types.ts
@@ -5,6 +5,17 @@ import type { Row } from '../../types/Row'
 
 export type RowSelectionState = Record<string, true>
 
+/**
+ * Controls how toggling a row affects its descendants.
+ */
+export interface ToggleSelectedOptions {
+  /**
+   * Whether selectable child rows should be toggled recursively. Defaults to
+   * `true`.
+   */
+  selectChildren?: boolean
+}
+
 export interface TableState_RowSelection {
   rowSelection: RowSelectionState
 }
@@ -13,6 +24,11 @@ export interface TableOptions_RowSelection<
   in out TFeatures extends TableFeatures,
   in out TData extends RowData,
 > {
+  /**
+   * Enables inclusive row range selection through
+   * `row.getToggleSelectedHandler()`. Defaults to `true`.
+   */
+  enableRowRangeSelection?: boolean
   /**
    * Allows rows to be selected alongside other rows.
    *
@@ -33,6 +49,14 @@ export interface TableOptions_RowSelection<
    */
   enableSubRowSelection?: boolean | ((row: Row<TFeatures, TData>) => boolean)
   /**
+   * Determines whether a row-selection handler event should select or
+   * deselect the inclusive range from the most recent handler interaction.
+   *
+   * By default, events with `shiftKey` directly on the event or on
+   * `event.nativeEvent` are treated as range-selection events.
+   */
+  isRowRangeSelectionEvent?: (event: unknown) => boolean
+  /**
    * Called with an updater when row selection state changes. Pair this with
    * `state.rowSelection` when using external state; external atoms can own the
    * slice without this callback.
@@ -44,7 +68,6 @@ export interface TableOptions_RowSelection<
   //       row: Row<TFeatures, TData>
   //     ) => boolean)
   // isAdditiveSelectEvent?: (e: unknown) => boolean
-  // isInclusiveSelectEvent?: (e: unknown) => boolean
   // selectRowsFn?: (
   //   table: Table<TFeatures, TData>,
   //   rowModel: RowModel<TFeatures, TData>
@@ -79,17 +102,25 @@ export interface Row_RowSelection {
   /**
    * Creates a checkbox-style handler that toggles this row's selected state.
    */
-  getToggleSelectedHandler: () => (event: unknown) => void
+  getToggleSelectedHandler: (
+    opts?: ToggleSelectedOptions,
+  ) => (event: unknown) => void
   /**
    * Selects/deselects the row.
    */
-  toggleSelected: (value?: boolean, opts?: { selectChildren?: boolean }) => void
+  toggleSelected: (value?: boolean, opts?: ToggleSelectedOptions) => void
 }
 
 export interface Table_RowSelection<
   in out TFeatures extends TableFeatures,
   in out TData extends RowData,
 > {
+  /**
+   * The most recent row interacted with through the row selection handler.
+   *
+   * @internal
+   */
+  _lastSelectedRowId: string | null
   /**
    * Builds a selected-row model from rows after filtering.
    */

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
@@ -10,7 +10,10 @@ import type { TableFeatures } from '../../types/TableFeatures'
 import type { RowModel } from '../../core/row-models/coreRowModelsFeature.types'
 import type { Table_Internal } from '../../types/Table'
 import type { Row } from '../../types/Row'
-import type { RowSelectionState } from './rowSelectionFeature.types'
+import type {
+  RowSelectionState,
+  ToggleSelectedOptions,
+} from './rowSelectionFeature.types'
 
 // State APIs
 
@@ -66,6 +69,8 @@ export function table_resetRowSelection<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+  // @ts-ignore - _lastSelectedRowId is part of the RowSelection feature
+  table._lastSelectedRowId = null
   table_setRowSelection(
     table,
     defaultState
@@ -98,6 +103,8 @@ export function table_toggleAllRowsSelected<
   value?: boolean,
   opts?: { deselectAll?: boolean },
 ) {
+  // @ts-ignore - _lastSelectedRowId is part of the RowSelection feature
+  table._lastSelectedRowId = null
   table_setRowSelection(table, (old) => {
     value =
       typeof value !== 'undefined'
@@ -153,6 +160,8 @@ export function table_toggleAllPageRowsSelected<
   value?: boolean,
   opts?: { deselectAll?: boolean },
 ) {
+  // @ts-ignore - _lastSelectedRowId is part of the RowSelection feature
+  table._lastSelectedRowId = null
   table_setRowSelection(table, (old) => {
     const resolvedValue =
       typeof value !== 'undefined'
@@ -492,13 +501,7 @@ export function table_getToggleAllPageRowsSelectedHandler<
 export function row_toggleSelected<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(
-  row: Row<TFeatures, TData>,
-  value?: boolean,
-  opts?: {
-    selectChildren?: boolean
-  },
-) {
+>(row: Row<TFeatures, TData>, value?: boolean, opts?: ToggleSelectedOptions) {
   const isSelected = row_getIsSelected(row)
 
   table_setRowSelection(row.table, (old) => {
@@ -643,7 +646,11 @@ export function row_getCanMultiSelect<
  * Creates a checkbox-style handler that selects or deselects this row.
  *
  * The handler is a no-op when the row cannot be selected and reads
- * `event.target.checked`.
+ * `event.target.checked`. Shift events select or deselect the inclusive range
+ * from the most recent selectable row handled by this table. The event's
+ * optional `persist()` method is called before it is read. Pass
+ * `selectChildren: false` to limit changes to rows explicitly present in the
+ * display-order interval.
  *
  * @example
  * ```ts
@@ -653,16 +660,109 @@ export function row_getCanMultiSelect<
 export function row_getToggleSelectedHandler<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(row: Row<TFeatures, TData>) {
+>(row: Row<TFeatures, TData>, opts?: ToggleSelectedOptions) {
   const canSelect = row_getCanSelect(row)
 
   return (e: unknown) => {
     if (!canSelect) return
-    row_toggleSelected(
-      row,
-      ((e as MouseEvent).target as HTMLInputElement).checked,
-    )
+
+    const event = e as {
+      persist?: () => void
+      target: { checked: boolean }
+    }
+    event.persist?.()
+
+    const table = row.table
+    // @ts-ignore - _lastSelectedRowId is part of the RowSelection feature
+    const rowSelectionTable = table._lastSelectedRowId
+    const checked = event.target.checked
+    const anchorId = rowSelectionTable._lastSelectedRowId
+    const canSelectRange =
+      table.options.enableRowRangeSelection !== false &&
+      anchorId !== null &&
+      row_getCanMultiSelect(row) &&
+      (table.options.isRowRangeSelectionEvent?.(e) ?? false)
+
+    if (
+      !canSelectRange ||
+      !selectRowRange(row, anchorId, checked, opts?.selectChildren ?? true)
+    ) {
+      row_toggleSelected(row, checked, opts)
+    }
+
+    rowSelectionTable._lastSelectedRowId = row.id
   }
+}
+
+/**
+ * Resolves and mutates an inclusive interval in the table's latest logical
+ * display order.
+ *
+ * The anchor is resolved without throwing from the pre-pagination row model,
+ * then the core row model. Both endpoint display indexes must still identify
+ * those rows in the current order and both endpoints must support
+ * multi-selection. Eligible interval rows are applied through one row
+ * selection updater; non-selectable and non-multi-selectable rows are skipped.
+ * Returns `false` when the interaction should fall back to an ordinary toggle.
+ */
+function selectRowRange<TFeatures extends TableFeatures, TData extends RowData>(
+  row: Row<TFeatures, TData>,
+  anchorId: string,
+  value: boolean,
+  includeChildren: boolean,
+): boolean {
+  const table = row.table
+  const rows = table.getRowsInDisplayOrder()
+  const anchorRow =
+    table.getPrePaginatedRowModel().rowsById[anchorId] ??
+    table.getCoreRowModel().rowsById[anchorId]
+
+  if (!anchorRow) {
+    return false
+  }
+
+  const anchorIndex = anchorRow.getDisplayIndex()
+  const rowIndex = row.getDisplayIndex()
+  const anchorAtIndex = rows[anchorIndex]
+  const rowAtIndex = rows[rowIndex]
+
+  if (
+    anchorIndex < 0 ||
+    rowIndex < 0 ||
+    anchorIndex >= rows.length ||
+    rowIndex >= rows.length ||
+    anchorAtIndex?.id !== anchorRow.id ||
+    rowAtIndex?.id !== row.id ||
+    !row_getCanMultiSelect(anchorRow) ||
+    !row_getCanMultiSelect(row)
+  ) {
+    return false
+  }
+
+  const start = Math.min(anchorIndex, rowIndex)
+  const end = Math.max(anchorIndex, rowIndex)
+
+  table_setRowSelection(table, (old) => {
+    const rowSelection = Object.assign(makeObjectMap<true>(), old)
+
+    for (let index = start; index <= end; index++) {
+      const rangeRow = rows[index]!
+      if (!row_getCanSelect(rangeRow) || !row_getCanMultiSelect(rangeRow)) {
+        continue
+      }
+      mutateRowIsSelected(
+        rowSelection,
+        rangeRow.id,
+        value,
+        includeChildren,
+        table,
+      )
+    }
+
+    return rowSelection
+  })
+
+  return true
 }
 
 const mutateRowIsSelected = <

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
@@ -673,10 +673,9 @@ export function row_getToggleSelectedHandler<
     event.persist?.()
 
     const table = row.table
-    // @ts-ignore - _lastSelectedRowId is part of the RowSelection feature
-    const rowSelectionTable = table._lastSelectedRowId
     const checked = event.target.checked
-    const anchorId = rowSelectionTable._lastSelectedRowId
+    // @ts-ignore - _lastSelectedRowId is part of the RowSelection feature
+    const anchorId = table._lastSelectedRowId
     const canSelectRange =
       table.options.enableRowRangeSelection !== false &&
       anchorId !== null &&
@@ -690,7 +689,8 @@ export function row_getToggleSelectedHandler<
       row_toggleSelected(row, checked, opts)
     }
 
-    rowSelectionTable._lastSelectedRowId = row.id
+    // @ts-ignore - _lastSelectedRowId is part of the RowSelection feature
+    table._lastSelectedRowId = row.id
   }
 }
 

--- a/packages/table-core/src/types/TableFeatures.ts
+++ b/packages/table-core/src/types/TableFeatures.ts
@@ -368,8 +368,9 @@ export interface TableFeature {
    *
    * The table is a singleton, unlike rows, columns, headers, and cells, so
    * table APIs are assigned directly instead of through a shared prototype.
-   * This runs while the table is being constructed, after options and initial
-   * state have been resolved.
+   * This hook is exclusively for assigning table methods. It runs after
+   * options, state atoms, and the store have been created and after every
+   * feature's `initTableInstanceData` hook has completed.
    */
   constructTableAPIs?: <TFeatures extends TableFeatures, TData extends RowData>(
     table: Table_Internal<TFeatures, TData>,
@@ -410,6 +411,22 @@ export interface TableFeature {
    */
   getInitialState?: (initialState: Partial<TableState_All>) => TableState_All
   /**
+   * Initializes mutable, non-reactive data owned by this feature on the table
+   * instance.
+   *
+   * This runs once during table construction after options, state atoms, and
+   * the store are available, and before any feature's `constructTableAPIs`
+   * hook runs. Use `constructTableAPIs` exclusively for assigning table
+   * methods. Table resets do not rerun this hook; use
+   * `resetTableInstanceData` to clear transient instance data instead.
+   */
+  initTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
+  ) => void
+  /**
    * Initializes instance-specific data on each column.
    *
    * This runs for every constructed column after core column fields such as
@@ -437,5 +454,18 @@ export interface TableFeature {
     TData extends RowData,
   >(
     row: Row<TFeatures, TData>,
+  ) => void
+  /**
+   * Resets mutable, non-reactive table-instance data owned by this feature.
+   *
+   * This runs after internally owned state atoms have been restored to
+   * `table.initialState` by `table.reset()`. It is intended for transient
+   * feature data, not table state slices or externally controlled state.
+   */
+  resetTableInstanceData?: <
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+  >(
+    table: Table_Internal<TFeatures, TData>,
   ) => void
 }

--- a/packages/table-core/tests/implementation/features/row-selection/rowSelectionRange.test.ts
+++ b/packages/table-core/tests/implementation/features/row-selection/rowSelectionRange.test.ts
@@ -1,0 +1,508 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  columnFilteringFeature,
+  columnGroupingFeature,
+  constructTable,
+  createExpandedRowModel,
+  createFilteredRowModel,
+  createGroupedRowModel,
+  createPaginatedRowModel,
+  createSortedRowModel,
+  filterFns,
+  rowExpandingFeature,
+  rowPaginationFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  sortFns,
+} from '../../../../src'
+import { testFeatures } from '../../../fixtures/features'
+import type {
+  RowSelectionState,
+  TableOptions,
+  ToggleSelectedOptions,
+  Updater,
+} from '../../../../src'
+
+interface TestRow {
+  id: string
+  kind?: string
+  value: number
+  subRows?: Array<TestRow>
+}
+
+const selectionFeatures = testFeatures({ rowSelectionFeature })
+const pipelineFeatures = testFeatures({
+  columnFilteringFeature,
+  columnGroupingFeature,
+  filterFns,
+  filteredRowModel: createFilteredRowModel(),
+  groupedRowModel: createGroupedRowModel(),
+  rowExpandingFeature,
+  expandedRowModel: createExpandedRowModel(),
+  rowPaginationFeature,
+  paginatedRowModel: createPaginatedRowModel(),
+  rowSelectionFeature,
+  rowSortingFeature,
+  sortFns,
+  sortedRowModel: createSortedRowModel(),
+})
+
+const flatData: Array<TestRow> = Array.from({ length: 6 }, (_, value) => ({
+  id: String(value),
+  kind: value % 2 ? 'odd' : 'even',
+  value,
+}))
+
+function makeSelectionTable(
+  options: Partial<
+    Omit<
+      TableOptions<typeof selectionFeatures, TestRow>,
+      'columns' | 'data' | 'features'
+    >
+  > = {},
+  data: Array<TestRow> = flatData,
+) {
+  return constructTable<typeof selectionFeatures, TestRow>({
+    features: selectionFeatures,
+    columns: [{ accessorKey: 'value', id: 'value' }],
+    data,
+    getRowId: (row) => row.id,
+    getSubRows: (row) => row.subRows,
+    ...options,
+  })
+}
+
+function makePipelineTable(
+  options: Partial<
+    Omit<
+      TableOptions<typeof pipelineFeatures, TestRow>,
+      'columns' | 'data' | 'features'
+    >
+  > = {},
+  data: Array<TestRow> = flatData,
+) {
+  return constructTable<typeof pipelineFeatures, TestRow>({
+    features: pipelineFeatures,
+    columns: [
+      { accessorKey: 'id', id: 'id', filterFn: 'includesString' },
+      { accessorKey: 'kind', id: 'kind', filterFn: 'equalsString' },
+      { accessorKey: 'value', id: 'value' },
+    ],
+    data,
+    getRowId: (row) => row.id,
+    getSubRows: (row) => row.subRows,
+    ...options,
+  })
+}
+
+function interact(
+  row: {
+    getToggleSelectedHandler: (
+      opts?: ToggleSelectedOptions,
+    ) => (event: unknown) => void
+  },
+  checked: boolean,
+  event: Record<string, unknown> = {},
+  opts?: ToggleSelectedOptions,
+) {
+  row.getToggleSelectedHandler(opts)({
+    target: { checked },
+    ...event,
+  })
+}
+
+function selected(table: {
+  atoms: { rowSelection: { get(): RowSelectionState } }
+}) {
+  return Object.keys(table.atoms.rowSelection.get()).sort()
+}
+
+describe('row selection range event detection', () => {
+  it('detects direct and wrapped Shift events but ignores ordinary events', () => {
+    const direct = makeSelectionTable()
+    interact(direct.getRow('0'), true)
+    interact(direct.getRow('2'), true, { shiftKey: true })
+    expect(selected(direct)).toEqual(['0', '1', '2'])
+
+    const wrapped = makeSelectionTable()
+    interact(wrapped.getRow('0'), true)
+    interact(wrapped.getRow('2'), true, {
+      nativeEvent: { shiftKey: true },
+    })
+    expect(selected(wrapped)).toEqual(['0', '1', '2'])
+
+    const ordinary = makeSelectionTable()
+    interact(ordinary.getRow('0'), true)
+    interact(ordinary.getRow('2'), true)
+    expect(selected(ordinary)).toEqual(['0', '2'])
+  })
+
+  it('supports custom range event detection', () => {
+    const detector = vi.fn(
+      (event: unknown) => (event as { range?: boolean }).range === true,
+    )
+    const table = makeSelectionTable({
+      isRowRangeSelectionEvent: detector,
+    })
+
+    interact(table.getRow('0'), true)
+    interact(table.getRow('2'), true, { shiftKey: true })
+    expect(selected(table)).toEqual(['0', '2'])
+
+    interact(table.getRow('4'), true, { range: true })
+    expect(selected(table)).toEqual(['0', '2', '3', '4'])
+    expect(detector).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('row selection ranges', () => {
+  it('establishes an anchor and selects forward and reverse inclusive ranges', () => {
+    const forward = makeSelectionTable()
+    interact(forward.getRow('1'), true)
+    expect(forward._lastSelectedRowId).toBe('1')
+    interact(forward.getRow('4'), true, { shiftKey: true })
+    expect(selected(forward)).toEqual(['1', '2', '3', '4'])
+
+    const reverse = makeSelectionTable()
+    interact(reverse.getRow('4'), true)
+    interact(reverse.getRow('1'), true, { shiftKey: true })
+    expect(selected(reverse)).toEqual(['1', '2', '3', '4'])
+  })
+
+  it('uses the checkbox value for inclusive deselection and same-row ranges', () => {
+    const table = makeSelectionTable({
+      initialState: {
+        rowSelection: {
+          '0': true,
+          '1': true,
+          '2': true,
+          '3': true,
+          '4': true,
+          '5': true,
+        },
+      },
+    })
+    interact(table.getRow('1'), false)
+    interact(table.getRow('4'), false, { shiftKey: true })
+    expect(selected(table)).toEqual(['0', '5'])
+
+    interact(table.getRow('5'), true)
+    interact(table.getRow('5'), false, { shiftKey: true })
+    expect(selected(table)).toEqual(['0'])
+  })
+
+  it('preserves selections outside the interval and advances the anchor', () => {
+    const table = makeSelectionTable({
+      initialState: { rowSelection: { '5': true } },
+    })
+    interact(table.getRow('0'), true)
+    interact(table.getRow('2'), true, { shiftKey: true })
+    expect(table._lastSelectedRowId).toBe('2')
+    interact(table.getRow('4'), false, { shiftKey: true })
+
+    expect(selected(table)).toEqual(['0', '1', '5'])
+    expect(table._lastSelectedRowId).toBe('4')
+  })
+})
+
+describe('row selection range performance', () => {
+  it('does not resolve display order for ordinary clicks but does for ranges', () => {
+    const table = makeSelectionTable()
+    const getRowsInDisplayOrder = vi.spyOn(table, 'getRowsInDisplayOrder')
+
+    interact(table.getRow('0'), true)
+    expect(getRowsInDisplayOrder).not.toHaveBeenCalled()
+
+    interact(table.getRow('2'), true, { shiftKey: true })
+    expect(getRowsInDisplayOrder).toHaveBeenCalled()
+  })
+
+  it('uses one selection change and never calls row.toggleSelected per interval row', () => {
+    let rowSelection: RowSelectionState = {}
+    const onRowSelectionChange = vi.fn(
+      (updater: Updater<RowSelectionState>) => {
+        rowSelection =
+          typeof updater === 'function' ? updater(rowSelection) : updater
+      },
+    )
+    const table = makeSelectionTable({ onRowSelectionChange })
+    const toggleSelected = vi.spyOn(table.getRow('1'), 'toggleSelected')
+
+    interact(table.getRow('0'), true)
+    onRowSelectionChange.mockClear()
+    interact(table.getRow('4'), true, { shiftKey: true })
+
+    expect(onRowSelectionChange).toHaveBeenCalledOnce()
+    expect(toggleSelected).not.toHaveBeenCalled()
+    expect(Object.keys(rowSelection).sort()).toEqual(['0', '1', '2', '3', '4'])
+  })
+
+  it('persists framework events before reading them', () => {
+    const table = makeSelectionTable()
+    const persist = vi.fn()
+
+    interact(table.getRow('0'), true, { persist })
+
+    expect(persist).toHaveBeenCalledOnce()
+  })
+})
+
+describe('row selection range options and invalid anchors', () => {
+  it('can disable range selection', () => {
+    const table = makeSelectionTable({ enableRowRangeSelection: false })
+    interact(table.getRow('0'), true)
+    interact(table.getRow('3'), true, { shiftKey: true })
+    expect(selected(table)).toEqual(['0', '3'])
+  })
+
+  it('falls back to ordinary selection when the current row cannot multi-select', () => {
+    const table = makeSelectionTable({ enableMultiRowSelection: false })
+    interact(table.getRow('0'), true)
+    interact(table.getRow('3'), true, { shiftKey: true })
+    expect(selected(table)).toEqual(['3'])
+  })
+
+  it('respects per-row multi-select predicates at endpoints and inside ranges', () => {
+    const endpoint = makeSelectionTable({
+      enableMultiRowSelection: (row) => row.id !== '3',
+    })
+    interact(endpoint.getRow('0'), true)
+    interact(endpoint.getRow('3'), true, { shiftKey: true })
+    expect(selected(endpoint)).toEqual(['3'])
+
+    const inside = makeSelectionTable({
+      enableMultiRowSelection: (row) => row.id !== '2',
+    })
+    interact(inside.getRow('0'), true)
+    interact(inside.getRow('4'), true, { shiftKey: true })
+    expect(selected(inside)).toEqual(['0', '1', '3', '4'])
+  })
+
+  it('skips non-selectable rows inside a range', () => {
+    const table = makeSelectionTable({
+      enableRowSelection: (row) => row.id !== '2',
+    })
+    interact(table.getRow('0'), true)
+    interact(table.getRow('4'), true, { shiftKey: true })
+    expect(selected(table)).toEqual(['0', '1', '3', '4'])
+  })
+
+  it('falls back to an ordinary toggle for invalid and removed anchor ids', () => {
+    const invalid = makeSelectionTable()
+    invalid._lastSelectedRowId = 'missing'
+    interact(invalid.getRow('3'), true, { shiftKey: true })
+    expect(selected(invalid)).toEqual(['3'])
+    expect(invalid._lastSelectedRowId).toBe('3')
+
+    const removed = makePipelineTable()
+    interact(removed.getRow('0'), true)
+    removed.setColumnFilters([{ id: 'id', value: '2' }])
+    interact(removed.getRow('2'), true, { shiftKey: true })
+    expect(selected(removed)).toEqual(['0', '2'])
+    expect(removed._lastSelectedRowId).toBe('2')
+  })
+})
+
+describe('range child selection semantics', () => {
+  const nestedData: Array<TestRow> = [
+    { id: 'a', value: 0 },
+    {
+      id: 'parent',
+      value: 1,
+      subRows: [
+        { id: 'child-1', value: 11 },
+        { id: 'child-2', value: 12 },
+      ],
+    },
+    { id: 'z', value: 2 },
+  ]
+
+  it('selects collapsed descendants by default and can limit selection to displayed rows', () => {
+    const recursive = makePipelineTable({}, nestedData)
+    interact(recursive.getRow('a'), true)
+    interact(recursive.getRow('z'), true, { shiftKey: true })
+    expect(selected(recursive)).toEqual([
+      'a',
+      'child-1',
+      'child-2',
+      'parent',
+      'z',
+    ])
+
+    const displayedOnly = makePipelineTable({}, nestedData)
+    interact(displayedOnly.getRow('a'), true)
+    interact(
+      displayedOnly.getRow('z'),
+      true,
+      { shiftKey: true },
+      { selectChildren: false },
+    )
+    expect(selected(displayedOnly)).toEqual(['a', 'parent', 'z'])
+  })
+
+  it('respects boolean and per-row sub-selection options', () => {
+    const disabled = makePipelineTable(
+      { enableSubRowSelection: false },
+      nestedData,
+    )
+    interact(disabled.getRow('a'), true)
+    interact(disabled.getRow('z'), true, { shiftKey: true })
+    expect(selected(disabled)).toEqual(['a', 'parent', 'z'])
+
+    const predicate = makePipelineTable(
+      { enableSubRowSelection: (row) => row.id !== 'parent' },
+      nestedData,
+    )
+    interact(predicate.getRow('a'), true)
+    interact(predicate.getRow('z'), true, { shiftKey: true })
+    expect(selected(predicate)).toEqual(['a', 'parent', 'z'])
+  })
+
+  it('changes expanded descendants explicitly when child recursion is disabled', () => {
+    const table = makePipelineTable(
+      { initialState: { expanded: { parent: true } } },
+      nestedData,
+    )
+    interact(table.getRow('a'), true)
+    interact(
+      table.getRow('z'),
+      true,
+      { shiftKey: true },
+      { selectChildren: false },
+    )
+    expect(selected(table)).toEqual(['a', 'child-1', 'child-2', 'parent', 'z'])
+  })
+})
+
+describe('range selection follows the display pipeline', () => {
+  it('uses the latest sorting order between interactions', () => {
+    const table = makePipelineTable()
+    interact(table.getRow('0'), true)
+    table.setSorting([{ id: 'value', desc: true }])
+    interact(table.getRow('3'), true, { shiftKey: true })
+    expect(selected(table)).toEqual(['0', '1', '2', '3'])
+  })
+
+  it('uses the latest filtered order while a visible anchor remains valid', () => {
+    const table = makePipelineTable()
+    interact(table.getRow('0'), true)
+    table.setColumnFilters([{ id: 'kind', value: 'even' }])
+    interact(table.getRow('4'), true, { shiftKey: true })
+    expect(selected(table)).toEqual(['0', '2', '4'])
+  })
+
+  it('includes grouped rows in display order', () => {
+    const table = makePipelineTable()
+    table.setGrouping(['kind'])
+
+    interact(table.getRow('kind:even'), true, {}, { selectChildren: false })
+    interact(
+      table.getRow('kind:odd'),
+      true,
+      { shiftKey: true },
+      { selectChildren: false },
+    )
+
+    expect(selected(table)).toEqual(['kind:even', 'kind:odd'])
+  })
+
+  it('selects across client-side pages', () => {
+    const table = makePipelineTable({
+      initialState: { pagination: { pageIndex: 0, pageSize: 2 } },
+    })
+    interact(table.getRow('0'), true)
+    table.setPageIndex(2)
+    interact(table.getRow('4'), true, { shiftKey: true })
+    expect(selected(table)).toEqual(['0', '1', '2', '3', '4'])
+  })
+
+  it.each([true, false])(
+    'includes expanded rows when paginateExpandedRows is %s',
+    (paginateExpandedRows) => {
+      const data: Array<TestRow> = [
+        {
+          id: 'parent',
+          value: 0,
+          subRows: [
+            { id: 'child-1', value: 1 },
+            { id: 'child-2', value: 2 },
+          ],
+        },
+        { id: 'z', value: 3 },
+      ]
+      const table = makePipelineTable(
+        {
+          paginateExpandedRows,
+          initialState: {
+            expanded: { parent: true },
+            pagination: { pageIndex: 0, pageSize: 1 },
+          },
+        },
+        data,
+      )
+
+      interact(table.getRow('child-1'), true)
+      interact(
+        table.getRow('z'),
+        true,
+        { shiftKey: true },
+        { selectChildren: false },
+      )
+      expect(selected(table)).toEqual(['child-1', 'child-2', 'z'])
+    },
+  )
+
+  it('preserves anchors across data replacement only when the id remains loaded', () => {
+    const preserved = makePipelineTable()
+    interact(preserved.getRow('1'), true)
+    preserved.setOptions((old) => ({
+      ...old,
+      data: flatData.map((row) => ({ ...row, value: row.value + 10 })),
+    }))
+    interact(preserved.getRow('3'), true, { shiftKey: true })
+    expect(selected(preserved)).toEqual(['1', '2', '3'])
+
+    const removed = makePipelineTable()
+    interact(removed.getRow('1'), true)
+    removed.setOptions((old) => ({
+      ...old,
+      data: flatData.filter((row) => row.id !== '1'),
+    }))
+    interact(removed.getRow('3'), true, { shiftKey: true })
+    expect(selected(removed)).toEqual(['1', '3'])
+  })
+})
+
+describe('row selection anchor lifecycle', () => {
+  function establishAnchor() {
+    const table = makeSelectionTable()
+    interact(table.getRow('1'), true)
+    expect(table._lastSelectedRowId).toBe('1')
+    return table
+  }
+
+  it('is not changed by direct row or table state APIs', () => {
+    const table = makeSelectionTable()
+    table.getRow('0').toggleSelected(true)
+    table.setRowSelection({ '1': true })
+    expect(table._lastSelectedRowId).toBeNull()
+  })
+
+  it('clears through every selection reset and select-all path', () => {
+    const resetSelection = establishAnchor()
+    resetSelection.resetRowSelection()
+    expect(resetSelection._lastSelectedRowId).toBeNull()
+
+    const allRows = establishAnchor()
+    allRows.toggleAllRowsSelected()
+    expect(allRows._lastSelectedRowId).toBeNull()
+
+    const allPageRows = establishAnchor()
+    allPageRows.toggleAllPageRowsSelected()
+    expect(allPageRows._lastSelectedRowId).toBeNull()
+
+    const globalReset = establishAnchor()
+    globalReset.reset()
+    expect(globalReset._lastSelectedRowId).toBeNull()
+  })
+})

--- a/packages/table-core/tests/unit/core/table/constructTable.test.ts
+++ b/packages/table-core/tests/unit/core/table/constructTable.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { constructTable } from '../../../../src'
 import { table_mergeOptions } from '../../../../src/static-functions'
 import { testFeatures } from '../../../fixtures/features'
+import type { TableFeature } from '../../../../src'
 
 function getterOnlyMerge(...sources: Array<any>) {
   const target = {}
@@ -34,6 +35,116 @@ function getterOnlyMerge(...sources: Array<any>) {
 }
 
 describe('constructTable', () => {
+  it('initializes feature-owned table data before constructing any table APIs', () => {
+    const calls: Array<string> = []
+    const initA = vi.fn((table: any) => {
+      calls.push('init-a')
+      expect(table.options.lifecycleMarker).toBe('available')
+      expect(table.baseAtoms.lifecycle.get()).toBe('initial')
+      expect(table.atoms.lifecycle.get()).toBe('initial')
+      expect(table.store.state.lifecycle).toBe('initial')
+      expect(table.reset).toBeUndefined()
+      table.firstInitialized = true
+    })
+    const initB = vi.fn((table: any) => {
+      calls.push('init-b')
+      expect(table.firstInitialized).toBe(true)
+      table.secondInitialized = true
+    })
+    const apiA = vi.fn((table: any) => {
+      calls.push('api-a')
+      expect(table.firstInitialized).toBe(true)
+      expect(table.secondInitialized).toBe(true)
+    })
+    const apiB = vi.fn((table: any) => {
+      calls.push('api-b')
+      expect(table.firstInitialized).toBe(true)
+      expect(table.secondInitialized).toBe(true)
+    })
+    const apiWithoutInit = vi.fn((table: any) => {
+      calls.push('api-without-init')
+      table.apiWithoutInit = true
+    })
+    const featureA: TableFeature = {
+      getInitialState: (initialState) =>
+        ({ lifecycle: 'initial', ...initialState }) as any,
+      initTableInstanceData: initA,
+      constructTableAPIs: apiA,
+    }
+    const featureB: TableFeature = {
+      initTableInstanceData: initB,
+      constructTableAPIs: apiB,
+    }
+    const featureWithoutInit: TableFeature = {
+      constructTableAPIs: apiWithoutInit,
+    }
+    const features = {
+      ...testFeatures({}),
+      featureA,
+      featureB,
+      featureWithoutInit,
+    } as any
+
+    const table = constructTable({
+      features,
+      columns: [],
+      data: [],
+      lifecycleMarker: 'available',
+    } as any) as any
+
+    expect(calls).toEqual([
+      'init-a',
+      'init-b',
+      'api-a',
+      'api-b',
+      'api-without-init',
+    ])
+    expect(initA).toHaveBeenCalledOnce()
+    expect(initB).toHaveBeenCalledOnce()
+    expect(apiWithoutInit).toHaveBeenCalledOnce()
+    expect(table.apiWithoutInit).toBe(true)
+  })
+
+  it('resets feature-owned table data after internal atoms without rerunning initialization', () => {
+    const init = vi.fn((table: any) => {
+      table.transientValue = 'initialized'
+    })
+    const reset = vi.fn((table: any) => {
+      expect(table.baseAtoms.lifecycle.get()).toBe('initial')
+      expect(table.store.state.lifecycle).toBe('initial')
+      table.transientValue = null
+    })
+    const lifecycleFeature: TableFeature = {
+      getInitialState: (initialState) =>
+        ({ lifecycle: 'initial', ...initialState }) as any,
+      initTableInstanceData: init,
+      resetTableInstanceData: reset,
+    }
+    const features = {
+      ...testFeatures({}),
+      lifecycleFeature,
+    } as any
+    const table = constructTable({
+      features,
+      columns: [],
+      data: [],
+    } as any) as any
+
+    table.baseAtoms.lifecycle.set('changed')
+    table.transientValue = 'changed'
+    table.reset()
+
+    expect(reset).toHaveBeenCalledOnce()
+    expect(init).toHaveBeenCalledOnce()
+    expect(table.transientValue).toBeNull()
+
+    table.baseAtoms.lifecycle.set('changed-again')
+    table.reset()
+
+    expect(reset).toHaveBeenCalledTimes(2)
+    expect(init).toHaveBeenCalledOnce()
+  })
+
   it('should create a table with all core table APIs and properties', () => {
     const table = constructTable({
       features: testFeatures({}),


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inclusive Shift-click range selection for row toggles, following the table’s current display order, with options to disable/override range detection and limit selection to displayed rows.
* **Documentation**
  * Documented feature instance lifecycle hooks (`initTableInstanceData` / `resetTableInstanceData`), updated row-selection migration guidance, and added row-number guidance using display indexes (plus related reference pages).
* **Examples**
  * Updated selection checkbox wiring to use click events (so Shift modifiers are preserved) and enhanced virtualized examples with selection UI, live counts, and indeterminate states.
* **Tests**
  * Added automated coverage for Shift range selection and feature lifecycle ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->