### PR TITLE
docs: Clarify column visibility toggle labels

### DIFF
--- a/docs/framework/react/guide/column-visibility.md
+++ b/docs/framework/react/guide/column-visibility.md
@@ -139,6 +139,11 @@ There are several column API methods that are useful for rendering column visibi
 - `column.getToggleVisibilityHandler` - Shortcut for hooking up the `column.toggleVisibility` method to a UI event handler.
 
 ```tsx
+const columnLabels: Record<string, string> = {
+  firstName: 'First Name',
+  lastName: 'Last Name',
+}
+
 {
   table.getAllColumns().map((column) => (
     <label key={column.id}>
@@ -148,11 +153,20 @@ There are several column API methods that are useful for rendering column visibi
         onChange={column.getToggleVisibilityHandler()}
         type="checkbox"
       />
-      {column.columnDef.header}
+      {columnLabels[column.id] ?? column.id}
     </label>
   ))
 }
 ```
+
+> **Note**: `column.columnDef.header` is a header render template. It can be a
+> string, JSX, or a function that needs a header context and should be rendered
+> with `flexRender` when you are rendering actual table headers. A column
+> visibility menu is usually rendering columns rather than header objects, and a
+> hidden column may not have an active header context. For visibility toggles,
+> prefer a stable text label such as a custom map of labels keyed by column ID,
+> typed `columnDef.meta` (for example `column.columnDef.meta.label`), or
+> `column.id`.
 
 ### Column Visibility Aware Table APIs
 


### PR DESCRIPTION
## What changed

- Updated the React column visibility guide to avoid rendering `column.columnDef.header` directly in a visibility toggle menu.
- Added a stable label-map example for column visibility controls.
- Added a note explaining that `columnDef.header` is a header render template and should be rendered with `flexRender` when rendering actual headers, while visibility menus should use stable text labels.

## Why

`column.columnDef.header` can be a string or render template that needs header context. In a visibility menu we are rendering column objects, and hidden columns may not have an active header context. This caused confusion in #5751 when JSX/template headers were used as toggle labels.

## Validation

- `pnpm prettier --write docs/framework/react/guide/column-visibility.md`
- `pnpm test:docs`

Related: #5751


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the React column visibility guide to use stable, column ID-based labels in visibility toggle menus.
  * Added guidance explaining that column header templates require context and may not be suitable for toggle labels.
  * Recommended defining custom text labels for consistent visibility controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->