### PR TITLE
fix(pagination): Reset auto page index to first page

### DIFF
--- a/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
+++ b/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
@@ -46,7 +46,7 @@ export function table_autoResetPageIndex<
     table.options.autoResetPageIndex ??
     !table.options.manualPagination
   ) {
-    table_resetPageIndex(table)
+    table_resetPageIndex(table, true)
   }
 }
 

--- a/packages/table-core/tests/unit/features/row-pagination/rowPaginationFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/row-pagination/rowPaginationFeature.utils.test.ts
@@ -447,6 +447,19 @@ describe('table_autoResetPageIndex', () => {
     expect(table.atoms.pagination.get().pageIndex).toBe(0)
   })
 
+  it('should reset to the first page instead of the initial page index', () => {
+    const table = makeTable(25, {
+      initialState: { pagination: { pageIndex: 1, pageSize: 10 } },
+    })
+
+    table.setPageIndex(2)
+    expect(table.atoms.pagination.get().pageIndex).toBe(2)
+
+    table_autoResetPageIndex(table)
+
+    expect(table.atoms.pagination.get().pageIndex).toBe(0)
+  })
+
   it('should not reset when manualPagination is set', () => {
     const onPaginationChange = vi.fn()
     const table = makeTable(25, {


### PR DESCRIPTION
## Summary

Fixes #6207.

`table_autoResetPageIndex` now resets the page index to the feature default first page (`0`) instead of restoring `initialState.pagination.pageIndex`.

## Root cause

`table_autoResetPageIndex` called `table_resetPageIndex(table)` without `defaultState = true`. That call path preserves `initialState.pagination.pageIndex`, which is correct for explicit reset APIs but incorrect for automatic row-model resets after filtering, sorting, grouping, or data updates.

## Changes

- Pass `true` to `table_resetPageIndex` from the automatic page-index reset path.
- Add a regression test where `initialState.pagination.pageIndex` is non-zero and auto reset must still return to page `0`.

## Note

I noticed #6208 is already open for the same issue. This PR is intentionally based on the current `beta` branch structure and includes a regression test for the behavior.

## Validation

- `pnpm vitest run packages/table-core/tests/unit/features/row-pagination/rowPaginationFeature.utils.test.ts`
- `pnpm nx run @tanstack/table-core:test:lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic pagination resets now consistently return to the first page, even when a different initial page was configured.
  * Added coverage to verify the corrected reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->