### PR TITLE
fix(table-core): refresh faceted values on option updates

### DIFF
--- a/.changeset/fresh-facets-update.md
+++ b/.changeset/fresh-facets-update.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Refresh custom faceted unique value getters when `getFacetedUniqueValues` changes.

--- a/packages/table-core/src/features/ColumnFaceting.ts
+++ b/packages/table-core/src/features/ColumnFaceting.ts
@@ -60,10 +60,16 @@ export const ColumnFaceting: TableFeature = {
 
       return column._getFacetedRowModel()
     }
+    let getFacetedUniqueValues = table.options.getFacetedUniqueValues
     column._getFacetedUniqueValues =
-      table.options.getFacetedUniqueValues &&
-      table.options.getFacetedUniqueValues(table, column.id)
+      getFacetedUniqueValues && getFacetedUniqueValues(table, column.id)
     column.getFacetedUniqueValues = () => {
+      if (getFacetedUniqueValues !== table.options.getFacetedUniqueValues) {
+        getFacetedUniqueValues = table.options.getFacetedUniqueValues
+        column._getFacetedUniqueValues =
+          getFacetedUniqueValues && getFacetedUniqueValues(table, column.id)
+      }
+
       if (!column._getFacetedUniqueValues) {
         return new Map()
       }

--- a/packages/table-core/src/features/GlobalFaceting.ts
+++ b/packages/table-core/src/features/GlobalFaceting.ts
@@ -41,10 +41,16 @@ export const GlobalFaceting: TableFeature = {
       return table._getGlobalFacetedRowModel()
     }
 
+    let getFacetedUniqueValues = table.options.getFacetedUniqueValues
     table._getGlobalFacetedUniqueValues =
-      table.options.getFacetedUniqueValues &&
-      table.options.getFacetedUniqueValues(table, '__global__')
+      getFacetedUniqueValues && getFacetedUniqueValues(table, '__global__')
     table.getGlobalFacetedUniqueValues = () => {
+      if (getFacetedUniqueValues !== table.options.getFacetedUniqueValues) {
+        getFacetedUniqueValues = table.options.getFacetedUniqueValues
+        table._getGlobalFacetedUniqueValues =
+          getFacetedUniqueValues && getFacetedUniqueValues(table, '__global__')
+      }
+
       if (!table._getGlobalFacetedUniqueValues) {
         return new Map()
       }

--- a/packages/table-core/tests/ColumnFaceting.test.ts
+++ b/packages/table-core/tests/ColumnFaceting.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ColumnDef, createTable, getCoreRowModel } from '../src'
+
+type Person = {
+  name: string
+}
+
+const data: Person[] = [{ name: 'Alice' }]
+const columns: ColumnDef<Person>[] = [{ accessorKey: 'name' }]
+
+function createFacetedValuesFactory(value: string) {
+  return vi.fn(() => () => new Map([[value, 1]]))
+}
+
+describe('ColumnFaceting', () => {
+  it('updates custom faceted unique values when the option changes', () => {
+    const initialFactory = createFacetedValuesFactory('initial')
+    const updatedFactory = createFacetedValuesFactory('updated')
+    const table = createTable<Person>({
+      columns,
+      data,
+      getCoreRowModel: getCoreRowModel(),
+      getFacetedUniqueValues: initialFactory,
+      onStateChange() {},
+      renderFallbackValue: null,
+      state: {},
+    })
+    const column = table.getColumn('name')!
+
+    expect(column.getFacetedUniqueValues()).toEqual(new Map([['initial', 1]]))
+    expect(table.getGlobalFacetedUniqueValues()).toEqual(
+      new Map([['initial', 1]]),
+    )
+
+    table.setOptions((options) => ({
+      ...options,
+      getFacetedUniqueValues: updatedFactory,
+    }))
+
+    expect(column.getFacetedUniqueValues()).toEqual(new Map([['updated', 1]]))
+    expect(table.getGlobalFacetedUniqueValues()).toEqual(
+      new Map([['updated', 1]]),
+    )
+    expect(column.getFacetedUniqueValues()).toEqual(new Map([['updated', 1]]))
+    expect(table.getGlobalFacetedUniqueValues()).toEqual(
+      new Map([['updated', 1]]),
+    )
+    expect(initialFactory).toHaveBeenCalledTimes(2)
+    expect(updatedFactory).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes #6081.

Custom `getFacetedUniqueValues` factories are now refreshed when the table option changes. This prevents column and global faceting APIs from retaining a getter created during the first React render while still preserving the cached getter when the factory reference is unchanged.

The root cause was that column and global faceting captured the initial factory result during table construction. Although `useReactTable` updates `table.options` on every render, those cached getters were never rebuilt.

This PR also adds a regression test covering option updates for both column and global faceted unique values, including verification that unchanged factories remain cached, plus a patch changeset for `@tanstack/table-core`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
