### PR TITLE
fix(table-core): preserve clicked row in single-select mode

### DIFF
--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
@@ -487,7 +487,8 @@ export function table_getToggleAllPageRowsSelectedHandler<
  * Selects or deselects this row.
  *
  * Omitting `value` toggles the row. Child rows are selected recursively unless
- * `opts.selectChildren` is `false` or sub-row selection is disabled.
+ * `opts.selectChildren` is `false`, sub-row selection is disabled, or the row
+ * only supports single selection.
  *
  * @example
  * ```ts
@@ -513,7 +514,7 @@ export function row_toggleSelected<
       rowSelection,
       row.id,
       value,
-      opts?.selectChildren ?? true,
+      (opts?.selectChildren ?? true) && row_getCanMultiSelect(row),
       row.table,
     )
 

--- a/packages/table-core/tests/unit/features/row-selection/rowSelectionFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/row-selection/rowSelectionFeature.utils.test.ts
@@ -353,6 +353,20 @@ describe('row_toggleSelected', () => {
       '0': true,
     })
   })
+
+  it('should select the clicked parent row when multi-select is disabled', () => {
+    const onRowSelectionChange = vi.fn()
+    const table = makeTable(
+      { onRowSelectionChange, enableMultiRowSelection: false },
+      [3, 2],
+    )
+
+    row_toggleSelected(table.getRow('0'), true)
+
+    expect(getUpdaterResult(onRowSelectionChange, {})).toEqual({
+      '0': true,
+    })
+  })
 })
 
 describe('row_getIsSomeSelected / row_getIsAllSubRowsSelected', () => {


### PR DESCRIPTION
## Summary

- prevent automatic sub-row selection when the clicked row only supports single selection
- add a regression test covering a parent row with selectable children

## Root cause

Selecting a parent recursively selected its descendants. With `enableMultiRowSelection: false`, each recursive descendant cleared the preceding selection, so the final leaf row replaced the parent that the user clicked.

## Impact

Single-select tables now preserve the clicked parent row instead of selecting its final descendant. Existing multi-select sub-row behavior is unchanged.

## Validation

- `pnpm dlx --package=vitest@4.1.9 vitest run packages/table-core/tests/unit/features/row-selection packages/table-core/tests/implementation/features/row-selection` (91 tests passed)
- Prettier check passed for the changed files
- `git diff --check`

Closes #4299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed row selection so selecting a parent row in single-selection mode no longer selects its child rows.
  * Ensured descendant rows are selected only when multi-row selection is allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->