### PR TITLE
fix numeric zero global filters

### DIFF
--- a/packages/table-core/src/features/column-faceting/createFacetedRowModel.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedRowModel.ts
@@ -54,9 +54,15 @@ function _createFacetedRowModel<
   columnId: string,
   preRowModel: RowModel<TFeatures, TData>,
   columnFilters?: ColumnFiltersState,
-  globalFilter?: string,
+  globalFilter?: any,
 ) {
-  if (!preRowModel.rows.length || (!columnFilters?.length && !globalFilter)) {
+  const hasGlobalFilter =
+    globalFilter !== undefined && globalFilter !== null && globalFilter !== ''
+
+  if (
+    !preRowModel.rows.length ||
+    (!columnFilters?.length && !hasGlobalFilter)
+  ) {
     return preRowModel
   }
 
@@ -69,7 +75,7 @@ function _createFacetedRowModel<
   }
   // The global context excludes the global filter itself, mirroring how a
   // column's faceted model excludes that column's own filter
-  if (globalFilter && columnId !== '__global__')
+  if (hasGlobalFilter && columnId !== '__global__')
     filterableIds.push('__global__')
 
   if (!filterableIds.length) {

--- a/packages/table-core/src/features/column-filtering/createFilteredRowModel.ts
+++ b/packages/table-core/src/features/column-filtering/createFilteredRowModel.ts
@@ -57,8 +57,10 @@ function _createFilteredRowModel<
   const rowModel = table.getPreFilteredRowModel()
   const columnFilters = table.atoms.columnFilters?.get()
   const globalFilter = table.atoms.globalFilter?.get()
+  const hasGlobalFilter =
+    globalFilter !== undefined && globalFilter !== null && globalFilter !== ''
 
-  if (!rowModel.rows.length || (!columnFilters?.length && !globalFilter)) {
+  if (!rowModel.rows.length || (!columnFilters?.length && !hasGlobalFilter)) {
     const flatRows = rowModel.flatRows as Array<
       Row<TFeatures, TData> & Partial<Row_ColumnFiltering<TFeatures, TData>>
     >
@@ -106,7 +108,7 @@ function _createFilteredRowModel<
     .getAllLeafColumns()
     .filter((column) => column_getCanGlobalFilter(column))
 
-  if (globalFilter && globalFilterFn && globallyFilterableColumns.length) {
+  if (hasGlobalFilter && globalFilterFn && globallyFilterableColumns.length) {
     filterableIds.push('__global__')
 
     globallyFilterableColumns.forEach((column) => {

--- a/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
+++ b/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
@@ -509,6 +509,19 @@ describe('createFilteredRowModel', () => {
 
       expect(rowNames(table.getFilteredRowModel().rows)).toEqual(['Keep Me'])
     })
+
+    it('should apply a numeric zero global filter value', () => {
+      const table = constructTable<typeof features, TestRow>({
+        features,
+        columns,
+        data: [{ name: 'status 0' }, { name: 'status 1' }],
+        initialState: {
+          globalFilter: 0,
+        },
+      })
+
+      expect(rowNames(table.getFilteredRowModel().rows)).toEqual(['status 0'])
+    })
   })
 
   describe('unresolvable global filter fn', () => {


### PR DESCRIPTION
## What changed

- treat numeric `0` as an active global filter value
- apply the same active-value check in filtered and faceted row models
- retain the existing inactive behavior for `undefined`, `null`, and the empty string
- add a regression test using a numeric-zero global filter

## Why

The row-model pipeline used truthiness to decide whether global filtering was active. That skipped `0`, even though numeric status values are valid filter inputs.

The filtered model and faceted model now agree on explicit empty values instead of relying on truthiness.

## Validation

- `packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts` — 27 tests passed
- Prettier and `git diff --check`

Closes #4488


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved global filtering behavior for empty, null, and undefined values.
  - Numeric global filter values such as `0` now work correctly.
  - Ensured filtering and faceting consistently apply active global filters.

- **Tests**
  - Added coverage for filtering with a numeric value of `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->