### PR TITLE
fix auto filters for nullable columns

### DIFF
--- a/packages/table-core/src/features/column-filtering/columnFilteringFeature.utils.ts
+++ b/packages/table-core/src/features/column-filtering/columnFilteringFeature.utils.ts
@@ -47,9 +47,18 @@ export function column_getAutoFilterFn<
   const filterFns: Record<string, FilterFn<TFeatures, TData>> | undefined =
     column.table._rowModelFns.filterFns
 
-  const firstRow = column.table.getCoreRowModel().flatRows[0]
+  const rows = column.table.getCoreRowModel().flatRows
+  let value: unknown
 
-  const value = firstRow ? firstRow.getValue(column.id) : undefined
+  // Nullable columns should be inferred from their first available value,
+  // rather than changing filter behavior based on which row happens to lead.
+  for (let i = 0; i < rows.length; i++) {
+    const rowValue = rows[i]!.getValue(column.id)
+    if (rowValue !== null && rowValue !== undefined) {
+      value = rowValue
+      break
+    }
+  }
 
   let filterFnName: string
 

--- a/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
+++ b/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
@@ -511,6 +511,22 @@ describe('createFilteredRowModel', () => {
     })
   })
 
+  it('should auto-filter a nullable string column when the first value is null', () => {
+    type NullableTestRow = { name: string | null }
+    const table = constructTable<typeof features, NullableTestRow>({
+      features,
+      columns: [{ accessorKey: 'name', id: 'name' }],
+      data: [{ name: null }, { name: 'hello' }, { name: 'welcome' }],
+      initialState: {
+        columnFilters: [{ id: 'name', value: 'ell' }],
+      },
+    })
+
+    expect(
+      table.getFilteredRowModel().rows.map((row) => row.original.name),
+    ).toEqual(['hello'])
+  })
+
   describe('unresolvable global filter fn', () => {
     afterEach(() => {
       vi.unstubAllEnvs()

--- a/packages/table-core/tests/unit/features/column-filtering/columnFilteringFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/column-filtering/columnFilteringFeature.utils.test.ts
@@ -4,6 +4,7 @@ import {
   constructTable,
   filterFn_arrIncludes,
   filterFn_equals,
+  filterFn_includesString,
   filterFns,
 } from '../../../../src'
 import {
@@ -63,6 +64,19 @@ describe('column_getAutoFilterFn', () => {
     const column = table.getColumn('details')!
 
     expect(column_getAutoFilterFn(column)).toBe(filterFn_equals)
+  })
+
+  it('infers the filter from the first non-null column value', () => {
+    type NullableSample = { name: string | null }
+    const table = constructTable({
+      features,
+      columns: [{ accessorKey: 'name', id: 'name' }],
+      data: [{ name: null }, { name: 'hello' }] satisfies Array<NullableSample>,
+    })
+
+    expect(column_getAutoFilterFn(table.getColumn('name')!)).toBe(
+      filterFn_includesString,
+    )
   })
 })
 


### PR DESCRIPTION
## What changed

- infer an automatic column filter from the first non-nullish value in the column
- retain the existing `weakEquals` fallback when no value is available
- add unit coverage for filter-function inference and integration coverage for nullable string filtering

## Why

Automatic filter selection previously inspected only the first row. If that row contained `null`, a nullable string column received `weakEquals`, so partial string filtering failed and behavior changed when row order changed.

Using the first available value keeps the existing automatic filter choices while making nullable columns deterministic for the reported case.

## Validation

- column-filtering unit and implementation suites — 52 tests passed
- Prettier and `git diff --check`

Closes #4711


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic column filter selection when leading rows contain empty values.
  * Column filters now correctly identify and match non-empty string values even when the first row is null or undefined.
* **Tests**
  * Added regression coverage for nullable columns and automatic string-filter detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->