### PR TITLE
fix(table-core): support numeric accessor keys

### DIFF
--- a/packages/table-core/src/core/columns/constructColumn.ts
+++ b/packages/table-core/src/core/columns/constructColumn.ts
@@ -51,10 +51,12 @@ export function constructColumn<
   } as ColumnDefResolved<{}, TData, TValue>
 
   const accessorKey = resolvedColumnDef.accessorKey
+  const accessorKeyString =
+    accessorKey === undefined ? undefined : String(accessorKey)
 
   const id =
     resolvedColumnDef.id ??
-    (accessorKey ? accessorKey.replaceAll('.', '_') : undefined) ??
+    accessorKeyString?.replaceAll('.', '_') ??
     (typeof resolvedColumnDef.header === 'string'
       ? resolvedColumnDef.header
       : undefined)
@@ -63,9 +65,9 @@ export function constructColumn<
 
   if (resolvedColumnDef.accessorFn) {
     accessorFn = resolvedColumnDef.accessorFn
-  } else if (accessorKey) {
+  } else if (accessorKey !== undefined) {
     // Support deep accessor keys
-    if (accessorKey.includes('.')) {
+    if (typeof accessorKey === 'string' && accessorKey.includes('.')) {
       const keys = accessorKey.split('.')
       accessorFn = (originalRow: TData) => {
         let result = originalRow as Record<string, any> | undefined

--- a/packages/table-core/src/types/ColumnDef.ts
+++ b/packages/table-core/src/types/ColumnDef.ts
@@ -254,5 +254,5 @@ export type ColumnDefResolved<
   TData extends RowData,
   TValue extends CellData = CellData,
 > = Partial<UnionToIntersection<ColumnDef<TFeatures, TData, TValue>>> & {
-  accessorKey?: string
+  accessorKey?: (string & {}) | keyof TData
 }

--- a/packages/table-core/src/types/type-utils.ts
+++ b/packages/table-core/src/types/type-utils.ts
@@ -80,7 +80,7 @@ export type DeepValue<T, TProp> =
   T extends Record<string | number, any>
     ? TProp extends `${infer TBranch}.${infer TDeepProp}`
       ? DeepValue<T[TBranch], TDeepProp>
-      : T[TProp & string]
+      : T[TProp & keyof T]
     : never
 
 export type NoInfer<T> = [T][T extends any ? 0 : never]

--- a/packages/table-core/src/worker/initTableWorker.ts
+++ b/packages/table-core/src/worker/initTableWorker.ts
@@ -94,9 +94,9 @@ export function initTableWorker<
           .map(
             (def) =>
               def.id ??
-              (typeof def.accessorKey === 'string'
-                ? def.accessorKey.replaceAll('.', '_')
-                : undefined),
+              (def.accessorKey === undefined
+                ? undefined
+                : String(def.accessorKey).replaceAll('.', '_')),
           )
           .filter((id): id is string => id != null)
       } else {

--- a/packages/table-core/tests/unit/helpers/columnHelper.test.ts
+++ b/packages/table-core/tests/unit/helpers/columnHelper.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { constructTable, createColumnHelper } from '../../../src'
 import { testFeatures } from '../../fixtures/features'
 
@@ -73,5 +73,30 @@ describe('createColumnHelper', () => {
     expect(row.getValue('firstName')).toBe('Tanner')
     expect(row.getValue('shouty')).toBe('LINSLEY')
     expect(row.getValue('actions')).toBeUndefined()
+  })
+
+  it('should resolve numeric accessor keys for tuple rows', () => {
+    type TupleRow = [string, number]
+    const tupleHelper = createColumnHelper<typeof features, TupleRow>()
+    const firstColumn = tupleHelper.accessor(0, {
+      cell: (info) => {
+        expectTypeOf(info.getValue()).toEqualTypeOf<string>()
+        return info.getValue()
+      },
+    })
+    const secondColumn = tupleHelper.accessor(1, {})
+    const table = constructTable<typeof features, TupleRow>({
+      features,
+      columns: tupleHelper.columns([firstColumn, secondColumn]),
+      data: [['Alice', 42]],
+    })
+    const row = table.getRowModel().rows[0]!
+
+    expect(table.getAllLeafColumns().map((column) => column.id)).toEqual([
+      '0',
+      '1',
+    ])
+    expect(row.getValue('0')).toBe('Alice')
+    expect(row.getValue('1')).toBe(42)
   })
 })


### PR DESCRIPTION
## What changed

- support numeric `accessorKey` values when constructing tuple/array columns
- derive stable string column IDs while retaining the numeric key for row access
- preserve numeric tuple value inference in `DeepValue`
- keep worker aggregation column IDs consistent with normal column construction
- add runtime and type-level regression coverage for tuple indices `0` and `1`

## Why

Numeric tuple accessors are accepted by the public types and documented usage, but column construction treated index `0` as absent and called string methods on other numeric indices. This caused valid array-index columns either to lack an ID/accessor or to throw.

## Validation

- all `@tanstack/table-core` tests: 52 files, 1,002 tests passed
- TypeScript source and declaration-emit checks passed
- Prettier check passed
- `git diff --check` passed

Closes #4815


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for numeric accessor keys, including tuple-based row data.
  * Column identifiers are now generated correctly from numeric and other defined accessor keys.
  * Improved type support for accessing properties through non-string keys.

* **Bug Fixes**
  * Corrected handling of falsy accessor keys such as `0` and empty strings.
  * Improved deep property access and aggregation column identifier generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->