### PR TITLE
fix(table-core): respect resize handler context document

### DIFF
--- a/packages/table-core/src/features/column-resizing/columnResizingFeature.utils.ts
+++ b/packages/table-core/src/features/column-resizing/columnResizingFeature.utils.ts
@@ -239,7 +239,7 @@ export function header_getResizeHandler<
     }
 
     const contextDocument =
-      _contextDocument || typeof document !== 'undefined' ? document : null
+      _contextDocument || (typeof document !== 'undefined' ? document : null)
 
     const mouseEvents = {
       moveHandler: (e: MouseEvent) => onMove(e.clientX),

--- a/packages/table-core/tests/unit/features/column-resizing/columnResizingFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/column-resizing/columnResizingFeature.utils.test.ts
@@ -259,6 +259,27 @@ describe('header_getResizeHandler', () => {
     expect(typeof handler).toBe('function')
   })
 
+  it('should attach listeners to an explicit context document', () => {
+    const table = makeTable(1)
+    const header = createTestResizeHeader(table)
+    const contextDocument = document.implementation.createHTMLDocument()
+    const addEventListener = vi.spyOn(contextDocument, 'addEventListener')
+    const handler = header_getResizeHandler(header as any, contextDocument)
+
+    handler({ type: 'mousedown', clientX: 100 })
+
+    expect(addEventListener).toHaveBeenCalledWith(
+      'mousemove',
+      expect.any(Function),
+      expect.anything(),
+    )
+    expect(addEventListener).toHaveBeenCalledWith(
+      'mouseup',
+      expect.any(Function),
+      expect.anything(),
+    )
+  })
+
   it('should not resize when column resizing is disabled', () => {
     const table = makeTable(1, {
       enableColumnResizing: false,


### PR DESCRIPTION
## What changed

- respect the `Document` passed to `header.getResizeHandler`
- add a regression test that verifies resize listeners attach to that document

## Why

The context-document fallback mixed `||` with a conditional expression without parentheses. In browser environments, that made the global `document` win even when a portal or detached-window document was explicitly supplied, so move and up events were observed on the wrong page.

This restores the existing API's intended behavior without adding new surface area.

## Validation

- all `@tanstack/table-core` tests: 52 files, 1,002 tests passed
- Prettier check passed
- `git diff --check` passed

Closes #4483


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved column resizing behavior when operating with a provided document context.
  * Ensured resize event listeners attach to the intended document in supported environments.

* **Tests**
  * Added coverage confirming mouse movement and release events use the provided document context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->