### PR TITLE
fix controlled state handling for undefined options

### DIFF
--- a/packages/table-core/src/core/table/constructTable.ts
+++ b/packages/table-core/src/core/table/constructTable.ts
@@ -74,6 +74,19 @@ export function constructTable<
 
   const mergedOptions = { ...defaultOptions, ...tableOptions }
 
+  // Optional options passed through wrapper components commonly arrive as
+  // explicit `undefined` values. Treat those the same as omitted options so
+  // they do not replace feature defaults such as state updater callbacks.
+  for (const key in tableOptions) {
+    if (
+      tableOptions[key as keyof typeof tableOptions] === undefined &&
+      defaultOptions[key as keyof typeof defaultOptions] !== undefined
+    ) {
+      ;(mergedOptions as Record<string, unknown>)[key] =
+        defaultOptions[key as keyof typeof defaultOptions]
+    }
+  }
+
   if (_reactivity.wrapExternalAtoms && mergedOptions.atoms) {
     for (const [atomKey, _atom] of Object.entries(mergedOptions.atoms)) {
       const atom = _atom as Atom<any>

--- a/packages/table-core/src/core/table/coreTablesFeature.utils.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.utils.ts
@@ -26,12 +26,16 @@ export function table_syncExternalStateToBaseAtoms<
 
   table._reactivity.batch(() => {
     for (const key in state) {
+      const externalState = state[key as keyof typeof state]
+      if (externalState === undefined) {
+        continue
+      }
+
       const baseAtom = (table.baseAtoms as Record<string, any>)[key]
       if (!baseAtom) {
         continue
       }
 
-      const externalState = state[key as keyof typeof state]
       if (externalState !== table._reactivity.untrack(() => baseAtom.get())) {
         baseAtom.set(() => externalState)
       }
@@ -94,13 +98,20 @@ export function table_mergeOptions<
 
   // simple merge if no mergeOptions is provided - performant
   if (!table.options.mergeOptions) {
+    const mergedOptions = { ...table.options }
+    for (const key in newOptions) {
+      const value = newOptions[key as keyof typeof newOptions]
+      if (value !== undefined) {
+        ;(mergedOptions as Record<string, unknown>)[key] = value
+      }
+    }
+
     return {
-      ...table.options,
-      ...newOptions,
+      ...mergedOptions,
       features,
       atoms,
       initialState,
-    }
+    } as TableOptions<TFeatures, TData>
   }
 
   // else use the mergeOptions function and preserve getters/setters

--- a/packages/table-core/tests/unit/core/tableAtoms.test.ts
+++ b/packages/table-core/tests/unit/core/tableAtoms.test.ts
@@ -68,6 +68,26 @@ describe('three-layer atom architecture', () => {
       expect(table.store.state.sorting).toEqual(external)
     })
 
+    it('treats undefined controlled state and callbacks as omitted', () => {
+      const table = makeTable({
+        // Simulate optional wrapper props passed through without conditionally
+        // removing their keys.
+        state: { sorting: undefined } as unknown as { sorting: SortingState },
+        onSortingChange: undefined,
+      })
+
+      expect(table.atoms.sorting.get()).toEqual([])
+
+      table.setOptions((old) => ({
+        ...old,
+        state: { sorting: undefined },
+        onSortingChange: undefined,
+      }))
+      table.setSorting([{ id: 'name', desc: false }])
+
+      expect(table.atoms.sorting.get()).toEqual([{ id: 'name', desc: false }])
+    })
+
     it('options.atoms[key] takes precedence over options.state[key] when both are present', () => {
       const externalAtom = createAtom<SortingState>([
         { id: 'fromAtom', desc: true },


### PR DESCRIPTION
## What changed

- treat explicitly `undefined` top-level options as omitted when resolving and updating table options
- ignore `undefined` values in legacy controlled `state` synchronization
- add a regression test covering optional controlled state and callback props passed through a wrapper

## Why

Wrapper components commonly forward optional state and change callback props. Previously, an explicit `undefined` state slice overwrote the table's valid base atom, while an explicit `undefined` callback replaced the feature's default internal updater. Either value could accidentally freeze an otherwise uncontrolled state slice.

This keeps defined controlled values unchanged while making `undefined` behave like an omitted optional prop.

## Validation

- `pnpm exec vitest run packages/table-core/tests/unit/core/tableAtoms.test.ts` (11 tests)
- `pnpm nx run @tanstack/table-core:test:lib --run` (52 files, 1002 tests)
- `pnpm nx run @tanstack/table-core:test:types`
- ESLint on changed files
- `git diff --check`

Closes #4764
