### PR TITLE
fix(table-core): expand rows with manual pagination

### DIFF
--- a/packages/table-core/src/features/row-expanding/createExpandedRowModel.ts
+++ b/packages/table-core/src/features/row-expanding/createExpandedRowModel.ts
@@ -25,6 +25,7 @@ export function createExpandedRowModel<
         table.atoms.expanded?.get(),
         table.getPreExpandedRowModel(),
         table.options.paginateExpandedRows,
+        table.options.manualPagination,
       ],
       fn: () => _createExpandedRowModel(table),
     })
@@ -45,7 +46,7 @@ function _createExpandedRowModel<
     return rowModel
   }
 
-  if (!table.options.paginateExpandedRows) {
+  if (!table.options.paginateExpandedRows && !table.options.manualPagination) {
     // Only expand rows at this point if they are being paginated
     return rowModel
   }

--- a/packages/table-core/tests/implementation/features/row-pagination/createPaginatedRowModel.test.ts
+++ b/packages/table-core/tests/implementation/features/row-pagination/createPaginatedRowModel.test.ts
@@ -232,5 +232,23 @@ describe('createPaginatedRowModel', () => {
         '4',
       ])
     })
+
+    it('should include expanded children when expanded rows bypass manual pagination', () => {
+      const table = createTable({
+        data: makeNestedData(),
+        manualPagination: true,
+        paginateExpandedRows: false,
+      })
+
+      table.getRow('0').toggleExpanded()
+
+      expect(table.getRowModel().rows.map((row) => row.id)).toEqual([
+        '0',
+        '0.0',
+        '0.1',
+        '1',
+        '2',
+      ])
+    })
   })
 })


### PR DESCRIPTION
## Summary

- expand already-paginated parent rows when manual pagination bypasses the client pagination row model
- keep deferring expansion when client pagination is responsible for slicing parents before inserting descendants
- include manualPagination in the expanded row-model memo dependencies
- add a regression test for manualPagination with paginateExpandedRows disabled

## Why

With manualPagination enabled, the table assumes incoming data already represents a page and bypasses createPaginatedRowModel. When paginateExpandedRows was false, createExpandedRowModel also deferred expansion to that skipped pagination stage, so expanded children never appeared.

This preserves the documented behavior that expanded children remain on their parent page without consuming page slots, while making it work for data paginated outside the table.

## Validation

- 52 table-core test files passed (1,005 tests)
- table-core TypeScript checks passed, including declaration emit
- table-core ESLint passed
- Prettier check passed

Closes #5110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed row expansion behavior when manual pagination is enabled.
  * Expanded child rows now appear correctly when expanded rows are not paginated.

* **Tests**
  * Added coverage verifying expanded row ordering and visibility under manual pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->