### PR TITLE
fix(table-core): avoid parent lookup re-entrancy

### DIFF
--- a/packages/table-core/src/core/rows/coreRowsFeature.utils.ts
+++ b/packages/table-core/src/core/rows/coreRowsFeature.utils.ts
@@ -188,8 +188,8 @@ export function table_getMaxSubRowDepth<
 /**
  * Looks up this row's direct parent, if it has one.
  *
- * Parent lookup searches the pre-pagination row model so parent relationships
- * are available even when the parent is not on the current page.
+ * Parent lookup prefers the core row model for structural parents, then falls
+ * back to the pre-pagination row model for generated parent rows.
  *
  * @example
  * ```ts
@@ -200,7 +200,14 @@ export function row_getParentRow<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>) {
-  return row.parentId ? row.table.getRow(row.parentId, true) : undefined
+  if (!row.parentId) {
+    return undefined
+  }
+
+  return (
+    row.table.getCoreRowModel().rowsById[row.parentId] ??
+    row.table.getRow(row.parentId, true)
+  )
 }
 
 /**

--- a/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
+++ b/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
@@ -80,6 +80,55 @@ const rowNames = (rows: Array<{ original: { name: string } }>) =>
   rows.map((row) => row.original.name)
 
 describe('createFilteredRowModel', () => {
+  it('allows a filter function to inspect structural parent rows', () => {
+    const parentAwareFilter: FilterFn<typeof features, NestedRow> = (
+      row,
+      columnId,
+      filterValue,
+    ) => {
+      const parent = row.getParentRow()
+      return [row, parent]
+        .filter((candidate) => candidate !== undefined)
+        .some((candidate) =>
+          String(candidate.getValue(columnId))
+            .toLowerCase()
+            .includes(String(filterValue).toLowerCase()),
+        )
+    }
+    const table = constructTable<typeof features, NestedRow>({
+      features,
+      columns: [
+        {
+          accessorKey: 'name',
+          id: 'name',
+          filterFn: parentAwareFilter,
+        },
+      ],
+      data: [
+        { name: 'parent', subRows: [{ name: 'child' }] },
+        { name: 'other', subRows: [{ name: 'nested' }] },
+      ],
+      getSubRows: (row) => row.subRows,
+      initialState: {
+        columnFilters: [{ id: 'name', value: 'parent' }],
+      },
+    })
+
+    expect(() => table.getFilteredRowModel()).not.toThrow()
+    expect(rowNames(table.getFilteredRowModel().flatRows).sort()).toEqual([
+      'child',
+      'parent',
+    ])
+
+    table.setColumnFilters([{ id: 'name', value: 'other' }])
+
+    expect(() => table.getFilteredRowModel()).not.toThrow()
+    expect(rowNames(table.getFilteredRowModel().flatRows).sort()).toEqual([
+      'nested',
+      'other',
+    ])
+  })
+
   it('should assign display indexes in filtered row order', () => {
     const table = constructTable<typeof features, TestRow>({
       features,


### PR DESCRIPTION
Closes #5630

## What changed

- Resolve structural parent rows from the core row model before consulting the pre-pagination model.
- Preserve the pre-pagination fallback for generated parent rows, such as grouped rows.
- Add a regression test for parent-aware column filter functions with both an initial filter and a subsequent filter update.

## Why

During filtered-row-model construction, a custom filter function can call row.getParentRow(). The previous lookup entered the pre-pagination pipeline, which requests the filtered model currently being built and reads rowsById from an incomplete result. Looking up structural parents from the already-built core row model avoids this re-entrancy without changing support for generated parents.

## Validation

- pnpm --filter @tanstack/table-core test:lib --run (52 files, 1005 tests)
- pnpm --filter @tanstack/table-core test:types
- pnpm --filter @tanstack/table-core test:eslint
- Prettier check on changed files
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested-row filtering so filter functions can reliably inspect structural parent rows.
  * Ensured matching child rows and their relevant parent rows are included correctly in filtered results.
  * Prevented errors when filtering nested data across different parent branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->