### PR TITLE
fix(table-core): reset expansion when data changes

### DIFF
--- a/packages/table-core/src/core/row-models/createCoreRowModel.ts
+++ b/packages/table-core/src/core/row-models/createCoreRowModel.ts
@@ -1,5 +1,6 @@
 import { constructRow } from '../rows/constructRow'
 import { makeObjectMap, tableMemo } from '../../utils'
+import { table_autoResetExpanded } from '../../features/row-expanding/rowExpandingFeature.utils'
 import { table_autoResetPageIndex } from '../../features/row-pagination/rowPaginationFeature.utils'
 import type { Table_Internal } from '../../types/Table'
 import type { RowModel } from './coreRowModelsFeature.types'
@@ -25,7 +26,10 @@ export function createCoreRowModel<
       fnName: 'table.getCoreRowModel',
       memoDeps: () => [table.options.data],
       fn: () => _createCoreRowModel(table, table.options.data),
-      onAfterUpdate: () => table_autoResetPageIndex(table),
+      onAfterUpdate: () => {
+        table_autoResetExpanded(table)
+        table_autoResetPageIndex(table)
+      },
     })
   }
 }

--- a/packages/table-core/tests/implementation/core/autoReset.test.ts
+++ b/packages/table-core/tests/implementation/core/autoReset.test.ts
@@ -52,6 +52,10 @@ const features = testFeatures({
   sortFns,
 })
 
+const expandingOnlyFeatures = testFeatures({
+  rowExpandingFeature,
+})
+
 const columns: Array<ColumnDef<typeof features, Person, any>> = [
   { accessorKey: 'name', id: 'name' },
   { accessorKey: 'age', id: 'age' },
@@ -91,7 +95,7 @@ function makeTable(
 
 // Pull the row model once and flush so the initial memo runs (which itself
 // schedules autoReset callbacks) do not interfere with the test assertions.
-async function primeTable(table: ReturnType<typeof makeTable>) {
+async function primeTable(table: { getRowModel: () => unknown }) {
   table.getRowModel()
   await flushMicrotasks()
   await flushMicrotasks()
@@ -241,6 +245,26 @@ describe('autoResetPageIndex end-to-end wiring', () => {
 })
 
 describe('autoResetExpanded end-to-end wiring', () => {
+  it('should reset expanded when data changes without the grouping feature', async () => {
+    const table = constructTable<typeof expandingOnlyFeatures, Person>({
+      features: expandingOnlyFeatures,
+      columns: [{ accessorKey: 'name', id: 'name' }],
+      data: makeData(),
+      getSubRows: (row) => row.subRows,
+    })
+    await primeTable(table)
+
+    table.getRow('1').toggleExpanded(true)
+    expect(table.atoms.expanded.get()).toEqual({ '1': true })
+
+    table.setOptions((old) => ({ ...old, data: makeData() }))
+    table.getRowModel()
+    await flushMicrotasks()
+    await flushMicrotasks()
+
+    expect(table.atoms.expanded.get()).toEqual({})
+  })
+
   it('should reset expanded to an empty map when grouping changes', async () => {
     const table = makeTable()
     await primeTable(table)


### PR DESCRIPTION
Closes #5801

## Decision

This remains a valid, narrowly scoped bug in the latest v9 beta. The existing automatic expansion reset is attached to the grouped row-model stage, so it happens only when grouping support is installed. A table using row expansion without grouping retains stale expanded row IDs after its data reference changes, despite the autoResetExpanded option contract.

This is not a new API or a behavior redesign. It connects the existing reset helper to the core data-dependent row model, alongside the existing automatic page-index reset.

## Changes

- run the existing expanded-state auto-reset after the core row model recomputes for a new data reference
- add an end-to-end regression test using expansion without the grouping feature
- retain the existing autoResetAll, autoResetExpanded, manualExpanding, initial-state, and controlled-state updater semantics

## Verification

- regression test fails on beta before the implementation change, retaining the expanded row ID
- table-core focused auto-reset suite: 22 tests passed
- full table-core suite: 52 files and 1,005 tests passed
- TypeScript source and declaration-emit checks passed
- ESLint passed for changed files
- Prettier check passed for changed files