### PR TITLE
fix(table-core): preserve `undefined` in DeepValue for optional deep accessor keys

### DIFF
--- a/.changeset/deep-value-optional-key.md
+++ b/.changeset/deep-value-optional-key.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Preserve `undefined` in `DeepValue` accessor value types when a deep string accessor key traverses an optional or nullable parent key. `getValue()` for a path like `user.salary.amount` is now typed as `number | undefined` when `salary` is optional, matching the optional-chaining behavior of the runtime deep accessor.

--- a/packages/table-core/src/types/type-utils.ts
+++ b/packages/table-core/src/types/type-utils.ts
@@ -76,8 +76,9 @@ type DeepKeysPrefix<
   ? `${TPrefix}.${DeepKeys<T[TPrefix], [...TDepth, any]> & string}`
   : never
 
-export type DeepValue<T, TProp> =
-  T extends Record<string | number, any>
+export type DeepValue<T, TProp> = T extends null | undefined
+  ? undefined
+  : T extends Record<string | number, any>
     ? TProp extends `${infer TBranch}.${infer TDeepProp}`
       ? DeepValue<T[TBranch], TDeepProp>
       : T[TProp & keyof T]

--- a/packages/table-core/tests/unit/helpers/columnHelper.test.ts
+++ b/packages/table-core/tests/unit/helpers/columnHelper.test.ts
@@ -99,4 +99,33 @@ describe('createColumnHelper', () => {
     expect(row.getValue('0')).toBe('Alice')
     expect(row.getValue('1')).toBe(42)
   })
+
+  it('should preserve undefined for optional deep accessor keys', () => {
+    type DeepPerson = {
+      user: {
+        salary?: {
+          amount: number
+        }
+      }
+    }
+    const deepHelper = createColumnHelper<typeof features, DeepPerson>()
+    const column = deepHelper.accessor('user.salary.amount', {
+      cell: (info) => {
+        // `salary` is optional, so the resolved deep value can be `undefined`
+        expectTypeOf(info.getValue()).toEqualTypeOf<number | undefined>()
+        return info.getValue()
+      },
+    })
+    const table = constructTable<typeof features, DeepPerson>({
+      features,
+      columns: deepHelper.columns([column]),
+      data: [{ user: { salary: { amount: 42 } } }],
+    })
+    const row = table.getRowModel().rows[0]!
+
+    expect(table.getAllLeafColumns().map((c) => c.id)).toEqual([
+      'user_salary_amount',
+    ])
+    expect(row.getValue('user_salary_amount')).toBe(42)
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Fixes the `DeepValue` type so that a deep string accessor key that traverses an **optional** (or nullable) parent key keeps `undefined` in the resolved value type.

```ts
type Row = {
  user: {
    salary?: {
      amount: number
    }
  }
}

const columnHelper = createColumnHelper<Row>()

columnHelper.accessor('user.salary.amount', {
  cell: (info) => {
    const amount = info.getValue()
    //    ^? before: number   (🐛 optional `salary` dropped)
    //    ^? after:  number | undefined
    return amount
  },
})
```

## 🔎 Root cause

`DeepValue` recurses down the dotted key path. When a parent key is optional, the branch value is a union such as `{ amount: number } | undefined`. The conditional distributes over that union, and the `undefined` member falls through to the final `: never`, so the `undefined` was silently dropped from the leaf type.

The runtime deep accessor built in `constructColumn` walks the path with optional chaining (`result?.[key]`), so a missing/`null`/`undefined` intermediate value actually resolves to `undefined` at runtime. The type therefore under-reported the possible values.

## 🛠️ The fix

Add a leading `T extends null | undefined ? undefined` guard to `DeepValue`. Because the conditional distributes over the leaf union, `undefined`/`null` intermediates now contribute `undefined` (matching the optional-chaining behavior of the runtime accessor), while every existing non-nullish path is unchanged.

```ts
export type DeepValue<T, TProp> = T extends null | undefined
  ? undefined
  : T extends Record<string | number, any>
    ? TProp extends `${infer TBranch}.${infer TDeepProp}`
      ? DeepValue<T[TBranch], TDeepProp>
      : T[TProp & keyof T]
    : never
```

## ✅ How this was checked

Added a regression test in `tests/unit/helpers/columnHelper.test.ts` alongside the existing accessor type tests. It asserts, via `expectTypeOf`, that `info.getValue()` is `number | undefined` for the optional deep path `user.salary.amount`, and confirms the value still resolves at runtime. This is exercised by `test:types` (`tsc`) and `test:lib` (vitest); non-optional and numeric/tuple accessor paths keep their existing types.

Note: this targets the v9 `beta` branch. The equivalent v8 report is [#6238](https://github.com/TanStack/table/issues/6238) (the v8 code lives in a different file, `src/utils.ts`).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript typing for deep accessors that traverse optional or nullable properties.
  * Accessor values now correctly include `undefined` when intermediate data may be missing.
  * Preserved expected runtime behavior for optional deep paths and column value resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->