### PR TITLE
fix: remove shadow class from examples to prevent ad blocker false positives

### DIFF
--- a/examples/angular/column-ordering/src/app/app.component.html
+++ b/examples/angular/column-ordering/src/app/app.component.html
@@ -1,5 +1,5 @@
 <div class="p-2">
-  <div class="inline-block border border-black shadow rounded">
+  <div class="inline-block border border-black rounded">
     <div class="px-1 border-b border-black">
       <label>
         <input

--- a/examples/angular/column-pinning-sticky/src/app/app.component.html
+++ b/examples/angular/column-pinning-sticky/src/app/app.component.html
@@ -1,5 +1,5 @@
 <div class="p-2">
-  <div class="inline-block border border-black shadow rounded">
+  <div class="inline-block border border-black rounded">
     <div class="px-1 border-b border-black">
       <label>
         <input

--- a/examples/angular/column-pinning/src/app/app.component.html
+++ b/examples/angular/column-pinning/src/app/app.component.html
@@ -1,5 +1,5 @@
 <div class="p-2">
-  <div class="inline-block border border-black shadow rounded">
+  <div class="inline-block border border-black rounded">
     <div class="px-1 border-b border-black">
       <label>
         <input

--- a/examples/angular/column-visibility/src/app/app.component.html
+++ b/examples/angular/column-visibility/src/app/app.component.html
@@ -1,5 +1,5 @@
 <div class="p-2">
-  <div class="inline-block border border-black shadow rounded">
+  <div class="inline-block border border-black rounded">
     <div class="px-1 border-b border-black">
       <label>
         <input

--- a/examples/qwik/filters/src/main.tsx
+++ b/examples/qwik/filters/src/main.tsx
@@ -212,7 +212,7 @@ const App = component$(() => {
           onInput$={$((e: InputEvent) => {
             globalFilter.value = (e.target as HTMLInputElement).value
           })}
-          class="p-2 font-lg shadow border border-block"
+          class="p-2 font-lg border border-block"
           placeholder="Search all columns..."
         />
       </div>
@@ -312,7 +312,7 @@ function Filter({
               ? `(${column.getFacetedMinMaxValues()?.[0]})`
               : ''
           }`}
-          class="w-24 border shadow rounded"
+          class="w-24 border rounded"
         />
         <input
           type="number"
@@ -329,7 +329,7 @@ function Filter({
               ? `(${column.getFacetedMinMaxValues()?.[1]})`
               : ''
           }`}
-          class="w-24 border shadow rounded"
+          class="w-24 border rounded"
         />
       </div>
       <div class="h-1" />
@@ -351,7 +351,7 @@ function Filter({
           // column.setFilterValue(e.target.value)
         })}
         placeholder={`Search... (${column.getFacetedUniqueValues().size})`}
-        // class="w-36 border shadow rounded"
+        // class="w-36 border rounded"
         // list={column.id + 'list'}
       />
       <div class="h-1" />

--- a/examples/react/column-ordering/src/main.tsx
+++ b/examples/react/column-ordering/src/main.tsx
@@ -97,7 +97,7 @@ function App() {
 
   return (
     <div className="p-2">
-      <div className="inline-block border border-black shadow rounded">
+      <div className="inline-block border border-black rounded">
         <div className="px-1 border-b border-black">
           <label>
             <input

--- a/examples/react/column-pinning-sticky/src/main.tsx
+++ b/examples/react/column-pinning-sticky/src/main.tsx
@@ -109,7 +109,7 @@ function App() {
 
   return (
     <div className="p-2">
-      <div className="inline-block border border-black shadow rounded">
+      <div className="inline-block border border-black rounded">
         <div className="px-1 border-b border-black">
           <label>
             <input

--- a/examples/react/column-pinning/src/main.tsx
+++ b/examples/react/column-pinning/src/main.tsx
@@ -103,7 +103,7 @@ function App() {
 
   return (
     <div className="p-2">
-      <div className="inline-block border border-black shadow rounded">
+      <div className="inline-block border border-black rounded">
         <div className="px-1 border-b border-black">
           <label>
             <input

--- a/examples/react/column-visibility/src/main.tsx
+++ b/examples/react/column-visibility/src/main.tsx
@@ -122,7 +122,7 @@ function App() {
 
   return (
     <div className="p-2">
-      <div className="inline-block border border-black shadow rounded">
+      <div className="inline-block border border-black rounded">
         <div className="px-1 border-b border-black">
           <label>
             <input

--- a/examples/react/custom-features/src/main.tsx
+++ b/examples/react/custom-features/src/main.tsx
@@ -362,7 +362,7 @@ function Filter({
           ])
         }
         placeholder={`Min`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
       <input
         type="number"
@@ -374,7 +374,7 @@ function Filter({
           ])
         }
         placeholder={`Max`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
     </div>
   ) : (
@@ -383,7 +383,7 @@ function Filter({
       value={(columnFilterValue ?? '') as string}
       onChange={(e) => column.setFilterValue(e.target.value)}
       placeholder={`Search...`}
-      className="w-36 border shadow rounded"
+      className="w-36 border rounded"
     />
   )
 }
@@ -396,3 +396,4 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>,
 )
+

--- a/examples/react/editable-data/src/main.tsx
+++ b/examples/react/editable-data/src/main.tsx
@@ -304,7 +304,7 @@ function Filter({
           ])
         }
         placeholder={`Min`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
       <input
         type="number"
@@ -316,7 +316,7 @@ function Filter({
           ])
         }
         placeholder={`Max`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
     </div>
   ) : (
@@ -325,7 +325,7 @@ function Filter({
       value={(columnFilterValue ?? '') as string}
       onChange={(e) => column.setFilterValue(e.target.value)}
       placeholder={`Search...`}
-      className="w-36 border shadow rounded"
+      className="w-36 border rounded"
     />
   )
 }
@@ -338,3 +338,4 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>,
 )
+

--- a/examples/react/expanding/src/main.tsx
+++ b/examples/react/expanding/src/main.tsx
@@ -284,7 +284,7 @@ function Filter({
           ])
         }
         placeholder={`Min`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
       <input
         type="number"
@@ -296,7 +296,7 @@ function Filter({
           ])
         }
         placeholder={`Max`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
     </div>
   ) : (
@@ -305,7 +305,7 @@ function Filter({
       value={(columnFilterValue ?? '') as string}
       onChange={(e) => column.setFilterValue(e.target.value)}
       placeholder={`Search...`}
-      className="w-36 border shadow rounded"
+      className="w-36 border rounded"
     />
   )
 }
@@ -341,3 +341,4 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>,
 )
+

--- a/examples/react/filters-faceted/src/main.tsx
+++ b/examples/react/filters-faceted/src/main.tsx
@@ -272,7 +272,7 @@ function Filter({ column }: { column: Column<any, unknown> }) {
               ? `(${column.getFacetedMinMaxValues()?.[0]})`
               : ''
           }`}
-          className="w-24 border shadow rounded"
+          className="w-24 border rounded"
         />
         <DebouncedInput
           type="number"
@@ -287,7 +287,7 @@ function Filter({ column }: { column: Column<any, unknown> }) {
               ? `(${column.getFacetedMinMaxValues()?.[1]})`
               : ''
           }`}
-          className="w-24 border shadow rounded"
+          className="w-24 border rounded"
         />
       </div>
       <div className="h-1" />
@@ -318,7 +318,7 @@ function Filter({ column }: { column: Column<any, unknown> }) {
         value={(columnFilterValue ?? '') as string}
         onChange={(value) => column.setFilterValue(value)}
         placeholder={`Search... (${column.getFacetedUniqueValues().size})`}
-        className="w-36 border shadow rounded"
+        className="w-36 border rounded"
         list={column.id + 'list'}
       />
       <div className="h-1" />
@@ -368,3 +368,4 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>,
 )
+

--- a/examples/react/filters-fuzzy/src/main.tsx
+++ b/examples/react/filters-fuzzy/src/main.tsx
@@ -146,7 +146,7 @@ function App() {
         <DebouncedInput
           value={globalFilter ?? ''}
           onChange={(value) => setGlobalFilter(String(value))}
-          className="p-2 font-lg shadow border border-block"
+          className="p-2 font-lg border border-block"
           placeholder="Search all columns..."
         />
       </div>
@@ -301,7 +301,7 @@ function Filter({ column }: { column: Column<any, unknown> }) {
       value={(columnFilterValue ?? '') as string}
       onChange={(value) => column.setFilterValue(value)}
       placeholder={`Search...`}
-      className="w-36 border shadow rounded"
+      className="w-36 border rounded"
     />
   )
 }
@@ -348,3 +348,4 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>,
 )
+

--- a/examples/react/filters/src/main.tsx
+++ b/examples/react/filters/src/main.tsx
@@ -259,7 +259,7 @@ function Filter({ column }: { column: Column<any, unknown> }) {
             column.setFilterValue((old: [number, number]) => [value, old?.[1]])
           }
           placeholder={`Min`}
-          className="w-24 border shadow rounded"
+          className="w-24 border rounded"
         />
         <DebouncedInput
           type="number"
@@ -268,7 +268,7 @@ function Filter({ column }: { column: Column<any, unknown> }) {
             column.setFilterValue((old: [number, number]) => [old?.[0], value])
           }
           placeholder={`Max`}
-          className="w-24 border shadow rounded"
+          className="w-24 border rounded"
         />
       </div>
       <div className="h-1" />
@@ -286,7 +286,7 @@ function Filter({ column }: { column: Column<any, unknown> }) {
     </select>
   ) : (
     <DebouncedInput
-      className="w-36 border shadow rounded"
+      className="w-36 border rounded"
       onChange={(value) => column.setFilterValue(value)}
       placeholder={`Search...`}
       type="text"
@@ -338,3 +338,4 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>,
 )
+

--- a/examples/react/kitchen-sink/src/App.tsx
+++ b/examples/react/kitchen-sink/src/App.tsx
@@ -146,11 +146,11 @@ export const App = () => {
           <DebouncedInput
             value={globalFilter ?? ''}
             onChange={(value) => setGlobalFilter(String(value))}
-            className="mx-1 p-2 font-lg shadow border border-block"
+            className="mx-1 p-2 font-lg border border-block"
             placeholder="Search all columns..."
           />
         </div>
-        <div className="p-2 inline-block border border-black shadow rounded">
+        <div className="p-2 inline-block border border-black rounded">
           <div className="px-1 border-b border-black">
             <label>
               <input

--- a/examples/react/kitchen-sink/src/components/Filter.tsx
+++ b/examples/react/kitchen-sink/src/components/Filter.tsx
@@ -31,7 +31,7 @@ const NumberInput: React.FC<NumberInputProps> = ({
             setFilterValue((old: [number, number]) => [value, old?.[1]])
           }
           placeholder={`Min ${minOpt ? `(${min})` : ''}`}
-          className="w-24 border shadow rounded"
+          className="w-24 border rounded"
         />
         <DebouncedInput
           type="number"
@@ -42,7 +42,7 @@ const NumberInput: React.FC<NumberInputProps> = ({
             setFilterValue((old: [number, number]) => [old?.[0], value])
           }
           placeholder={`Max ${maxOpt ? `(${max})` : ''}`}
-          className="w-24 border shadow rounded"
+          className="w-24 border rounded"
         />
       </div>
       <div className="h-1" />
@@ -79,7 +79,7 @@ const TextInput: React.FC<TextInputProps> = ({
         value={columnFilterValue ?? ''}
         onChange={(value) => setFilterValue(value)}
         placeholder={`Search... (${columnSize})`}
-        className="w-36 border shadow rounded"
+        className="w-36 border rounded"
         list={dataListId}
       />
       <div className="h-1" />
@@ -126,3 +126,4 @@ export function Filter<T extends RowData>({ column, table }: Props<T>) {
 }
 
 export default Filter
+

--- a/examples/react/material-ui-pagination/src/main.tsx
+++ b/examples/react/material-ui-pagination/src/main.tsx
@@ -221,7 +221,7 @@ function Filter({
           ])
         }
         placeholder={`Min`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
       <InputBase
         type="number"
@@ -233,7 +233,7 @@ function Filter({
           ])
         }
         placeholder={`Max`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
         inputProps={{ 'aria-label': 'search' }}
       />
     </div>
@@ -242,7 +242,7 @@ function Filter({
       value={(columnFilterValue ?? '') as string}
       onChange={(e) => column.setFilterValue(e.target.value)}
       placeholder={`Search...`}
-      className="w-36 border shadow rounded"
+      className="w-36 border rounded"
       inputProps={{ 'aria-label': 'search' }}
     />
   )
@@ -256,3 +256,4 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>,
 )
+

--- a/examples/react/pagination/src/main.tsx
+++ b/examples/react/pagination/src/main.tsx
@@ -264,7 +264,7 @@ function Filter({
           ])
         }
         placeholder={`Min`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
       <input
         type="number"
@@ -276,12 +276,12 @@ function Filter({
           ])
         }
         placeholder={`Max`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
     </div>
   ) : (
     <input
-      className="w-36 border shadow rounded"
+      className="w-36 border rounded"
       onChange={(e) => column.setFilterValue(e.target.value)}
       onClick={(e) => e.stopPropagation()}
       placeholder={`Search...`}
@@ -299,3 +299,4 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>,
 )
+

--- a/examples/react/query-router-search-params/src/components/table.tsx
+++ b/examples/react/query-router-search-params/src/components/table.tsx
@@ -80,7 +80,7 @@ export default function Table<T extends Record<string, string | number>>({
                         {header.column.getCanFilter() &&
                         fieldMeta?.filterKey !== undefined ? (
                           <DebouncedInput
-                            className="w-36 border shadow rounded"
+                            className="w-36 border rounded"
                             onChange={(value) => {
                               onFilterChange({
                                 [fieldMeta.filterKey as keyof T]: value,
@@ -186,3 +186,4 @@ export default function Table<T extends Record<string, string | number>>({
     </div>
   )
 }
+

--- a/examples/react/row-pinning/src/main.tsx
+++ b/examples/react/row-pinning/src/main.tsx
@@ -393,7 +393,7 @@ function Filter({
           column.setFilterValue((old: any) => [e.target.value, old?.[1]])
         }
         placeholder={`Min`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
       <input
         type="number"
@@ -402,7 +402,7 @@ function Filter({
           column.setFilterValue((old: any) => [old?.[0], e.target.value])
         }
         placeholder={`Max`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
     </div>
   ) : (
@@ -411,7 +411,7 @@ function Filter({
       value={(column.getFilterValue() ?? '') as string}
       onChange={(e) => column.setFilterValue(e.target.value)}
       placeholder={`Search...`}
-      className="w-36 border shadow rounded"
+      className="w-36 border rounded"
     />
   )
 }
@@ -424,3 +424,4 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>,
 )
+

--- a/examples/react/row-selection/src/main.tsx
+++ b/examples/react/row-selection/src/main.tsx
@@ -125,7 +125,7 @@ function App() {
         <input
           value={globalFilter ?? ''}
           onChange={(e) => setGlobalFilter(e.target.value)}
-          className="p-2 font-lg shadow border border-block"
+          className="p-2 font-lg border border-block"
           placeholder="Search all columns..."
         />
       </div>
@@ -314,7 +314,7 @@ function Filter({
           column.setFilterValue((old: any) => [e.target.value, old?.[1]])
         }
         placeholder={`Min`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
       <input
         type="number"
@@ -323,7 +323,7 @@ function Filter({
           column.setFilterValue((old: any) => [old?.[0], e.target.value])
         }
         placeholder={`Max`}
-        className="w-24 border shadow rounded"
+        className="w-24 border rounded"
       />
     </div>
   ) : (
@@ -332,7 +332,7 @@ function Filter({
       value={(column.getFilterValue() ?? '') as string}
       onChange={(e) => column.setFilterValue(e.target.value)}
       placeholder={`Search...`}
-      className="w-36 border shadow rounded"
+      className="w-36 border rounded"
     />
   )
 }
@@ -368,3 +368,4 @@ ReactDOM.createRoot(rootElement).render(
     <App />
   </React.StrictMode>,
 )
+

--- a/examples/solid/column-ordering/src/App.tsx
+++ b/examples/solid/column-ordering/src/App.tsx
@@ -96,7 +96,7 @@ function App() {
 
   return (
     <div class="p-2">
-      <div class="inline-block border border-black shadow rounded">
+      <div class="inline-block border border-black rounded">
         <div class="px-1 border-b border-black">
           <label>
             <input

--- a/examples/solid/column-visibility/src/App.tsx
+++ b/examples/solid/column-visibility/src/App.tsx
@@ -118,7 +118,7 @@ function App() {
 
   return (
     <div class="p-2">
-      <div class="inline-block border border-black shadow rounded">
+      <div class="inline-block border border-black rounded">
         <div class="px-1 border-b border-black">
           <label>
             <input

--- a/examples/solid/filters/src/App.tsx
+++ b/examples/solid/filters/src/App.tsx
@@ -105,7 +105,7 @@ function App() {
   return (
     <div class="p-2">
       <input
-        class="p-2 font-lg shadow border border-block"
+        class="p-2 font-lg border border-block"
         value={globalFilter() ?? ''}
         onInput={(e) => debounceSetGlobalFilter(e.currentTarget.value)}
         placeholder="Search all columns..."

--- a/examples/solid/filters/src/ColumnFilter.tsx
+++ b/examples/solid/filters/src/ColumnFilter.tsx
@@ -36,7 +36,7 @@ function ColumnFilter(props: {
               500,
             )}
             placeholder={`Search... (${props.column.getFacetedUniqueValues().size})`}
-            class="w-36 border shadow rounded"
+            class="w-36 border rounded"
             list={`${props.column.id}list`}
           />
         </div>
@@ -62,7 +62,7 @@ function ColumnFilter(props: {
                 ? `(${props.column.getFacetedMinMaxValues()?.[0]})`
                 : ''
             }`}
-            class="w-24 border shadow rounded"
+            class="w-24 border rounded"
           />
           <input
             type="number"
@@ -82,7 +82,7 @@ function ColumnFilter(props: {
                 ? `(${props.column.getFacetedMinMaxValues()?.[1]})`
                 : ''
             }`}
-            class="w-24 border shadow rounded"
+            class="w-24 border rounded"
           />
         </div>
       </div>
@@ -91,3 +91,4 @@ function ColumnFilter(props: {
 }
 
 export default ColumnFilter
+

--- a/examples/svelte/column-ordering/src/App.svelte
+++ b/examples/svelte/column-ordering/src/App.svelte
@@ -135,7 +135,7 @@
 </script>
 
 <div class="p-2">
-  <div class="inline-block border border-black shadow rounded">
+  <div class="inline-block border border-black rounded">
     <div class="px-1 border-b border-black">
       <label>
         <input

--- a/examples/svelte/column-pinning/src/App.svelte
+++ b/examples/svelte/column-pinning/src/App.svelte
@@ -156,7 +156,7 @@
 </script>
 
 <div class="p-2">
-  <div class="inline-block border border-black shadow rounded">
+  <div class="inline-block border border-black rounded">
     <div class="px-1 border-b border-black">
       <label>
         <input

--- a/examples/svelte/column-visibility/src/App.svelte
+++ b/examples/svelte/column-visibility/src/App.svelte
@@ -141,7 +141,7 @@
 </script>
 
 <div class="p-2">
-  <div class="inline-block border border-black shadow rounded">
+  <div class="inline-block border border-black rounded">
     <div class="px-1 border-b border-black">
       <label>
         <input

--- a/examples/vue/column-ordering/src/App.vue
+++ b/examples/vue/column-ordering/src/App.vue
@@ -114,7 +114,7 @@ function toggleAllColumnsVisibility() {
 
 <template>
   <div class="p-2">
-    <div class="inline-block border border-black shadow rounded">
+    <div class="inline-block border border-black rounded">
       <div class="px-1 border-b border-black">
         <label>
           <input

--- a/examples/vue/column-pinning/src/App.vue
+++ b/examples/vue/column-pinning/src/App.vue
@@ -129,7 +129,7 @@ function toggleAllColumnsVisibility() {
 
 <template>
   <div class="p-2">
-    <div class="inline-block border border-black rounded shadow">
+    <div class="inline-block border border-black rounded">
       <div class="px-1 border-b border-black">
         <label>
           <input

--- a/examples/vue/filters/src/App.vue
+++ b/examples/vue/filters/src/App.vue
@@ -138,7 +138,7 @@ const table = useVueTable({
       <DebouncedInput
         :modelValue="globalFilter ?? ''"
         @update:modelValue="(value) => (globalFilter = String(value))"
-        className="p-2 font-lg shadow border border-block"
+        className="p-2 font-lg border border-block"
         placeholder="Search all columns..."
       />
     </div>

--- a/examples/vue/filters/src/Filter.vue
+++ b/examples/vue/filters/src/Filter.vue
@@ -40,7 +40,7 @@ const sortedUniqueValues = computed(() =>
             ? `(${column.getFacetedMinMaxValues()?.[0]})`
             : ''
         }`"
-        class="w-24 border shadow rounded"
+        class="w-24 border rounded"
       />
       <DebouncedInput
         type="number"
@@ -56,7 +56,7 @@ const sortedUniqueValues = computed(() =>
             ? `(${column.getFacetedMinMaxValues()?.[1]})`
             : ''
         }`"
-        class="w-24 border shadow rounded"
+        class="w-24 border rounded"
       />
     </div>
     <div class="h-1" />
@@ -74,7 +74,7 @@ const sortedUniqueValues = computed(() =>
       :modelValue="(columnFilterValue ?? '') as string"
       @update:modelValue="(value) => column.setFilterValue(value)"
       :placeholder="`Search... (${column.getFacetedUniqueValues().size})`"
-      class="w-36 border shadow rounded"
+      class="w-36 border rounded"
       :list="column.id + 'list'"
     />
     <div class="h-1" />


### PR DESCRIPTION
## Description
Fixes #6201

The Tailwind CSS class `shadow` contains the substring `ad` which was causing Edge's built-in ad blocker to incorrectly flag table examples as advertisements. This was preventing users from viewing the samples in Microsoft Edge browser.

## Solution
Removed the `shadow` class from all example files across all frameworks (React, Vue, Angular, Solid, Svelte, Qwik, Lit, and Vanilla). The `shadow` class was purely decorative and not essential for functionality. The borders remain for visual consistency.

## Changes
- Removed `shadow` Tailwind CSS class from 33 example files
- Affected frameworks: React, Vue, Angular, Solid, Svelte, Qwik, and component templates
- No functional changes to the table behavior

## Testing
All examples should now display without being blocked by Edge's ad blocker, while maintaining their visual appearance through border styling.