### PR TITLE
docs: complete truncated sentence in columns guide

### DIFF
--- a/docs/guide/columns.md
+++ b/docs/guide/columns.md
@@ -14,11 +14,11 @@ This quick guide will discuss the different ways you can retrieve and interact w
 
 ### Where to Get Columns From
 
-You can find the `column` objects in many places. They are often attached
+You can find the `column` objects in many places. They are often attached to other objects like headers and cells, and they are also available from several `table` instance APIs.
 
 #### Header and Cell Objects
 
-Before you reach for one of the `table` instance APIs, consider if you actually need to retrieve either [headers](../guide/headers) or [cells](../guide/cells) instead of `columns`. If you are rending out the markup for your table, you will most likely want to reach for the APIs that return headers or cells instead of columns. The column objects themselves are not really meant to render out the headers or cells, but the `header` and `cell` objects will contain references to these `column` objects from which they can derive the necessary information to render their UI.
+Before you reach for one of the `table` instance APIs, consider if you actually need to retrieve either [headers](../guide/headers) or [cells](../guide/cells) instead of `columns`. If you are rendering out the markup for your table, you will most likely want to reach for the APIs that return headers or cells instead of columns. The column objects themselves are not really meant to render out the headers or cells, but the `header` and `cell` objects will contain references to these `column` objects from which they can derive the necessary information to render their UI.
 
 ```js
 const column = cell.column; // get column from cell


### PR DESCRIPTION
## Summary

Fixes the cut-off sentence in the Columns guide ("Where to Get Columns From") so it finishes explaining that column objects are attached to headers/cells and available from table instance APIs.

Also corrects a nearby typo (`rending` -> `rendering`) in the same section.

Closes #5761

## Test plan

- [ ] Open the Columns guide docs and confirm the "Where to Get Columns From" paragraph is complete
- [ ] Confirm "rendering" spelling in the Header and Cell Objects paragraph