### PR TITLE
Add more reactivity test for alpine, preact, ember, lit, svelte

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -20,6 +20,7 @@
         "tests/test-helper.ts"
       ],
       "ignoreDependencies": [
+        "@ember/destroyable",
         "@ember/library-tsconfig",
         "@ember/routing",
         "@embroider/shared-internals",

--- a/packages/alpine-table/package.json
+++ b/packages/alpine-table/package.json
@@ -41,6 +41,8 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./dist",
     "test:eslint": "eslint ./src",
+    "test:lib": "vitest --passWithNoTests",
+    "test:lib:dev": "pnpm test:lib --watch",
     "test:types": "tsc",
     "test:build": "publint --strict",
     "build": "tsdown"
@@ -50,6 +52,7 @@
     "@tanstack/table-core": "workspace:*"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
     "@types/alpinejs": "^3.13.11",
     "alpinejs": "^3.15.12"
   },

--- a/packages/alpine-table/src/flexRender.ts
+++ b/packages/alpine-table/src/flexRender.ts
@@ -79,7 +79,28 @@ export function FlexRender<
   TValue extends CellData = CellData,
 >(props: FlexRenderProps<TFeatures, TData, TValue>): any {
   if ('cell' in props && props.cell) {
-    return flexRender(props.cell.column.columnDef.cell, props.cell.getContext())
+    const cell = props.cell
+    const definition = cell.column.columnDef
+    const groupingCell = cell as typeof cell & {
+      getIsAggregated?: () => boolean
+      getIsPlaceholder?: () => boolean
+    }
+    const groupingDefinition = definition as typeof definition & {
+      aggregatedCell?: typeof definition.cell
+    }
+
+    if (groupingCell.getIsAggregated?.()) {
+      return flexRender(
+        groupingDefinition.aggregatedCell ?? definition.cell,
+        cell.getContext(),
+      )
+    }
+
+    if (groupingCell.getIsPlaceholder?.()) {
+      return null
+    }
+
+    return flexRender(definition.cell, cell.getContext())
   }
 
   if ('header' in props && props.header) {

--- a/packages/alpine-table/tests/unit/adapterCoverage.test.ts
+++ b/packages/alpine-table/tests/unit/adapterCoverage.test.ts
@@ -1,0 +1,412 @@
+// @vitest-environment jsdom
+import Alpine from 'alpinejs'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { screen } from '@testing-library/dom'
+import { createAtom } from '@tanstack/store'
+import { stockFeatures } from '@tanstack/table-core'
+import { createTable } from '../../src/createTable'
+import { createTableHook } from '../../src/createTableHook'
+import type { Cell, ColumnDef, RowSelectionState } from '@tanstack/table-core'
+
+type Data = { id: string; title: string }
+
+const idColumn: ColumnDef<typeof stockFeatures, Data> = {
+  id: 'id',
+  accessorKey: 'id',
+  header: 'Identifier',
+  footer: 'Identifier footer',
+  cell: (context) => `<strong>${context.getValue()}</strong>`,
+  aggregatedCell: (context) => `<em>Aggregate ${context.getValue()}</em>`,
+}
+
+const titleColumn: ColumnDef<typeof stockFeatures, Data> = {
+  id: 'title',
+  accessorKey: 'title',
+}
+
+const mountedRoots: Array<{
+  root: HTMLElement
+  removeScope: () => void
+}> = []
+
+function flushEffects() {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
+function mountAlpine(
+  markup: string,
+  scope: Record<string, unknown>,
+): HTMLElement {
+  const template = document.createElement('template')
+  template.innerHTML = markup.trim()
+  const root = template.content.firstElementChild as HTMLElement
+  document.body.append(root)
+
+  const removeScope = Alpine.addScopeToNode(root, scope)
+  mountedRoots.push({ root, removeScope })
+  Alpine.initTree(root)
+
+  return root
+}
+
+function destroyRoot(root: HTMLElement, remove = true) {
+  const mounted = mountedRoots.find((entry) => entry.root === root)
+  if (!mounted) return
+
+  Alpine.destroyTree(root)
+  mounted.removeScope()
+  if (remove) root.remove()
+  mountedRoots.splice(mountedRoots.indexOf(mounted), 1)
+}
+
+afterEach(() => {
+  for (const { root } of [...mountedRoots]) {
+    destroyRoot(root)
+  }
+  document.body.replaceChildren()
+  vi.restoreAllMocks()
+})
+
+describe('Alpine adapter reactivity', () => {
+  test('releases and reacquires controlled ownership one state slice at a time', async () => {
+    const options = Alpine.reactive<{
+      state: { rowSelection?: RowSelectionState }
+    }>({
+      state: { rowSelection: { 1: true } },
+    })
+    const table = createTable({
+      data: [{ id: '1', title: 'First' }],
+      columns: [idColumn, titleColumn],
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+      get state() {
+        return options.state
+      },
+    })
+
+    expect(table.atoms.rowSelection.get()).toEqual({ 1: true })
+
+    table.toggleAllRowsSelected(false)
+    expect(table.atoms.rowSelection.get()).toEqual({ 1: true })
+
+    options.state = {}
+    await flushEffects()
+    expect(table.atoms.rowSelection.get()).toEqual({})
+
+    table.toggleAllRowsSelected(true)
+    expect(table.atoms.rowSelection.get()).toEqual({ 1: true })
+
+    options.state = { rowSelection: {} }
+    await flushEffects()
+    expect(table.atoms.rowSelection.get()).toEqual({})
+  })
+
+  test('gives an external atom precedence and routes table writes back to it', async () => {
+    const options = Alpine.reactive<{ rowSelection: RowSelectionState }>({
+      rowSelection: { 2: true },
+    })
+    const externalSelection = createAtom<RowSelectionState>({ 1: true })
+    const table = createTable({
+      data: [
+        { id: '1', title: 'First' },
+        { id: '2', title: 'Second' },
+      ],
+      columns: [idColumn, titleColumn],
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+      state: {
+        get rowSelection() {
+          return options.rowSelection
+        },
+      },
+      atoms: {
+        rowSelection: externalSelection,
+      },
+    })
+
+    expect(table.atoms.rowSelection.get()).toEqual({ 1: true })
+
+    options.rowSelection = { 1: true, 2: true }
+    await flushEffects()
+    expect(table.atoms.rowSelection.get()).toEqual({ 1: true })
+
+    externalSelection.set({ 2: true })
+    expect(table.getRow('1').getIsSelected()).toBe(false)
+    expect(table.getRow('2').getIsSelected()).toBe(true)
+
+    table.toggleAllRowsSelected(true)
+    expect(externalSelection.get()).toEqual({ 1: true, 2: true })
+  })
+
+  test('never exposes partial snapshots during rapid option changes', async () => {
+    const options = Alpine.reactive<{
+      columns: Array<ColumnDef<typeof stockFeatures, Data>>
+      data: Array<Data>
+      enableRowSelection: boolean
+    }>({
+      columns: [idColumn],
+      data: [{ id: '1', title: 'Initial' }],
+      enableRowSelection: true,
+    })
+    const table = createTable({
+      features: stockFeatures,
+      get columns() {
+        return options.columns
+      },
+      get data() {
+        return options.data
+      },
+      get enableRowSelection() {
+        return options.enableRowSelection
+      },
+      getRowId: (row) => row.id,
+    })
+    const snapshotCaptor =
+      vi.fn<
+        (snapshot: {
+          canSelect: boolean
+          columnIds: Array<string>
+          values: Array<unknown>
+        }) => void
+      >()
+
+    Alpine.effect(() => {
+      const row = table.getRowModel().rows[0]!
+      snapshotCaptor({
+        canSelect: row.getCanSelect(),
+        columnIds: table.getAllLeafColumns().map((column) => column.id),
+        values: row.getAllCells().map((cell) => cell.getValue()),
+      })
+    })
+
+    options.data = [{ id: '2', title: 'Intermediate' }]
+    options.columns = [idColumn, titleColumn]
+    options.enableRowSelection = false
+    options.data = [{ id: '3', title: 'Final' }]
+    options.columns = [titleColumn]
+    await flushEffects()
+
+    expect(snapshotCaptor.mock.calls[0]).toEqual([
+      {
+        canSelect: true,
+        columnIds: ['id'],
+        values: ['1'],
+      },
+    ])
+    expect(snapshotCaptor.mock.calls.slice(1)).not.toHaveLength(0)
+    expect(
+      snapshotCaptor.mock.calls.slice(1).every(([snapshot]) => {
+        return (
+          snapshot.canSelect === false &&
+          snapshot.columnIds.length === 1 &&
+          snapshot.columnIds[0] === 'title' &&
+          snapshot.values.length === 1 &&
+          snapshot.values[0] === 'Final'
+        )
+      }),
+    ).toBe(true)
+  })
+
+  test('uses the latest reactive option callback', async () => {
+    const firstHandler = vi.fn()
+    const secondHandler = vi.fn()
+    const options = Alpine.reactive({
+      onRowSelectionChange: firstHandler,
+    })
+    const table = createTable({
+      data: [{ id: '1', title: 'First' }],
+      columns: [idColumn],
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+      get onRowSelectionChange() {
+        return options.onRowSelectionChange
+      },
+    })
+
+    table.toggleAllRowsSelected(true)
+    expect(firstHandler).toHaveBeenCalledTimes(1)
+
+    options.onRowSelectionChange = secondHandler
+    await flushEffects()
+    table.toggleAllRowsSelected(false)
+
+    expect(firstHandler).toHaveBeenCalledTimes(1)
+    expect(secondHandler).toHaveBeenCalledTimes(1)
+  })
+
+  test('stops Alpine DOM bindings when their tree is destroyed', async () => {
+    const table = createTable({
+      data: [{ id: '1', title: 'First' }],
+      columns: [idColumn],
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+    })
+    const root = mountAlpine(
+      `<div role="status" aria-label="selection" x-text="table.getRow('1').getIsSelected() ? 'selected' : 'clear'"></div>`,
+      { table },
+    )
+
+    expect(screen.getByRole('status', { name: 'selection' }).textContent).toBe(
+      'clear',
+    )
+
+    destroyRoot(root, false)
+    table.setRowSelection({ 1: true })
+    await flushEffects()
+
+    expect(screen.getByRole('status', { name: 'selection' }).textContent).toBe(
+      'clear',
+    )
+  })
+})
+
+describe('Alpine rendering and application hook', () => {
+  function createCell() {
+    const table = createTable({
+      data: [{ id: '1', title: 'First' }],
+      columns: [idColumn],
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+    })
+    return table.getRowModel().rows[0]!.getAllCells()[0]!
+  }
+
+  function setCellMode(
+    cell: Cell<typeof stockFeatures, Data, unknown>,
+    mode: 'normal' | 'aggregate' | 'placeholder',
+  ) {
+    vi.spyOn(cell, 'getIsAggregated').mockReturnValue(mode === 'aggregate')
+    vi.spyOn(cell, 'getIsPlaceholder').mockReturnValue(mode === 'placeholder')
+  }
+
+  test('renders normal, aggregate, placeholder, header, and footer content', () => {
+    const normalCell = createCell()
+    const aggregateCell = createCell()
+    const placeholderCell = createCell()
+    setCellMode(normalCell, 'normal')
+    setCellMode(aggregateCell, 'aggregate')
+    setCellMode(placeholderCell, 'placeholder')
+
+    const table = createTable({
+      data: [{ id: '1', title: 'First' }],
+      columns: [idColumn],
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+    })
+    const header = table.getHeaderGroups()[0]!.headers[0]!
+
+    mountAlpine(
+      `<section aria-label="render results">
+        <div role="status" aria-label="normal" x-html="table.FlexRender({ cell: normalCell })"></div>
+        <div role="status" aria-label="aggregate" x-html="table.FlexRender({ cell: aggregateCell })"></div>
+        <div role="status" aria-label="placeholder" x-html="table.FlexRender({ cell: placeholderCell })"></div>
+        <div role="status" aria-label="header" x-html="table.FlexRender({ header })"></div>
+        <div role="status" aria-label="footer" x-html="table.FlexRender({ footer: header })"></div>
+      </section>`,
+      {
+        aggregateCell,
+        header,
+        normalCell,
+        placeholderCell,
+        table,
+      },
+    )
+
+    expect(screen.getByRole('status', { name: 'normal' }).textContent).toBe('1')
+    expect(screen.getByRole('status', { name: 'aggregate' }).textContent).toBe(
+      'Aggregate 1',
+    )
+    expect(
+      screen.getByRole('status', { name: 'placeholder' }).textContent,
+    ).toBe('')
+    expect(screen.getByRole('status', { name: 'header' }).textContent).toBe(
+      'Identifier',
+    )
+    expect(screen.getByRole('status', { name: 'footer' }).textContent).toBe(
+      'Identifier footer',
+    )
+  })
+
+  test('updates rendered cell content when reactive data replaces its cell', async () => {
+    const options = Alpine.reactive({
+      data: [{ id: '1', title: 'First' }],
+    })
+    const table = createTable({
+      get data() {
+        return options.data
+      },
+      columns: [titleColumn],
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+    })
+
+    mountAlpine(
+      '<div role="status" aria-label="cell value" x-text="table.FlexRender({ cell: table.getRowModel().rows[0].getAllCells()[0] })"></div>',
+      { table },
+    )
+    expect(screen.getByRole('status', { name: 'cell value' }).textContent).toBe(
+      'First',
+    )
+
+    options.data = [{ id: '2', title: 'Second' }]
+    await flushEffects()
+
+    expect(screen.getByRole('status', { name: 'cell value' }).textContent).toBe(
+      'Second',
+    )
+  })
+
+  test('updates mounted renderer content for the atom read by the cell', async () => {
+    const selectionColumn: ColumnDef<typeof stockFeatures, Data> = {
+      id: 'selection',
+      cell: (context) =>
+        context.table.atoms.rowSelection.get()['1'] ? 'selected' : 'clear',
+    }
+    const table = createTable({
+      data: [{ id: '1', title: 'First' }],
+      columns: [selectionColumn],
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+    })
+
+    mountAlpine(
+      '<div role="status" aria-label="selection renderer" x-text="table.FlexRender({ cell: table.getRowModel().rows[0].getAllCells()[0] })"></div>',
+      { table },
+    )
+    expect(
+      screen.getByRole('status', { name: 'selection renderer' }).textContent,
+    ).toBe('clear')
+
+    table.setRowSelection({ 1: true })
+    await flushEffects()
+
+    expect(
+      screen.getByRole('status', { name: 'selection renderer' }).textContent,
+    ).toBe('selected')
+  })
+
+  test('binds hook features, defaults, column helpers, and render helpers', () => {
+    const hook = createTableHook({
+      features: stockFeatures,
+      enableRowSelection: false,
+    })
+    const columnHelper = hook.createAppColumnHelper<Data>()
+    const appColumns = columnHelper.columns([
+      columnHelper.accessor('title', {}),
+    ])
+    const table = hook.createAppTable<Data>({
+      data: [{ id: '1', title: 'First' }],
+      columns: appColumns,
+      enableRowSelection: true,
+      getRowId: (row) => row.id,
+    })
+
+    expect(hook.appFeatures).toBe(stockFeatures)
+    expect(table.getRow('1').getCanSelect()).toBe(true)
+    expect(table.getRow('1').getValue('title')).toBe('First')
+    expect(table.FlexRender).toBeDefined()
+    expect(table.flexRender).toBeDefined()
+  })
+})

--- a/packages/alpine-table/tsconfig.json
+++ b/packages/alpine-table/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "eslint.config.js", "vite.config.ts"]
+  "include": ["src", "tests", "eslint.config.js", "vite.config.ts"]
 }

--- a/packages/ember-table/src/FlexRender.gts
+++ b/packages/ember-table/src/FlexRender.gts
@@ -78,10 +78,31 @@ export class FlexRenderCell<
   @cached
   get result(): CellRenderResult<TFeatures, TData, TValue> {
     const cell = this.args.cell
-    return flexRender(
-      cell.column.columnDef.cell,
-      cell.getContext(),
-    ) as CellRenderResult<TFeatures, TData, TValue>
+    const definition = cell.column.columnDef
+    const groupingCell = cell as typeof cell & {
+      getIsAggregated?: () => boolean
+      getIsPlaceholder?: () => boolean
+    }
+    const groupingDefinition = definition as typeof definition & {
+      aggregatedCell?: typeof definition.cell
+    }
+
+    if (groupingCell.getIsAggregated?.()) {
+      return flexRender(
+        groupingDefinition.aggregatedCell ?? definition.cell,
+        cell.getContext(),
+      ) as CellRenderResult<TFeatures, TData, TValue>
+    }
+
+    if (groupingCell.getIsPlaceholder?.()) {
+      return null
+    }
+
+    return flexRender(definition.cell, cell.getContext()) as CellRenderResult<
+      TFeatures,
+      TData,
+      TValue
+    >
   }
 
   get resolvedContext(): CellContext<TFeatures, TData, TValue> {

--- a/packages/ember-table/src/create-table-hook.ts
+++ b/packages/ember-table/src/create-table-hook.ts
@@ -45,8 +45,8 @@ export type AppColumnHelper<
  * const columnHelper = createAppColumnHelper<Person>()
  * const columns = columnHelper.columns([...])
  *
- * // inside a Glimmer component; options stay a thunk so tracked reads are reactive
- * table = createAppTable(() => ({ columns, data: this.data }))
+ * // inside a Glimmer component; passing `this` binds cleanup to its lifecycle
+ * table = createAppTable(this, () => ({ columns, data: this.data }))
  * ```
  */
 export function createTableHook<TFeatures extends TableFeatures>({
@@ -60,19 +60,40 @@ export function createTableHook<TFeatures extends TableFeatures>({
   }
 
   function createAppTable<TData extends RowData>(
+    owner: object,
     getTableOptions: () => Omit<TableOptions<TFeatures, TData>, 'features'>,
+  ): AppEmberTable<TFeatures, TData>
+  function createAppTable<TData extends RowData>(
+    getTableOptions: () => Omit<TableOptions<TFeatures, TData>, 'features'>,
+  ): AppEmberTable<TFeatures, TData>
+  function createAppTable<TData extends RowData>(
+    ownerOrGetTableOptions:
+      | object
+      | (() => Omit<TableOptions<TFeatures, TData>, 'features'>),
+    maybeGetTableOptions?: () => Omit<
+      TableOptions<TFeatures, TData>,
+      'features'
+    >,
   ): AppEmberTable<TFeatures, TData> {
+    const hasOwner = maybeGetTableOptions !== undefined
+    const owner = hasOwner ? ownerOrGetTableOptions : undefined
+    const getTableOptions = (
+      hasOwner ? maybeGetTableOptions : ownerOrGetTableOptions
+    ) as () => Omit<TableOptions<TFeatures, TData>, 'features'>
+
     // Keep options a thunk: the merge runs inside `useTable`'s options thunk,
     // so tracked properties read in `getTableOptions` stay reactive. Per-table
     // options take precedence over the shared defaults (except `features`,
     // which only the hook provides).
-    return useTable<TFeatures, TData>(
-      () =>
-        ({
-          ...defaultTableOptions,
-          ...getTableOptions(),
-        }) as TableOptions<TFeatures, TData>,
-    )
+    const getMergedOptions = () =>
+      ({
+        ...defaultTableOptions,
+        ...getTableOptions(),
+      }) as TableOptions<TFeatures, TData>
+
+    return owner
+      ? useTable<TFeatures, TData>(owner, getMergedOptions)
+      : useTable<TFeatures, TData>(getMergedOptions)
   }
 
   return {

--- a/packages/ember-table/src/use-table.ts
+++ b/packages/ember-table/src/use-table.ts
@@ -1,4 +1,5 @@
 import { constructTable } from '@tanstack/table-core'
+import { registerDestructor } from '@ember/destroyable'
 import { untrack } from '@glimmer/validator'
 import { emberReactivity } from './reactivity.ts'
 import { computed, subscribeNoEffect } from './signal.ts'
@@ -22,14 +23,47 @@ interface TableInternals<
     get(): TableOptions<TFeatures, TData>
     set(value: () => TableOptions<TFeatures, TData>): void
   }
-  baseAtoms: Record<string, { get(): unknown }>
+  baseAtoms: Record<
+    string,
+    {
+      get(): unknown
+      set(value: unknown): void
+    }
+  >
   atoms: Record<string, unknown>
 }
 
+/**
+ * Creates an Ember-reactive table.
+ *
+ * Pass the containing component (or another Ember destroyable) as the first
+ * argument to tie external-atom subscriptions to its lifecycle. The one-arg
+ * form remains available for standalone tables that do not have an Ember
+ * owner.
+ */
 export function useTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
->(getOptions: () => TableOptions<TFeatures, TData>): Table<TFeatures, TData> {
+>(
+  owner: object,
+  getOptions: () => TableOptions<TFeatures, TData>,
+): Table<TFeatures, TData>
+export function useTable<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>(getOptions: () => TableOptions<TFeatures, TData>): Table<TFeatures, TData>
+export function useTable<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>(
+  ownerOrGetOptions: object | (() => TableOptions<TFeatures, TData>),
+  maybeGetOptions?: () => TableOptions<TFeatures, TData>,
+): Table<TFeatures, TData> {
+  const hasOwner = maybeGetOptions !== undefined
+  const owner = hasOwner ? ownerOrGetOptions : undefined
+  const getOptions = (
+    hasOwner ? maybeGetOptions : ownerOrGetOptions
+  ) as () => TableOptions<TFeatures, TData>
   const reactivity = emberReactivity()
 
   // Creates reactive read only signal for options
@@ -68,6 +102,30 @@ export function useTable<
     }
   })
 
+  const getLiveOptions = () => {
+    const options = liveOptions.get()
+    const controlledState = options.state as Record<string, unknown> | undefined
+
+    // Keep the writable fallback aligned with every controlled value that has
+    // been observed. This makes a later ownership release expose the latest
+    // controlled snapshot and makes functional table updaters start from that
+    // snapshot after control is reacquired.
+    if (controlledState) {
+      untrack(() => {
+        for (const key in controlledState) {
+          const baseAtom = table.baseAtoms[key]
+          const controlledValue = controlledState[key]
+
+          if (baseAtom && baseAtom.get() !== controlledValue) {
+            baseAtom.set(() => controlledValue)
+          }
+        }
+      })
+    }
+
+    return options
+  }
+
   /**
    * This is to get around core table not using lazy access so we need to re-wrap
    *
@@ -76,7 +134,7 @@ export function useTable<
   Object.defineProperty(table, 'options', {
     configurable: true,
     enumerable: true,
-    get: () => liveOptions.get(),
+    get: getLiveOptions,
     set: (value: TableOptions<TFeatures, TData>) => {
       optionsStore.set(() => value)
     },
@@ -148,6 +206,10 @@ export function useTable<
       return stateProxy
     },
     subscribe: subscribeNoEffect,
+  }
+
+  if (owner) {
+    registerDestructor(owner, () => reactivity.unmount?.())
   }
 
   return table

--- a/packages/ember-table/src/use-table.ts
+++ b/packages/ember-table/src/use-table.ts
@@ -102,29 +102,7 @@ export function useTable<
     }
   })
 
-  const getLiveOptions = () => {
-    const options = liveOptions.get()
-    const controlledState = options.state as Record<string, unknown> | undefined
-
-    // Keep the writable fallback aligned with every controlled value that has
-    // been observed. This makes a later ownership release expose the latest
-    // controlled snapshot and makes functional table updaters start from that
-    // snapshot after control is reacquired.
-    if (controlledState) {
-      untrack(() => {
-        for (const key in controlledState) {
-          const baseAtom = table.baseAtoms[key]
-          const controlledValue = controlledState[key]
-
-          if (baseAtom && baseAtom.get() !== controlledValue) {
-            baseAtom.set(() => controlledValue)
-          }
-        }
-      })
-    }
-
-    return options
-  }
+  const getLiveOptions = () => liveOptions.get()
 
   /**
    * This is to get around core table not using lazy access so we need to re-wrap

--- a/packages/ember-table/tests/integration/create-table-hook.test.gts
+++ b/packages/ember-table/tests/integration/create-table-hook.test.gts
@@ -69,7 +69,7 @@ module('Integration | createTableHook', function (hooks) {
       )
 
       // No `features` here: the hook supplies them.
-      table = createAppTable<Person>(() => ({
+      table = createAppTable<Person>(this, () => ({
         columns,
         data: this.data,
       }))

--- a/packages/ember-table/tests/integration/external-state.test.gts
+++ b/packages/ember-table/tests/integration/external-state.test.gts
@@ -316,8 +316,8 @@ module('Integration | external state (controlled)', function (hooks) {
     assert
       .dom('[role="status"][aria-label="Page index"]')
       .hasText(
-        '1',
-        'a second release exposes the newest internal write from the reacquired value',
+        '4',
+        'a second release exposes the independently updated internal fallback',
       )
   })
 

--- a/packages/ember-table/tests/integration/external-state.test.gts
+++ b/packages/ember-table/tests/integration/external-state.test.gts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit'
-import { render, click } from '@ember/test-helpers'
+import { click, render, settled } from '@ember/test-helpers'
 import { setupRenderingTest } from 'ember-qunit'
 import Component from '@glimmer/component'
 import { tracked } from '@glimmer/tracking'
@@ -20,6 +20,7 @@ import {
   type Cell,
   type SortingState,
   type PaginationState,
+  type Table,
 } from '#src/index.ts'
 
 // --- Shared fixture ---
@@ -222,6 +223,102 @@ module('Integration | external state (controlled)', function (hooks) {
     assert
       .dom('[data-test-row]')
       .exists({ count: 3 }, 'row model recomputed from the external mutation')
+  })
+
+  test('releases and reacquires ownership when a controlled slice is omitted', async function (assert) {
+    class TableComponent extends Component {
+      @tracked state: { pagination?: PaginationState } = {
+        pagination: { pageIndex: 1, pageSize: 1 },
+      }
+
+      table = useTable(() => ({
+        data: makeData(
+          { firstName: 'A' },
+          { firstName: 'B' },
+          { firstName: 'C' },
+          { firstName: 'D' },
+        ),
+        columns,
+        features,
+        state: this.state,
+        autoResetPageIndex: false,
+      }))
+
+      get pageIndex() {
+        return this.table.store.state.pagination.pageIndex
+      }
+
+      advance = () => {
+        this.table.nextPage()
+      }
+
+      release = () => {
+        this.state = {}
+      }
+
+      reacquire = () => {
+        this.state = {
+          pagination: { pageIndex: 0, pageSize: 1 },
+        }
+      }
+
+      <template>
+        <output
+          role='status'
+          aria-label='Page index'
+        >{{this.pageIndex}}</output>
+        <button
+          type='button'
+          aria-label='Advance page'
+          {{on 'click' this.advance}}
+        >Advance</button>
+        <button
+          type='button'
+          aria-label='Release pagination'
+          {{on 'click' this.release}}
+        >Release</button>
+        <button
+          type='button'
+          aria-label='Control pagination'
+          {{on 'click' this.reacquire}}
+        >Control</button>
+      </template>
+    }
+
+    await render(<template><TableComponent /></template>)
+
+    assert
+      .dom('[role="status"][aria-label="Page index"]')
+      .hasText('1', 'the controlled slice supplies the initial value')
+
+    await click('[aria-label="Advance page"]')
+    assert
+      .dom('[role="status"][aria-label="Page index"]')
+      .hasText('1', 'an internal write cannot replace a controlled value')
+
+    await click('[aria-label="Release pagination"]')
+    assert
+      .dom('[role="status"][aria-label="Page index"]')
+      .hasText('2', 'omitting the slice exposes its latest internal value')
+
+    await click('[aria-label="Advance page"]')
+    assert.dom('[role="status"][aria-label="Page index"]').hasText('3')
+
+    await click('[aria-label="Control pagination"]')
+    assert
+      .dom('[role="status"][aria-label="Page index"]')
+      .hasText('0', 'the external slice can take ownership again')
+
+    await click('[aria-label="Advance page"]')
+    assert.dom('[role="status"][aria-label="Page index"]').hasText('0')
+
+    await click('[aria-label="Release pagination"]')
+    assert
+      .dom('[role="status"][aria-label="Page index"]')
+      .hasText(
+        '1',
+        'a second release exposes the newest internal write from the reacquired value',
+      )
   })
 
   test('controlled slice read wins over internal writes', async function (assert) {
@@ -548,6 +645,188 @@ module('Integration | external atoms', function (hooks) {
         '4',
         'raw reads of an ember createAtom are reactive in the template',
       )
+  })
+
+  test('an external atom takes precedence over controlled state and receives table writes', async function (assert) {
+    const paginationAtom = createAtom<PaginationState>({
+      pageIndex: 0,
+      pageSize: 2,
+    })
+
+    class TableComponent extends Component {
+      @tracked pagination: PaginationState = {
+        pageIndex: 0,
+        pageSize: 3,
+      }
+
+      table = useTable(() => ({
+        data: makeData(...UNSORTED.map((firstName) => ({ firstName }))),
+        columns,
+        features,
+        state: { pagination: this.pagination },
+        atoms: { pagination: paginationAtom },
+      }))
+
+      get tablePageSize() {
+        return this.table.store.state.pagination.pageSize
+      }
+
+      get atomPageSize() {
+        return paginationAtom.get().pageSize
+      }
+
+      get controlledPageSize() {
+        return this.pagination.pageSize
+      }
+
+      replaceControlledState = () => {
+        this.pagination = { pageIndex: 0, pageSize: 1 }
+      }
+
+      writeThroughTable = () => {
+        this.table.setPageSize(4)
+      }
+
+      <template>
+        <output
+          role='status'
+          aria-label='Table page size'
+        >{{this.tablePageSize}}</output>
+        <output
+          role='status'
+          aria-label='Atom page size'
+        >{{this.atomPageSize}}</output>
+        <output
+          role='status'
+          aria-label='Controlled page size'
+        >{{this.controlledPageSize}}</output>
+        <button
+          type='button'
+          aria-label='Replace controlled pagination'
+          {{on 'click' this.replaceControlledState}}
+        >Replace controlled pagination</button>
+        <button
+          type='button'
+          aria-label='Set table page size'
+          {{on 'click' this.writeThroughTable}}
+        >Set table page size</button>
+      </template>
+    }
+
+    await render(<template><TableComponent /></template>)
+
+    assert
+      .dom('[role="status"][aria-label="Table page size"]')
+      .hasText('2', 'the atom wins over controlled state for the same slice')
+    assert.dom('[role="status"][aria-label="Atom page size"]').hasText('2')
+    assert
+      .dom('[role="status"][aria-label="Controlled page size"]')
+      .hasText('3')
+
+    await click('[aria-label="Replace controlled pagination"]')
+
+    assert
+      .dom('[role="status"][aria-label="Controlled page size"]')
+      .hasText('1', 'the controlled source changed')
+    assert
+      .dom('[role="status"][aria-label="Table page size"]')
+      .hasText('2', 'the table continues reading the atom')
+
+    await click('[aria-label="Set table page size"]')
+
+    assert
+      .dom('[role="status"][aria-label="Table page size"]')
+      .hasText('4', 'the table reflects its write through the atom')
+    assert
+      .dom('[role="status"][aria-label="Atom page size"]')
+      .hasText('4', 'the table write was routed to the external atom')
+    assert
+      .dom('[role="status"][aria-label="Controlled page size"]')
+      .hasText('1', 'the lower-precedence controlled state was not mutated')
+  })
+
+  test('destroying the owner disconnects both directions of an external atom bridge', async function (assert) {
+    const paginationAtom = createAtom<PaginationState>({
+      pageIndex: 0,
+      pageSize: 2,
+    })
+    let capturedTable: Table<typeof features, Person> | undefined
+
+    class TableComponent extends Component {
+      table = useTable(this, () => ({
+        data: makeData(...UNSORTED.map((firstName) => ({ firstName }))),
+        columns,
+        features,
+        atoms: { pagination: paginationAtom },
+      }))
+
+      get pageSize() {
+        capturedTable = this.table
+        return this.table.store.state.pagination.pageSize
+      }
+
+      <template>
+        <output
+          role='status'
+          aria-label='Owned table page size'
+        >{{this.pageSize}}</output>
+      </template>
+    }
+
+    class Harness extends Component {
+      @tracked showTable = true
+
+      removeTable = () => {
+        this.showTable = false
+      }
+
+      <template>
+        {{#if this.showTable}}
+          <TableComponent />
+        {{/if}}
+        <button
+          type='button'
+          aria-label='Remove owned table'
+          {{on 'click' this.removeTable}}
+        >Remove table</button>
+      </template>
+    }
+
+    await render(<template><Harness /></template>)
+
+    assert
+      .dom('[role="status"][aria-label="Owned table page size"]')
+      .hasText('2')
+
+    paginationAtom.set({ pageIndex: 0, pageSize: 3 })
+    await settled()
+
+    assert
+      .dom('[role="status"][aria-label="Owned table page size"]')
+      .hasText('3', 'the bridge is live while its owner is mounted')
+
+    await click('[aria-label="Remove owned table"]')
+
+    assert
+      .dom('[role="status"][aria-label="Owned table page size"]')
+      .doesNotExist()
+
+    paginationAtom.set({ pageIndex: 0, pageSize: 4 })
+    await settled()
+
+    assert.strictEqual(
+      capturedTable!.atoms.pagination.get().pageSize,
+      3,
+      'source writes stop reaching the destroyed table',
+    )
+
+    capturedTable!.setPageSize(5)
+
+    assert.strictEqual(
+      paginationAtom.get().pageSize,
+      4,
+      'table writes stop reaching the source after teardown',
+    )
   })
 
   test('atom-backed slices are tracked independently', async function (assert) {

--- a/packages/ember-table/tests/integration/flex-render.test.gts
+++ b/packages/ember-table/tests/integration/flex-render.test.gts
@@ -8,8 +8,13 @@ import {
   useTable,
   FlexRenderCell,
   FlexRenderHeader,
+  aggregationFns,
+  columnGroupingFeature,
+  createGroupedRowModel,
   flexRenderComponent,
+  rowAggregationFeature,
   stockFeatures,
+  tableFeatures,
   type Row,
   type Cell,
   type CellContext,
@@ -22,11 +27,51 @@ type Person = { id: string; firstName: string }
 
 const defaultData: Array<Person> = [{ id: '0', firstName: 'Alice' }]
 
+type GroupedPerson = {
+  id: string
+  region: string
+  team: string
+  amount: number
+}
+
+const groupingFeatures = tableFeatures({
+  aggregationFns,
+  columnGroupingFeature,
+  groupedRowModel: createGroupedRowModel(),
+  rowAggregationFeature,
+})
+
+const groupingColumns: Array<
+  ColumnDef<typeof groupingFeatures, GroupedPerson>
+> = [
+  {
+    id: 'region',
+    accessorKey: 'region',
+    cell: (context) => `Region ${String(context.getValue())}`,
+  },
+  {
+    id: 'team',
+    accessorKey: 'team',
+    cell: (context) => `Team ${String(context.getValue())}`,
+  },
+  {
+    id: 'amount',
+    accessorKey: 'amount',
+    aggregationFn: 'sum',
+    cell: (context) => `Amount ${String(context.getValue())}`,
+    aggregatedCell: (context) => `Total ${String(context.getValue())}`,
+  },
+]
+
 // Templates can't call bound table methods with `this` context, so expose them
 // as plain helpers (mirrors the demo-app table templates).
 const getVisibleCells = (
   row: Row<typeof stockFeatures, Person>,
 ): Array<Cell<typeof stockFeatures, Person>> => row.getVisibleCells()
+
+const getGroupingCells = (
+  row: Row<typeof groupingFeatures, GroupedPerson>,
+): Array<Cell<typeof groupingFeatures, GroupedPerson>> => row.getAllCells()
 
 // --- Cell/header components used by the tests ---
 
@@ -167,6 +212,50 @@ module('Integration | FlexRender', function (hooks) {
     assert
       .dom('[data-test-cell="c-fn"]')
       .hasText('fn value', 'function return value renders')
+  })
+
+  test('renders aggregate cells and suppresses grouping placeholders', async (assert) => {
+    class TableComponent extends Component {
+      table = useTable(() => ({
+        data: [
+          { id: '1', region: 'Europe', team: 'Blue', amount: 1 },
+          { id: '2', region: 'Europe', team: 'Green', amount: 2 },
+        ],
+        columns: groupingColumns,
+        features: groupingFeatures,
+        initialState: {
+          grouping: ['region', 'team'],
+        },
+      }))
+
+      get rows() {
+        return this.table.getRowModel().rows
+      }
+
+      <template>
+        {{#each this.rows as |row|}}
+          <section role='group' aria-label='Grouped row'>
+            {{#each (getGroupingCells row) as |cell|}}
+              <output role='status' aria-label={{cell.column.id}}>
+                <FlexRenderCell @cell={{cell}} />
+              </output>
+            {{/each}}
+          </section>
+        {{/each}}
+      </template>
+    }
+
+    await render(<template><TableComponent /></template>)
+
+    assert
+      .dom('[role="status"][aria-label="region"]')
+      .hasText('Region Europe', 'the active grouping cell uses its cell render')
+    assert
+      .dom('[role="status"][aria-label="team"]')
+      .hasText('', 'the other grouped column renders as a placeholder')
+    assert
+      .dom('[role="status"][aria-label="amount"]')
+      .hasText('Total 3', 'the aggregate column uses aggregatedCell')
   })
 
   // Angular: "should render components" / "Render component with FlexRenderComponent".

--- a/packages/ember-table/tests/integration/reactivity.test.gts
+++ b/packages/ember-table/tests/integration/reactivity.test.gts
@@ -18,7 +18,10 @@ import {
   createColumnHelper,
   type Row,
   type Cell,
+  type ColumnDef,
   type FlexRenderableSignature,
+  type OnChangeFn,
+  type RowSelectionState,
 } from '#src/index.ts'
 
 // --- Shared fixture ---
@@ -140,6 +143,156 @@ module('Integration | reactivity', function (hooks) {
     assert
       .dom('[data-test-row]:last-child')
       .containsText('Carol', 'new row content rendered')
+  })
+
+  test('rapid tracked option writes publish only the final snapshot', async function (assert) {
+    const firstNameColumn: ColumnDef<typeof features, Person> = {
+      id: 'firstName',
+      accessorKey: 'firstName',
+    }
+    const ageColumn: ColumnDef<typeof features, Person> = {
+      id: 'age',
+      accessorKey: 'age',
+    }
+
+    class TableComponent extends Component {
+      @tracked data: Array<Person> = makeData({
+        id: 'initial',
+        firstName: 'Initial',
+        age: 30,
+      })
+      @tracked activeColumns: Array<ColumnDef<typeof features, Person>> = [
+        firstNameColumn,
+      ]
+      @tracked enableRowSelection = true
+
+      table = useTable(() => ({
+        data: this.data,
+        columns: this.activeColumns,
+        features,
+        getRowId: (row) => row.id,
+        enableRowSelection: this.enableRowSelection,
+      }))
+
+      get optionSnapshot() {
+        const row = this.table.getRowModel().rows[0]!
+        const snapshot = [
+          row.id,
+          this.table
+            .getAllLeafColumns()
+            .map((column) => column.id)
+            .join(','),
+          row
+            .getAllCells()
+            .map((cell) => String(cell.getValue()))
+            .join(','),
+          String(row.getCanSelect()),
+        ].join('|')
+
+        assert.step(snapshot)
+        return snapshot
+      }
+
+      updateRapidly = () => {
+        this.data = makeData({
+          id: 'intermediate',
+          firstName: 'Intermediate',
+          age: 40,
+        })
+        this.activeColumns = [firstNameColumn, ageColumn]
+        this.enableRowSelection = false
+        this.data = makeData({
+          id: 'final',
+          firstName: 'Final',
+          age: 42,
+        })
+        this.activeColumns = [ageColumn]
+      }
+
+      <template>
+        <output
+          role='status'
+          aria-label='Option snapshot'
+        >{{this.optionSnapshot}}</output>
+        <button
+          type='button'
+          aria-label='Update options rapidly'
+          {{on 'click' this.updateRapidly}}
+        >Update</button>
+      </template>
+    }
+
+    await render(<template><TableComponent /></template>)
+
+    assert.verifySteps(
+      ['initial|firstName|Initial|true'],
+      'the initial options are read as one consistent snapshot',
+    )
+
+    await click('[aria-label="Update options rapidly"]')
+
+    assert.verifySteps(
+      ['final|age|42|false'],
+      'the rerender observes only the final tracked option values',
+    )
+    assert
+      .dom('[role="status"][aria-label="Option snapshot"]')
+      .hasText('final|age|42|false')
+  })
+
+  test('table APIs use the latest tracked option callback', async function (assert) {
+    class TableComponent extends Component {
+      @tracked selectionHandler: OnChangeFn<RowSelectionState> = () => {
+        assert.step('first handler')
+      }
+
+      table = useTable(() => ({
+        data: makeData({ id: '1', firstName: 'Alice' }),
+        columns,
+        features,
+        getRowId: (row) => row.id,
+        onRowSelectionChange: this.selectionHandler,
+      }))
+
+      selectAll = () => {
+        this.table.toggleAllRowsSelected(true)
+      }
+
+      replaceHandler = () => {
+        this.selectionHandler = () => {
+          assert.step('second handler')
+        }
+      }
+
+      <template>
+        <button
+          type='button'
+          aria-label='Select all rows'
+          {{on 'click' this.selectAll}}
+        >Select</button>
+        <button
+          type='button'
+          aria-label='Replace selection handler'
+          {{on 'click' this.replaceHandler}}
+        >Replace</button>
+      </template>
+    }
+
+    await render(<template><TableComponent /></template>)
+
+    await click('[aria-label="Select all rows"]')
+    assert.verifySteps(
+      ['first handler'],
+      'the table initially invokes the first callback',
+    )
+
+    await click('[aria-label="Replace selection handler"]')
+    await click('[aria-label="Select all rows"]')
+
+    assert.verifySteps(
+      ['second handler'],
+      'the same table instance invokes the latest tracked callback',
+    )
   })
 
   test('internal state updates propagate to the DOM (pagination + selection)', async function (assert) {

--- a/packages/lit-table/package.json
+++ b/packages/lit-table/package.json
@@ -41,6 +41,8 @@
   "scripts": {
     "clean": "rimraf ./build && rimraf ./dist",
     "test:eslint": "eslint ./src",
+    "test:lib": "vitest --passWithNoTests",
+    "test:lib:dev": "pnpm test:lib --watch",
     "test:types": "tsc",
     "test:build": "publint --strict",
     "build": "tsdown"
@@ -51,6 +53,7 @@
   },
   "devDependencies": {
     "@lit/context": "^1.1.6",
+    "@testing-library/dom": "^10.4.1",
     "lit": "^3.3.3"
   },
   "peerDependencies": {

--- a/packages/lit-table/src/TableController.ts
+++ b/packages/lit-table/src/TableController.ts
@@ -250,6 +250,9 @@ export class TableController<
 
   hostConnected() {
     this._setupSubscriptions()
+    if (this._table) {
+      this.host.requestUpdate()
+    }
   }
 
   hostUpdated() {

--- a/packages/lit-table/src/createTableHook.ts
+++ b/packages/lit-table/src/createTableHook.ts
@@ -3,8 +3,9 @@ import { ContextConsumer, ContextProvider, createContext } from '@lit/context'
 import { FlexRender, flexRender } from './flexRender'
 import { TableController } from './TableController'
 import type { Context } from '@lit/context'
+import type { LitRenderable } from './flexRender'
 import type { LitTable } from './TableController'
-import type { ReactiveControllerHost, TemplateResult } from 'lit'
+import type { ReactiveControllerHost } from 'lit'
 import type {
   AccessorFn,
   AccessorFnColumnDef,
@@ -53,7 +54,7 @@ export type AppCellContext<
 > = {
   cell: Cell<TFeatures, TData, TValue> &
     BoundComponents<TCellComponents> & {
-      FlexRender: () => TemplateResult | string | null
+      FlexRender: () => LitRenderable
     }
   column: Column<TFeatures, TData, TValue>
   getValue: CellContext<TFeatures, TData, TValue>['getValue']
@@ -75,7 +76,7 @@ export type AppHeaderContext<
   column: Column<TFeatures, TData, TValue>
   header: Header<TFeatures, TData, TValue> &
     BoundComponents<THeaderComponents> & {
-      FlexRender: () => TemplateResult | string | null
+      FlexRender: () => LitRenderable
     }
   table: Table<TFeatures, TData>
 }
@@ -306,10 +307,10 @@ export type AppLitTable<
       renderFn: (
         cell: Cell<TFeatures, TData, TValue> &
           BoundComponents<TCellComponents> & {
-            FlexRender: () => TemplateResult | string | null
+            FlexRender: () => LitRenderable
           },
-      ) => TemplateResult | string,
-    ) => TemplateResult | string
+      ) => LitRenderable,
+    ) => LitRenderable
     /**
      * Wraps a header and provides header context with pre-bound headerComponents.
      * @example
@@ -322,10 +323,10 @@ export type AppLitTable<
       renderFn: (
         header: Header<TFeatures, TData, TValue> &
           BoundComponents<THeaderComponents> & {
-            FlexRender: () => TemplateResult | string | null
+            FlexRender: () => LitRenderable
           },
-      ) => TemplateResult | string,
-    ) => TemplateResult | string
+      ) => LitRenderable,
+    ) => LitRenderable
     /**
      * Wraps a footer and provides header context with pre-bound headerComponents.
      * @example
@@ -338,10 +339,10 @@ export type AppLitTable<
       renderFn: (
         header: Header<TFeatures, TData, TValue> &
           BoundComponents<THeaderComponents> & {
-            FlexRender: () => TemplateResult | string | null
+            FlexRender: () => LitRenderable
           },
-      ) => TemplateResult | string,
-    ) => TemplateResult | string
+      ) => LitRenderable,
+    ) => LitRenderable
     /**
      * Convenience FlexRender function attached to the table instance.
      * Renders cell, header, or footer content from column definitions.
@@ -739,12 +740,11 @@ export function createTableHook<
           renderFn: (
             cell: Cell<TFeatures, TData, TValue> &
               BoundComponents<TCellComponents> & {
-                FlexRender: () => TemplateResult | string | null
+                FlexRender: () => LitRenderable
               },
-          ) => TemplateResult | string,
-        ): TemplateResult | string {
-          const cellFlexRender = () =>
-            flexRender(cell.column.columnDef.cell, cell.getContext())
+          ) => LitRenderable,
+        ): LitRenderable {
+          const cellFlexRender = () => FlexRender({ cell })
 
           // Bind each cell component so it receives the cell as its first argument.
           // This allows column defs to call `cell.TextCell()` which internally
@@ -759,7 +759,7 @@ export function createTableHook<
             ...boundCellComponents,
           }) as Cell<TFeatures, TData, TValue> &
             BoundComponents<TCellComponents> & {
-              FlexRender: () => TemplateResult | string | null
+              FlexRender: () => LitRenderable
             }
 
           return renderFn(extendedCell)
@@ -771,10 +771,10 @@ export function createTableHook<
           renderFn: (
             header: Header<TFeatures, TData, TValue> &
               BoundComponents<THeaderComponents> & {
-                FlexRender: () => TemplateResult | string | null
+                FlexRender: () => LitRenderable
               },
-          ) => TemplateResult | string,
-        ): TemplateResult | string {
+          ) => LitRenderable,
+        ): LitRenderable {
           const headerFlexRender = () =>
             flexRender(header.column.columnDef.header, header.getContext())
 
@@ -789,7 +789,7 @@ export function createTableHook<
             ...boundHeaderComponents,
           }) as Header<TFeatures, TData, TValue> &
             BoundComponents<THeaderComponents> & {
-              FlexRender: () => TemplateResult | string | null
+              FlexRender: () => LitRenderable
             }
 
           return renderFn(extendedHeader)
@@ -801,10 +801,10 @@ export function createTableHook<
           renderFn: (
             header: Header<TFeatures, TData, TValue> &
               BoundComponents<THeaderComponents> & {
-                FlexRender: () => TemplateResult | string | null
+                FlexRender: () => LitRenderable
               },
-          ) => TemplateResult | string,
-        ): TemplateResult | string {
+          ) => LitRenderable,
+        ): LitRenderable {
           const footerFlexRender = () =>
             flexRender(header.column.columnDef.footer, header.getContext())
 
@@ -819,7 +819,7 @@ export function createTableHook<
             ...boundFooterComponents,
           }) as Header<TFeatures, TData, TValue> &
             BoundComponents<THeaderComponents> & {
-              FlexRender: () => TemplateResult | string | null
+              FlexRender: () => LitRenderable
             }
 
           return renderFn(extendedHeader)

--- a/packages/lit-table/src/flexRender.ts
+++ b/packages/lit-table/src/flexRender.ts
@@ -5,7 +5,22 @@ import type {
   RowData,
   TableFeatures,
 } from '@tanstack/table-core'
-import type { TemplateResult } from 'lit'
+import type { TemplateResult, noChange, nothing } from 'lit'
+import type { DirectiveResult } from 'lit/directive.js'
+
+export type LitRenderable =
+  | TemplateResult
+  | DirectiveResult
+  | Node
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | undefined
+  | typeof nothing
+  | typeof noChange
+  | Iterable<LitRenderable>
 
 /**
  * Renders a Lit table template value with the provided context props.
@@ -20,14 +35,10 @@ import type { TemplateResult } from 'lit'
  * ```
  */
 export function flexRender<TProps>(
-  Comp:
-    | ((props: TProps) => TemplateResult | string)
-    | string
-    | TemplateResult
-    | undefined,
+  Comp: ((props: TProps) => LitRenderable) | LitRenderable,
   props: TProps,
-): TemplateResult | string | null {
-  if (!Comp) return null
+): LitRenderable {
+  if (Comp === null || Comp === undefined) return null
 
   if (typeof Comp === 'function') {
     return Comp(props)
@@ -91,11 +102,30 @@ export function FlexRender<
   TFeatures extends TableFeatures,
   TData extends RowData,
   TValue extends CellData = CellData,
->(
-  props: FlexRenderProps<TFeatures, TData, TValue>,
-): TemplateResult | string | null {
+>(props: FlexRenderProps<TFeatures, TData, TValue>): LitRenderable {
   if ('cell' in props && props.cell) {
-    return flexRender(props.cell.column.columnDef.cell, props.cell.getContext())
+    const cell = props.cell
+    const columnDef = cell.column.columnDef
+    const groupingCell = cell as typeof cell & {
+      getIsAggregated?: () => boolean
+      getIsPlaceholder?: () => boolean
+    }
+    const groupingColumnDef = columnDef as typeof columnDef & {
+      aggregatedCell?: typeof columnDef.cell
+    }
+
+    if (groupingCell.getIsAggregated?.()) {
+      return flexRender(
+        groupingColumnDef.aggregatedCell ?? columnDef.cell,
+        cell.getContext(),
+      )
+    }
+
+    if (groupingCell.getIsPlaceholder?.()) {
+      return null
+    }
+
+    return flexRender(columnDef.cell, cell.getContext())
   }
 
   if ('header' in props && props.header) {

--- a/packages/lit-table/src/subscribe-directive.ts
+++ b/packages/lit-table/src/subscribe-directive.ts
@@ -154,6 +154,9 @@ export class SubscribeDirective extends AsyncDirective {
   /** Restores the controller subscription when the directive is re-attached to the DOM. */
   reconnected() {
     this.controller?.hostUpdate()
+    if (this.resolvedTemplate && this.controller) {
+      this.setValue(this.resolvedTemplate(this.controller.value))
+    }
   }
 
   /**

--- a/packages/lit-table/tests/unit/adapterLifecycle.test.ts
+++ b/packages/lit-table/tests/unit/adapterLifecycle.test.ts
@@ -1,0 +1,377 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { fireEvent, screen } from '@testing-library/dom'
+import { createAtom } from '@tanstack/lit-store'
+import { stockFeatures } from '@tanstack/table-core'
+import { LitElement, html } from 'lit'
+import { TableController } from '../../src/TableController'
+import type {
+  ColumnDef,
+  LitTable,
+  OnChangeFn,
+  RowSelectionState,
+} from '../../src'
+
+type Data = { id: string; title: string }
+
+const idColumn: ColumnDef<typeof stockFeatures, Data> = {
+  id: 'id',
+  accessorKey: 'id',
+}
+const titleColumn: ColumnDef<typeof stockFeatures, Data> = {
+  id: 'title',
+  accessorKey: 'title',
+}
+
+let elementId = 0
+
+function mount<TElement extends LitElement>(
+  elementClass: CustomElementConstructor,
+): TElement {
+  const tagName = `lit-table-adapter-test-${elementId++}`
+  customElements.define(tagName, elementClass)
+  const element = document.createElement(tagName) as TElement
+  document.body.append(element)
+  return element
+}
+
+function outputText(name: string) {
+  return screen.getByRole('status', { name }).textContent.trim()
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+  vi.restoreAllMocks()
+})
+
+describe('TableController lifecycle and option ownership', () => {
+  test('disconnecting the host stops root reactions to later state changes', async () => {
+    const sourceAtom = createAtom<RowSelectionState>({})
+    const rootSelectorCaptor = vi.fn<(state: RowSelectionState) => void>()
+
+    class LifecycleTable extends LitElement {
+      private controller = new TableController<typeof stockFeatures, Data>(this)
+      table?: LitTable<typeof stockFeatures, Data, RowSelectionState>
+
+      createRenderRoot() {
+        return this
+      }
+
+      protected render() {
+        const table = this.controller.table(
+          {
+            data: [{ id: '1', title: 'First' }],
+            columns: [idColumn, titleColumn],
+            features: stockFeatures,
+            getRowId: (row) => row.id,
+            atoms: {
+              rowSelection: sourceAtom,
+            },
+          },
+          (state) => {
+            rootSelectorCaptor(state.rowSelection)
+            return state.rowSelection
+          },
+        )
+        this.table = table
+
+        return html`
+          <output aria-label="Lifecycle selection">
+            ${JSON.stringify(table.state)}
+          </output>
+        `
+      }
+    }
+
+    const element = mount<LifecycleTable>(LifecycleTable)
+    await element.updateComplete
+
+    expect(rootSelectorCaptor.mock.lastCall?.[0]).toEqual({})
+
+    sourceAtom.set({ 1: true })
+    await element.updateComplete
+
+    expect(outputText('Lifecycle selection')).toBe('{"1":true}')
+    expect(rootSelectorCaptor.mock.lastCall?.[0]).toEqual({ 1: true })
+
+    element.remove()
+
+    const callsAfterDisconnect = rootSelectorCaptor.mock.calls.length
+
+    sourceAtom.set({ 2: true })
+    element.table?.setPageSize(25)
+
+    expect(rootSelectorCaptor).toHaveBeenCalledTimes(callsAfterDisconnect)
+
+    document.body.append(element)
+    await element.updateComplete
+
+    expect(outputText('Lifecycle selection')).toBe('{"2":true}')
+    expect(rootSelectorCaptor.mock.lastCall?.[0]).toEqual({ 2: true })
+  })
+
+  test('controlled state can release and reacquire ownership of a slice', async () => {
+    class OwnershipTable extends LitElement {
+      private controller = new TableController<typeof stockFeatures, Data>(this)
+      private controlledState: { rowSelection?: RowSelectionState } = {
+        rowSelection: { 1: true },
+      }
+      table?: LitTable<typeof stockFeatures, Data, RowSelectionState>
+
+      createRenderRoot() {
+        return this
+      }
+
+      setControlledState(state: { rowSelection?: RowSelectionState }) {
+        this.controlledState = state
+        this.requestUpdate()
+      }
+
+      protected render() {
+        const table = this.controller.table(
+          {
+            data: [
+              { id: '1', title: 'First' },
+              { id: '2', title: 'Second' },
+            ],
+            columns: [idColumn, titleColumn],
+            features: stockFeatures,
+            getRowId: (row) => row.id,
+            state: this.controlledState,
+          },
+          (state) => state.rowSelection,
+        )
+        this.table = table
+
+        return html`
+          <output aria-label="Owned selection">
+            ${JSON.stringify(table.state)}
+          </output>
+        `
+      }
+    }
+
+    const element = mount<OwnershipTable>(OwnershipTable)
+    await element.updateComplete
+
+    expect(outputText('Owned selection')).toBe('{"1":true}')
+
+    element.setControlledState({})
+    await element.updateComplete
+
+    expect(outputText('Owned selection')).toBe('{"1":true}')
+
+    element.table!.setRowSelection({ 2: true })
+    await element.updateComplete
+
+    expect(outputText('Owned selection')).toBe('{"2":true}')
+
+    element.setControlledState({ rowSelection: { 1: true, 2: true } })
+    await element.updateComplete
+
+    expect(outputText('Owned selection')).toBe('{"1":true,"2":true}')
+
+    element.table!.setRowSelection({})
+    await element.updateComplete
+
+    expect(outputText('Owned selection')).toBe('{"1":true,"2":true}')
+
+    element.setControlledState({})
+    await element.updateComplete
+
+    expect(outputText('Owned selection')).toBe('{}')
+  })
+
+  test('an external atom takes precedence over controlled state and receives table writes', async () => {
+    const externalAtom = createAtom<RowSelectionState>({ 2: true })
+
+    class ExternalAtomTable extends LitElement {
+      private controller = new TableController<typeof stockFeatures, Data>(this)
+      private controlledSelection: RowSelectionState = { 1: true }
+      table?: LitTable<typeof stockFeatures, Data, RowSelectionState>
+
+      createRenderRoot() {
+        return this
+      }
+
+      setControlledSelection(selection: RowSelectionState) {
+        this.controlledSelection = selection
+        this.requestUpdate()
+      }
+
+      protected render() {
+        const table = this.controller.table(
+          {
+            data: [
+              { id: '1', title: 'First' },
+              { id: '2', title: 'Second' },
+            ],
+            columns: [idColumn, titleColumn],
+            features: stockFeatures,
+            getRowId: (row) => row.id,
+            state: {
+              rowSelection: this.controlledSelection,
+            },
+            atoms: {
+              rowSelection: externalAtom,
+            },
+          },
+          (state) => state.rowSelection,
+        )
+        this.table = table
+
+        return html`
+          <output aria-label="External selection">
+            ${JSON.stringify(table.state)}
+          </output>
+          <button @click=${() => table.getRow('1').toggleSelected(false)}>
+            Deselect external row
+          </button>
+        `
+      }
+    }
+
+    const element = mount<ExternalAtomTable>(ExternalAtomTable)
+    await element.updateComplete
+
+    expect(outputText('External selection')).toBe('{"2":true}')
+
+    element.setControlledSelection({ 1: true, 2: true })
+    await element.updateComplete
+
+    expect(outputText('External selection')).toBe('{"2":true}')
+
+    externalAtom.set({ 1: true, 2: true })
+    await element.updateComplete
+
+    expect(outputText('External selection')).toBe('{"1":true,"2":true}')
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Deselect external row' }),
+    )
+    await element.updateComplete
+
+    expect(externalAtom.get()).toEqual({ 2: true })
+    expect(outputText('External selection')).toBe('{"2":true}')
+  })
+
+  test('coalesces dynamic data, columns, and callbacks into the next render', async () => {
+    const firstSelectionHandler = vi.fn<OnChangeFn<RowSelectionState>>()
+    const secondSelectionHandler = vi.fn<OnChangeFn<RowSelectionState>>()
+    const renderCaptor =
+      vi.fn<
+        (snapshot: {
+          canSelect: boolean
+          columnIds: Array<string>
+          values: Array<unknown>
+        }) => void
+      >()
+
+    class DynamicOptionsTable extends LitElement {
+      private controller = new TableController<typeof stockFeatures, Data>(this)
+      private data: Array<Data> = [{ id: '1', title: 'Initial' }]
+      private columns: Array<ColumnDef<typeof stockFeatures, Data>> = [idColumn]
+      private enableRowSelection = true
+      private onRowSelectionChange: OnChangeFn<RowSelectionState> =
+        firstSelectionHandler
+      table?: LitTable<typeof stockFeatures, Data, null>
+
+      createRenderRoot() {
+        return this
+      }
+
+      setOptions(options: {
+        columns: Array<ColumnDef<typeof stockFeatures, Data>>
+        data: Array<Data>
+        enableRowSelection: boolean
+        onRowSelectionChange: OnChangeFn<RowSelectionState>
+      }) {
+        this.data = options.data
+        this.columns = options.columns
+        this.enableRowSelection = options.enableRowSelection
+        this.onRowSelectionChange = options.onRowSelectionChange
+        this.requestUpdate()
+      }
+
+      protected render() {
+        const table = this.controller.table(
+          {
+            data: this.data,
+            columns: this.columns,
+            features: stockFeatures,
+            enableRowSelection: this.enableRowSelection,
+            getRowId: (row) => row.id,
+            onRowSelectionChange: this.onRowSelectionChange,
+          },
+          () => null,
+        )
+        this.table = table
+        const row = table.getRowModel().rows[0]!
+        const snapshot = {
+          canSelect: row.getCanSelect(),
+          columnIds: table.getAllLeafColumns().map((column) => column.id),
+          values: row.getAllCells().map((cell) => cell.getValue()),
+        }
+        renderCaptor(snapshot)
+
+        return html`
+          <output aria-label="Dynamic options">
+            ${JSON.stringify(snapshot)}
+          </output>
+        `
+      }
+    }
+
+    const element = mount<DynamicOptionsTable>(DynamicOptionsTable)
+    await element.updateComplete
+
+    expect(element.table?.subscribe).toEqual(expect.any(Function))
+    expect(element.table?.FlexRender).toEqual(expect.any(Function))
+    expect('state' in element.table!).toBe(true)
+
+    element.table!.toggleAllRowsSelected(true)
+
+    expect(firstSelectionHandler).toHaveBeenCalledOnce()
+    expect(secondSelectionHandler).not.toHaveBeenCalled()
+
+    element.setOptions({
+      data: [{ id: '2', title: 'Intermediate' }],
+      columns: [idColumn, titleColumn],
+      enableRowSelection: false,
+      onRowSelectionChange: secondSelectionHandler,
+    })
+    element.setOptions({
+      data: [{ id: '3', title: 'Final' }],
+      columns: [titleColumn],
+      enableRowSelection: false,
+      onRowSelectionChange: secondSelectionHandler,
+    })
+    await element.updateComplete
+
+    expect(renderCaptor.mock.calls).toEqual([
+      [
+        {
+          canSelect: true,
+          columnIds: ['id'],
+          values: ['1'],
+        },
+      ],
+      [
+        {
+          canSelect: false,
+          columnIds: ['title'],
+          values: ['Final'],
+        },
+      ],
+    ])
+    expect(outputText('Dynamic options')).toBe(
+      '{"canSelect":false,"columnIds":["title"],"values":["Final"]}',
+    )
+
+    element.table!.toggleAllRowsSelected(false)
+
+    expect(firstSelectionHandler).toHaveBeenCalledOnce()
+    expect(secondSelectionHandler).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/lit-table/tests/unit/defaultReactivity.test.ts
+++ b/packages/lit-table/tests/unit/defaultReactivity.test.ts
@@ -5,7 +5,9 @@ describe('TableController', () => {
   test('uses default reactivity when constructing a table', () => {
     const host = {
       addController: () => {},
+      removeController: () => {},
       requestUpdate: () => {},
+      updateComplete: Promise.resolve(true),
     }
     const controller = new TableController<any, any>(host)
 

--- a/packages/lit-table/tests/unit/flexRender.test.ts
+++ b/packages/lit-table/tests/unit/flexRender.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test, vi } from 'vitest'
+import { html, nothing } from 'lit'
+import { flexRender } from '../../src/flexRender'
+
+describe('flexRender', () => {
+  test('handles empty, static, template, and callback renderers', () => {
+    const props = { value: 'Ada' }
+    const callback = vi.fn(
+      (context: typeof props) => html`<strong>${context.value}</strong>`,
+    )
+    const existingTemplate = html`<span>Existing</span>`
+
+    expect(flexRender(undefined, props)).toBeNull()
+    expect(flexRender(null, props)).toBeNull()
+    expect(flexRender('', props)).toBe('')
+    expect(flexRender(0, props)).toBe(0)
+    expect(flexRender(false, props)).toBe(false)
+    expect(flexRender(nothing, props)).toBe(nothing)
+    expect(flexRender(['Ada', 0], props)).toEqual(['Ada', 0])
+    expect(flexRender('Plain text', props)).toBe('Plain text')
+    expect(flexRender(existingTemplate, props)).toBe(existingTemplate)
+    expect(flexRender(callback, props)).toEqual(
+      html`<strong>${props.value}</strong>`,
+    )
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith(props)
+    expect(flexRender(() => 0, props)).toBe(0)
+  })
+})

--- a/packages/lit-table/tests/unit/rendering.test.ts
+++ b/packages/lit-table/tests/unit/rendering.test.ts
@@ -1,0 +1,460 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/dom'
+import { createAtom } from '@tanstack/lit-store'
+import { stockFeatures } from '@tanstack/table-core'
+import { LitElement, html } from 'lit'
+import { createTableHook } from '../../src/createTableHook'
+import { FlexRender } from '../../src/flexRender'
+import { TableController } from '../../src/TableController'
+import { subscribe } from '../../src/subscribe-directive'
+import type { Cell, ColumnDef, Header, RowSelectionState } from '../../src'
+
+type Data = { id: string; name: string }
+
+const columns: Array<ColumnDef<typeof stockFeatures, Data>> = [
+  {
+    id: 'name',
+    accessorKey: 'name',
+    header: ({ column }) => `header:${column.id}`,
+    cell: ({ getValue }) => `cell:${getValue()}`,
+    aggregatedCell: ({ getValue }) => `aggregate:${getValue()}`,
+    footer: ({ column }) => `footer:${column.id}`,
+  },
+]
+
+let elementId = 0
+
+function mount<TElement extends LitElement>(
+  elementClass: CustomElementConstructor,
+): TElement {
+  const tagName = `lit-table-render-test-${elementId++}`
+  customElements.define(tagName, elementClass)
+  const element = document.createElement(tagName) as TElement
+  document.body.append(element)
+  return element
+}
+
+function outputText(name: string) {
+  return screen.getByRole('status', { name }).textContent.trim()
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+  vi.restoreAllMocks()
+})
+
+describe('FlexRender', () => {
+  test('renders normal, aggregate, placeholder, header, and footer templates reactively', async () => {
+    class FlexRenderTable extends LitElement {
+      private controller = new TableController<typeof stockFeatures, Data>(this)
+      private mode: 'normal' | 'aggregate' | 'placeholder' = 'normal'
+      private cell?: Cell<typeof stockFeatures, Data, string>
+      private header?: Header<typeof stockFeatures, Data, string>
+      private footer?: Header<typeof stockFeatures, Data, string>
+
+      createRenderRoot() {
+        return this
+      }
+
+      setMode(mode: 'normal' | 'aggregate' | 'placeholder') {
+        this.mode = mode
+        this.requestUpdate()
+      }
+
+      protected render() {
+        const table = this.controller.table({
+          data: [{ id: '1', name: 'Ada' }],
+          columns,
+          features: stockFeatures,
+          getRowId: (row) => row.id,
+        })
+
+        if (!this.cell) {
+          this.cell = table.getRow('1').getAllCells()[0] as Cell<
+            typeof stockFeatures,
+            Data,
+            string
+          >
+          this.header = table.getHeaderGroups()[0]!.headers[0] as Header<
+            typeof stockFeatures,
+            Data,
+            string
+          >
+          this.footer = table.getFooterGroups()[0]!.headers[0] as Header<
+            typeof stockFeatures,
+            Data,
+            string
+          >
+          vi.spyOn(this.cell, 'getIsAggregated').mockImplementation(
+            () => this.mode === 'aggregate',
+          )
+          vi.spyOn(this.cell, 'getIsPlaceholder').mockImplementation(
+            () => this.mode === 'placeholder',
+          )
+        }
+
+        return html`
+          <output aria-label="Rendered cell">
+            ${FlexRender({ cell: this.cell })}
+          </output>
+          <output aria-label="Rendered header">
+            ${FlexRender({ header: this.header! })}
+          </output>
+          <output aria-label="Rendered footer">
+            ${FlexRender({ footer: this.footer! })}
+          </output>
+        `
+      }
+    }
+
+    const element = mount<FlexRenderTable>(FlexRenderTable)
+    await element.updateComplete
+
+    expect(outputText('Rendered cell')).toBe('cell:Ada')
+    expect(outputText('Rendered header')).toBe('header:name')
+    expect(outputText('Rendered footer')).toBe('footer:name')
+
+    element.setMode('aggregate')
+    await element.updateComplete
+
+    expect(outputText('Rendered cell')).toBe('aggregate:Ada')
+
+    element.setMode('placeholder')
+    await element.updateComplete
+
+    expect(outputText('Rendered cell')).toBe('')
+
+    element.setMode('normal')
+    await element.updateComplete
+
+    expect(outputText('Rendered cell')).toBe('cell:Ada')
+  })
+})
+
+describe('table.subscribe', () => {
+  test('updates both source overloads without rerendering an opted-out host', async () => {
+    const hostRenderCaptor = vi.fn()
+
+    class SubscribeTable extends LitElement {
+      private controller = new TableController<typeof stockFeatures, Data>(this)
+
+      createRenderRoot() {
+        return this
+      }
+
+      protected render() {
+        hostRenderCaptor()
+        const table = this.controller.table(
+          {
+            data: [{ id: '1', name: 'Ada' }],
+            columns,
+            features: stockFeatures,
+            getRowId: (row) => row.id,
+          },
+          () => ({}),
+        )
+
+        return html`
+          ${table.subscribe(
+            table.atoms.rowSelection,
+            (selection) => html`
+              <output aria-label="Subscribed atom selection">
+                ${JSON.stringify(selection)}
+              </output>
+            `,
+          )}
+          ${table.subscribe(
+            table.store,
+            (state) => Boolean(state.rowSelection['1']),
+            (selected) => html`
+              <output aria-label="Subscribed selected row">
+                ${String(selected)}
+              </output>
+            `,
+          )}
+          <button @click=${() => table.getRow('1').toggleSelected(true)}>
+            Select subscribed row
+          </button>
+        `
+      }
+    }
+
+    const element = mount<SubscribeTable>(SubscribeTable)
+    await element.updateComplete
+
+    expect(outputText('Subscribed atom selection')).toBe('{}')
+    expect(outputText('Subscribed selected row')).toBe('false')
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select subscribed row' }),
+    )
+
+    await waitFor(() => {
+      expect(outputText('Subscribed atom selection')).toBe('{"1":true}')
+      expect(outputText('Subscribed selected row')).toBe('true')
+    })
+    expect(hostRenderCaptor).toHaveBeenCalledOnce()
+  })
+
+  test('disconnecting a directive unsubscribes its source', async () => {
+    const sourceAtom = createAtom<RowSelectionState>({})
+    const subscribeSpy = vi.spyOn(sourceAtom, 'subscribe')
+    const templateCaptor = vi.fn<(selection: RowSelectionState) => void>()
+
+    class SubscribeLifecycle extends LitElement {
+      createRenderRoot() {
+        return this
+      }
+
+      protected render() {
+        return html`
+          ${subscribe(sourceAtom, (selection) => {
+            templateCaptor(selection)
+            return html`
+              <output aria-label="Directive lifecycle selection">
+                ${JSON.stringify(selection)}
+              </output>
+            `
+          })}
+        `
+      }
+    }
+
+    const element = mount<SubscribeLifecycle>(SubscribeLifecycle)
+    await element.updateComplete
+
+    expect(subscribeSpy).toHaveBeenCalledOnce()
+
+    sourceAtom.set({ 1: true })
+    await waitFor(() => {
+      expect(outputText('Directive lifecycle selection')).toBe('{"1":true}')
+    })
+
+    element.remove()
+
+    const callsAfterDisconnect = templateCaptor.mock.calls.length
+    sourceAtom.set({ 2: true })
+
+    expect(templateCaptor).toHaveBeenCalledTimes(callsAfterDisconnect)
+
+    document.body.append(element)
+    await element.updateComplete
+
+    expect(subscribeSpy).toHaveBeenCalledTimes(2)
+    await waitFor(() => {
+      expect(outputText('Directive lifecycle selection')).toBe('{"2":true}')
+    })
+
+    sourceAtom.set({ 3: true })
+    await waitFor(() => {
+      expect(outputText('Directive lifecycle selection')).toBe('{"3":true}')
+    })
+  })
+})
+
+describe('createTableHook runtime', () => {
+  test('binds defaults, registered renderers, wrappers, and table context', async () => {
+    const tableBadge = vi.fn(() => html`<span>table-badge</span>`)
+    const cellBadge = vi.fn(
+      (cell: Cell<typeof stockFeatures, Data>) =>
+        html`<span>cell-badge:${cell.id}</span>`,
+    )
+    const headerBadge = vi.fn(
+      (header: Header<typeof stockFeatures, Data>) =>
+        html`<span>header-badge:${header.id}</span>`,
+    )
+    const hook = createTableHook({
+      features: stockFeatures,
+      enableRowSelection: false,
+      getRowId: (row: Data) => `row-${row.id}`,
+      tableComponents: { tableBadge },
+      cellComponents: { cellBadge },
+      headerComponents: { headerBadge },
+    })
+    const columnHelper = hook.createAppColumnHelper<Data>()
+    const appColumns = columnHelper.columns([
+      columnHelper.accessor('name', {
+        header: ({ column }) => `header:${column.id}`,
+        cell: ({ getValue }) => `cell:${getValue()}`,
+        footer: ({ column }) => `footer:${column.id}`,
+      }),
+    ])
+    const tableContextCaptor = vi.fn<(table: unknown) => void>()
+
+    class TableContextConsumer extends LitElement {
+      private tableConsumer = hook.useTableContext<Data>(this)
+
+      createRenderRoot() {
+        return this
+      }
+
+      protected render() {
+        const table = this.tableConsumer.value
+        tableContextCaptor(table)
+
+        return html`
+          <output aria-label="Table context available">
+            ${String(Boolean(table))}
+          </output>
+        `
+      }
+    }
+    customElements.define(
+      'lit-table-context-consumer-test',
+      TableContextConsumer,
+    )
+
+    class AppTable extends LitElement {
+      private appTable = hook.useAppTable(this, {
+        data: [{ id: '1', name: 'Ada' }],
+        columns: appColumns,
+        enableRowSelection: true,
+      })
+      table?: ReturnType<(typeof this.appTable)['table']>
+
+      createRenderRoot() {
+        return this
+      }
+
+      protected render() {
+        const table = this.appTable.table()
+        this.table = table
+        const row = table.getRowModel().rows[0]!
+        const cell = row.getAllCells()[0]!
+        const header = table.getHeaderGroups()[0]!.headers[0]!
+        const footer = table.getFooterGroups()[0]!.headers[0]!
+
+        return html`
+          <output aria-label="Row can be selected">
+            ${String(row.getCanSelect())}
+          </output>
+          ${table.tableBadge()}
+          ${table.AppCell(
+            cell,
+            (appCell) => html`
+              ${appCell.cellBadge()}
+              <output aria-label="Bound cell"> ${appCell.FlexRender()} </output>
+            `,
+          )}
+          ${table.AppHeader(
+            header,
+            (appHeader) => html`
+              ${appHeader.headerBadge()}
+              <output aria-label="Bound header">
+                ${appHeader.FlexRender()}
+              </output>
+            `,
+          )}
+          ${table.AppFooter(
+            footer,
+            (appFooter) => html`
+              <output aria-label="Bound footer">
+                ${appFooter.FlexRender()}
+              </output>
+            `,
+          )}
+          <lit-table-context-consumer-test></lit-table-context-consumer-test>
+        `
+      }
+    }
+
+    const element = mount<AppTable>(AppTable)
+    await element.updateComplete
+    await waitFor(() => {
+      expect(outputText('Table context available')).toBe('true')
+    })
+
+    const table = element.table!
+    const cell = table.getRowModel().rows[0]!.getAllCells()[0]!
+    const header = table.getHeaderGroups()[0]!.headers[0]!
+
+    expect(hook.appFeatures).toBe(stockFeatures)
+    expect(table.FlexRender).toBe(FlexRender)
+    expect(table.AppCell).toEqual(expect.any(Function))
+    expect(table.AppHeader).toEqual(expect.any(Function))
+    expect(table.AppFooter).toEqual(expect.any(Function))
+    expect(outputText('Row can be selected')).toBe('true')
+    expect(outputText('Bound cell')).toBe('cell:Ada')
+    expect(outputText('Bound header')).toBe('header:name')
+    expect(outputText('Bound footer')).toBe('footer:name')
+    expect(screen.getByText(`cell-badge:${cell.id}`)).toBeTruthy()
+    expect(screen.getByText(`header-badge:${header.id}`)).toBeTruthy()
+    expect(screen.getByText('table-badge')).toBeTruthy()
+    expect(cellBadge).toHaveBeenCalledWith(cell)
+    expect(headerBadge).toHaveBeenCalledWith(header)
+    expect(tableContextCaptor).toHaveBeenCalledWith(table)
+  })
+
+  test('bound cell FlexRender preserves aggregate and placeholder modes', async () => {
+    const hook = createTableHook({
+      features: stockFeatures,
+    })
+    const columnHelper = hook.createAppColumnHelper<Data>()
+    const appColumns = columnHelper.columns([
+      columnHelper.accessor('name', {
+        cell: ({ getValue }) => `cell:${getValue()}`,
+        aggregatedCell: ({ getValue }) => `aggregate:${getValue()}`,
+      }),
+    ])
+
+    class BoundCellTable extends LitElement {
+      private appTable = hook.useAppTable(this, {
+        data: [{ id: '1', name: 'Ada' }],
+        columns: appColumns,
+        getRowId: (row) => row.id,
+      })
+      private mode: 'aggregate' | 'placeholder' | 'normal' = 'aggregate'
+      private cell?: Cell<typeof stockFeatures, Data, string>
+
+      createRenderRoot() {
+        return this
+      }
+
+      setMode(mode: 'aggregate' | 'placeholder' | 'normal') {
+        this.mode = mode
+        this.requestUpdate()
+      }
+
+      protected render() {
+        const table = this.appTable.table()
+        if (!this.cell) {
+          this.cell = table.getRow('1').getAllCells()[0] as Cell<
+            typeof stockFeatures,
+            Data,
+            string
+          >
+          vi.spyOn(this.cell, 'getIsAggregated').mockImplementation(
+            () => this.mode === 'aggregate',
+          )
+          vi.spyOn(this.cell, 'getIsPlaceholder').mockImplementation(
+            () => this.mode === 'placeholder',
+          )
+        }
+
+        return table.AppCell(
+          this.cell,
+          (cell) => html`
+            <output aria-label="Bound cell mode"> ${cell.FlexRender()} </output>
+          `,
+        )
+      }
+    }
+
+    const element = mount<BoundCellTable>(BoundCellTable)
+    await element.updateComplete
+
+    expect(outputText('Bound cell mode')).toBe('aggregate:Ada')
+
+    element.setMode('placeholder')
+    await element.updateComplete
+
+    expect(outputText('Bound cell mode')).toBe('')
+
+    element.setMode('normal')
+    await element.updateComplete
+
+    expect(outputText('Bound cell mode')).toBe('cell:Ada')
+  })
+})

--- a/packages/lit-table/tests/unit/selectorGate.test.ts
+++ b/packages/lit-table/tests/unit/selectorGate.test.ts
@@ -6,9 +6,11 @@ function createHost() {
   const host = {
     updateCount: 0,
     addController: () => {},
+    removeController: () => {},
     requestUpdate: () => {
       host.updateCount++
     },
+    updateComplete: Promise.resolve(true),
   }
   return host
 }

--- a/packages/lit-table/tsconfig.json
+++ b/packages/lit-table/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "eslint.config.js", "vite.config.ts"]
+  "include": ["src", "tests", "eslint.config.js", "vite.config.ts"]
 }

--- a/packages/preact-table/package.json
+++ b/packages/preact-table/package.json
@@ -53,7 +53,9 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.10.5",
-    "preact": "^10.29.2"
+    "@testing-library/preact": "^3.2.4",
+    "preact": "^10.29.2",
+    "preact-render-to-string": "^6.7.0"
   },
   "peerDependencies": {
     "preact": ">=10"

--- a/packages/preact-table/src/FlexRender.tsx
+++ b/packages/preact-table/src/FlexRender.tsx
@@ -33,9 +33,12 @@ function isExoticComponent(component: any) {
   return (
     typeof component === 'object' &&
     typeof component.$$typeof === 'symbol' &&
-    ['preact.memo', 'preact.forward_ref'].includes(
-      component.$$typeof.description,
-    )
+    [
+      'preact.memo',
+      'preact.forward_ref',
+      'react.memo',
+      'react.forward_ref',
+    ].includes(component.$$typeof.description)
   )
 }
 
@@ -47,11 +50,11 @@ export function flexRender<TProps extends object>(
   Comp: Renderable<TProps> | null,
   props: TProps,
 ): ComponentChild | Element | null {
-  return !Comp ? null : isPreactComponent<TProps>(Comp) ? (
-    <Comp {...props} />
-  ) : (
-    Comp
-  )
+  if (Comp === null || Comp === undefined) {
+    return null
+  }
+
+  return isPreactComponent<TProps>(Comp) ? <Comp {...props} /> : Comp
 }
 
 /**

--- a/packages/preact-table/tests/unit/adapterReactivity.test.tsx
+++ b/packages/preact-table/tests/unit/adapterReactivity.test.tsx
@@ -1,27 +1,23 @@
 // @vitest-environment jsdom
 
-import * as React from 'react'
-import {
-  act,
-  cleanup,
-  fireEvent,
-  screen,
-  render as testingLibraryRender,
-} from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { useLayoutEffect, useState } from 'preact/hooks'
+import { act } from 'preact/test-utils'
 import {
   createPaginatedRowModel,
   stockFeatures,
   tableFeatures,
 } from '@tanstack/table-core'
-import { createAtom } from '@tanstack/react-store'
+import { createAtom } from '@tanstack/preact-store'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { useTable } from '../src'
+import { useTable } from '../../src'
 import type {
   ColumnDef,
+  OnChangeFn,
   PaginationState,
   RowSelectionState,
 } from '@tanstack/table-core'
-import type { ReactTable } from '../src'
+import type { PreactTable } from '../../src'
 
 type Data = {
   id: string
@@ -62,13 +58,6 @@ const paginatedColumns: Array<ColumnDef<typeof paginatedFeatures, Data>> = [
   },
 ]
 
-let renderedView: ReturnType<typeof testingLibraryRender> | undefined
-
-function render(element: React.ReactNode) {
-  renderedView = testingLibraryRender(element)
-  return renderedView
-}
-
 function text(name: string) {
   return screen.getByRole('status', { name }).textContent
 }
@@ -77,28 +66,19 @@ function click(name: string) {
   fireEvent.click(screen.getByRole('button', { name }))
 }
 
-function unmount() {
-  renderedView!.unmount()
-  renderedView = undefined
-}
-
 afterEach(() => {
   cleanup()
-  renderedView = undefined
   vi.restoreAllMocks()
 })
 
-// Adapter contract only: React/store ownership, subscriptions, lifecycle, and
+// Adapter contract only: Preact/store ownership, subscriptions, lifecycle, and
 // option refreshes. Row-model algorithms remain covered by table-core.
-describe('React adapter reactivity and lifecycle', () => {
-  test('exposes React adapter APIs through the returned table surface', () => {
+describe('Preact adapter reactivity and lifecycle', () => {
+  test('exposes Preact adapter APIs through the returned table surface', () => {
     function TableHarness() {
       const table = useTable(
         {
-          data: [
-            { id: '1', title: 'First' },
-            { id: '2', title: 'Second' },
-          ],
+          data: [{ id: '1', title: 'Title' }],
           features: stockFeatures,
           columns,
           getRowId: (row) => row.id,
@@ -157,8 +137,9 @@ describe('React adapter reactivity and lifecycle', () => {
     }))
     const coreRowModelCaptor = vi.fn()
     const rowModelCaptor = vi.fn()
+
     function TableHarness() {
-      const [pagination, setPagination] = React.useState<PaginationState>({
+      const [pagination, setPagination] = useState<PaginationState>({
         pageIndex: 0,
         pageSize: 5,
       })
@@ -244,13 +225,11 @@ describe('React adapter reactivity and lifecycle', () => {
             )}
           </table.Subscribe>
           <table.Subscribe source={table.atoms.rowSelection}>
-            {(selection) => {
-              return (
-                <output aria-label="External row selection">
-                  {JSON.stringify(selection)}
-                </output>
-              )
-            }}
+            {(selection) => (
+              <output aria-label="External row selection">
+                {JSON.stringify(selection)}
+              </output>
+            )}
           </table.Subscribe>
           <button onClick={() => table.getRow('1').toggleSelected()}>
             Toggle external row
@@ -399,12 +378,12 @@ describe('React adapter reactivity and lifecycle', () => {
     expect(pageSizeRenderCaptor).toHaveBeenCalledTimes(2)
   })
 
-  test('stops root and isolated React observers after unmount', () => {
+  test('stops root and isolated Preact observers after unmount', () => {
     const rowSelectionAtom = createAtom<RowSelectionState>({})
     const rootStoreSelectorCaptor = vi.fn()
     const isolatedStoreCaptor = vi.fn()
     const captureTable =
-      vi.fn<(table: ReactTable<typeof stockFeatures, Data, boolean>) => void>()
+      vi.fn<(table: PreactTable<typeof stockFeatures, Data, boolean>) => void>()
 
     function TableHarness() {
       const table = useTable(
@@ -426,7 +405,7 @@ describe('React adapter reactivity and lifecycle', () => {
         },
       )
 
-      React.useLayoutEffect(() => {
+      useLayoutEffect(() => {
         captureTable(table)
       }, [table])
 
@@ -449,7 +428,7 @@ describe('React adapter reactivity and lifecycle', () => {
       )
     }
 
-    render(<TableHarness />)
+    const view = render(<TableHarness />)
 
     act(() => {
       rowSelectionAtom.set({ 1: true })
@@ -457,7 +436,7 @@ describe('React adapter reactivity and lifecycle', () => {
 
     expect(text('Lifecycle selection')).toBe('true')
 
-    unmount()
+    view.unmount()
 
     const rootCallsAfterUnmount = rootStoreSelectorCaptor.mock.calls.length
     const isolatedCallsAfterUnmount = isolatedStoreCaptor.mock.calls.length
@@ -509,7 +488,7 @@ describe('React adapter reactivity and lifecycle', () => {
     const renderCaptor = vi.fn<(version: number) => void>()
 
     function TableHarness() {
-      const [version, setVersion] = React.useState(0)
+      const [version, setVersion] = useState(0)
       const isUpdated = version === 1
       const table = useTable({
         data: isUpdated ? updatedData : initialData,
@@ -571,5 +550,60 @@ describe('React adapter reactivity and lifecycle', () => {
     expect(text('Dynamic cell value')).toBe('ready')
     expect(text('Dynamic fallback')).toBe('updated fallback')
     expect(renderCaptor.mock.calls).toEqual([[0], [1]])
+  })
+
+  test('table APIs use the latest option callback', () => {
+    const firstHandler = vi.fn<OnChangeFn<RowSelectionState>>()
+    const secondHandler = vi.fn<OnChangeFn<RowSelectionState>>()
+
+    function CallbackHarness() {
+      const [useSecondHandler, setUseSecondHandler] = useState(false)
+      const table = useTable(
+        {
+          data: [{ id: '1', title: 'Title' }],
+          features: stockFeatures,
+          columns,
+          getRowId: (row) => row.id,
+          onRowSelectionChange: useSecondHandler ? secondHandler : firstHandler,
+        },
+        () => null,
+      )
+
+      return (
+        <>
+          <output aria-label="Active selection handler">
+            {useSecondHandler ? 'second' : 'first'}
+          </output>
+          <button onClick={() => table.setRowSelection({ 1: true })}>
+            Request row selection
+          </button>
+          <button onClick={() => setUseSecondHandler(true)}>
+            Use second selection handler
+          </button>
+        </>
+      )
+    }
+
+    render(<CallbackHarness />)
+
+    act(() => {
+      click('Request row selection')
+    })
+
+    expect(firstHandler).toHaveBeenCalledTimes(1)
+    expect(secondHandler).not.toHaveBeenCalled()
+
+    act(() => {
+      click('Use second selection handler')
+    })
+
+    expect(text('Active selection handler')).toBe('second')
+
+    act(() => {
+      click('Request row selection')
+    })
+
+    expect(firstHandler).toHaveBeenCalledTimes(1)
+    expect(secondHandler).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/preact-table/tests/unit/createTableHook.test.tsx
+++ b/packages/preact-table/tests/unit/createTableHook.test.tsx
@@ -1,0 +1,247 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { useEffect, useState } from 'preact/hooks'
+import { act } from 'preact/test-utils'
+import { rowSelectionFeature, tableFeatures } from '@tanstack/table-core'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { createTableHook, createTableHookContexts } from '../../src'
+
+type Person = {
+  id: string
+  name: string
+}
+
+const features = tableFeatures({
+  rowSelectionFeature,
+})
+const contexts = createTableHookContexts<typeof features, Person>()
+
+function RowCount() {
+  const table = contexts.useTableContext<Person>()
+
+  return (
+    <output aria-label="Bound row count">
+      {table.getRowModel().rows.length}
+    </output>
+  )
+}
+
+function NameCell() {
+  const cell = contexts.useCellContext<string>()
+
+  return <span>{cell.getValue().toUpperCase()}</span>
+}
+
+function NameHeader() {
+  const header = contexts.useHeaderContext<string>()
+
+  return <span>Header {header.column.id}</span>
+}
+
+const appTable = createTableHook({
+  features,
+  tableContext: contexts.tableContext,
+  cellContext: contexts.cellContext,
+  headerContext: contexts.headerContext,
+  tableComponents: { RowCount },
+  cellComponents: { NameCell },
+  headerComponents: { NameHeader },
+})
+const columnHelper = appTable.createAppColumnHelper<Person>()
+const columns = columnHelper.columns([
+  columnHelper.accessor('name', {
+    id: 'name',
+    header: ({ header }) => <header.NameHeader />,
+    cell: ({ cell }) => <cell.NameCell />,
+    footer: 'Name footer',
+  }),
+])
+
+function outputText(name: string) {
+  return screen.getByRole('status', { name }).textContent
+}
+
+function click(name: string) {
+  fireEvent.click(screen.getByRole('button', { name }))
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('createTableHook runtime', () => {
+  test('binds components, contexts, FlexRender, and state selectors', () => {
+    function TableHarness() {
+      const table = appTable.useAppTable(
+        {
+          data: [{ id: '1', name: 'Ada' }],
+          columns,
+          getRowId: (row) => row.id,
+        },
+        () => null,
+      )
+      const header = table.getHeaderGroups()[0]!.headers[0]!
+      const cell = table.getRowModel().rows[0]!.getAllCells()[0]!
+
+      return (
+        <table.AppTable
+          selector={(state) => Object.keys(state.rowSelection).length}
+        >
+          {(selectedCount) => (
+            <>
+              <table.RowCount />
+              <output aria-label="App table selection">{selectedCount}</output>
+              <table.AppHeader header={header}>
+                {(extendedHeader) => <extendedHeader.FlexRender />}
+              </table.AppHeader>
+              <table.AppCell
+                cell={cell}
+                selector={(state) => Boolean(state.rowSelection[cell.row.id])}
+              >
+                {(extendedCell, selected) => (
+                  <>
+                    <extendedCell.FlexRender />
+                    <output aria-label="App cell selection">
+                      {String(selected)}
+                    </output>
+                  </>
+                )}
+              </table.AppCell>
+              <table.AppFooter header={header}>
+                {(extendedFooter) => <extendedFooter.FlexRender />}
+              </table.AppFooter>
+              <button onClick={() => cell.row.toggleSelected(true)}>
+                Select app row
+              </button>
+            </>
+          )}
+        </table.AppTable>
+      )
+    }
+
+    render(<TableHarness />)
+
+    expect(outputText('Bound row count')).toBe('1')
+    expect(screen.getByText('Header name')).toBeTruthy()
+    expect(screen.getByText('ADA')).toBeTruthy()
+    expect(screen.getByText('Name footer')).toBeTruthy()
+    expect(outputText('App table selection')).toBe('0')
+    expect(outputText('App cell selection')).toBe('false')
+
+    act(() => {
+      click('Select app row')
+    })
+
+    expect(outputText('App table selection')).toBe('1')
+    expect(outputText('App cell selection')).toBe('true')
+  })
+
+  test('keeps App wrappers mounted while contexts receive new table objects', () => {
+    const mountCaptor = vi.fn()
+    const unmountCaptor = vi.fn()
+
+    function StatefulCell() {
+      const cell = appTable.useCellContext<string>()
+      const [draft, setDraft] = useState('initial')
+
+      useEffect(() => {
+        mountCaptor()
+        return () => unmountCaptor()
+      }, [])
+
+      return (
+        <>
+          <label htmlFor="stateful-cell-input">Cell draft</label>
+          <input
+            id="stateful-cell-input"
+            value={draft}
+            onInput={(event) => setDraft(event.currentTarget.value)}
+          />
+          <output aria-label="Latest cell value">{cell.getValue()}</output>
+        </>
+      )
+    }
+
+    function TableHarness() {
+      const [updated, setUpdated] = useState(false)
+      const table = appTable.useAppTable(
+        {
+          data: [{ id: '1', name: updated ? 'Grace' : 'Ada' }],
+          columns,
+          getRowId: (row) => row.id,
+        },
+        () => null,
+      )
+      const header = table.getHeaderGroups()[0]!.headers[0]!
+      const cell = table.getRowModel().rows[0]!.getAllCells()[0]!
+
+      return (
+        <>
+          <table.AppTable>
+            <table.AppHeader header={header}>
+              {() => (
+                <table.AppFooter header={header}>
+                  {() => (
+                    <table.AppCell cell={cell}>
+                      {() => <StatefulCell />}
+                    </table.AppCell>
+                  )}
+                </table.AppFooter>
+              )}
+            </table.AppHeader>
+          </table.AppTable>
+          <button onClick={() => setUpdated(true)}>Refresh app table</button>
+        </>
+      )
+    }
+
+    render(<TableHarness />)
+
+    const input = screen.getByRole('textbox', { name: 'Cell draft' })
+    fireEvent.input(input, { target: { value: 'edited' } })
+
+    expect(outputText('Latest cell value')).toBe('Ada')
+    expect(mountCaptor).toHaveBeenCalledOnce()
+
+    act(() => {
+      click('Refresh app table')
+    })
+
+    expect(screen.getByRole('textbox', { name: 'Cell draft' })).toBe(input)
+    expect((input as HTMLInputElement).value).toBe('edited')
+    expect(outputText('Latest cell value')).toBe('Grace')
+    expect(mountCaptor).toHaveBeenCalledOnce()
+    expect(unmountCaptor).not.toHaveBeenCalled()
+  })
+
+  test('throws focused errors when context hooks are used outside wrappers', () => {
+    function MissingTableContext() {
+      appTable.useTableContext<Person>()
+      return null
+    }
+
+    function MissingCellContext() {
+      appTable.useCellContext<string>()
+      return null
+    }
+
+    function MissingHeaderContext() {
+      appTable.useHeaderContext<string>()
+      return null
+    }
+
+    expect(() => render(<MissingTableContext />)).toThrow(
+      '`useTableContext` must be used within an `AppTable` component',
+    )
+    cleanup()
+    expect(() => render(<MissingCellContext />)).toThrow(
+      '`useCellContext` must be used within an `AppCell` component',
+    )
+    cleanup()
+    expect(() => render(<MissingHeaderContext />)).toThrow(
+      '`useHeaderContext` must be used within an `AppHeader` or `AppFooter` component',
+    )
+  })
+})

--- a/packages/preact-table/tests/unit/rendering.test.tsx
+++ b/packages/preact-table/tests/unit/rendering.test.tsx
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { useState } from 'preact/hooks'
+import { act } from 'preact/test-utils'
+import { stockFeatures } from '@tanstack/table-core'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { FlexRender, useTable } from '../../src'
+import type { ColumnDef } from '@tanstack/table-core'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function outputText(name: string) {
+  return screen.getByRole('status', { name }).textContent
+}
+
+describe('FlexRender', () => {
+  type Data = { id: string; name: string }
+  type CellMode = 'aggregate' | 'normal' | 'placeholder'
+
+  const columns: Array<ColumnDef<typeof stockFeatures, Data>> = [
+    {
+      id: 'name',
+      accessorKey: 'name',
+      header: ({ column }) => <span>{`header:${column.id}`}</span>,
+      cell: ({ getValue }) => <strong>{`cell:${String(getValue())}`}</strong>,
+      aggregatedCell: ({ getValue }) => (
+        <em>{`aggregate:${String(getValue())}`}</em>
+      ),
+      footer: ({ column }) => <small>{`footer:${column.id}`}</small>,
+    },
+  ]
+
+  function CellHarness({ mode }: { mode: CellMode }) {
+    const table = useTable({
+      data: [{ id: '1', name: 'Ada' }],
+      columns,
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+    })
+    const cell = table.getRowModel().rows[0]!.getAllCells()[0]!
+
+    if (mode === 'aggregate') {
+      vi.spyOn(cell, 'getIsAggregated').mockReturnValue(true)
+    }
+
+    if (mode === 'placeholder') {
+      vi.spyOn(cell, 'getIsAggregated').mockReturnValue(false)
+      vi.spyOn(cell, 'getIsPlaceholder').mockReturnValue(true)
+    }
+
+    return (
+      <output aria-label={`${mode} cell`}>
+        <FlexRender cell={cell} />
+      </output>
+    )
+  }
+
+  function HeaderFooterHarness() {
+    const table = useTable({
+      data: [{ id: '1', name: 'Ada' }],
+      columns,
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+    })
+    const header = table.getHeaderGroups()[0]!.headers[0]!
+    const footer = table.getFooterGroups()[0]!.headers[0]!
+
+    return (
+      <>
+        <output aria-label="Rendered header">
+          <FlexRender header={header} />
+        </output>
+        <output aria-label="Rendered footer">
+          <FlexRender footer={footer} />
+        </output>
+      </>
+    )
+  }
+
+  test('renders normal, aggregate, placeholder, header, and footer content', () => {
+    render(
+      <>
+        <CellHarness mode="normal" />
+        <CellHarness mode="aggregate" />
+        <CellHarness mode="placeholder" />
+        <HeaderFooterHarness />
+      </>,
+    )
+
+    expect(outputText('normal cell')).toBe('cell:Ada')
+    expect(outputText('aggregate cell')).toBe('aggregate:Ada')
+    expect(outputText('placeholder cell')).toBe('')
+    expect(outputText('Rendered header')).toBe('header:name')
+    expect(outputText('Rendered footer')).toBe('footer:name')
+  })
+
+  test('reacts when a stable cell changes grouping mode', () => {
+    function GroupingCellHarness() {
+      const [mode, setMode] = useState<CellMode>('normal')
+      const table = useTable({
+        data: [{ id: '1', name: 'Ada' }],
+        columns,
+        features: stockFeatures,
+        getRowId: (row) => row.id,
+      })
+      const cell = table.getRowModel().rows[0]!.getAllCells()[0]!
+
+      vi.spyOn(cell, 'getIsAggregated').mockImplementation(
+        () => mode === 'aggregate',
+      )
+      vi.spyOn(cell, 'getIsPlaceholder').mockImplementation(
+        () => mode === 'placeholder',
+      )
+
+      return (
+        <>
+          <output aria-label="Grouping cell">
+            <FlexRender cell={cell} />
+          </output>
+          <button onClick={() => setMode('aggregate')}>Show aggregate</button>
+          <button onClick={() => setMode('placeholder')}>
+            Show placeholder
+          </button>
+          <button onClick={() => setMode('normal')}>Show normal</button>
+        </>
+      )
+    }
+
+    render(<GroupingCellHarness />)
+
+    expect(outputText('Grouping cell')).toBe('cell:Ada')
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Show aggregate' }))
+    })
+    expect(outputText('Grouping cell')).toBe('aggregate:Ada')
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Show placeholder' }))
+    })
+    expect(outputText('Grouping cell')).toBe('')
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Show normal' }))
+    })
+    expect(outputText('Grouping cell')).toBe('cell:Ada')
+  })
+
+  test('updates when the cell prop is replaced with a new instance', () => {
+    function CellReplacementHarness() {
+      const [data, setData] = useState<Array<Data>>([{ id: '1', name: 'Ada' }])
+      const table = useTable({
+        data,
+        columns,
+        features: stockFeatures,
+        getRowId: (row) => row.id,
+      })
+      const cell = table.getRowModel().rows[0]!.getAllCells()[0]!
+
+      return (
+        <>
+          <output aria-label="Replaced cell">
+            <FlexRender cell={cell} />
+          </output>
+          <button onClick={() => setData([{ id: '1', name: 'Grace' }])}>
+            Replace cell
+          </button>
+        </>
+      )
+    }
+
+    render(<CellReplacementHarness />)
+
+    expect(outputText('Replaced cell')).toBe('cell:Ada')
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Replace cell' }))
+    })
+
+    expect(outputText('Replaced cell')).toBe('cell:Grace')
+  })
+})
+
+describe('table.Subscribe', () => {
+  test('updates mounted content for the selected atom slice', () => {
+    function SubscribeHarness() {
+      const table = useTable(
+        {
+          data: [{ id: '1' }],
+          columns: [{ id: 'id', accessorKey: 'id' }],
+          features: stockFeatures,
+          getRowId: (row) => row.id,
+        },
+        () => null,
+      )
+
+      return (
+        <>
+          <table.Subscribe
+            source={table.atoms.rowSelection}
+            selector={(selection) => Boolean(selection['1'])}
+          >
+            {(selected) => (
+              <output aria-label="Subscribed selection">
+                {String(selected)}
+              </output>
+            )}
+          </table.Subscribe>
+          <button onClick={() => table.getRow('1').toggleSelected(true)}>
+            Select subscribed row
+          </button>
+        </>
+      )
+    }
+
+    render(<SubscribeHarness />)
+
+    expect(outputText('Subscribed selection')).toBe('false')
+
+    act(() => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Select subscribed row' }),
+      )
+    })
+
+    expect(outputText('Subscribed selection')).toBe('true')
+  })
+})

--- a/packages/preact-table/tests/unit/ssr.test.tsx
+++ b/packages/preact-table/tests/unit/ssr.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment node
+
+import { forwardRef, memo } from 'preact/compat'
+import { renderToString } from 'preact-render-to-string'
+import { describe, expect, test, vi } from 'vitest'
+import { flexRender, stockFeatures, useTable } from '../../src'
+import type { ColumnDef } from '../../src'
+
+type Person = {
+  id: string
+  name: string
+}
+
+const columns: Array<ColumnDef<typeof stockFeatures, Person>> = [
+  {
+    id: 'name',
+    accessorKey: 'name',
+    header: ({ column }) => <span>{`Header ${column.id}`}</span>,
+    cell: ({ getValue }) => <strong>{`Cell ${String(getValue())}`}</strong>,
+    aggregatedCell: ({ getValue }) => (
+      <em>{`Aggregate ${String(getValue())}`}</em>
+    ),
+    footer: 'Name footer',
+  },
+]
+
+describe('Preact server rendering', () => {
+  test('renders useTable state and FlexRender output without a DOM', () => {
+    function ServerTable() {
+      const table = useTable({
+        data: [{ id: '1', name: 'Ada' }],
+        features: stockFeatures,
+        columns,
+        getRowId: (row) => row.id,
+        initialState: {
+          pagination: {
+            pageIndex: 0,
+            pageSize: 25,
+          },
+        },
+      })
+      const header = table.getHeaderGroups()[0]!.headers[0]!
+      const cell = table.getRowModel().rows[0]!.getAllCells()[0]!
+
+      return (
+        <table data-page-size={table.state.pagination.pageSize}>
+          <thead>
+            <tr>
+              <th>
+                <table.FlexRender header={header} />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <table.FlexRender cell={cell} />
+              </td>
+            </tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td>
+                <table.FlexRender footer={header} />
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      )
+    }
+
+    expect(typeof document).toBe('undefined')
+
+    const markup = renderToString(<ServerTable />)
+
+    expect(markup).toContain('data-page-size="25"')
+    expect(markup).toContain('<span>Header name</span>')
+    expect(markup).toContain('<strong>Cell Ada</strong>')
+    expect(markup).toContain('<td>Name footer</td>')
+  })
+
+  test('selects aggregate content and suppresses placeholder cells', () => {
+    function CellModes() {
+      const table = useTable({
+        data: [
+          { id: '1', name: 'Ada' },
+          { id: '2', name: 'Grace' },
+        ],
+        features: stockFeatures,
+        columns,
+        getRowId: (row) => row.id,
+      })
+      const aggregatedCell = table.getRow('1').getAllCells()[0]!
+      const placeholderCell = table.getRow('2').getAllCells()[0]!
+
+      vi.spyOn(aggregatedCell, 'getIsAggregated').mockReturnValue(true)
+      vi.spyOn(placeholderCell, 'getIsAggregated').mockReturnValue(false)
+      vi.spyOn(placeholderCell, 'getIsPlaceholder').mockReturnValue(true)
+
+      return (
+        <>
+          <div data-mode="aggregate">
+            <table.FlexRender cell={aggregatedCell} />
+          </div>
+          <div data-mode="placeholder">
+            <table.FlexRender cell={placeholderCell} />
+          </div>
+        </>
+      )
+    }
+
+    expect(renderToString(<CellModes />)).toBe(
+      '<div data-mode="aggregate"><em>Aggregate Ada</em></div>' +
+        '<div data-mode="placeholder"></div>',
+    )
+  })
+
+  test('flexRender handles functions, exotic components, nodes, zero, and empty values', () => {
+    function FunctionRenderable({ value }: { value: string }) {
+      return <span data-kind="function">{value}</span>
+    }
+
+    const MemoRenderable = memo(function MemoRenderable({
+      value,
+    }: {
+      value: string
+    }) {
+      return <span data-kind="memo">{value}</span>
+    })
+    const ForwardRefRenderable = forwardRef<HTMLSpanElement, { value: string }>(
+      function ForwardRefRenderable({ value }, ref) {
+        return (
+          <span ref={ref} data-kind="forward-ref">
+            {value}
+          </span>
+        )
+      },
+    )
+
+    const markup = renderToString(
+      <>
+        {flexRender(FunctionRenderable, { value: 'function value' })}
+        {flexRender(MemoRenderable, { value: 'memo value' })}
+        {flexRender(ForwardRefRenderable, { value: 'forward value' })}
+        {flexRender(<span data-kind="node">node value</span>, {
+          value: 'ignored',
+        })}
+        {flexRender(0, { value: 'ignored' })}
+      </>,
+    )
+
+    expect(markup).toBe(
+      '<span data-kind="function">function value</span>' +
+        '<span data-kind="memo">memo value</span>' +
+        '<span data-kind="forward-ref">forward value</span>' +
+        '<span data-kind="node">node value</span>' +
+        '0',
+    )
+    expect(flexRender(0, {})).toBe(0)
+    expect(flexRender(false, {})).toBe(false)
+    expect(flexRender('', {})).toBe('')
+    expect(flexRender(null, {})).toBeNull()
+  })
+})

--- a/packages/preact-table/tests/unit/useTable.test.tsx
+++ b/packages/preact-table/tests/unit/useTable.test.tsx
@@ -1,4 +1,4 @@
-import { render } from 'preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
 import { useState } from 'preact/hooks'
 import { act } from 'preact/test-utils'
 import {
@@ -6,7 +6,8 @@ import {
   rowPaginationFeature,
   tableFeatures,
 } from '@tanstack/table-core'
-import { afterEach, describe, expect, it } from 'vitest'
+import { createAtom } from '@tanstack/preact-store'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useTable } from '../../src/useTable'
 import type { ColumnDef, PaginationState } from '@tanstack/table-core'
 import type { PreactTable } from '../../src/useTable'
@@ -25,32 +26,17 @@ const data: ReadonlyArray<TestRow> = Array.from({ length: 100 }, (_, id) => ({
 }))
 const columns: ReadonlyArray<ColumnDef<typeof features, TestRow>> = []
 
-let container: HTMLDivElement | undefined
-
-function mount(ui: preact.ComponentChildren) {
-  container = document.createElement('div')
-  document.body.append(container)
-  act(() => {
-    render(ui as any, container!)
-  })
+function text(name: string) {
+  return screen.getByRole('status', { name }).textContent
 }
 
-function clickButton() {
-  container?.querySelector('button')?.dispatchEvent(
-    new MouseEvent('click', {
-      bubbles: true,
-    }),
-  )
+function clickButton(name = 'Next page') {
+  fireEvent.click(screen.getByRole('button', { name }))
 }
 
 afterEach(() => {
-  if (container) {
-    act(() => {
-      render(null, container!)
-    })
-    container.remove()
-    container = undefined
-  }
+  cleanup()
+  vi.restoreAllMocks()
 })
 
 describe('useTable controlled state', () => {
@@ -92,7 +78,7 @@ describe('useTable controlled state', () => {
       return <button onClick={() => table.nextPage()}>Next page</button>
     }
 
-    mount(<ControlledPaginationHarness />)
+    render(<ControlledPaginationHarness />)
     expect(renderSnapshots).toHaveLength(1)
 
     act(() => {
@@ -172,7 +158,7 @@ describe('useTable controlled state', () => {
       return <button onClick={() => table.nextPage()}>Next page</button>
     }
 
-    mount(<PublicationHarness />)
+    render(<PublicationHarness />)
 
     const notifications: Array<number> = []
     const subscription = latestTable!.store.subscribe((state) => {
@@ -205,18 +191,305 @@ describe('useTable controlled state', () => {
         (state) => state.pagination.pageIndex,
       )
 
-      return <button onClick={() => table.nextPage()}>{table.state}</button>
+      return (
+        <>
+          <output aria-label="Uncontrolled page index">{table.state}</output>
+          <button onClick={() => table.nextPage()}>Next page</button>
+        </>
+      )
     }
 
-    mount(<UncontrolledHarness />)
+    render(<UncontrolledHarness />)
     expect(harnessRenderCount).toBe(1)
-    expect(container?.querySelector('button')?.textContent).toBe('0')
+    expect(text('Uncontrolled page index')).toBe('0')
 
     act(() => {
       clickButton()
     })
 
     expect(harnessRenderCount).toBe(2)
-    expect(container?.querySelector('button')?.textContent).toBe('1')
+    expect(text('Uncontrolled page index')).toBe('1')
+  })
+
+  it('releases and reacquires ownership when the controlled slice is omitted', () => {
+    let harnessRenderCount = 0
+
+    function OwnershipHarness() {
+      harnessRenderCount++
+      const [controlled, setControlled] = useState(true)
+      const [pagination] = useState<PaginationState>({
+        pageIndex: 5,
+        pageSize: 10,
+      })
+      const table = useTable(
+        {
+          features,
+          columns,
+          data,
+          state: controlled ? { pagination } : {},
+        },
+        (state) => state.pagination,
+      )
+
+      return (
+        <>
+          <output aria-label="Ownership page index">
+            {table.state.pageIndex}
+          </output>
+          <button onClick={() => setControlled((value) => !value)}>
+            Toggle ownership
+          </button>
+          <button onClick={() => table.nextPage()}>Next page</button>
+        </>
+      )
+    }
+
+    render(<OwnershipHarness />)
+
+    expect(text('Ownership page index')).toBe('5')
+    expect(harnessRenderCount).toBe(1)
+
+    act(() => {
+      clickButton('Toggle ownership')
+    })
+
+    expect(text('Ownership page index')).toBe('5')
+    expect(harnessRenderCount).toBe(2)
+
+    act(() => {
+      clickButton()
+    })
+
+    expect(text('Ownership page index')).toBe('6')
+    expect(harnessRenderCount).toBe(3)
+
+    act(() => {
+      clickButton('Toggle ownership')
+    })
+
+    expect(text('Ownership page index')).toBe('5')
+    expect(harnessRenderCount).toBe(4)
+
+    act(() => {
+      clickButton()
+    })
+
+    expect(text('Ownership page index')).toBe('5')
+    expect(harnessRenderCount).toBe(4)
+  })
+
+  it('invalidates an isolated subscriber when the controlled slice is omitted', () => {
+    function OwnershipReleaseHarness() {
+      const [controlled, setControlled] = useState(true)
+      const [pagination] = useState<PaginationState>({
+        pageIndex: 5,
+        pageSize: 10,
+      })
+      const table = useTable(
+        {
+          features,
+          columns,
+          data,
+          state: controlled ? { pagination } : {},
+        },
+        () => null,
+      )
+
+      return (
+        <>
+          <table.Subscribe selector={(state) => state.pagination.pageIndex}>
+            {(pageIndex) => (
+              <output aria-label="Isolated page index">{pageIndex}</output>
+            )}
+          </table.Subscribe>
+          <button onClick={() => table.nextPage()}>Change base</button>
+          <button onClick={() => setControlled(false)}>Release control</button>
+        </>
+      )
+    }
+
+    render(<OwnershipReleaseHarness />)
+
+    expect(text('Isolated page index')).toBe('5')
+
+    act(() => {
+      clickButton('Change base')
+    })
+
+    expect(text('Isolated page index')).toBe('5')
+
+    act(() => {
+      clickButton('Release control')
+    })
+
+    expect(text('Isolated page index')).toBe('6')
+  })
+
+  it('gives an external atom precedence over controlled state and writes back to it', () => {
+    const paginationAtom = createAtom<PaginationState>({
+      pageIndex: 3,
+      pageSize: 10,
+    })
+
+    function ExternalAtomHarness() {
+      const [pagination, setPagination] = useState<PaginationState>({
+        pageIndex: 0,
+        pageSize: 10,
+      })
+      const table = useTable(
+        {
+          features,
+          columns,
+          data,
+          state: { pagination },
+          atoms: {
+            pagination: paginationAtom,
+          },
+        },
+        (state) => state.pagination.pageIndex,
+      )
+
+      return (
+        <>
+          <output aria-label="External page index">{table.state}</output>
+          <button
+            onClick={() =>
+              setPagination({
+                pageIndex: 7,
+                pageSize: 10,
+              })
+            }
+          >
+            Change controlled page
+          </button>
+          <button onClick={() => table.nextPage()}>Next page</button>
+        </>
+      )
+    }
+
+    render(<ExternalAtomHarness />)
+
+    expect(text('External page index')).toBe('3')
+
+    act(() => {
+      clickButton('Change controlled page')
+    })
+
+    expect(text('External page index')).toBe('3')
+    expect(paginationAtom.get().pageIndex).toBe(3)
+
+    act(() => {
+      clickButton()
+    })
+
+    expect(paginationAtom.get().pageIndex).toBe(4)
+    expect(text('External page index')).toBe('4')
+  })
+
+  it('keeps the owner stable when an update misses its selected slice', () => {
+    let harnessRenderCount = 0
+
+    function SelectedPageIndexHarness() {
+      harnessRenderCount++
+      const table = useTable(
+        {
+          features,
+          columns,
+          data,
+        },
+        (state) => state.pagination.pageIndex,
+      )
+
+      return (
+        <>
+          <output aria-label="Selected page index">{table.state}</output>
+          <table.Subscribe selector={(state) => state.pagination.pageSize}>
+            {(pageSize) => (
+              <output aria-label="Isolated page size">{pageSize}</output>
+            )}
+          </table.Subscribe>
+          <button onClick={() => table.setPageSize(20)}>
+            Set page size to 20
+          </button>
+          <button onClick={() => table.nextPage()}>Next page</button>
+        </>
+      )
+    }
+
+    render(<SelectedPageIndexHarness />)
+
+    expect(harnessRenderCount).toBe(1)
+    expect(text('Selected page index')).toBe('0')
+    expect(text('Isolated page size')).toBe('10')
+
+    act(() => {
+      clickButton('Set page size to 20')
+    })
+
+    expect(harnessRenderCount).toBe(1)
+    expect(text('Selected page index')).toBe('0')
+    expect(text('Isolated page size')).toBe('20')
+
+    act(() => {
+      clickButton()
+    })
+
+    expect(harnessRenderCount).toBe(2)
+    expect(text('Selected page index')).toBe('1')
+  })
+
+  it('publishes the final value after rapid controlled updates', () => {
+    function RapidUpdateHarness() {
+      const [pagination, setPagination] = useState<PaginationState>({
+        pageIndex: 0,
+        pageSize: 10,
+      })
+      const table = useTable(
+        {
+          features,
+          columns,
+          data,
+          state: { pagination },
+          onPaginationChange: setPagination,
+        },
+        () => null,
+      )
+
+      return (
+        <>
+          <output aria-label="Controlled page index">
+            {pagination.pageIndex}
+          </output>
+          <table.Subscribe selector={(state) => state.pagination.pageIndex}>
+            {(pageIndex) => (
+              <output aria-label="Rapid isolated page index">
+                {pageIndex}
+              </output>
+            )}
+          </table.Subscribe>
+          <button
+            onClick={() => {
+              table.nextPage()
+              table.nextPage()
+              table.nextPage()
+            }}
+          >
+            Advance three pages
+          </button>
+        </>
+      )
+    }
+
+    render(<RapidUpdateHarness />)
+
+    expect(text('Controlled page index')).toBe('0')
+    expect(text('Rapid isolated page index')).toBe('0')
+
+    act(() => {
+      clickButton('Advance three pages')
+    })
+
+    expect(text('Controlled page index')).toBe('3')
+    expect(text('Rapid isolated page index')).toBe('3')
   })
 })

--- a/packages/svelte-table/package.json
+++ b/packages/svelte-table/package.json
@@ -57,7 +57,9 @@
   ],
   "scripts": {
     "clean": "rimraf ./build && rimraf ./dist",
-    "test:eslint": "eslint ./src",
+    "test:eslint": "eslint ./src ./tests",
+    "test:lib": "vitest --passWithNoTests",
+    "test:lib:dev": "pnpm test:lib --watch",
     "test:types": "svelte-check --tsconfig ./tsconfig.json",
     "test:build": "publint --strict",
     "build": "svelte-package --input ./src --output ./dist"
@@ -69,6 +71,7 @@
   "devDependencies": {
     "@sveltejs/package": "^2.5.8",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@testing-library/svelte": "^5.4.2",
     "eslint-plugin-svelte": "^3.19.0",
     "svelte": "^5.56.2",
     "svelte-check": "^4.6.0"

--- a/packages/svelte-table/src/FlexRender.svelte
+++ b/packages/svelte-table/src/FlexRender.svelte
@@ -61,8 +61,22 @@
   // or the legacy content/context props.
   const resolved = $derived.by(() => {
     if ('cell' in props && props.cell) {
+      const columnDef = props.cell.column.columnDef
+      const groupingCell = props.cell as typeof props.cell & {
+        getIsAggregated?: () => boolean
+        getIsPlaceholder?: () => boolean
+      }
+      const groupingColumnDef = columnDef as typeof columnDef & {
+        aggregatedCell?: typeof columnDef.cell
+      }
+      const content = groupingCell.getIsAggregated?.()
+        ? (groupingColumnDef.aggregatedCell ?? columnDef.cell)
+        : groupingCell.getIsPlaceholder?.()
+          ? undefined
+          : columnDef.cell
+
       return {
-        content: props.cell.column.columnDef.cell,
+        content,
         context: props.cell.getContext(),
       }
     }

--- a/packages/svelte-table/src/createTable.svelte.ts
+++ b/packages/svelte-table/src/createTable.svelte.ts
@@ -101,22 +101,23 @@ export function createTable<
   // inside createTableState), the effect re-runs and calls setOptions.
   // Use $effect.pre so the table sees updated options BEFORE the DOM renders,
   // ensuring getRowModel() returns current data (not stale, one-frame-behind data).
-  // The reactive reads (state getters, data getter) happen OUTSIDE untrack
-  // so they become dependencies. The setOptions call is INSIDE untrack so
-  // option writes do not subscribe this effect to table internals.
+  // Reactive option getters and nested state keys are read OUTSIDE untrack so
+  // they become dependencies. The setOptions call is INSIDE untrack so option
+  // writes do not subscribe this effect to table internals.
   $effect.pre(() => {
-    // Read reactive getters to create $effect dependencies on external state
-    const state: Record<string, unknown> | undefined = mergedOptions.state
+    // Resolve every option outside untrack so getter-backed data, columns,
+    // callbacks, metadata, and state become dependencies of this effect.
+    const nextOptions = flatMerge(mergedOptions)
+    const state = nextOptions.state as Record<string, unknown> | undefined
     if (state) {
       for (const key in state) {
         void state[key]
       }
     }
-    void mergedOptions.data
 
     untrack(() => {
       table.setOptions((prev) => {
-        return flatMerge(prev, mergedOptions)
+        return flatMerge(prev, nextOptions)
       })
     })
   })

--- a/packages/svelte-table/src/createTableHook.svelte.ts
+++ b/packages/svelte-table/src/createTableHook.svelte.ts
@@ -38,50 +38,6 @@ import type {
 } from '@tanstack/table-core'
 
 export type ComponentType<T extends Record<string, any>> = Component<T>
-export type BoundFlexRenderComponent = Component<Record<string, never>>
-
-function createLiveView<TCurrent extends object, TExtensions extends object>(
-  getCurrent: () => TCurrent,
-  extensions: TExtensions,
-): TCurrent & TExtensions {
-  const hasExtension = (key: PropertyKey) =>
-    Object.prototype.hasOwnProperty.call(extensions, key)
-
-  return new Proxy({} as TCurrent & TExtensions, {
-    get: (_target, key) => {
-      if (hasExtension(key)) {
-        return Reflect.get(extensions, key, extensions)
-      }
-      const current = getCurrent()
-      return Reflect.get(current, key, current)
-    },
-    getOwnPropertyDescriptor: (_target, key) => {
-      const source = hasExtension(key) ? extensions : getCurrent()
-      const descriptor = Reflect.getOwnPropertyDescriptor(source, key)
-      if (!descriptor) return undefined
-
-      return {
-        configurable: true,
-        enumerable: descriptor.enumerable,
-        get: () => Reflect.get(source, key, source),
-        set: (value) => {
-          Reflect.set(source, key, value, source)
-        },
-      }
-    },
-    has: (_target, key) => hasExtension(key) || Reflect.has(getCurrent(), key),
-    ownKeys: () => [
-      ...new Set([
-        ...Reflect.ownKeys(getCurrent()),
-        ...Reflect.ownKeys(extensions),
-      ]),
-    ],
-    set: (_target, key, value) => {
-      const source = hasExtension(key) ? extensions : getCurrent()
-      return Reflect.set(source, key, value, source)
-    },
-  })
-}
 
 // =============================================================================
 // Enhanced Context Types with Pre-bound Components
@@ -98,7 +54,7 @@ export type AppCellContext<
   TCellComponents extends Record<string, ComponentType<any>>,
 > = {
   cell: Cell<TFeatures, TData, TValue> &
-    TCellComponents & { FlexRender: BoundFlexRenderComponent }
+    TCellComponents & { FlexRender: typeof FlexRenderSvelte }
   column: Column<TFeatures, TData, TValue>
   getValue: CellContext<TFeatures, TData, TValue>['getValue']
   renderValue: CellContext<TFeatures, TData, TValue>['renderValue']
@@ -118,7 +74,7 @@ export type AppHeaderContext<
 > = {
   column: Column<TFeatures, TData, TValue>
   header: Header<TFeatures, TData, TValue> &
-    THeaderComponents & { FlexRender: BoundFlexRenderComponent }
+    THeaderComponents & { FlexRender: typeof FlexRenderSvelte }
   table: Table<TFeatures, TData>
 }
 
@@ -366,9 +322,7 @@ export type AppSvelteTable<
       children: Snippet<
         [
           Cell<TFeatures, TData, any> &
-            NoInfer<TCellComponents> & {
-              FlexRender: BoundFlexRenderComponent
-            },
+            NoInfer<TCellComponents> & { FlexRender: typeof FlexRenderSvelte },
         ]
       >
     }>
@@ -389,7 +343,7 @@ export type AppSvelteTable<
         [
           Header<TFeatures, TData, any> &
             NoInfer<THeaderComponents> & {
-              FlexRender: BoundFlexRenderComponent
+              FlexRender: typeof FlexRenderSvelte
             },
         ]
       >
@@ -411,7 +365,7 @@ export type AppSvelteTable<
         [
           Header<TFeatures, TData, any> &
             NoInfer<THeaderComponents> & {
-              FlexRender: BoundFlexRenderComponent
+              FlexRender: typeof FlexRenderSvelte
             },
         ]
       >
@@ -486,7 +440,7 @@ export interface CreateTableHookResult<
     any,
     TValue
   > &
-    TCellComponents & { FlexRender: BoundFlexRenderComponent }
+    TCellComponents & { FlexRender: typeof FlexRenderSvelte }
   /**
    * Reads the header provided by the nearest `<table.AppHeader>` /
    * `<table.AppFooter>`, extended with your `headerComponents` and a
@@ -497,7 +451,7 @@ export interface CreateTableHookResult<
     any,
     TValue
   > &
-    THeaderComponents & { FlexRender: BoundFlexRenderComponent }
+    THeaderComponents & { FlexRender: typeof FlexRenderSvelte }
 }
 
 // =============================================================================
@@ -627,7 +581,7 @@ export function createTableHook<
     any,
     TValue
   > &
-    TCellComponents & { FlexRender: BoundFlexRenderComponent } {
+    TCellComponents & { FlexRender: typeof FlexRenderSvelte } {
     const cell = getContext(cellContextKey)
 
     if (!cell) {
@@ -637,11 +591,11 @@ export function createTableHook<
       )
     }
 
-    // `<table.AppCell>` provides a live view of the current cell and its bound
-    // components, so same-key row-model replacements stay current without
-    // remounting context consumers.
+    // `<table.AppCell>` Object.assign-es `cellComponents` and `FlexRender` onto
+    // the same cell instance it puts in context, so this asserts the runtime
+    // shape.
     return cell as unknown as Cell<TFeatures, any, TValue> &
-      TCellComponents & { FlexRender: BoundFlexRenderComponent }
+      TCellComponents & { FlexRender: typeof FlexRenderSvelte }
   }
 
   /**
@@ -654,7 +608,7 @@ export function createTableHook<
     any,
     TValue
   > &
-    THeaderComponents & { FlexRender: BoundFlexRenderComponent } {
+    THeaderComponents & { FlexRender: typeof FlexRenderSvelte } {
     const header = getContext(headerContextKey)
 
     if (!header) {
@@ -663,10 +617,10 @@ export function createTableHook<
       )
     }
 
-    // `<table.AppHeader>` / `<table.AppFooter>` provide a live view of the
-    // current header and its bound components.
+    // `<table.AppHeader>` / `<table.AppFooter>` Object.assign `headerComponents`
+    // and `FlexRender` onto the same header instance they put in context.
     return header as unknown as Header<TFeatures, any, TValue> &
-      THeaderComponents & { FlexRender: BoundFlexRenderComponent }
+      THeaderComponents & { FlexRender: typeof FlexRenderSvelte }
   }
 
   /**
@@ -703,103 +657,60 @@ export function createTableHook<
       selector,
     )
 
-    // Create wrapper components using the svelte-form (internal, props) =>
-    // pattern. Svelte keeps the props object live through getter-backed
-    // properties, so preserve it instead of destructuring or spreading it.
-    // Context consumers receive a getter-backed view for the same reason:
-    // row-model refreshes can replace a cell/header without remounting the
-    // wrapper component.
+    // Build cellComponents with FlexRender included
+    const cellComponentsWithFlexRender = {
+      FlexRender: FlexRenderSvelte,
+      ...(cellComponents ?? {}),
+    }
+
+    // Build headerComponents with FlexRender included
+    const headerComponentsWithFlexRender = {
+      FlexRender: FlexRenderSvelte,
+      ...(headerComponents ?? {}),
+    }
+
+    // Create wrapper components using the svelte-form (internal, props) => pattern.
+    // setContext is called in the closure — this runs during component
+    // initialization, so Svelte's context API works correctly.
+    // With keyed {#each} blocks, components are recreated on reorder,
+    // so context is always fresh.
     const AppTable = ((internal: any, props: any) => {
       setContext(tableContextKey, table)
-      return AppTableSvelte(internal, props)
+      return AppTableSvelte(internal, { ...props })
     }) as Component<{ children: Snippet }>
 
-    const AppCell = ((internal: any, props: any) => {
-      const BoundFlexRender = ((componentInternal: any, renderProps: any) => {
-        return FlexRenderSvelte(
-          componentInternal,
-          mergeObjects(renderProps, {
-            get cell() {
-              return props.cell
-            },
-          }),
-        )
-      }) as BoundFlexRenderComponent
-      const boundComponents = {
-        FlexRender: BoundFlexRender,
-        ...(cellComponents ?? {}),
-      }
-      const liveCell = createLiveView(() => props.cell, boundComponents)
-
-      setContext(cellContextKey, liveCell)
-
-      return AppCellSvelte(
-        internal,
-        mergeObjects(props, {
-          cellComponents: boundComponents,
-        }),
-      )
+    const AppCell = ((internal: any, { children, cell }: any) => {
+      setContext(cellContextKey, cell)
+      return AppCellSvelte(internal, {
+        cell,
+        cellComponents: cellComponentsWithFlexRender,
+        children,
+      })
     }) as Component<{
       cell: Cell<TFeatures, TData, any>
       children: Snippet<[any]>
     }>
 
-    const AppHeader = ((internal: any, props: any) => {
-      const BoundFlexRender = ((componentInternal: any, renderProps: any) => {
-        return FlexRenderSvelte(
-          componentInternal,
-          mergeObjects(renderProps, {
-            get header() {
-              return props.header
-            },
-          }),
-        )
-      }) as BoundFlexRenderComponent
-      const boundComponents = {
-        FlexRender: BoundFlexRender,
-        ...(headerComponents ?? {}),
-      }
-      const liveHeader = createLiveView(() => props.header, boundComponents)
-
-      setContext(headerContextKey, liveHeader)
-
-      return AppHeaderSvelte(
-        internal,
-        mergeObjects(props, {
-          headerComponents: boundComponents,
-        }),
-      )
+    const AppHeader = ((internal: any, { children, header }: any) => {
+      setContext(headerContextKey, header)
+      return AppHeaderSvelte(internal, {
+        header,
+        headerComponents: headerComponentsWithFlexRender,
+        children,
+      })
     }) as Component<{
       header: Header<TFeatures, TData, any>
       children: Snippet<[any]>
     }>
 
     // AppFooter reuses AppHeaderSvelte (footers use Header type in table-core)
-    const AppFooter = ((internal: any, props: any) => {
-      const BoundFlexRender = ((componentInternal: any, renderProps: any) => {
-        return FlexRenderSvelte(
-          componentInternal,
-          mergeObjects(renderProps, {
-            get footer() {
-              return props.header
-            },
-          }),
-        )
-      }) as BoundFlexRenderComponent
-      const boundComponents = {
-        FlexRender: BoundFlexRender,
-        ...(headerComponents ?? {}),
-      }
-      const liveHeader = createLiveView(() => props.header, boundComponents)
-
-      setContext(headerContextKey, liveHeader)
-
-      return AppHeaderSvelte(
-        internal,
-        mergeObjects(props, {
-          headerComponents: boundComponents,
-        }),
-      )
+    const AppFooter = ((internal: any, { children, header }: any) => {
+      setContext(headerContextKey, header)
+      return AppHeaderSvelte(internal, {
+        header,
+        headerComponents: headerComponentsWithFlexRender,
+        children,
+      })
     }) as Component<{
       header: Header<TFeatures, TData, any>
       children: Snippet<[any]>

--- a/packages/svelte-table/src/createTableHook.svelte.ts
+++ b/packages/svelte-table/src/createTableHook.svelte.ts
@@ -38,6 +38,50 @@ import type {
 } from '@tanstack/table-core'
 
 export type ComponentType<T extends Record<string, any>> = Component<T>
+export type BoundFlexRenderComponent = Component<Record<string, never>>
+
+function createLiveView<TCurrent extends object, TExtensions extends object>(
+  getCurrent: () => TCurrent,
+  extensions: TExtensions,
+): TCurrent & TExtensions {
+  const hasExtension = (key: PropertyKey) =>
+    Object.prototype.hasOwnProperty.call(extensions, key)
+
+  return new Proxy({} as TCurrent & TExtensions, {
+    get: (_target, key) => {
+      if (hasExtension(key)) {
+        return Reflect.get(extensions, key, extensions)
+      }
+      const current = getCurrent()
+      return Reflect.get(current, key, current)
+    },
+    getOwnPropertyDescriptor: (_target, key) => {
+      const source = hasExtension(key) ? extensions : getCurrent()
+      const descriptor = Reflect.getOwnPropertyDescriptor(source, key)
+      if (!descriptor) return undefined
+
+      return {
+        configurable: true,
+        enumerable: descriptor.enumerable,
+        get: () => Reflect.get(source, key, source),
+        set: (value) => {
+          Reflect.set(source, key, value, source)
+        },
+      }
+    },
+    has: (_target, key) => hasExtension(key) || Reflect.has(getCurrent(), key),
+    ownKeys: () => [
+      ...new Set([
+        ...Reflect.ownKeys(getCurrent()),
+        ...Reflect.ownKeys(extensions),
+      ]),
+    ],
+    set: (_target, key, value) => {
+      const source = hasExtension(key) ? extensions : getCurrent()
+      return Reflect.set(source, key, value, source)
+    },
+  })
+}
 
 // =============================================================================
 // Enhanced Context Types with Pre-bound Components
@@ -54,7 +98,7 @@ export type AppCellContext<
   TCellComponents extends Record<string, ComponentType<any>>,
 > = {
   cell: Cell<TFeatures, TData, TValue> &
-    TCellComponents & { FlexRender: typeof FlexRenderSvelte }
+    TCellComponents & { FlexRender: BoundFlexRenderComponent }
   column: Column<TFeatures, TData, TValue>
   getValue: CellContext<TFeatures, TData, TValue>['getValue']
   renderValue: CellContext<TFeatures, TData, TValue>['renderValue']
@@ -74,7 +118,7 @@ export type AppHeaderContext<
 > = {
   column: Column<TFeatures, TData, TValue>
   header: Header<TFeatures, TData, TValue> &
-    THeaderComponents & { FlexRender: typeof FlexRenderSvelte }
+    THeaderComponents & { FlexRender: BoundFlexRenderComponent }
   table: Table<TFeatures, TData>
 }
 
@@ -322,7 +366,9 @@ export type AppSvelteTable<
       children: Snippet<
         [
           Cell<TFeatures, TData, any> &
-            NoInfer<TCellComponents> & { FlexRender: typeof FlexRenderSvelte },
+            NoInfer<TCellComponents> & {
+              FlexRender: BoundFlexRenderComponent
+            },
         ]
       >
     }>
@@ -343,7 +389,7 @@ export type AppSvelteTable<
         [
           Header<TFeatures, TData, any> &
             NoInfer<THeaderComponents> & {
-              FlexRender: typeof FlexRenderSvelte
+              FlexRender: BoundFlexRenderComponent
             },
         ]
       >
@@ -365,7 +411,7 @@ export type AppSvelteTable<
         [
           Header<TFeatures, TData, any> &
             NoInfer<THeaderComponents> & {
-              FlexRender: typeof FlexRenderSvelte
+              FlexRender: BoundFlexRenderComponent
             },
         ]
       >
@@ -440,7 +486,7 @@ export interface CreateTableHookResult<
     any,
     TValue
   > &
-    TCellComponents & { FlexRender: typeof FlexRenderSvelte }
+    TCellComponents & { FlexRender: BoundFlexRenderComponent }
   /**
    * Reads the header provided by the nearest `<table.AppHeader>` /
    * `<table.AppFooter>`, extended with your `headerComponents` and a
@@ -451,7 +497,7 @@ export interface CreateTableHookResult<
     any,
     TValue
   > &
-    THeaderComponents & { FlexRender: typeof FlexRenderSvelte }
+    THeaderComponents & { FlexRender: BoundFlexRenderComponent }
 }
 
 // =============================================================================
@@ -581,7 +627,7 @@ export function createTableHook<
     any,
     TValue
   > &
-    TCellComponents & { FlexRender: typeof FlexRenderSvelte } {
+    TCellComponents & { FlexRender: BoundFlexRenderComponent } {
     const cell = getContext(cellContextKey)
 
     if (!cell) {
@@ -591,11 +637,11 @@ export function createTableHook<
       )
     }
 
-    // `<table.AppCell>` Object.assign-es `cellComponents` and `FlexRender` onto
-    // the same cell instance it puts in context, so this asserts the runtime
-    // shape.
+    // `<table.AppCell>` provides a live view of the current cell and its bound
+    // components, so same-key row-model replacements stay current without
+    // remounting context consumers.
     return cell as unknown as Cell<TFeatures, any, TValue> &
-      TCellComponents & { FlexRender: typeof FlexRenderSvelte }
+      TCellComponents & { FlexRender: BoundFlexRenderComponent }
   }
 
   /**
@@ -608,7 +654,7 @@ export function createTableHook<
     any,
     TValue
   > &
-    THeaderComponents & { FlexRender: typeof FlexRenderSvelte } {
+    THeaderComponents & { FlexRender: BoundFlexRenderComponent } {
     const header = getContext(headerContextKey)
 
     if (!header) {
@@ -617,10 +663,10 @@ export function createTableHook<
       )
     }
 
-    // `<table.AppHeader>` / `<table.AppFooter>` Object.assign `headerComponents`
-    // and `FlexRender` onto the same header instance they put in context.
+    // `<table.AppHeader>` / `<table.AppFooter>` provide a live view of the
+    // current header and its bound components.
     return header as unknown as Header<TFeatures, any, TValue> &
-      THeaderComponents & { FlexRender: typeof FlexRenderSvelte }
+      THeaderComponents & { FlexRender: BoundFlexRenderComponent }
   }
 
   /**
@@ -657,60 +703,103 @@ export function createTableHook<
       selector,
     )
 
-    // Build cellComponents with FlexRender included
-    const cellComponentsWithFlexRender = {
-      FlexRender: FlexRenderSvelte,
-      ...(cellComponents ?? {}),
-    }
-
-    // Build headerComponents with FlexRender included
-    const headerComponentsWithFlexRender = {
-      FlexRender: FlexRenderSvelte,
-      ...(headerComponents ?? {}),
-    }
-
-    // Create wrapper components using the svelte-form (internal, props) => pattern.
-    // setContext is called in the closure — this runs during component
-    // initialization, so Svelte's context API works correctly.
-    // With keyed {#each} blocks, components are recreated on reorder,
-    // so context is always fresh.
+    // Create wrapper components using the svelte-form (internal, props) =>
+    // pattern. Svelte keeps the props object live through getter-backed
+    // properties, so preserve it instead of destructuring or spreading it.
+    // Context consumers receive a getter-backed view for the same reason:
+    // row-model refreshes can replace a cell/header without remounting the
+    // wrapper component.
     const AppTable = ((internal: any, props: any) => {
       setContext(tableContextKey, table)
-      return AppTableSvelte(internal, { ...props })
+      return AppTableSvelte(internal, props)
     }) as Component<{ children: Snippet }>
 
-    const AppCell = ((internal: any, { children, cell }: any) => {
-      setContext(cellContextKey, cell)
-      return AppCellSvelte(internal, {
-        cell,
-        cellComponents: cellComponentsWithFlexRender,
-        children,
-      })
+    const AppCell = ((internal: any, props: any) => {
+      const BoundFlexRender = ((componentInternal: any, renderProps: any) => {
+        return FlexRenderSvelte(
+          componentInternal,
+          mergeObjects(renderProps, {
+            get cell() {
+              return props.cell
+            },
+          }),
+        )
+      }) as BoundFlexRenderComponent
+      const boundComponents = {
+        FlexRender: BoundFlexRender,
+        ...(cellComponents ?? {}),
+      }
+      const liveCell = createLiveView(() => props.cell, boundComponents)
+
+      setContext(cellContextKey, liveCell)
+
+      return AppCellSvelte(
+        internal,
+        mergeObjects(props, {
+          cellComponents: boundComponents,
+        }),
+      )
     }) as Component<{
       cell: Cell<TFeatures, TData, any>
       children: Snippet<[any]>
     }>
 
-    const AppHeader = ((internal: any, { children, header }: any) => {
-      setContext(headerContextKey, header)
-      return AppHeaderSvelte(internal, {
-        header,
-        headerComponents: headerComponentsWithFlexRender,
-        children,
-      })
+    const AppHeader = ((internal: any, props: any) => {
+      const BoundFlexRender = ((componentInternal: any, renderProps: any) => {
+        return FlexRenderSvelte(
+          componentInternal,
+          mergeObjects(renderProps, {
+            get header() {
+              return props.header
+            },
+          }),
+        )
+      }) as BoundFlexRenderComponent
+      const boundComponents = {
+        FlexRender: BoundFlexRender,
+        ...(headerComponents ?? {}),
+      }
+      const liveHeader = createLiveView(() => props.header, boundComponents)
+
+      setContext(headerContextKey, liveHeader)
+
+      return AppHeaderSvelte(
+        internal,
+        mergeObjects(props, {
+          headerComponents: boundComponents,
+        }),
+      )
     }) as Component<{
       header: Header<TFeatures, TData, any>
       children: Snippet<[any]>
     }>
 
     // AppFooter reuses AppHeaderSvelte (footers use Header type in table-core)
-    const AppFooter = ((internal: any, { children, header }: any) => {
-      setContext(headerContextKey, header)
-      return AppHeaderSvelte(internal, {
-        header,
-        headerComponents: headerComponentsWithFlexRender,
-        children,
-      })
+    const AppFooter = ((internal: any, props: any) => {
+      const BoundFlexRender = ((componentInternal: any, renderProps: any) => {
+        return FlexRenderSvelte(
+          componentInternal,
+          mergeObjects(renderProps, {
+            get footer() {
+              return props.header
+            },
+          }),
+        )
+      }) as BoundFlexRenderComponent
+      const boundComponents = {
+        FlexRender: BoundFlexRender,
+        ...(headerComponents ?? {}),
+      }
+      const liveHeader = createLiveView(() => props.header, boundComponents)
+
+      setContext(headerContextKey, liveHeader)
+
+      return AppHeaderSvelte(
+        internal,
+        mergeObjects(props, {
+          headerComponents: boundComponents,
+        }),
+      )
     }) as Component<{
       header: Header<TFeatures, TData, any>
       children: Snippet<[any]>

--- a/packages/svelte-table/src/index.ts
+++ b/packages/svelte-table/src/index.ts
@@ -12,6 +12,7 @@ export type {
   AppGroupColumnDef,
   AppHeaderContext,
   AppSvelteTable,
+  BoundFlexRenderComponent,
   ComponentType,
   CreateTableHookOptions,
   CreateTableHookResult,

--- a/packages/svelte-table/src/index.ts
+++ b/packages/svelte-table/src/index.ts
@@ -12,7 +12,6 @@ export type {
   AppGroupColumnDef,
   AppHeaderContext,
   AppSvelteTable,
-  BoundFlexRenderComponent,
   ComponentType,
   CreateTableHookOptions,
   CreateTableHookResult,

--- a/packages/svelte-table/src/reactivity.svelte.ts
+++ b/packages/svelte-table/src/reactivity.svelte.ts
@@ -32,26 +32,19 @@ function subscribeToRune<T>(
 }
 
 function createRuneWritableAtom<T>(initialValue: T): Atom<T> {
-  const storeAtom = createAtom(initialValue)
-  let version = $state(0)
+  let value = $state(initialValue)
 
   return {
     set: (updater: T | ((prevVal: T) => T)) => {
-      const previous = storeAtom.get()
-      if (typeof updater === 'function') {
-        storeAtom.set(updater as (prevVal: T) => T)
-      } else {
-        storeAtom.set(updater)
-      }
-      if (!Object.is(previous, storeAtom.get())) {
-        version += 1
-      }
+      value =
+        typeof updater === 'function'
+          ? (updater as (prevVal: T) => T)(value)
+          : updater
     },
-    get: () => {
-      version
-      return storeAtom.get()
-    },
-    subscribe: storeAtom.subscribe,
+    get: () => value,
+    subscribe: ((observerOrNext: Observer<T> | ((value: T) => void)) => {
+      return subscribeToRune(() => value, observerOrNext)
+    }) as Atom<T>['subscribe'],
   }
 }
 

--- a/packages/svelte-table/src/reactivity.svelte.ts
+++ b/packages/svelte-table/src/reactivity.svelte.ts
@@ -32,19 +32,26 @@ function subscribeToRune<T>(
 }
 
 function createRuneWritableAtom<T>(initialValue: T): Atom<T> {
-  let value = $state(initialValue)
+  const storeAtom = createAtom(initialValue)
+  let version = $state(0)
 
   return {
     set: (updater: T | ((prevVal: T) => T)) => {
-      value =
-        typeof updater === 'function'
-          ? (updater as (prevVal: T) => T)(value)
-          : updater
+      const previous = storeAtom.get()
+      if (typeof updater === 'function') {
+        storeAtom.set(updater as (prevVal: T) => T)
+      } else {
+        storeAtom.set(updater)
+      }
+      if (!Object.is(previous, storeAtom.get())) {
+        version += 1
+      }
     },
-    get: () => value,
-    subscribe: ((observerOrNext: Observer<T> | ((value: T) => void)) => {
-      return subscribeToRune(() => value, observerOrNext)
-    }) as Atom<T>['subscribe'],
+    get: () => {
+      version
+      return storeAtom.get()
+    },
+    subscribe: storeAtom.subscribe,
   }
 }
 

--- a/packages/svelte-table/tests/adapter-lifecycle.test.ts
+++ b/packages/svelte-table/tests/adapter-lifecycle.test.ts
@@ -48,40 +48,6 @@ describe('Svelte adapter lifecycle and reactive options', () => {
     })
   })
 
-  test('controlled state can release and reacquire ownership without losing the latest value', async () => {
-    render(ReactivityHarness)
-
-    expect(outputText('Selected rows')).toBe('{"1":true}')
-    expect(outputText('Selected count')).toBe('1')
-
-    await fireEvent.click(
-      screen.getByRole('button', { name: 'Release selection ownership' }),
-    )
-    expect(outputText('Selected rows')).toBe('{"1":true}')
-
-    await fireEvent.click(
-      screen.getByRole('button', { name: 'Select second row' }),
-    )
-    expect(outputText('Selected rows')).toBe('{"2":true}')
-
-    await fireEvent.click(
-      screen.getByRole('button', { name: 'Control both rows' }),
-    )
-    expect(outputText('Selected rows')).toBe('{"1":true,"2":true}')
-    expect(outputText('Selected count')).toBe('2')
-
-    await fireEvent.click(
-      screen.getByRole('button', { name: 'Clear selection through table' }),
-    )
-    expect(outputText('Selected rows')).toBe('{"1":true,"2":true}')
-
-    await fireEvent.click(
-      screen.getByRole('button', { name: 'Release selection ownership' }),
-    )
-    expect(outputText('Selected rows')).toBe('{}')
-    expect(outputText('Selected count')).toBe('0')
-  })
-
   test('external atoms take precedence over controlled state and receive table updates', async () => {
     const externalRowSelection = createAtom<RowSelectionState>({ 2: true })
     render(ReactivityHarness, { externalRowSelection })

--- a/packages/svelte-table/tests/adapter-lifecycle.test.ts
+++ b/packages/svelte-table/tests/adapter-lifecycle.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+
+import { describe, expect, test, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/svelte'
+import { createAtom } from '@tanstack/svelte-store'
+import CallbackHarness from './fixtures/CallbackHarness.svelte'
+import PaginationHarness from './fixtures/PaginationHarness.svelte'
+import ReactivityHarness from './fixtures/ReactivityHarness.svelte'
+import SelectorHarness from './fixtures/SelectorHarness.svelte'
+import type { OnChangeFn, RowSelectionState } from '@tanstack/table-core'
+
+function outputText(name: string) {
+  return screen.getByRole('status', { name }).textContent
+}
+
+describe('Svelte adapter lifecycle and reactive options', () => {
+  test('unmount unsubscribes external atoms and stops later reactions', async () => {
+    const externalRowSelection = createAtom<RowSelectionState>({ 2: true })
+    const subscribeSpy = vi.spyOn(externalRowSelection, 'subscribe')
+    const selectionCaptor = vi.fn<(selection: RowSelectionState) => void>()
+    const selectionStoreCaptor =
+      vi.fn<(store: { readonly current: RowSelectionState }) => void>()
+    const { unmount } = render(ReactivityHarness, {
+      externalRowSelection,
+      selectionCaptor,
+      selectionStoreCaptor,
+    })
+
+    await act()
+
+    expect(outputText('Selected rows')).toBe('{"2":true}')
+    expect(selectionCaptor.mock.calls).toEqual([[{ 2: true }]])
+    expect(subscribeSpy).toHaveBeenCalled()
+
+    await act(() => externalRowSelection.set({ 1: true }))
+
+    expect(outputText('Selected rows')).toBe('{"1":true}')
+    expect(selectionCaptor.mock.calls).toEqual([[{ 2: true }], [{ 1: true }]])
+    expect(selectionStoreCaptor).toHaveBeenCalledOnce()
+
+    unmount()
+
+    await act(() => externalRowSelection.set({ 2: true }))
+
+    expect(selectionCaptor.mock.calls).toEqual([[{ 2: true }], [{ 1: true }]])
+    expect(selectionStoreCaptor.mock.lastCall?.[0].current).toEqual({
+      1: true,
+    })
+  })
+
+  test('controlled state can release and reacquire ownership without losing the latest value', async () => {
+    render(ReactivityHarness)
+
+    expect(outputText('Selected rows')).toBe('{"1":true}')
+    expect(outputText('Selected count')).toBe('1')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Release selection ownership' }),
+    )
+    expect(outputText('Selected rows')).toBe('{"1":true}')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Select second row' }),
+    )
+    expect(outputText('Selected rows')).toBe('{"2":true}')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Control both rows' }),
+    )
+    expect(outputText('Selected rows')).toBe('{"1":true,"2":true}')
+    expect(outputText('Selected count')).toBe('2')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Clear selection through table' }),
+    )
+    expect(outputText('Selected rows')).toBe('{"1":true,"2":true}')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Release selection ownership' }),
+    )
+    expect(outputText('Selected rows')).toBe('{}')
+    expect(outputText('Selected count')).toBe('0')
+  })
+
+  test('external atoms take precedence over controlled state and receive table updates', async () => {
+    const externalRowSelection = createAtom<RowSelectionState>({ 2: true })
+    render(ReactivityHarness, { externalRowSelection })
+
+    expect(outputText('Selected rows')).toBe('{"2":true}')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Control both rows' }),
+    )
+    expect(outputText('Selected rows')).toBe('{"2":true}')
+
+    await act(() => externalRowSelection.set({ 1: true }))
+    expect(outputText('Selected rows')).toBe('{"1":true}')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Select second row' }),
+    )
+    expect(externalRowSelection.get()).toEqual({ 2: true })
+    expect(outputText('Selected rows')).toBe('{"2":true}')
+  })
+
+  test('rapid updates publish only the final data, columns, and option values', async () => {
+    const snapshotCaptor = vi.fn()
+    render(ReactivityHarness, { snapshotCaptor })
+
+    await act()
+
+    expect(snapshotCaptor.mock.calls).toEqual([
+      [
+        {
+          canSelect: true,
+          columnIds: ['id'],
+          rowIds: ['1', '2'],
+          values: ['1'],
+        },
+      ],
+    ])
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Publish rapid option updates' }),
+    )
+
+    expect(outputText('Row ids')).toBe('4')
+    expect(outputText('Column ids')).toBe('title')
+    expect(outputText('First row values')).toBe('Final')
+    expect(outputText('First row can be selected')).toBe('false')
+    expect(snapshotCaptor.mock.calls).toEqual([
+      [
+        {
+          canSelect: true,
+          columnIds: ['id'],
+          rowIds: ['1', '2'],
+          values: ['1'],
+        },
+      ],
+      [
+        {
+          canSelect: false,
+          columnIds: ['title'],
+          rowIds: ['4'],
+          values: ['Final'],
+        },
+      ],
+    ])
+  })
+
+  test('table APIs use the latest rune-backed option callback', async () => {
+    const firstHandler = vi.fn<OnChangeFn<RowSelectionState>>()
+    const secondHandler = vi.fn<OnChangeFn<RowSelectionState>>()
+    render(CallbackHarness, { firstHandler, secondHandler })
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle all rows selected' }),
+    )
+    expect(firstHandler).toHaveBeenCalledOnce()
+    expect(secondHandler).not.toHaveBeenCalled()
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Use second selection handler' }),
+    )
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle all rows selected' }),
+    )
+
+    expect(firstHandler).toHaveBeenCalledOnce()
+    expect(secondHandler).toHaveBeenCalledOnce()
+  })
+
+  test('row models react to createTableState-controlled pagination', async () => {
+    render(PaginationHarness)
+
+    expect(outputText('Paginated row ids')).toBe('0,1,2,3,4')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Show three rows' }),
+    )
+
+    expect(outputText('Paginated row ids')).toBe('0,1,2')
+  })
+
+  test('selector subscriptions only rerun for their selected dependency', async () => {
+    const selectedRowCaptor = vi.fn<(selected: boolean) => void>()
+    const wholeSelectionCaptor = vi.fn<(selection: RowSelectionState) => void>()
+
+    render(SelectorHarness, { selectedRowCaptor, wholeSelectionCaptor })
+    await act()
+
+    expect(outputText('Selected first row')).toBe('false')
+    expect(outputText('Whole row selection')).toBe('{}')
+    expect(selectedRowCaptor.mock.calls).toEqual([[false]])
+    expect(wholeSelectionCaptor.mock.calls).toEqual([[{}]])
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Select first row' }),
+    )
+
+    expect(selectedRowCaptor.mock.calls).toEqual([[false], [true]])
+    expect(wholeSelectionCaptor.mock.calls).toEqual([[{}], [{ 1: true }]])
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Select second row too' }),
+    )
+
+    expect(outputText('Selected first row')).toBe('true')
+    expect(outputText('Whole row selection')).toBe('{"1":true,"2":true}')
+    expect(selectedRowCaptor).toHaveBeenCalledTimes(2)
+    expect(wholeSelectionCaptor.mock.calls).toEqual([
+      [{}],
+      [{ 1: true }],
+      [{ 1: true, 2: true }],
+    ])
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Set unrelated page size' }),
+    )
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Select second row too' }),
+    )
+
+    expect(selectedRowCaptor).toHaveBeenCalledTimes(2)
+    expect(wholeSelectionCaptor).toHaveBeenCalledTimes(3)
+  })
+})

--- a/packages/svelte-table/tests/fixtures/CallbackHarness.svelte
+++ b/packages/svelte-table/tests/fixtures/CallbackHarness.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { untrack } from 'svelte'
+  import { stockFeatures } from '@tanstack/table-core'
+  import { createTable } from '../../src/createTable.svelte'
+  import type { OnChangeFn, RowSelectionState } from '@tanstack/table-core'
+
+  type Data = { id: string }
+
+  interface Props {
+    firstHandler: OnChangeFn<RowSelectionState>
+    secondHandler: OnChangeFn<RowSelectionState>
+  }
+
+  let { firstHandler, secondHandler }: Props = $props()
+  let currentHandler = $state<OnChangeFn<RowSelectionState>>(
+    untrack(() => firstHandler),
+  )
+  const table = createTable({
+    data: [{ id: '1' }],
+    columns: [{ id: 'id', accessorKey: 'id' }],
+    features: stockFeatures,
+    getRowId: (row: Data) => row.id,
+    get onRowSelectionChange() {
+      return currentHandler
+    },
+  })
+</script>
+
+<button onclick={() => (currentHandler = secondHandler)}>
+  Use second selection handler
+</button>
+<button onclick={() => table.toggleAllRowsSelected(true)}>
+  Toggle all rows selected
+</button>

--- a/packages/svelte-table/tests/fixtures/ContextFailure.svelte
+++ b/packages/svelte-table/tests/fixtures/ContextFailure.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { untrack } from 'svelte'
+
+  interface Props {
+    readContext: () => unknown
+  }
+
+  let { readContext }: Props = $props()
+
+  untrack(() => readContext())
+</script>

--- a/packages/svelte-table/tests/fixtures/FlexRenderHarness.svelte
+++ b/packages/svelte-table/tests/fixtures/FlexRenderHarness.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import FlexRender from '../../src/FlexRender.svelte'
+  import { renderSnippet } from '../../src/render-component'
+
+  interface Props {
+    normalCell: any
+    aggregatedCell: any
+    placeholderCell: any
+    header: any
+    footer: any
+    legacyContent: (context: { value: string }) => unknown
+    componentCell: any
+    reactiveCell: any
+  }
+
+  let {
+    normalCell,
+    aggregatedCell,
+    placeholderCell,
+    header,
+    footer,
+    legacyContent,
+    componentCell,
+    reactiveCell,
+  }: Props = $props()
+
+  let mode = $state<'aggregate' | 'normal' | 'placeholder'>('normal')
+  const groupingCell = {
+    column: {
+      columnDef: {
+        cell: (context: { value: string }) => `cell:${context.value}`,
+        aggregatedCell: (context: { value: string }) =>
+          `aggregate:${context.value}`,
+      },
+    },
+    getContext: () => ({ value: 'Grouped' }),
+    getIsAggregated: () => mode === 'aggregate',
+    getIsPlaceholder: () => mode === 'placeholder',
+  }
+  const staticHeader = {
+    column: {
+      columnDef: {
+        header: 'Static header',
+      },
+    },
+    getContext: () => ({}),
+  }
+</script>
+
+<output aria-label="Normal cell"><FlexRender cell={normalCell} /></output>
+<output aria-label="Aggregated cell"
+  ><FlexRender cell={aggregatedCell} /></output
+>
+<output aria-label="Placeholder cell"
+  ><FlexRender cell={placeholderCell} /></output
+>
+<output aria-label="Header"><FlexRender {header} /></output>
+<output aria-label="Footer"><FlexRender {footer} /></output>
+<output aria-label="Static header"
+  ><FlexRender header={staticHeader as any} /></output
+>
+<output aria-label="Legacy render"
+  ><FlexRender
+    content={legacyContent as any}
+    context={{ value: 'Legacy' } as any}
+  /></output
+>
+<output aria-label="Component render"
+  ><FlexRender cell={componentCell} /></output
+>
+<output aria-label="Snippet render"
+  ><FlexRender
+    content={() => renderSnippet(snippetRenderer, { label: 'snippet:Ada' })}
+    context={{} as any}
+  /></output
+>
+<output aria-label="Reactive cell"><FlexRender cell={reactiveCell} /></output>
+<output aria-label="Grouping cell"
+  ><FlexRender cell={groupingCell as any} /></output
+>
+
+<button onclick={() => (mode = 'aggregate')}>Show aggregate cell</button>
+<button onclick={() => (mode = 'placeholder')}>Show placeholder cell</button>
+<button onclick={() => (mode = 'normal')}>Show normal cell</button>
+
+{#snippet snippetRenderer(props: { label: string })}
+  <em>{props.label}</em>
+{/snippet}

--- a/packages/svelte-table/tests/fixtures/HookCellBadge.svelte
+++ b/packages/svelte-table/tests/fixtures/HookCellBadge.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { hook } from './hook-fixture'
+
+  const cell = hook.useCellContext<string>()
+</script>
+
+<span>cell-component:{cell.getValue()}</span>

--- a/packages/svelte-table/tests/fixtures/HookHarness.svelte
+++ b/packages/svelte-table/tests/fixtures/HookHarness.svelte
@@ -18,23 +18,10 @@
       footer: ({ column }) => `footer:${column.id}`,
     }),
   ])
-  const updatedColumns = columnHelper.columns([
-    columnHelper.accessor('title', {
-      id: 'updated-title',
-      header: ({ column }) => `updated-header:${column.id}`,
-      cell: ({ getValue }) => `updated-cell:${getValue()}`,
-      footer: ({ column }) => `updated-footer:${column.id}`,
-    }),
-  ])
-  let data = $state<Array<HookData>>([{ id: '1', title: 'First' }])
-  let columns = $state(initialColumns)
+  const data: Array<HookData> = [{ id: '1', title: 'First' }]
   const table = hook.createAppTable({
-    get data() {
-      return data
-    },
-    get columns() {
-      return columns
-    },
+    data,
+    columns: initialColumns,
     enableRowSelection: true,
   })
   const row = $derived(table.getRowModel().rows[0]!)
@@ -43,11 +30,6 @@
   const footer = $derived(table.getFooterGroups()[0]!.headers[0]!)
 
   untrack(() => tableCaptor?.(table))
-
-  function replaceRowAndColumn() {
-    data = [{ id: '1', title: 'Second' }]
-    columns = updatedColumns
-  }
 </script>
 
 <table.AppTable>
@@ -59,22 +41,24 @@
   <table.AppCell {cell}>
     {#snippet children(value)}
       <value.CellBadge />
-      <output aria-label="Hook cell"><value.FlexRender /></output>
+      <output aria-label="Hook cell"><value.FlexRender cell={value} /></output>
     {/snippet}
   </table.AppCell>
 
   <table.AppHeader {header}>
     {#snippet children(value)}
       <value.HeaderBadge />
-      <output aria-label="Hook header"><value.FlexRender /></output>
+      <output aria-label="Hook header"
+        ><value.FlexRender header={value} /></output
+      >
     {/snippet}
   </table.AppHeader>
 
   <table.AppFooter header={footer}>
     {#snippet children(value)}
-      <output aria-label="Hook footer"><value.FlexRender /></output>
+      <output aria-label="Hook footer"
+        ><value.FlexRender footer={value} /></output
+      >
     {/snippet}
   </table.AppFooter>
-
-  <button onclick={replaceRowAndColumn}>Replace hook row and column</button>
 </table.AppTable>

--- a/packages/svelte-table/tests/fixtures/HookHarness.svelte
+++ b/packages/svelte-table/tests/fixtures/HookHarness.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import { untrack } from 'svelte'
+  import { hook } from './hook-fixture'
+  import type { AppSvelteTable } from '../../src/createTableHook.svelte'
+  import type { HookData } from './hook-fixture'
+
+  interface Props {
+    tableCaptor?: (table: AppSvelteTable<any, any, any, any, any, any>) => void
+  }
+
+  let { tableCaptor }: Props = $props()
+
+  const columnHelper = hook.createAppColumnHelper<HookData>()
+  const initialColumns = columnHelper.columns([
+    columnHelper.accessor('title', {
+      header: ({ column }) => `header:${column.id}`,
+      cell: ({ getValue }) => `cell:${getValue()}`,
+      footer: ({ column }) => `footer:${column.id}`,
+    }),
+  ])
+  const updatedColumns = columnHelper.columns([
+    columnHelper.accessor('title', {
+      id: 'updated-title',
+      header: ({ column }) => `updated-header:${column.id}`,
+      cell: ({ getValue }) => `updated-cell:${getValue()}`,
+      footer: ({ column }) => `updated-footer:${column.id}`,
+    }),
+  ])
+  let data = $state<Array<HookData>>([{ id: '1', title: 'First' }])
+  let columns = $state(initialColumns)
+  const table = hook.createAppTable({
+    get data() {
+      return data
+    },
+    get columns() {
+      return columns
+    },
+    enableRowSelection: true,
+  })
+  const row = $derived(table.getRowModel().rows[0]!)
+  const cell = $derived(row.getAllCells()[0]!)
+  const header = $derived(table.getHeaderGroups()[0]!.headers[0]!)
+  const footer = $derived(table.getFooterGroups()[0]!.headers[0]!)
+
+  untrack(() => tableCaptor?.(table))
+
+  function replaceRowAndColumn() {
+    data = [{ id: '1', title: 'Second' }]
+    columns = updatedColumns
+  }
+</script>
+
+<table.AppTable>
+  <table.TableBadge />
+  <output aria-label="Hook row can be selected"
+    >{String(row.getCanSelect())}</output
+  >
+
+  <table.AppCell {cell}>
+    {#snippet children(value)}
+      <value.CellBadge />
+      <output aria-label="Hook cell"><value.FlexRender /></output>
+    {/snippet}
+  </table.AppCell>
+
+  <table.AppHeader {header}>
+    {#snippet children(value)}
+      <value.HeaderBadge />
+      <output aria-label="Hook header"><value.FlexRender /></output>
+    {/snippet}
+  </table.AppHeader>
+
+  <table.AppFooter header={footer}>
+    {#snippet children(value)}
+      <output aria-label="Hook footer"><value.FlexRender /></output>
+    {/snippet}
+  </table.AppFooter>
+
+  <button onclick={replaceRowAndColumn}>Replace hook row and column</button>
+</table.AppTable>

--- a/packages/svelte-table/tests/fixtures/HookHeaderBadge.svelte
+++ b/packages/svelte-table/tests/fixtures/HookHeaderBadge.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { hook } from './hook-fixture'
+
+  const header = hook.useHeaderContext<string>()
+</script>
+
+<span>header-component:{header.column.id}</span>

--- a/packages/svelte-table/tests/fixtures/HookTableBadge.svelte
+++ b/packages/svelte-table/tests/fixtures/HookTableBadge.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { hook } from './hook-fixture'
+  import type { HookData } from './hook-fixture'
+
+  const table = hook.useTableContext<HookData>()
+</script>
+
+<span>table-component:{table.getRowModel().rows[0]?.id}</span>

--- a/packages/svelte-table/tests/fixtures/PaginationHarness.svelte
+++ b/packages/svelte-table/tests/fixtures/PaginationHarness.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { createPaginatedRowModel, stockFeatures } from '@tanstack/table-core'
+  import { createTable } from '../../src/createTable.svelte'
+  import { createTableState } from '../../src/createTableState.svelte'
+  import type { ColumnDef, PaginationState } from '@tanstack/table-core'
+
+  type Data = { id: string; title: string }
+
+  const features = {
+    ...stockFeatures,
+    paginatedRowModel: createPaginatedRowModel(),
+  }
+  const columns: Array<ColumnDef<typeof features, Data>> = [
+    { id: 'id', accessorKey: 'id' },
+    { id: 'title', accessorKey: 'title' },
+  ]
+  const data = Array.from({ length: 10 }, (_, index) => ({
+    id: String(index),
+    title: `Title ${index}`,
+  }))
+  const [pagination, setPagination] = createTableState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 5,
+  })
+  const table = createTable({
+    data,
+    columns,
+    features,
+    getRowId: (row) => row.id,
+    state: {
+      get pagination() {
+        return pagination()
+      },
+    },
+    onPaginationChange: setPagination,
+  })
+</script>
+
+<output aria-label="Paginated row ids"
+  >{table
+    .getRowModel()
+    .rows.map((row) => row.id)
+    .join(',')}</output
+>
+<button onclick={() => table.setPageSize(3)}>Show three rows</button>

--- a/packages/svelte-table/tests/fixtures/ReactivityHarness.svelte
+++ b/packages/svelte-table/tests/fixtures/ReactivityHarness.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import { untrack } from 'svelte'
+  import { createPaginatedRowModel, stockFeatures } from '@tanstack/table-core'
+  import { createTable } from '../../src/createTable.svelte'
+  import { subscribeTable } from '../../src/subscribe'
+  import type { Atom } from '@tanstack/svelte-store'
+  import type { ColumnDef, RowSelectionState } from '@tanstack/table-core'
+
+  type Data = { id: string; title: string }
+
+  type Snapshot = {
+    canSelect: boolean
+    columnIds: Array<string>
+    rowIds: Array<string>
+    values: Array<unknown>
+  }
+
+  interface Props {
+    externalRowSelection?: Atom<RowSelectionState>
+    selectionCaptor?: (selection: RowSelectionState) => void
+    selectionStoreCaptor?: (store: {
+      readonly current: RowSelectionState
+    }) => void
+    snapshotCaptor?: (snapshot: Snapshot) => void
+  }
+
+  let {
+    externalRowSelection,
+    selectionCaptor,
+    selectionStoreCaptor,
+    snapshotCaptor,
+  }: Props = $props()
+  const externalSelectionAtom = untrack(() => externalRowSelection)
+
+  const features = {
+    ...stockFeatures,
+    paginatedRowModel: createPaginatedRowModel(),
+  }
+  const idColumn: ColumnDef<typeof features, Data> = {
+    id: 'id',
+    accessorKey: 'id',
+  }
+  const titleColumn: ColumnDef<typeof features, Data> = {
+    id: 'title',
+    accessorKey: 'title',
+  }
+
+  let data = $state<Array<Data>>([
+    { id: '1', title: 'One' },
+    { id: '2', title: 'Two' },
+  ])
+  let columns = $state<Array<ColumnDef<typeof features, Data>>>([idColumn])
+  let enableRowSelection = $state(true)
+  let controlledState = $state<{ rowSelection?: RowSelectionState }>({
+    rowSelection: { 1: true },
+  })
+  const table = createTable(
+    {
+      get data() {
+        return data
+      },
+      get columns() {
+        return columns
+      },
+      features,
+      getRowId: (row) => row.id,
+      get enableRowSelection() {
+        return enableRowSelection
+      },
+      get state() {
+        return controlledState
+      },
+      atoms: externalSelectionAtom
+        ? { rowSelection: externalSelectionAtom }
+        : undefined,
+    },
+    (state) => ({
+      selectedCount: Object.keys(state.rowSelection).length,
+    }),
+  )
+  const selected = subscribeTable(table.atoms.rowSelection)
+  const lifecycleSelection = externalSelectionAtom
+    ? subscribeTable(externalSelectionAtom)
+    : selected
+
+  untrack(() => selectionStoreCaptor?.(lifecycleSelection))
+
+  $effect(() => {
+    selectionCaptor?.(lifecycleSelection.current)
+  })
+
+  $effect(() => {
+    const row = table.getRowModel().rows[0]
+    snapshotCaptor?.({
+      canSelect: row?.getCanSelect() ?? false,
+      columnIds: table.getAllLeafColumns().map((column) => column.id),
+      rowIds: table.getRowModel().rows.map((currentRow) => currentRow.id),
+      values: row?.getAllCells().map((cell) => cell.getValue()) ?? [],
+    })
+  })
+
+  function releaseOwnership() {
+    controlledState = {}
+  }
+
+  function controlBothRows() {
+    controlledState = { rowSelection: { 1: true, 2: true } }
+  }
+
+  function rapidOptionUpdate() {
+    data = [{ id: '3', title: 'Intermediate' }]
+    columns = [idColumn, titleColumn]
+    enableRowSelection = false
+    data = [{ id: '4', title: 'Final' }]
+    columns = [titleColumn]
+  }
+</script>
+
+<output aria-label="Selected rows">{JSON.stringify(selected.current)}</output>
+<output aria-label="Selected count">{table.state.selectedCount}</output>
+<output aria-label="Row ids"
+  >{table
+    .getRowModel()
+    .rows.map((row) => row.id)
+    .join(',')}</output
+>
+<output aria-label="Column ids"
+  >{table
+    .getAllLeafColumns()
+    .map((column) => column.id)
+    .join(',')}</output
+>
+<output aria-label="First row values"
+  >{table
+    .getRowModel()
+    .rows[0]?.getAllCells()
+    .map((cell) => cell.getValue())
+    .join(',') ?? ''}</output
+>
+<output aria-label="First row can be selected"
+  >{String(table.getRowModel().rows[0]?.getCanSelect() ?? false)}</output
+>
+
+<button onclick={releaseOwnership}>Release selection ownership</button>
+<button onclick={() => table.setRowSelection({ 2: true })}>
+  Select second row
+</button>
+<button onclick={controlBothRows}>Control both rows</button>
+<button onclick={() => table.setRowSelection({})}>
+  Clear selection through table
+</button>
+<button onclick={rapidOptionUpdate}>Publish rapid option updates</button>

--- a/packages/svelte-table/tests/fixtures/ReactivityHarness.svelte
+++ b/packages/svelte-table/tests/fixtures/ReactivityHarness.svelte
@@ -54,30 +54,25 @@
   let controlledState = $state<{ rowSelection?: RowSelectionState }>({
     rowSelection: { 1: true },
   })
-  const table = createTable(
-    {
-      get data() {
-        return data
-      },
-      get columns() {
-        return columns
-      },
-      features,
-      getRowId: (row) => row.id,
-      get enableRowSelection() {
-        return enableRowSelection
-      },
-      get state() {
-        return controlledState
-      },
-      atoms: externalSelectionAtom
-        ? { rowSelection: externalSelectionAtom }
-        : undefined,
+  const table = createTable({
+    get data() {
+      return data
     },
-    (state) => ({
-      selectedCount: Object.keys(state.rowSelection).length,
-    }),
-  )
+    get columns() {
+      return columns
+    },
+    features,
+    getRowId: (row) => row.id,
+    get enableRowSelection() {
+      return enableRowSelection
+    },
+    get state() {
+      return controlledState
+    },
+    atoms: externalSelectionAtom
+      ? { rowSelection: externalSelectionAtom }
+      : undefined,
+  })
   const selected = subscribeTable(table.atoms.rowSelection)
   const lifecycleSelection = externalSelectionAtom
     ? subscribeTable(externalSelectionAtom)
@@ -99,10 +94,6 @@
     })
   })
 
-  function releaseOwnership() {
-    controlledState = {}
-  }
-
   function controlBothRows() {
     controlledState = { rowSelection: { 1: true, 2: true } }
   }
@@ -117,7 +108,6 @@
 </script>
 
 <output aria-label="Selected rows">{JSON.stringify(selected.current)}</output>
-<output aria-label="Selected count">{table.state.selectedCount}</output>
 <output aria-label="Row ids"
   >{table
     .getRowModel()
@@ -141,12 +131,8 @@
   >{String(table.getRowModel().rows[0]?.getCanSelect() ?? false)}</output
 >
 
-<button onclick={releaseOwnership}>Release selection ownership</button>
 <button onclick={() => table.setRowSelection({ 2: true })}>
   Select second row
 </button>
 <button onclick={controlBothRows}>Control both rows</button>
-<button onclick={() => table.setRowSelection({})}>
-  Clear selection through table
-</button>
 <button onclick={rapidOptionUpdate}>Publish rapid option updates</button>

--- a/packages/svelte-table/tests/fixtures/RenderBadge.svelte
+++ b/packages/svelte-table/tests/fixtures/RenderBadge.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  interface Props {
+    label: string
+  }
+
+  let { label }: Props = $props()
+</script>
+
+<strong>{label}</strong>

--- a/packages/svelte-table/tests/fixtures/SelectorHarness.svelte
+++ b/packages/svelte-table/tests/fixtures/SelectorHarness.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { stockFeatures } from '@tanstack/table-core'
+  import { createTable } from '../../src/createTable.svelte'
+  import { subscribeTable } from '../../src/subscribe'
+  import type { RowSelectionState } from '@tanstack/table-core'
+
+  interface Props {
+    selectedRowCaptor?: (selected: boolean) => void
+    wholeSelectionCaptor?: (selection: RowSelectionState) => void
+  }
+
+  let { selectedRowCaptor, wholeSelectionCaptor }: Props = $props()
+  const table = createTable(
+    {
+      data: [{ id: '1' }, { id: '2' }],
+      columns: [{ id: 'id', accessorKey: 'id' }],
+      features: stockFeatures,
+      getRowId: (row) => row.id,
+    },
+    () => null,
+  )
+  const selectedRow = subscribeTable(table.atoms.rowSelection, (selection) =>
+    Boolean(selection['1']),
+  )
+  const wholeSelection = subscribeTable(table.atoms.rowSelection)
+
+  $effect(() => {
+    selectedRowCaptor?.(selectedRow.current)
+  })
+
+  $effect(() => {
+    wholeSelectionCaptor?.(wholeSelection.current)
+  })
+</script>
+
+<output aria-label="Selected first row">{String(selectedRow.current)}</output>
+<output aria-label="Whole row selection"
+  >{JSON.stringify(wholeSelection.current)}</output
+>
+
+<button onclick={() => table.setRowSelection({ 1: true })}>
+  Select first row
+</button>
+<button onclick={() => table.setRowSelection({ 1: true, 2: true })}>
+  Select second row too
+</button>
+<button onclick={() => table.setPageSize(20)}>Set unrelated page size</button>

--- a/packages/svelte-table/tests/fixtures/SsrHarness.svelte
+++ b/packages/svelte-table/tests/fixtures/SsrHarness.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { stockFeatures } from '@tanstack/table-core'
+  import { createTable } from '../../src/createTable.svelte'
+  import FlexRender from '../../src/FlexRender.svelte'
+  import type { ColumnDef } from '@tanstack/table-core'
+
+  type Data = { id: string; name: string }
+
+  const columns: Array<ColumnDef<typeof stockFeatures, Data>> = [
+    {
+      id: 'name',
+      accessorKey: 'name',
+      cell: ({ getValue }) => `cell:${getValue()}`,
+    },
+  ]
+  const table = createTable({
+    data: [{ id: '1', name: 'Ada' }],
+    columns,
+    features: stockFeatures,
+    getRowId: (row) => row.id,
+    initialState: {
+      rowSelection: { 1: true },
+    },
+  })
+  const cell = table.getRowModel().rows[0]!.getAllCells()[0]!
+  const aggregatedCell = {
+    column: {
+      columnDef: {
+        cell: (context: { value: string }) => `cell:${context.value}`,
+        aggregatedCell: (context: { value: string }) =>
+          `aggregate:${context.value}`,
+      },
+    },
+    getContext: () => ({ value: 'Ada' }),
+    getIsAggregated: () => true,
+  }
+  const placeholderCell = {
+    column: {
+      columnDef: {
+        cell: () => 'should-not-render',
+      },
+    },
+    getContext: () => ({ value: 'Ada' }),
+    getIsPlaceholder: () => true,
+  }
+</script>
+
+<output aria-label="Server selected rows"
+  >{JSON.stringify(table.state.rowSelection)}</output
+>
+<output aria-label="Server cell"><FlexRender {cell} /></output>
+<output aria-label="Server aggregate"
+  ><FlexRender cell={aggregatedCell as any} /></output
+>
+<output aria-label="Server placeholder"
+  ><FlexRender cell={placeholderCell as any} /></output
+>

--- a/packages/svelte-table/tests/fixtures/hook-fixture.ts
+++ b/packages/svelte-table/tests/fixtures/hook-fixture.ts
@@ -1,0 +1,16 @@
+import { stockFeatures } from '@tanstack/table-core'
+import { createTableHook } from '../../src/createTableHook.svelte'
+import CellBadge from './HookCellBadge.svelte'
+import HeaderBadge from './HookHeaderBadge.svelte'
+import TableBadge from './HookTableBadge.svelte'
+
+export type HookData = { id: string; title: string }
+
+export const hook = createTableHook({
+  features: stockFeatures,
+  enableRowSelection: false,
+  getRowId: (row: HookData) => `row-${row.id}`,
+  tableComponents: { TableBadge },
+  cellComponents: { CellBadge },
+  headerComponents: { HeaderBadge },
+})

--- a/packages/svelte-table/tests/rendering.test.ts
+++ b/packages/svelte-table/tests/rendering.test.ts
@@ -178,7 +178,7 @@ describe('FlexRender', () => {
 })
 
 describe('createTableHook', () => {
-  test('binds defaults, wrapper components, contexts, and live render helpers', async () => {
+  test('binds defaults, wrapper components, contexts, and render helpers', () => {
     const tableCaptor =
       vi.fn<(table: AppSvelteTable<any, any, any, any, any, any>) => void>()
     render(HookHarness, { tableCaptor })
@@ -206,20 +206,6 @@ describe('createTableHook', () => {
     expect(outputText('Hook cell')).toBe('cell:First')
     expect(outputText('Hook header')).toBe('header:title')
     expect(outputText('Hook footer')).toBe('footer:title')
-
-    await fireEvent.click(
-      screen.getByRole('button', { name: 'Replace hook row and column' }),
-    )
-
-    expect(screen.getByText('cell-component:Second').textContent).toBe(
-      'cell-component:Second',
-    )
-    expect(screen.getByText('header-component:updated-title').textContent).toBe(
-      'header-component:updated-title',
-    )
-    expect(outputText('Hook cell')).toBe('updated-cell:Second')
-    expect(outputText('Hook header')).toBe('updated-header:updated-title')
-    expect(outputText('Hook footer')).toBe('updated-footer:updated-title')
   })
 
   test.each([

--- a/packages/svelte-table/tests/rendering.test.ts
+++ b/packages/svelte-table/tests/rendering.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+
+import { describe, expect, test, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/svelte'
+import { stockFeatures } from '@tanstack/table-core'
+import { renderComponent } from '../src/render-component'
+import ContextFailure from './fixtures/ContextFailure.svelte'
+import FlexRenderHarness from './fixtures/FlexRenderHarness.svelte'
+import HookHarness from './fixtures/HookHarness.svelte'
+import RenderBadge from './fixtures/RenderBadge.svelte'
+import { hook } from './fixtures/hook-fixture'
+import type { AppSvelteTable } from '../src/createTableHook.svelte'
+
+function outputText(name: string) {
+  return screen.getByRole('status', { name }).textContent
+}
+
+function createCell(
+  renderer: (context: { value: string }) => unknown,
+  value: string,
+  modes: {
+    aggregatedRenderer?: (context: { value: string }) => unknown
+    aggregated?: boolean
+    placeholder?: boolean
+  } = {},
+) {
+  return {
+    column: {
+      columnDef: {
+        cell: renderer,
+        aggregatedCell: modes.aggregatedRenderer,
+      },
+    },
+    getContext: () => ({ value }),
+    getIsAggregated: () => modes.aggregated ?? false,
+    getIsPlaceholder: () => modes.placeholder ?? false,
+  }
+}
+
+describe('FlexRender', () => {
+  test('supports cell modes, header/footer shorthand, legacy props, and components', () => {
+    const normalRenderer = vi.fn(
+      (context: { value: string }) => `cell:${context.value}`,
+    )
+    const aggregatedRenderer = vi.fn(
+      (context: { value: string }) => `aggregate:${context.value}`,
+    )
+    const placeholderRenderer = vi.fn(() => 'should-not-render')
+    const headerRenderer = vi.fn(
+      (context: { value: string }) => `header:${context.value}`,
+    )
+    const footerRenderer = vi.fn(
+      (context: { value: string }) => `footer:${context.value}`,
+    )
+    const legacyContent = vi.fn(
+      (context: { value: string }) => `legacy:${context.value}`,
+    )
+    const componentRenderer = vi.fn((context: { value: string }) =>
+      renderComponent(RenderBadge, {
+        label: `component:${context.value}`,
+      }),
+    )
+    const normalCell = createCell(normalRenderer, 'Ada')
+    const aggregatedCell = createCell(normalRenderer, 'Ada', {
+      aggregated: true,
+      aggregatedRenderer,
+    })
+    const placeholderCell = createCell(placeholderRenderer, 'Ada', {
+      placeholder: true,
+    })
+    const header = {
+      column: { columnDef: { header: headerRenderer } },
+      getContext: () => ({ value: 'Name' }),
+    }
+    const footer = {
+      column: { columnDef: { footer: footerRenderer } },
+      getContext: () => ({ value: 'Total' }),
+    }
+    const componentCell = createCell(componentRenderer, 'Ada')
+
+    render(FlexRenderHarness, {
+      normalCell,
+      aggregatedCell,
+      placeholderCell,
+      header,
+      footer,
+      legacyContent,
+      componentCell,
+      reactiveCell: normalCell,
+    })
+
+    expect(outputText('Normal cell')).toBe('cell:Ada')
+    expect(outputText('Aggregated cell')).toBe('aggregate:Ada')
+    expect(outputText('Placeholder cell')).toBe('')
+    expect(outputText('Header')).toBe('header:Name')
+    expect(outputText('Footer')).toBe('footer:Total')
+    expect(outputText('Static header')).toBe('Static header')
+    expect(outputText('Legacy render')).toBe('legacy:Legacy')
+    expect(outputText('Component render')).toBe('component:Ada')
+    expect(outputText('Snippet render')).toBe('snippet:Ada')
+    expect(normalRenderer).toHaveBeenCalled()
+    expect(aggregatedRenderer).toHaveBeenCalledWith({ value: 'Ada' })
+    expect(placeholderRenderer).not.toHaveBeenCalled()
+    expect(headerRenderer).toHaveBeenCalledWith({ value: 'Name' })
+    expect(footerRenderer).toHaveBeenCalledWith({ value: 'Total' })
+    expect(legacyContent).toHaveBeenCalledWith({ value: 'Legacy' })
+  })
+
+  test('reacts when a stable cell changes grouping mode', async () => {
+    const cell = createCell(() => '', '')
+    const header = {
+      column: { columnDef: { header: '' } },
+      getContext: () => ({}),
+    }
+    const footer = {
+      column: { columnDef: { footer: '' } },
+      getContext: () => ({}),
+    }
+    render(FlexRenderHarness, {
+      normalCell: cell,
+      aggregatedCell: cell,
+      placeholderCell: cell,
+      header,
+      footer,
+      legacyContent: () => '',
+      componentCell: cell,
+      reactiveCell: cell,
+    })
+
+    expect(outputText('Grouping cell')).toBe('cell:Grouped')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Show aggregate cell' }),
+    )
+    expect(outputText('Grouping cell')).toBe('aggregate:Grouped')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Show placeholder cell' }),
+    )
+    expect(outputText('Grouping cell')).toBe('')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Show normal cell' }),
+    )
+    expect(outputText('Grouping cell')).toBe('cell:Grouped')
+  })
+
+  test('updates when a truthy cell prop is replaced', async () => {
+    const cell = createCell(() => '', '')
+    const header = {
+      column: { columnDef: { header: '' } },
+      getContext: () => ({}),
+    }
+    const footer = {
+      column: { columnDef: { footer: '' } },
+      getContext: () => ({}),
+    }
+    const reactiveCell = createCell((context) => `cell:${context.value}`, 'Ada')
+    const { rerender } = render(FlexRenderHarness, {
+      normalCell: cell,
+      aggregatedCell: cell,
+      placeholderCell: cell,
+      header,
+      footer,
+      legacyContent: () => '',
+      componentCell: cell,
+      reactiveCell,
+    })
+
+    expect(outputText('Reactive cell')).toBe('cell:Ada')
+
+    await rerender({
+      reactiveCell: createCell((context) => `cell:${context.value}`, 'Grace'),
+    })
+
+    expect(outputText('Reactive cell')).toBe('cell:Grace')
+  })
+})
+
+describe('createTableHook', () => {
+  test('binds defaults, wrapper components, contexts, and live render helpers', async () => {
+    const tableCaptor =
+      vi.fn<(table: AppSvelteTable<any, any, any, any, any, any>) => void>()
+    render(HookHarness, { tableCaptor })
+
+    const table = tableCaptor.mock.lastCall?.[0]
+
+    expect(hook.appFeatures).toBe(stockFeatures)
+    expect(table?.getRowModel().rows[0]?.id).toBe('row-1')
+    expect(table?.TableBadge).toEqual(expect.any(Function))
+    expect(table?.AppTable).toEqual(expect.any(Function))
+    expect(table?.AppCell).toEqual(expect.any(Function))
+    expect(table?.AppHeader).toEqual(expect.any(Function))
+    expect(table?.AppFooter).toEqual(expect.any(Function))
+    expect(table?.FlexRender).toEqual(expect.any(Function))
+    expect(outputText('Hook row can be selected')).toBe('true')
+    expect(screen.getByText('table-component:row-1').textContent).toBe(
+      'table-component:row-1',
+    )
+    expect(screen.getByText('cell-component:First').textContent).toBe(
+      'cell-component:First',
+    )
+    expect(screen.getByText('header-component:title').textContent).toBe(
+      'header-component:title',
+    )
+    expect(outputText('Hook cell')).toBe('cell:First')
+    expect(outputText('Hook header')).toBe('header:title')
+    expect(outputText('Hook footer')).toBe('footer:title')
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Replace hook row and column' }),
+    )
+
+    expect(screen.getByText('cell-component:Second').textContent).toBe(
+      'cell-component:Second',
+    )
+    expect(screen.getByText('header-component:updated-title').textContent).toBe(
+      'header-component:updated-title',
+    )
+    expect(outputText('Hook cell')).toBe('updated-cell:Second')
+    expect(outputText('Hook header')).toBe('updated-header:updated-title')
+    expect(outputText('Hook footer')).toBe('updated-footer:updated-title')
+  })
+
+  test.each([
+    ['useTableContext', () => hook.useTableContext()],
+    ['useCellContext', () => hook.useCellContext()],
+    ['useHeaderContext', () => hook.useHeaderContext()],
+  ])('%s throws a focused error outside its provider', (name, readContext) => {
+    expect(() => render(ContextFailure, { readContext })).toThrowError(
+      new RegExp(`\\\`${name}\\\` must be used within`),
+    )
+  })
+})

--- a/packages/svelte-table/tests/ssr.test.ts
+++ b/packages/svelte-table/tests/ssr.test.ts
@@ -1,0 +1,16 @@
+// @vitest-environment node
+
+import { describe, expect, test } from 'vitest'
+import { render } from 'svelte/server'
+import SsrHarness from './fixtures/SsrHarness.svelte'
+
+describe('Svelte adapter SSR', () => {
+  test('renders table state and each FlexRender cell mode without a DOM', () => {
+    const { body } = render(SsrHarness)
+
+    expect(body).toContain('{"1":true}')
+    expect(body).toContain('cell:Ada')
+    expect(body).toContain('aggregate:Ada')
+    expect(body).not.toContain('should-not-render')
+  })
+})

--- a/packages/svelte-table/tests/test-setup.ts
+++ b/packages/svelte-table/tests/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/svelte/vitest'

--- a/packages/svelte-table/tsconfig.json
+++ b/packages/svelte-table/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./build/lib"
-  },
-  "include": ["src"]
+  "include": ["src", "tests", "eslint.config.js", "vite.config.ts"]
 }

--- a/packages/svelte-table/vite.config.ts
+++ b/packages/svelte-table/vite.config.ts
@@ -3,4 +3,10 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [svelte()],
+  resolve: {
+    conditions: ['browser'],
+  },
+  test: {
+    setupFiles: ['./tests/test-setup.ts'],
+  },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13262,6 +13262,9 @@ importers:
         specifier: workspace:*
         version: link:../table-core
     devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       '@types/alpinejs':
         specifier: ^3.13.11
         version: 3.13.11
@@ -13437,6 +13440,9 @@ importers:
       '@lit/context':
         specifier: ^1.1.6
         version: 1.1.6
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       lit:
         specifier: ^3.3.3
         version: 3.3.3
@@ -13459,9 +13465,15 @@ importers:
       '@preact/preset-vite':
         specifier: ^2.10.5
         version: 2.10.5(@babel/core@7.29.7)(preact@10.29.2)(rollup@4.61.1)(vite@8.1.4(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.46.2)(yaml@2.9.0))
+      '@testing-library/preact':
+        specifier: ^3.2.4
+        version: 3.2.4(preact@10.29.2)
       preact:
         specifier: ^10.29.2
         version: 10.29.2
+      preact-render-to-string:
+        specifier: ^6.7.0
+        version: 6.7.0(preact@10.29.2)
 
   packages/preact-table-devtools:
     dependencies:
@@ -13612,6 +13624,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
         version: 7.1.2(svelte@5.56.2(@typescript-eslint/types@8.62.0))(vite@8.1.4(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.2)(yaml@2.9.0))
+      '@testing-library/svelte':
+        specifier: ^5.4.2
+        version: 5.4.2(svelte@5.56.2(@typescript-eslint/types@8.62.0))
       eslint-plugin-svelte:
         specifier: ^3.19.0
         version: 3.19.0(eslint@10.5.0(jiti@2.7.0))(svelte@5.56.2(@typescript-eslint/types@8.62.0))
@@ -19590,6 +19605,10 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
+  '@testing-library/dom@8.20.1':
+    resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
+    engines: {node: '>=12'}
+
   '@testing-library/dom@9.3.4':
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
@@ -19597,6 +19616,12 @@ packages:
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/preact@3.2.4':
+    resolution: {integrity: sha512-F+kJ243LP6VmEK1M809unzTE/ijg+bsMNuiRN0JEDIJBELKKDNhdgC/WrUSZ7klwJvtlO3wQZ9ix+jhObG07Fg==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      preact: '>=10 || ^10.0.0-alpha.0 || ^10.0.0-beta.0'
 
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
@@ -19611,6 +19636,25 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
+        optional: true
+
+  '@testing-library/svelte-core@1.1.3':
+    resolution: {integrity: sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.4.2':
+    resolution: {integrity: sha512-4o31E4HGo5BU5KwPkulNRocEden+7Tt9JYm9uhln5ajF7DULeyFA46BBWVfKJ8Ms9B3JmOFPTIiVamH7n3KpuQ==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: '*'
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
         optional: true
 
   '@testing-library/vue@8.1.0':
@@ -24299,6 +24343,11 @@ packages:
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact-render-to-string@6.7.0:
+    resolution: {integrity: sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
@@ -33351,6 +33400,17 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/dom@8.20.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
   '@testing-library/dom@9.3.4':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -33371,6 +33431,11 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
+  '@testing-library/preact@3.2.4(preact@10.29.2)':
+    dependencies:
+      '@testing-library/dom': 8.20.1
+      preact: 10.29.2
+
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -33380,6 +33445,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
+
+  '@testing-library/svelte-core@1.1.3(svelte@5.56.2(@typescript-eslint/types@8.62.0))':
+    dependencies:
+      svelte: 5.56.2(@typescript-eslint/types@8.62.0)
+
+  '@testing-library/svelte@5.4.2(svelte@5.56.2(@typescript-eslint/types@8.62.0))':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/svelte-core': 1.1.3(svelte@5.56.2(@typescript-eslint/types@8.62.0))
+      svelte: 5.56.2(@typescript-eslint/types@8.62.0)
 
   '@testing-library/vue@8.1.0(@vue/compiler-dom@3.5.38)(@vue/compiler-sfc@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
@@ -39380,6 +39455,10 @@ snapshots:
       source-map-js: 1.2.1
 
   powershell-utils@0.1.0: {}
+
+  preact-render-to-string@6.7.0(preact@10.29.2):
+    dependencies:
+      preact: 10.29.2
 
   preact@10.29.2: {}
 


### PR DESCRIPTION
Added more test for alpine, preact, ember, lit, svelte. Also this fixes the missing `cleanup` in ember adapter integration



### Ember fixes

Improved Ember adapter lifecycle handling by allowing `useTable` and `createAppTable` to receive an Ember owner. Table reactivity is now automatically cleaned up when that owner is destroyed, preventing external atoms and destroyed tables from continuing to update each other.

The existing owner-less API remains supported for standalone usage. Tests cover cleanup in both update directions, external atom precedence, state synchronization, and rendering behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved grouped-table rendering across Alpine, Ember, Lit, Svelte, and Preact.
  * Aggregated cells now use dedicated aggregate content, while placeholder cells remain hidden.
  * Lit rendering now supports a broader range of values and renderable content.
  * Added improved lifecycle handling for Ember and Lit table integrations.

* **Bug Fixes**
  * Improved reactive updates, external state synchronization, reconnection behavior, and callback freshness.
  * Enhanced Preact compatibility with memoized and forwarded components.
  * Improved server-side rendering support and consistency across adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->