### PR TITLE
fix: header row spans work now

### DIFF
--- a/docs/guide/headers.md
+++ b/docs/guide/headers.md
@@ -53,9 +53,9 @@ For simple headers with no advanced nested or grouped headers logic, the `header
 There are a few properties on `header` objects that are only useful if the header is part of a nested or grouped header structure. These properties include:
 
 - `colspan`: The number of columns that the header should span. This is useful for rendering the `colSpan` attribute on the `<th>` element.
-- `rowSpan`: The number of rows that the header should span. This is useful for rendering the `rowSpan` attribute on the `<th>` element. (Currently not implemented in default TanStack Table)
+- `rowSpan`: The number of rows that the header should span when merging header cells vertically. A leaf column that is shallower than the deepest leaf column produces a chain of placeholder headers above its real header. The placeholder at the top of the chain reports the chain's full span, and every header it covers (including the real leaf header in the bottom row) reports 0. This is useful for rendering the `rowSpan` attribute on the `<th>` element. See [Header Row Spanning](#header-row-spanning) below.
 - `depth`: The header group "row index" that the header group belongs to.
-- `isPlaceholder`: A boolean flag that is true if the header is a placeholder header. Placeholder headers are used to fill in the gaps when a column is hidden or when a column is part of a group column.
+- `isPlaceholder`: A boolean flag that is true if the header is a placeholder header. Placeholder headers fill the rows above a shallow leaf column's real header so that every header row accounts for every visible column. Render them as empty cells to keep the header grid aligned, or use `header.rowSpan` to merge each placeholder chain into one vertically spanning header cell.
 - `placeholderId`: The unique identifier for the placeholder header.
 - `subHeaders`: The array of sub/child headers that belong to this header. Will be empty if the header is a leaf header.
 
@@ -83,3 +83,21 @@ Since the `header` column option you defined can be either a string, jsx, or a f
   ))
 }
 ```
+
+### Header Row Spanning
+
+If your column tree is uneven (some leaf columns are nested deeper than others), each shallow leaf column produces a chain of placeholder headers above its real header. The placeholder at the top of the chain reports the chain's full `rowSpan`, and every header it covers reports a `rowSpan` of 0. To merge those header cells vertically, skip headers with a `rowSpan` of 0 and render everything else with the `rowSpan` attribute. Note that this replaces the usual `header.isPlaceholder` check: the spanning placeholder renders its column's header content instead of an empty cell.
+
+```jsx
+{
+  headerGroup.headers.map((header) =>
+    header.rowSpan === 0 ? null : (
+      <th key={header.id} colSpan={header.colSpan} rowSpan={header.rowSpan}>
+        {flexRender(header.column.columnDef.header, header.getContext())}
+      </th>
+    ),
+  )
+}
+```
+
+> Note: This recipe is for the `<thead>` section only. Footer groups render the header rows in reverse order, which puts a spanning placeholder below the cells it would need to cover, so keep the `header.isPlaceholder` empty-cell pattern in the `<tfoot>` section.

--- a/examples/alpine/header-groups/index.html
+++ b/examples/alpine/header-groups/index.html
@@ -11,49 +11,186 @@
         <button @click="refreshData()">Regenerate Data</button>
         <button @click="stressTest()">Stress Test (1k rows)</button>
       </div>
-      <table>
-        <thead>
-          <template
-            x-for="headerGroup in table.getHeaderGroups()"
-            :key="headerGroup.id"
-          >
-            <tr>
-              <template x-for="header in headerGroup.headers" :key="header.id">
-                <th :colspan="header.colSpan">
-                  <template x-if="!header.isPlaceholder">
-                    <span x-html="FlexRender({ header })"></span>
+      <div class="spacer-md"></div>
+      <!-- The panels wrap into a grid whenever the viewport is wide enough. -->
+      <div class="example-grid">
+        <section class="example-panel">
+          <h2 class="section-title">Basic Header Groups</h2>
+          <table>
+            <thead>
+              <template
+                x-for="headerGroup in basicTable.getHeaderGroups()"
+                :key="headerGroup.id"
+              >
+                <tr>
+                  <template
+                    x-for="header in headerGroup.headers"
+                    :key="header.id"
+                  >
+                    <th :colspan="header.colSpan">
+                      <span x-html="FlexRender({ header })"></span>
+                    </th>
                   </template>
-                </th>
+                </tr>
               </template>
-            </tr>
-          </template>
-        </thead>
-        <tbody>
-          <template x-for="row in table.getRowModel().rows" :key="row.id">
-            <tr>
-              <template x-for="cell in row.getAllCells()" :key="cell.id">
-                <td x-html="FlexRender({ cell })"></td>
-              </template>
-            </tr>
-          </template>
-        </tbody>
-        <tfoot>
-          <template
-            x-for="footerGroup in table.getFooterGroups()"
-            :key="footerGroup.id"
-          >
-            <tr>
-              <template x-for="header in footerGroup.headers" :key="header.id">
-                <th :colspan="header.colSpan">
-                  <template x-if="!header.isPlaceholder">
-                    <span x-html="FlexRender({ footer: header })"></span>
+            </thead>
+            <tbody>
+              <template
+                x-for="row in basicTable.getRowModel().rows"
+                :key="row.id"
+              >
+                <tr>
+                  <template x-for="cell in row.getAllCells()" :key="cell.id">
+                    <td x-html="FlexRender({ cell })"></td>
                   </template>
-                </th>
+                </tr>
               </template>
-            </tr>
-          </template>
-        </tfoot>
-      </table>
+            </tbody>
+            <tfoot>
+              <template
+                x-for="footerGroup in basicFooterGroups()"
+                :key="footerGroup.id"
+              >
+                <tr>
+                  <template
+                    x-for="header in footerGroup.headers"
+                    :key="header.id"
+                  >
+                    <th :colspan="header.colSpan">
+                      <template x-if="!header.isPlaceholder">
+                        <span x-html="FlexRender({ footer: header })"></span>
+                      </template>
+                    </th>
+                  </template>
+                </tr>
+              </template>
+            </tfoot>
+          </table>
+        </section>
+
+        <section class="example-panel">
+          <h2 class="section-title">Nested Header Groups</h2>
+          <table>
+            <thead>
+              <template
+                x-for="headerGroup in nestedTable.getHeaderGroups()"
+                :key="headerGroup.id"
+              >
+                <tr>
+                  <template
+                    x-for="header in headerGroup.headers"
+                    :key="header.id"
+                  >
+                    <th :colspan="header.colSpan">
+                      <span x-html="FlexRender({ header })"></span>
+                    </th>
+                  </template>
+                </tr>
+              </template>
+            </thead>
+            <tbody>
+              <template
+                x-for="row in nestedTable.getRowModel().rows"
+                :key="row.id"
+              >
+                <tr>
+                  <template x-for="cell in row.getAllCells()" :key="cell.id">
+                    <td x-html="FlexRender({ cell })"></td>
+                  </template>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="example-panel">
+          <h2 class="section-title">Placeholder Headers</h2>
+          <table>
+            <thead>
+              <template
+                x-for="headerGroup in table.getHeaderGroups()"
+                :key="headerGroup.id"
+              >
+                <tr>
+                  <template
+                    x-for="header in headerGroup.headers"
+                    :key="header.id"
+                  >
+                    <th :colspan="header.colSpan">
+                      <template x-if="!header.isPlaceholder">
+                        <span x-html="FlexRender({ header })"></span>
+                      </template>
+                    </th>
+                  </template>
+                </tr>
+              </template>
+            </thead>
+            <tbody>
+              <template x-for="row in table.getRowModel().rows" :key="row.id">
+                <tr>
+                  <template x-for="cell in row.getAllCells()" :key="cell.id">
+                    <td x-html="FlexRender({ cell })"></td>
+                  </template>
+                </tr>
+              </template>
+            </tbody>
+            <tfoot>
+              <template
+                x-for="footerGroup in table.getFooterGroups()"
+                :key="footerGroup.id"
+              >
+                <tr>
+                  <template
+                    x-for="header in footerGroup.headers"
+                    :key="header.id"
+                  >
+                    <th :colspan="header.colSpan">
+                      <template x-if="!header.isPlaceholder">
+                        <span x-html="FlexRender({ footer: header })"></span>
+                      </template>
+                    </th>
+                  </template>
+                </tr>
+              </template>
+            </tfoot>
+          </table>
+        </section>
+
+        <section class="example-panel">
+          <h2 class="section-title">Header Row Spanning</h2>
+          <table>
+            <thead>
+              <template
+                x-for="headerGroup in unevenTable.getHeaderGroups()"
+                :key="headerGroup.id"
+              >
+                <tr>
+                  <template
+                    x-for="header in headerGroup.headers.filter((header) => header.rowSpan !== 0)"
+                    :key="header.id"
+                  >
+                    <th :colspan="header.colSpan" :rowspan="header.rowSpan">
+                      <span x-html="FlexRender({ header })"></span>
+                    </th>
+                  </template>
+                </tr>
+              </template>
+            </thead>
+            <tbody>
+              <template
+                x-for="row in unevenTable.getRowModel().rows"
+                :key="row.id"
+              >
+                <tr>
+                  <template x-for="cell in row.getAllCells()" :key="cell.id">
+                    <td x-html="FlexRender({ cell })"></td>
+                  </template>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </section>
+      </div>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/examples/alpine/header-groups/src/index.css
+++ b/examples/alpine/header-groups/src/index.css
@@ -131,3 +131,15 @@ button:disabled {
 .filter-input {
   width: 6rem;
 }
+
+/* Lays the header group examples side by side when the viewport allows it. */
+.example-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem 1.5rem;
+}
+
+.example-panel {
+  flex: 0 1 auto;
+}

--- a/examples/alpine/header-groups/src/main.ts
+++ b/examples/alpine/header-groups/src/main.ts
@@ -7,6 +7,117 @@ import type { Person } from './makeData'
 
 const features = tableFeatures({})
 
+// A traditional header group setup: every leaf column sits under a top-level
+// group, so the tree is even (2 header rows) and no placeholder headers are
+// created.
+const basicColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    header: 'Name',
+    columns: [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+        footer: 'First Name',
+      },
+      {
+        accessorFn: (row) => row.lastName,
+        id: 'lastName',
+        header: 'Last Name',
+        footer: 'Last Name',
+      },
+    ],
+  },
+  {
+    header: 'Stats',
+    columns: [
+      { accessorKey: 'age', header: 'Age', footer: 'Age' },
+      { accessorKey: 'visits', header: 'Visits', footer: 'Visits' },
+    ],
+  },
+  {
+    header: 'Profile',
+    columns: [
+      { accessorKey: 'status', header: 'Status', footer: 'Status' },
+      {
+        accessorKey: 'progress',
+        header: 'Profile Progress',
+        footer: 'Profile Progress',
+      },
+    ],
+  },
+]
+
+// Groups nested inside groups, with every leaf column at the same depth. The
+// tree stays even, so there are three header rows and still no placeholders,
+// and each group's colSpan is the sum of its descendants.
+const nestedColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    header: 'Person',
+    columns: [
+      {
+        header: 'Name',
+        columns: [
+          { accessorKey: 'firstName', header: 'First Name' },
+          {
+            accessorFn: (row) => row.lastName,
+            id: 'lastName',
+            header: 'Last Name',
+          },
+        ],
+      },
+      {
+        header: 'Demographics',
+        columns: [{ accessorKey: 'age', header: 'Age' }],
+      },
+    ],
+  },
+  {
+    header: 'Activity',
+    columns: [
+      {
+        header: 'Engagement',
+        columns: [
+          { accessorKey: 'visits', header: 'Visits' },
+          { accessorKey: 'status', header: 'Status' },
+        ],
+      },
+      {
+        header: 'Progress',
+        columns: [{ accessorKey: 'progress', header: 'Profile Progress' }],
+      },
+    ],
+  },
+]
+
+// An uneven column tree: `fullName` and `progress` are top-level leaf columns
+// while their siblings nest two and three levels deep. The placeholder at the
+// top of each column's placeholder chain carries the chain's full
+// `header.rowSpan`, and the headers it covers report a rowSpan of 0 so the
+// renderer can skip them.
+const unevenColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    accessorFn: (row) =>
+      [row.firstName, row.lastName].filter(Boolean).join(' '),
+    id: 'fullName',
+    header: 'Full Name',
+    cell: (info) => info.getValue(),
+  },
+  {
+    header: 'Info',
+    columns: [
+      { accessorKey: 'age', header: () => 'Age' },
+      {
+        header: 'More Info',
+        columns: [
+          { accessorKey: 'visits', header: () => '<span>Visits</span>' },
+          { accessorKey: 'status', header: 'Status' },
+        ],
+      },
+    ],
+  },
+  { accessorKey: 'progress', header: 'Profile Progress' },
+]
+
 const defaultColumns: Array<ColumnDef<typeof features, Person>> = [
   {
     header: 'Name',
@@ -60,22 +171,44 @@ const defaultColumns: Array<ColumnDef<typeof features, Person>> = [
 ]
 
 Alpine.data('table', () => {
-  const local = Alpine.reactive({ data: makeData(20) })
+  const local = Alpine.reactive({ data: makeData(5) })
 
-  const table = createTable({
-    features,
-    columns: defaultColumns,
-    get data() {
-      return local.data
-    },
-    debugTable: true,
-  })
+  const createExampleTable = (
+    columns: Array<ColumnDef<typeof features, Person>>,
+  ) =>
+    createTable({
+      features,
+      columns,
+      get data() {
+        return local.data
+      },
+      debugTable: true,
+    })
+
+  const table = createExampleTable(defaultColumns)
+  const basicTable = createExampleTable(basicColumns)
+  const nestedTable = createExampleTable(nestedColumns)
+  const unevenTable = createExampleTable(unevenColumns)
 
   return {
     table,
+    basicTable,
+    nestedTable,
+    unevenTable,
     FlexRender,
+    // Only the leaf columns declare footers, so skip the group row instead of
+    // rendering a blank one.
+    basicFooterGroups() {
+      return basicTable
+        .getFooterGroups()
+        .filter((footerGroup) =>
+          footerGroup.headers.some(
+            (header) => !header.isPlaceholder && header.column.columnDef.footer,
+          ),
+        )
+    },
     refreshData() {
-      local.data = makeData(20)
+      local.data = makeData(5)
     },
     stressTest() {
       local.data = makeData(1_000)

--- a/examples/alpine/header-groups/tests/e2e/smoke.spec.ts
+++ b/examples/alpine/header-groups/tests/e2e/smoke.spec.ts
@@ -102,3 +102,88 @@ test('renders the table without crashing', async ({ page }) => {
     await server.close()
   }
 })
+
+// The example renders four tables: an even tree with no placeholders, an even
+// tree of nested groups, an uneven tree that keeps placeholder headers as
+// empty cells, and an uneven tree that merges headers vertically via
+// `header.rowSpan`.
+function tableAt(page: Page, index: number) {
+  return page.locator('table').nth(index)
+}
+
+function headerRow(table: Locator, index: number) {
+  return table.locator('thead tr').nth(index).locator('th')
+}
+
+async function readSpans(cells: Locator, attribute: 'colspan' | 'rowspan') {
+  return cells.evaluateAll((elements, attributeName) => {
+    return elements.map((element) =>
+      Number(element.getAttribute(attributeName) ?? '1'),
+    )
+  }, attribute)
+}
+
+test('renders each header group layout', async ({ page }) => {
+  const { errors, server } = await openExample(page)
+
+  try {
+    const basicTable = tableAt(page, 0)
+    const nestedTable = tableAt(page, 1)
+    const placeholderTable = tableAt(page, 2)
+    const rowSpanTable = tableAt(page, 3)
+
+    await expect(page.locator('table')).toHaveCount(4)
+
+    // Even tree: two header rows, no placeholders.
+    await expect(basicTable.locator('thead tr')).toHaveCount(2)
+    await expect(headerRow(basicTable, 0)).toHaveText([
+      'Name',
+      'Stats',
+      'Profile',
+    ])
+    expect(await readSpans(headerRow(basicTable, 0), 'colspan')).toEqual([
+      2, 2, 2,
+    ])
+
+    // Groups inside groups, still even: three header rows, no placeholders.
+    await expect(nestedTable.locator('thead tr')).toHaveCount(3)
+    await expect(headerRow(nestedTable, 0)).toHaveText(['Person', 'Activity'])
+    await expect(headerRow(nestedTable, 1)).toHaveText([
+      'Name',
+      'Demographics',
+      'Engagement',
+      'Progress',
+    ])
+    expect(await readSpans(headerRow(nestedTable, 0), 'colspan')).toEqual([
+      3, 3,
+    ])
+
+    // Uneven tree: the middle row is mostly empty placeholder cells.
+    await expect(placeholderTable.locator('thead tr')).toHaveCount(3)
+    await expect(headerRow(placeholderTable, 1)).toHaveText([
+      '',
+      '',
+      '',
+      'More Info',
+    ])
+
+    // Uneven tree merged vertically: shallow leaf headers span extra rows and
+    // the headers they cover are skipped.
+    await expect(rowSpanTable.locator('thead tr')).toHaveCount(3)
+    await expect(headerRow(rowSpanTable, 0)).toHaveText([
+      'Full Name',
+      'Info',
+      'Profile Progress',
+    ])
+    expect(await readSpans(headerRow(rowSpanTable, 0), 'rowspan')).toEqual([
+      3, 1, 3,
+    ])
+    expect(await readSpans(headerRow(rowSpanTable, 1), 'rowspan')).toEqual([
+      2, 1,
+    ])
+
+    expect(errors).toEqual([])
+  } finally {
+    await server.close()
+  }
+})

--- a/examples/angular/header-groups/src/app/app.html
+++ b/examples/angular/header-groups/src/app/app.html
@@ -4,48 +4,169 @@
     <button class="demo-button" (click)="stressTest()">Stress Test (1k rows)</button>
   </div>
   <div class="spacer-md"></div>
-  <table>
-    <thead>
-      @for (headerGroup of table.getHeaderGroups(); track headerGroup.id) {
-        <tr>
-          @for (header of headerGroup.headers; track header.id) {
-            <th [attr.colSpan]="header.colSpan">
-              @if (!header.isPlaceholder) {
-                <ng-container *flexRenderHeader="header; let headerCell">{{
-                  headerCell
-                }}</ng-container>
+  <!-- The panels wrap into a grid whenever the viewport is wide enough. -->
+  <div class="example-grid">
+    <section class="example-panel">
+      <h2 class="section-title">Basic Header Groups</h2>
+      <table>
+        <thead>
+          @for (headerGroup of basicTable.getHeaderGroups(); track headerGroup.id) {
+            <tr>
+              @for (header of headerGroup.headers; track header.id) {
+                <th [attr.colSpan]="header.colSpan">
+                  <ng-container *flexRenderHeader="header; let headerCell">{{
+                    headerCell
+                  }}</ng-container>
+                </th>
               }
-            </th>
+            </tr>
           }
-        </tr>
-      }
-    </thead>
-    <tbody>
-      @for (row of table.getRowModel().rows; track row.id) {
-        <tr>
-          @for (cell of row.getAllCells(); track cell.id) {
-            <td>
-              <ng-container *flexRenderCell="cell; let renderCell">{{ renderCell }}</ng-container>
-            </td>
-          }
-        </tr>
-      }
-    </tbody>
-    <tfoot>
-      @for (footerGroup of table.getFooterGroups(); track footerGroup.id) {
-        <tr>
-          @for (footer of footerGroup.headers; track footer.id) {
-            <th [attr.colSpan]="footer.colSpan">
-              @if (!footer.isPlaceholder) {
-                <ng-container *flexRenderFooter="footer; let footerCell">{{
-                  footerCell
-                }}</ng-container>
+        </thead>
+        <tbody>
+          @for (row of basicTable.getRowModel().rows; track row.id) {
+            <tr>
+              @for (cell of row.getAllCells(); track cell.id) {
+                <td>
+                  <ng-container *flexRenderCell="cell; let renderCell">{{
+                    renderCell
+                  }}</ng-container>
+                </td>
               }
-            </th>
+            </tr>
           }
-        </tr>
-      }
-    </tfoot>
-  </table>
+        </tbody>
+        <tfoot>
+          @for (footerGroup of basicFooterGroups(); track footerGroup.id) {
+            <tr>
+              @for (footer of footerGroup.headers; track footer.id) {
+                <th [attr.colSpan]="footer.colSpan">
+                  @if (!footer.isPlaceholder) {
+                    <ng-container *flexRenderFooter="footer; let footerCell">{{
+                      footerCell
+                    }}</ng-container>
+                  }
+                </th>
+              }
+            </tr>
+          }
+        </tfoot>
+      </table>
+    </section>
+
+    <section class="example-panel">
+      <h2 class="section-title">Nested Header Groups</h2>
+      <table>
+        <thead>
+          @for (headerGroup of nestedTable.getHeaderGroups(); track headerGroup.id) {
+            <tr>
+              @for (header of headerGroup.headers; track header.id) {
+                <th [attr.colSpan]="header.colSpan">
+                  <ng-container *flexRenderHeader="header; let headerCell">{{
+                    headerCell
+                  }}</ng-container>
+                </th>
+              }
+            </tr>
+          }
+        </thead>
+        <tbody>
+          @for (row of nestedTable.getRowModel().rows; track row.id) {
+            <tr>
+              @for (cell of row.getAllCells(); track cell.id) {
+                <td>
+                  <ng-container *flexRenderCell="cell; let renderCell">{{
+                    renderCell
+                  }}</ng-container>
+                </td>
+              }
+            </tr>
+          }
+        </tbody>
+      </table>
+    </section>
+
+    <section class="example-panel">
+      <h2 class="section-title">Placeholder Headers</h2>
+      <table>
+        <thead>
+          @for (headerGroup of table.getHeaderGroups(); track headerGroup.id) {
+            <tr>
+              @for (header of headerGroup.headers; track header.id) {
+                <th [attr.colSpan]="header.colSpan">
+                  @if (!header.isPlaceholder) {
+                    <ng-container *flexRenderHeader="header; let headerCell">{{
+                      headerCell
+                    }}</ng-container>
+                  }
+                </th>
+              }
+            </tr>
+          }
+        </thead>
+        <tbody>
+          @for (row of table.getRowModel().rows; track row.id) {
+            <tr>
+              @for (cell of row.getAllCells(); track cell.id) {
+                <td>
+                  <ng-container *flexRenderCell="cell; let renderCell">{{
+                    renderCell
+                  }}</ng-container>
+                </td>
+              }
+            </tr>
+          }
+        </tbody>
+        <tfoot>
+          @for (footerGroup of table.getFooterGroups(); track footerGroup.id) {
+            <tr>
+              @for (footer of footerGroup.headers; track footer.id) {
+                <th [attr.colSpan]="footer.colSpan">
+                  @if (!footer.isPlaceholder) {
+                    <ng-container *flexRenderFooter="footer; let footerCell">{{
+                      footerCell
+                    }}</ng-container>
+                  }
+                </th>
+              }
+            </tr>
+          }
+        </tfoot>
+      </table>
+    </section>
+
+    <section class="example-panel">
+      <h2 class="section-title">Header Row Spanning</h2>
+      <table>
+        <thead>
+          @for (headerGroup of unevenTable.getHeaderGroups(); track headerGroup.id) {
+            <tr>
+              @for (header of headerGroup.headers; track header.id) {
+                @if (header.rowSpan !== 0) {
+                  <th [attr.colSpan]="header.colSpan" [attr.rowSpan]="header.rowSpan">
+                    <ng-container *flexRenderHeader="header; let headerCell">{{
+                      headerCell
+                    }}</ng-container>
+                  </th>
+                }
+              }
+            </tr>
+          }
+        </thead>
+        <tbody>
+          @for (row of unevenTable.getRowModel().rows; track row.id) {
+            <tr>
+              @for (cell of row.getAllCells(); track cell.id) {
+                <td>
+                  <ng-container *flexRenderCell="cell; let renderCell">{{
+                    renderCell
+                  }}</ng-container>
+                </td>
+              }
+            </tr>
+          }
+        </tbody>
+      </table>
+    </section>
+  </div>
   <div class="spacer-md"></div>
 </div>

--- a/examples/angular/header-groups/src/app/app.ts
+++ b/examples/angular/header-groups/src/app/app.ts
@@ -6,6 +6,117 @@ import type { Person } from './makeData'
 
 const features = tableFeatures({})
 
+// A traditional header group setup: every leaf column sits under a top-level
+// group, so the tree is even (2 header rows) and no placeholder headers are
+// created.
+const basicColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    header: 'Name',
+    columns: [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+        footer: 'First Name',
+      },
+      {
+        accessorFn: (row) => row.lastName,
+        id: 'lastName',
+        header: 'Last Name',
+        footer: 'Last Name',
+      },
+    ],
+  },
+  {
+    header: 'Stats',
+    columns: [
+      { accessorKey: 'age', header: 'Age', footer: 'Age' },
+      { accessorKey: 'visits', header: 'Visits', footer: 'Visits' },
+    ],
+  },
+  {
+    header: 'Profile',
+    columns: [
+      { accessorKey: 'status', header: 'Status', footer: 'Status' },
+      {
+        accessorKey: 'progress',
+        header: 'Profile Progress',
+        footer: 'Profile Progress',
+      },
+    ],
+  },
+]
+
+// Groups nested inside groups, with every leaf column at the same depth. The
+// tree stays even, so there are three header rows and still no placeholders,
+// and each group's colSpan is the sum of its descendants.
+const nestedColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    header: 'Person',
+    columns: [
+      {
+        header: 'Name',
+        columns: [
+          { accessorKey: 'firstName', header: 'First Name' },
+          {
+            accessorFn: (row) => row.lastName,
+            id: 'lastName',
+            header: 'Last Name',
+          },
+        ],
+      },
+      {
+        header: 'Demographics',
+        columns: [{ accessorKey: 'age', header: 'Age' }],
+      },
+    ],
+  },
+  {
+    header: 'Activity',
+    columns: [
+      {
+        header: 'Engagement',
+        columns: [
+          { accessorKey: 'visits', header: 'Visits' },
+          { accessorKey: 'status', header: 'Status' },
+        ],
+      },
+      {
+        header: 'Progress',
+        columns: [{ accessorKey: 'progress', header: 'Profile Progress' }],
+      },
+    ],
+  },
+]
+
+// An uneven column tree: `fullName` and `progress` are top-level leaf columns
+// while their siblings nest two and three levels deep. The placeholder at the
+// top of each column's placeholder chain carries the chain's full
+// `header.rowSpan`, and the headers it covers report a rowSpan of 0 so the
+// renderer can skip them.
+const unevenColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    accessorFn: (row) =>
+      [row.firstName, row.lastName].filter(Boolean).join(' '),
+    id: 'fullName',
+    header: 'Full Name',
+    cell: (info) => info.getValue(),
+  },
+  {
+    header: 'Info',
+    columns: [
+      { accessorKey: 'age', header: () => 'Age' },
+      {
+        header: 'More Info',
+        columns: [
+          { accessorKey: 'visits', header: () => 'Visits' },
+          { accessorKey: 'status', header: 'Status' },
+        ],
+      },
+    ],
+  },
+  { accessorKey: 'progress', header: 'Profile Progress' },
+]
+
 const columns: Array<ColumnDef<typeof features, Person>> = [
   {
     header: 'Name',
@@ -65,7 +176,7 @@ const columns: Array<ColumnDef<typeof features, Person>> = [
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class App {
-  readonly data = signal<Array<Person>>(makeData(20))
+  readonly data = signal<Array<Person>>(makeData(5))
 
   readonly table = injectTable<typeof features, Person>(() => ({
     features,
@@ -74,10 +185,43 @@ export class App {
     debugTable: true,
   }))
 
+  readonly basicTable = injectTable<typeof features, Person>(() => ({
+    features,
+    columns: basicColumns,
+    data: this.data(),
+    debugTable: true,
+  }))
+
+  readonly nestedTable = injectTable<typeof features, Person>(() => ({
+    features,
+    columns: nestedColumns,
+    data: this.data(),
+    debugTable: true,
+  }))
+
+  readonly unevenTable = injectTable<typeof features, Person>(() => ({
+    features,
+    columns: unevenColumns,
+    data: this.data(),
+    debugTable: true,
+  }))
+
   stringifiedState() {
     return JSON.stringify(this.table.store.get(), null, 2)
   }
 
-  refreshData = () => this.data.set(makeData(20))
+  // Only the leaf columns declare footers, so skip the group row instead of
+  // rendering a blank one.
+  basicFooterGroups() {
+    return this.basicTable
+      .getFooterGroups()
+      .filter((footerGroup) =>
+        footerGroup.headers.some(
+          (header) => !header.isPlaceholder && header.column.columnDef.footer,
+        ),
+      )
+  }
+
+  refreshData = () => this.data.set(makeData(5))
   stressTest = () => this.data.set(makeData(1_000))
 }

--- a/examples/angular/header-groups/src/styles.css
+++ b/examples/angular/header-groups/src/styles.css
@@ -369,3 +369,15 @@ tfoot th {
   font-size: 1.875rem;
   font-weight: 700;
 }
+
+/* Lays the header group examples side by side when the viewport allows it. */
+.example-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem 1.5rem;
+}
+
+.example-panel {
+  flex: 0 1 auto;
+}

--- a/examples/angular/header-groups/tests/e2e/smoke.spec.ts
+++ b/examples/angular/header-groups/tests/e2e/smoke.spec.ts
@@ -102,3 +102,88 @@ test('renders the table without crashing', async ({ page }) => {
     await server.close()
   }
 })
+
+// The example renders four tables: an even tree with no placeholders, an even
+// tree of nested groups, an uneven tree that keeps placeholder headers as
+// empty cells, and an uneven tree that merges headers vertically via
+// `header.rowSpan`.
+function tableAt(page: Page, index: number) {
+  return page.locator('table').nth(index)
+}
+
+function headerRow(table: Locator, index: number) {
+  return table.locator('thead tr').nth(index).locator('th')
+}
+
+async function readSpans(cells: Locator, attribute: 'colspan' | 'rowspan') {
+  return cells.evaluateAll((elements, attributeName) => {
+    return elements.map((element) =>
+      Number(element.getAttribute(attributeName) ?? '1'),
+    )
+  }, attribute)
+}
+
+test('renders each header group layout', async ({ page }) => {
+  const { errors, server } = await openExample(page)
+
+  try {
+    const basicTable = tableAt(page, 0)
+    const nestedTable = tableAt(page, 1)
+    const placeholderTable = tableAt(page, 2)
+    const rowSpanTable = tableAt(page, 3)
+
+    await expect(page.locator('table')).toHaveCount(4)
+
+    // Even tree: two header rows, no placeholders.
+    await expect(basicTable.locator('thead tr')).toHaveCount(2)
+    await expect(headerRow(basicTable, 0)).toHaveText([
+      'Name',
+      'Stats',
+      'Profile',
+    ])
+    expect(await readSpans(headerRow(basicTable, 0), 'colspan')).toEqual([
+      2, 2, 2,
+    ])
+
+    // Groups inside groups, still even: three header rows, no placeholders.
+    await expect(nestedTable.locator('thead tr')).toHaveCount(3)
+    await expect(headerRow(nestedTable, 0)).toHaveText(['Person', 'Activity'])
+    await expect(headerRow(nestedTable, 1)).toHaveText([
+      'Name',
+      'Demographics',
+      'Engagement',
+      'Progress',
+    ])
+    expect(await readSpans(headerRow(nestedTable, 0), 'colspan')).toEqual([
+      3, 3,
+    ])
+
+    // Uneven tree: the middle row is mostly empty placeholder cells.
+    await expect(placeholderTable.locator('thead tr')).toHaveCount(3)
+    await expect(headerRow(placeholderTable, 1)).toHaveText([
+      '',
+      '',
+      '',
+      'More Info',
+    ])
+
+    // Uneven tree merged vertically: shallow leaf headers span extra rows and
+    // the headers they cover are skipped.
+    await expect(rowSpanTable.locator('thead tr')).toHaveCount(3)
+    await expect(headerRow(rowSpanTable, 0)).toHaveText([
+      'Full Name',
+      'Info',
+      'Profile Progress',
+    ])
+    expect(await readSpans(headerRow(rowSpanTable, 0), 'rowspan')).toEqual([
+      3, 1, 3,
+    ])
+    expect(await readSpans(headerRow(rowSpanTable, 1), 'rowspan')).toEqual([
+      2, 1,
+    ])
+
+    expect(errors).toEqual([])
+  } finally {
+    await server.close()
+  }
+})

--- a/examples/ember/header-groups/app/app.css
+++ b/examples/ember/header-groups/app/app.css
@@ -299,3 +299,15 @@ button:disabled {
   padding: 0.5rem;
   font-size: 0.75rem;
 }
+
+/* Lays the header group examples side by side when the viewport allows it. */
+.example-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem 1.5rem;
+}
+
+.example-panel {
+  flex: 0 1 auto;
+}

--- a/examples/ember/header-groups/app/templates/application.gts
+++ b/examples/ember/header-groups/app/templates/application.gts
@@ -10,12 +10,124 @@ import {
   createColumnHelper,
   type Row,
   type Cell,
+  type Header,
+  type HeaderGroup,
 } from '@tanstack/ember-table'
 import { makeData, type Person } from '../utils/make-data'
 
 const features = tableFeatures({})
 
 const columnHelper = createColumnHelper<typeof features, Person>()
+
+// A traditional header group setup: every leaf column sits under a top-level
+// group, so the tree is even (2 header rows) and no placeholder headers are
+// created.
+const basicColumns = columnHelper.columns([
+  columnHelper.group({
+    id: 'basicName',
+    header: 'Name',
+    columns: columnHelper.columns([
+      columnHelper.accessor('firstName', {
+        header: () => 'First Name',
+        footer: () => 'First Name',
+      }),
+      columnHelper.accessor((row) => row.lastName, {
+        id: 'lastName',
+        header: () => 'Last Name',
+        footer: () => 'Last Name',
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    id: 'basicStats',
+    header: 'Stats',
+    columns: columnHelper.columns([
+      columnHelper.accessor('age', {
+        header: () => 'Age',
+        footer: () => 'Age',
+      }),
+      columnHelper.accessor('visits', {
+        header: () => 'Visits',
+        footer: () => 'Visits',
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    id: 'basicProfile',
+    header: 'Profile',
+    columns: columnHelper.columns([
+      columnHelper.accessor('status', {
+        header: () => 'Status',
+        footer: () => 'Status',
+      }),
+      columnHelper.accessor('progress', {
+        header: () => 'Profile Progress',
+        footer: () => 'Profile Progress',
+      }),
+    ]),
+  }),
+])
+
+// Groups nested inside groups, with every leaf column at the same depth. The
+// tree stays even, so there are three header rows and still no placeholders,
+// and each group's colSpan is the sum of its descendants.
+const nestedColumns = columnHelper.columns([
+  columnHelper.group({
+    id: 'person',
+    header: 'Person',
+    columns: columnHelper.columns([
+      columnHelper.group({
+        id: 'nestedName',
+        header: 'Name',
+        columns: columnHelper.columns([
+          columnHelper.accessor('firstName', {
+            header: () => 'First Name',
+          }),
+          columnHelper.accessor((row) => row.lastName, {
+            id: 'lastName',
+            header: () => 'Last Name',
+          }),
+        ]),
+      }),
+      columnHelper.group({
+        id: 'demographics',
+        header: 'Demographics',
+        columns: columnHelper.columns([
+          columnHelper.accessor('age', {
+            header: () => 'Age',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    id: 'activity',
+    header: 'Activity',
+    columns: columnHelper.columns([
+      columnHelper.group({
+        id: 'engagement',
+        header: 'Engagement',
+        columns: columnHelper.columns([
+          columnHelper.accessor('visits', {
+            header: () => 'Visits',
+          }),
+          columnHelper.accessor('status', {
+            header: () => 'Status',
+          }),
+        ]),
+      }),
+      columnHelper.group({
+        id: 'progressGroup',
+        header: 'Progress',
+        columns: columnHelper.columns([
+          columnHelper.accessor('progress', {
+            header: () => 'Profile Progress',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+])
 
 const columns = columnHelper.columns([
   columnHelper.group({
@@ -67,6 +179,46 @@ const columns = columnHelper.columns([
   }),
 ])
 
+// An uneven column tree: `fullName` and `progress` are top-level leaf columns
+// while their siblings nest two and three levels deep. The placeholder at the
+// top of each column's placeholder chain carries the chain's full
+// `header.rowSpan`, and the headers it covers report a rowSpan of 0 so the
+// renderer can skip them.
+const unevenColumns = columnHelper.columns([
+  columnHelper.accessor(
+    (row) => [row.firstName, row.lastName].filter(Boolean).join(' '),
+    {
+      id: 'fullName',
+      header: () => 'Full Name',
+      cell: (info) => info.getValue(),
+    },
+  ),
+  columnHelper.group({
+    id: 'unevenInfo',
+    header: 'Info',
+    columns: columnHelper.columns([
+      columnHelper.accessor('age', {
+        header: () => 'Age',
+      }),
+      columnHelper.group({
+        id: 'unevenMoreInfo',
+        header: 'More Info',
+        columns: columnHelper.columns([
+          columnHelper.accessor('visits', {
+            header: () => 'Visits',
+          }),
+          columnHelper.accessor('status', {
+            header: () => 'Status',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+  columnHelper.accessor('progress', {
+    header: () => 'Profile Progress',
+  }),
+])
+
 // TanStack Table v9 uses prototype-based methods that require `this` binding.
 // Ember templates extract function references without binding, so we provide
 // helpers that call methods on the correct object.
@@ -74,12 +226,35 @@ const getAllCells = (
   row: Row<typeof features, Person>,
 ): Array<Cell<typeof features, Person>> => row.getAllCells()
 
+// Glimmer templates have no inline operators, so the rowSpan check that skips
+// covered headers lives in a helper.
+const isNotCovered = (header: Header<typeof features, Person, unknown>) =>
+  header.rowSpan !== 0
+
 export default class HeaderGroupsTable extends Component {
-  @tracked data: Array<Person> = makeData(20)
+  @tracked data: Array<Person> = makeData(5)
 
   table = useTable(() => ({
     features,
     columns,
+    data: this.data,
+  }))
+
+  basicTable = useTable(() => ({
+    features,
+    columns: basicColumns,
+    data: this.data,
+  }))
+
+  nestedTable = useTable(() => ({
+    features,
+    columns: nestedColumns,
+    data: this.data,
+  }))
+
+  unevenTable = useTable(() => ({
+    features,
+    columns: unevenColumns,
     data: this.data,
   }))
 
@@ -95,12 +270,48 @@ export default class HeaderGroupsTable extends Component {
     return this.table.getFooterGroups()
   }
 
+  get basicHeaderGroups() {
+    return this.basicTable.getHeaderGroups()
+  }
+
+  get basicRows() {
+    return this.basicTable.getRowModel().rows
+  }
+
+  // Only the leaf columns declare footers, so skip the group row instead of
+  // rendering a blank one.
+  get basicFooterGroups(): Array<HeaderGroup<typeof features, Person>> {
+    return this.basicTable
+      .getFooterGroups()
+      .filter((footerGroup) =>
+        footerGroup.headers.some(
+          (header) => !header.isPlaceholder && header.column.columnDef.footer,
+        ),
+      )
+  }
+
+  get nestedHeaderGroups() {
+    return this.nestedTable.getHeaderGroups()
+  }
+
+  get nestedRows() {
+    return this.nestedTable.getRowModel().rows
+  }
+
+  get unevenHeaderGroups() {
+    return this.unevenTable.getHeaderGroups()
+  }
+
+  get unevenRows() {
+    return this.unevenTable.getRowModel().rows
+  }
+
   get tableState() {
     return JSON.stringify(this.table.store.state, null, 2)
   }
 
   refreshData = () => {
-    this.data = makeData(20)
+    this.data = makeData(5)
   }
 
   stressTest = () => {
@@ -115,43 +326,142 @@ export default class HeaderGroupsTable extends Component {
         rows)</button>
     </div>
     <div class='spacer-md'></div>
-    <table>
-      <thead>
-        {{#each this.headerGroups as |headerGroup|}}
-          <tr>
-            {{#each headerGroup.headers as |header|}}
-              <th colspan={{header.colSpan}}>
-                {{#unless header.isPlaceholder}}
-                  <FlexRenderHeader @header={{header}} />
-                {{/unless}}
-              </th>
+    {{! The panels wrap into a grid whenever the viewport is wide enough. }}
+    <div class='example-grid'>
+      <section class='example-panel'>
+        <h2 class='section-title'>Basic Header Groups</h2>
+        <table>
+          <thead>
+            {{#each this.basicHeaderGroups as |headerGroup|}}
+              <tr>
+                {{#each headerGroup.headers as |header|}}
+                  <th colspan={{header.colSpan}}>
+                    <FlexRenderHeader @header={{header}} />
+                  </th>
+                {{/each}}
+              </tr>
             {{/each}}
-          </tr>
-        {{/each}}
-      </thead>
-      <tbody>
-        {{#each this.rows as |row|}}
-          <tr>
-            {{#each (getAllCells row) as |cell|}}
-              <td><FlexRenderCell @cell={{cell}} /></td>
+          </thead>
+          <tbody>
+            {{#each this.basicRows as |row|}}
+              <tr>
+                {{#each (getAllCells row) as |cell|}}
+                  <td><FlexRenderCell @cell={{cell}} /></td>
+                {{/each}}
+              </tr>
             {{/each}}
-          </tr>
-        {{/each}}
-      </tbody>
-      <tfoot>
-        {{#each this.footerGroups as |footerGroup|}}
-          <tr>
-            {{#each footerGroup.headers as |header|}}
-              <th colspan={{header.colSpan}}>
-                {{#unless header.isPlaceholder}}
-                  <FlexRenderFooter @footer={{header}} />
-                {{/unless}}
-              </th>
+          </tbody>
+          <tfoot>
+            {{#each this.basicFooterGroups as |footerGroup|}}
+              <tr>
+                {{#each footerGroup.headers as |header|}}
+                  <th colspan={{header.colSpan}}>
+                    {{#unless header.isPlaceholder}}
+                      <FlexRenderFooter @footer={{header}} />
+                    {{/unless}}
+                  </th>
+                {{/each}}
+              </tr>
             {{/each}}
-          </tr>
-        {{/each}}
-      </tfoot>
-    </table>
+          </tfoot>
+        </table>
+      </section>
+
+      <section class='example-panel'>
+        <h2 class='section-title'>Nested Header Groups</h2>
+        <table>
+          <thead>
+            {{#each this.nestedHeaderGroups as |headerGroup|}}
+              <tr>
+                {{#each headerGroup.headers as |header|}}
+                  <th colspan={{header.colSpan}}>
+                    <FlexRenderHeader @header={{header}} />
+                  </th>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </thead>
+          <tbody>
+            {{#each this.nestedRows as |row|}}
+              <tr>
+                {{#each (getAllCells row) as |cell|}}
+                  <td><FlexRenderCell @cell={{cell}} /></td>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </section>
+
+      <section class='example-panel'>
+        <h2 class='section-title'>Placeholder Headers</h2>
+        <table>
+          <thead>
+            {{#each this.headerGroups as |headerGroup|}}
+              <tr>
+                {{#each headerGroup.headers as |header|}}
+                  <th colspan={{header.colSpan}}>
+                    {{#unless header.isPlaceholder}}
+                      <FlexRenderHeader @header={{header}} />
+                    {{/unless}}
+                  </th>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </thead>
+          <tbody>
+            {{#each this.rows as |row|}}
+              <tr>
+                {{#each (getAllCells row) as |cell|}}
+                  <td><FlexRenderCell @cell={{cell}} /></td>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </tbody>
+          <tfoot>
+            {{#each this.footerGroups as |footerGroup|}}
+              <tr>
+                {{#each footerGroup.headers as |header|}}
+                  <th colspan={{header.colSpan}}>
+                    {{#unless header.isPlaceholder}}
+                      <FlexRenderFooter @footer={{header}} />
+                    {{/unless}}
+                  </th>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </tfoot>
+        </table>
+      </section>
+
+      <section class='example-panel'>
+        <h2 class='section-title'>Header Row Spanning</h2>
+        <table>
+          <thead>
+            {{#each this.unevenHeaderGroups as |headerGroup|}}
+              <tr>
+                {{#each headerGroup.headers as |header|}}
+                  {{#if (isNotCovered header)}}
+                    <th colspan={{header.colSpan}} rowspan={{header.rowSpan}}>
+                      <FlexRenderHeader @header={{header}} />
+                    </th>
+                  {{/if}}
+                {{/each}}
+              </tr>
+            {{/each}}
+          </thead>
+          <tbody>
+            {{#each this.unevenRows as |row|}}
+              <tr>
+                {{#each (getAllCells row) as |cell|}}
+                  <td><FlexRenderCell @cell={{cell}} /></td>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </section>
+    </div>
     <div class='spacer-md'></div>
     <pre data-testid='table-state'>{{this.tableState}}</pre>
   </template>

--- a/examples/ember/header-groups/tests/e2e/smoke.spec.ts
+++ b/examples/ember/header-groups/tests/e2e/smoke.spec.ts
@@ -102,3 +102,88 @@ test('renders the table without crashing', async ({ page }) => {
     await server.close()
   }
 })
+
+// The example renders four tables: an even tree with no placeholders, an even
+// tree of nested groups, an uneven tree that keeps placeholder headers as
+// empty cells, and an uneven tree that merges headers vertically via
+// `header.rowSpan`.
+function tableAt(page: Page, index: number) {
+  return page.locator('table').nth(index)
+}
+
+function headerRow(table: Locator, index: number) {
+  return table.locator('thead tr').nth(index).locator('th')
+}
+
+async function readSpans(cells: Locator, attribute: 'colspan' | 'rowspan') {
+  return cells.evaluateAll((elements, attributeName) => {
+    return elements.map((element) =>
+      Number(element.getAttribute(attributeName) ?? '1'),
+    )
+  }, attribute)
+}
+
+test('renders each header group layout', async ({ page }) => {
+  const { errors, server } = await openExample(page)
+
+  try {
+    const basicTable = tableAt(page, 0)
+    const nestedTable = tableAt(page, 1)
+    const placeholderTable = tableAt(page, 2)
+    const rowSpanTable = tableAt(page, 3)
+
+    await expect(page.locator('table')).toHaveCount(4)
+
+    // Even tree: two header rows, no placeholders.
+    await expect(basicTable.locator('thead tr')).toHaveCount(2)
+    await expect(headerRow(basicTable, 0)).toHaveText([
+      'Name',
+      'Stats',
+      'Profile',
+    ])
+    expect(await readSpans(headerRow(basicTable, 0), 'colspan')).toEqual([
+      2, 2, 2,
+    ])
+
+    // Groups inside groups, still even: three header rows, no placeholders.
+    await expect(nestedTable.locator('thead tr')).toHaveCount(3)
+    await expect(headerRow(nestedTable, 0)).toHaveText(['Person', 'Activity'])
+    await expect(headerRow(nestedTable, 1)).toHaveText([
+      'Name',
+      'Demographics',
+      'Engagement',
+      'Progress',
+    ])
+    expect(await readSpans(headerRow(nestedTable, 0), 'colspan')).toEqual([
+      3, 3,
+    ])
+
+    // Uneven tree: the middle row is mostly empty placeholder cells.
+    await expect(placeholderTable.locator('thead tr')).toHaveCount(3)
+    await expect(headerRow(placeholderTable, 1)).toHaveText([
+      '',
+      '',
+      '',
+      'More Info',
+    ])
+
+    // Uneven tree merged vertically: shallow leaf headers span extra rows and
+    // the headers they cover are skipped.
+    await expect(rowSpanTable.locator('thead tr')).toHaveCount(3)
+    await expect(headerRow(rowSpanTable, 0)).toHaveText([
+      'Full Name',
+      'Info',
+      'Profile Progress',
+    ])
+    expect(await readSpans(headerRow(rowSpanTable, 0), 'rowspan')).toEqual([
+      3, 1, 3,
+    ])
+    expect(await readSpans(headerRow(rowSpanTable, 1), 'rowspan')).toEqual([
+      2, 1,
+    ])
+
+    expect(errors).toEqual([])
+  } finally {
+    await server.close()
+  }
+})

--- a/examples/lit/header-groups/src/main.ts
+++ b/examples/lit/header-groups/src/main.ts
@@ -8,6 +8,120 @@ import type { Person } from './makeData'
 
 const features = tableFeatures({})
 
+// A traditional header group setup: every leaf column sits under a top-level
+// group, so the tree is even (2 header rows) and no placeholder headers are
+// created.
+const basicColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    header: 'Name',
+    columns: [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+        footer: 'First Name',
+      },
+      {
+        accessorFn: (row) => row.lastName,
+        id: 'lastName',
+        header: 'Last Name',
+        footer: 'Last Name',
+      },
+    ],
+  },
+  {
+    header: 'Stats',
+    columns: [
+      { accessorKey: 'age', header: 'Age', footer: 'Age' },
+      { accessorKey: 'visits', header: 'Visits', footer: 'Visits' },
+    ],
+  },
+  {
+    header: 'Profile',
+    columns: [
+      { accessorKey: 'status', header: 'Status', footer: 'Status' },
+      {
+        accessorKey: 'progress',
+        header: 'Profile Progress',
+        footer: 'Profile Progress',
+      },
+    ],
+  },
+]
+
+// Groups nested inside groups, with every leaf column at the same depth. The
+// tree stays even, so there are three header rows and still no placeholders,
+// and each group's colSpan is the sum of its descendants.
+const nestedColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    header: 'Person',
+    columns: [
+      {
+        header: 'Name',
+        columns: [
+          { accessorKey: 'firstName', header: 'First Name' },
+          {
+            accessorFn: (row) => row.lastName,
+            id: 'lastName',
+            header: 'Last Name',
+          },
+        ],
+      },
+      {
+        header: 'Demographics',
+        columns: [{ accessorKey: 'age', header: 'Age' }],
+      },
+    ],
+  },
+  {
+    header: 'Activity',
+    columns: [
+      {
+        header: 'Engagement',
+        columns: [
+          { accessorKey: 'visits', header: 'Visits' },
+          { accessorKey: 'status', header: 'Status' },
+        ],
+      },
+      {
+        header: 'Progress',
+        columns: [{ accessorKey: 'progress', header: 'Profile Progress' }],
+      },
+    ],
+  },
+]
+
+// An uneven column tree: `fullName` and `progress` are top-level leaf columns
+// while their siblings nest two and three levels deep. The placeholder at the
+// top of each column's placeholder chain carries the chain's full
+// `header.rowSpan`, and the headers it covers report a rowSpan of 0 so the
+// renderer can skip them.
+const unevenColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    accessorFn: (row) =>
+      [row.firstName, row.lastName].filter(Boolean).join(' '),
+    id: 'fullName',
+    header: 'Full Name',
+    cell: (info) => info.getValue(),
+  },
+  {
+    header: 'Info',
+    columns: [
+      { accessorKey: 'age', header: () => 'Age' },
+      {
+        header: 'More Info',
+        columns: [
+          {
+            accessorKey: 'visits',
+            header: () => html`<span>Visits</span>`,
+          },
+          { accessorKey: 'status', header: 'Status' },
+        ],
+      },
+    ],
+  },
+  { accessorKey: 'progress', header: 'Profile Progress' },
+]
+
 const defaultColumns: Array<ColumnDef<typeof features, Person>> = [
   {
     header: 'Name',
@@ -63,9 +177,18 @@ const defaultColumns: Array<ColumnDef<typeof features, Person>> = [
 @customElement('lit-table-example')
 class LitTableExample extends LitElement {
   @state()
-  private _data: Array<Person> = makeData(20)
+  private _data: Array<Person> = makeData(5)
 
   private tableController = new TableController<typeof features, Person>(this)
+  private basicTableController = new TableController<typeof features, Person>(
+    this,
+  )
+  private nestedTableController = new TableController<typeof features, Person>(
+    this,
+  )
+  private unevenTableController = new TableController<typeof features, Person>(
+    this,
+  )
 
   protected render() {
     const table = this.tableController.table(
@@ -76,13 +199,55 @@ class LitTableExample extends LitElement {
       },
       () => ({}),
     )
+    const basicTable = this.basicTableController.table(
+      {
+        features,
+        columns: basicColumns,
+        data: this._data,
+      },
+      () => ({}),
+    )
+    const nestedTable = this.nestedTableController.table(
+      {
+        features,
+        columns: nestedColumns,
+        data: this._data,
+      },
+      () => ({}),
+    )
+    const unevenTable = this.unevenTableController.table(
+      {
+        features,
+        columns: unevenColumns,
+        data: this._data,
+      },
+      () => ({}),
+    )
+
+    const renderBody = (bodyTable: typeof table) => html`
+      <tbody>
+        ${repeat(
+          bodyTable.getRowModel().rows,
+          (row) => row.id,
+          (row) => html`
+            <tr>
+              ${repeat(
+                row.getAllCells(),
+                (cell) => cell.id,
+                (cell) => html` <td>${FlexRender({ cell })}</td> `,
+              )}
+            </tr>
+          `,
+        )}
+      </tbody>
+    `
 
     return html`
       <div class="demo-root">
         <div>
           <button
             @click=${() => {
-              this._data = makeData(20)
+              this._data = makeData(5)
             }}
           >
             Regenerate Data
@@ -95,65 +260,178 @@ class LitTableExample extends LitElement {
             Stress Test (1k rows)
           </button>
         </div>
-        <table>
-          <thead>
-            ${repeat(
-              table.getHeaderGroups(),
-              (headerGroup) => headerGroup.id,
-              (headerGroup) => html`
-                <tr>
-                  ${repeat(
-                    headerGroup.headers,
-                    (header) => header.id,
-                    (header) => html`
-                      <th colspan="${header.colSpan}">
-                        ${header.isPlaceholder ? null : FlexRender({ header })}
-                      </th>
-                    `,
-                  )}
-                </tr>
-              `,
-            )}
-          </thead>
-          <tbody>
-            ${repeat(
-              table.getRowModel().rows,
-              (row) => row.id,
-              (row) => html`
-                <tr>
-                  ${repeat(
-                    row.getAllCells(),
-                    (cell) => cell.id,
-                    (cell) => html` <td>${FlexRender({ cell })}</td> `,
-                  )}
-                </tr>
-              `,
-            )}
-          </tbody>
-          <tfoot>
-            ${repeat(
-              table.getFooterGroups(),
-              (footerGroup) => footerGroup.id,
-              (footerGroup) => html`
-                <tr>
-                  ${repeat(
-                    footerGroup.headers,
-                    (header) => header.id,
-                    (header) => html`
-                      <th colspan="${header.colSpan}">
-                        ${
-                          header.isPlaceholder
-                            ? null
-                            : FlexRender({ footer: header })
-                        }
-                      </th>
-                    `,
-                  )}
-                </tr>
-              `,
-            )}
-          </tfoot>
-        </table>
+        <div class="spacer-md"></div>
+        <!-- The panels wrap into a grid whenever the viewport is wide enough. -->
+        <div class="example-grid">
+          <section class="example-panel">
+            <h2 class="section-title">Basic Header Groups</h2>
+            <table>
+              <thead>
+                ${repeat(
+                  basicTable.getHeaderGroups(),
+                  (headerGroup) => headerGroup.id,
+                  (headerGroup) => html`
+                    <tr>
+                      ${repeat(
+                        headerGroup.headers,
+                        (header) => header.id,
+                        (header) => html`
+                          <th colspan="${header.colSpan}">
+                            ${FlexRender({ header })}
+                          </th>
+                        `,
+                      )}
+                    </tr>
+                  `,
+                )}
+              </thead>
+              ${renderBody(basicTable)}
+              <tfoot>
+                ${repeat(
+                  basicTable
+                    .getFooterGroups()
+                    // Only the leaf columns declare footers, so skip the group
+                    // row instead of rendering a blank one.
+                    .filter((footerGroup) =>
+                      footerGroup.headers.some(
+                        (header) =>
+                          !header.isPlaceholder &&
+                          header.column.columnDef.footer,
+                      ),
+                    ),
+                  (footerGroup) => footerGroup.id,
+                  (footerGroup) => html`
+                    <tr>
+                      ${repeat(
+                        footerGroup.headers,
+                        (header) => header.id,
+                        (header) => html`
+                          <th colspan="${header.colSpan}">
+                            ${
+                              header.isPlaceholder
+                                ? null
+                                : FlexRender({ footer: header })
+                            }
+                          </th>
+                        `,
+                      )}
+                    </tr>
+                  `,
+                )}
+              </tfoot>
+            </table>
+          </section>
+
+          <section class="example-panel">
+            <h2 class="section-title">Nested Header Groups</h2>
+            <table>
+              <thead>
+                ${repeat(
+                  nestedTable.getHeaderGroups(),
+                  (headerGroup) => headerGroup.id,
+                  (headerGroup) => html`
+                    <tr>
+                      ${repeat(
+                        headerGroup.headers,
+                        (header) => header.id,
+                        (header) => html`
+                          <th colspan="${header.colSpan}">
+                            ${FlexRender({ header })}
+                          </th>
+                        `,
+                      )}
+                    </tr>
+                  `,
+                )}
+              </thead>
+              ${renderBody(nestedTable)}
+            </table>
+          </section>
+
+          <section class="example-panel">
+            <h2 class="section-title">Placeholder Headers</h2>
+            <table>
+              <thead>
+                ${repeat(
+                  table.getHeaderGroups(),
+                  (headerGroup) => headerGroup.id,
+                  (headerGroup) => html`
+                    <tr>
+                      ${repeat(
+                        headerGroup.headers,
+                        (header) => header.id,
+                        (header) => html`
+                          <th colspan="${header.colSpan}">
+                            ${
+                              header.isPlaceholder
+                                ? null
+                                : FlexRender({ header })
+                            }
+                          </th>
+                        `,
+                      )}
+                    </tr>
+                  `,
+                )}
+              </thead>
+              ${renderBody(table)}
+              <tfoot>
+                ${repeat(
+                  table.getFooterGroups(),
+                  (footerGroup) => footerGroup.id,
+                  (footerGroup) => html`
+                    <tr>
+                      ${repeat(
+                        footerGroup.headers,
+                        (header) => header.id,
+                        (header) => html`
+                          <th colspan="${header.colSpan}">
+                            ${
+                              header.isPlaceholder
+                                ? null
+                                : FlexRender({ footer: header })
+                            }
+                          </th>
+                        `,
+                      )}
+                    </tr>
+                  `,
+                )}
+              </tfoot>
+            </table>
+          </section>
+
+          <section class="example-panel">
+            <h2 class="section-title">Header Row Spanning</h2>
+            <table>
+              <thead>
+                ${repeat(
+                  unevenTable.getHeaderGroups(),
+                  (headerGroup) => headerGroup.id,
+                  (headerGroup) => html`
+                    <tr>
+                      ${repeat(
+                        headerGroup.headers.filter(
+                          (header) => header.rowSpan !== 0,
+                        ),
+                        (header) => header.id,
+                        (header) => html`
+                          <th
+                            colspan="${header.colSpan}"
+                            rowspan="${header.rowSpan}"
+                          >
+                            ${FlexRender({ header })}
+                          </th>
+                        `,
+                      )}
+                    </tr>
+                  `,
+                )}
+              </thead>
+              ${renderBody(unevenTable)}
+            </table>
+          </section>
+        </div>
       </div>
       <style>
         * {
@@ -386,6 +664,17 @@ class LitTableExample extends LitElement {
           flex-wrap: wrap;
           justify-content: center;
           gap: 0.5rem;
+        }
+        /* Lays the header group examples side by side when the viewport
+           allows it. */
+        .example-grid {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: flex-start;
+          gap: 1rem 1.5rem;
+        }
+        .example-panel {
+          flex: 0 1 auto;
         }
       </style>
     `

--- a/examples/lit/header-groups/tests/e2e/smoke.spec.ts
+++ b/examples/lit/header-groups/tests/e2e/smoke.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { expect, test } from '@playwright/test'
 import { startExampleServer } from '../../../../../tests/e2e/helpers/startExampleServer'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 const exampleDir = path.resolve()
 
@@ -70,36 +70,74 @@ async function openExample(page: Page) {
   return errors
 }
 
-function headerRow(page: Page, index: number) {
-  return page.locator('thead tr').nth(index).locator('th')
+// The example renders four tables: an even tree with no placeholders, an even
+// tree of nested groups, an uneven tree that keeps placeholder headers as
+// empty cells, and an uneven tree that merges headers vertically via
+// `header.rowSpan`.
+function basicTable(page: Page) {
+  return page.locator('table').nth(0)
 }
 
-function footerRow(page: Page, index: number) {
-  return page.locator('tfoot tr').nth(index).locator('th')
+function nestedTable(page: Page) {
+  return page.locator('table').nth(1)
 }
 
-async function readColSpans(page: Page, selector: string) {
-  return page
-    .locator(selector)
-    .evaluateAll((cells) =>
-      cells.map((cell) => Number(cell.getAttribute('colspan') ?? '1')),
+function placeholderTable(page: Page) {
+  return page.locator('table').nth(2)
+}
+
+function rowSpanTable(page: Page) {
+  return page.locator('table').nth(3)
+}
+
+function headerRow(table: Locator, index: number) {
+  return table.locator('thead tr').nth(index).locator('th')
+}
+
+function footerRow(table: Locator, index: number) {
+  return table.locator('tfoot tr').nth(index).locator('th')
+}
+
+async function readSpans(cells: Locator, attribute: 'colspan' | 'rowspan') {
+  return cells.evaluateAll((elements, attributeName) => {
+    return elements.map((element) =>
+      Number(element.getAttribute(attributeName) ?? '1'),
     )
+  }, attribute)
 }
 
-async function getFirstBodyRowText(page: Page) {
-  const text = await page.locator('tbody tr').first().textContent()
+async function getFirstBodyRowText(table: Locator) {
+  const text = await table.locator('tbody tr').first().textContent()
   return text?.replace(/\s+/g, ' ').trim() ?? ''
 }
 
-test('renders the table without crashing', async ({ page }) => {
+test('renders all four tables without crashing', async ({ page }) => {
   const errors = await openExample(page)
-  const table = page.locator('table').first()
 
-  await expect(table).toBeVisible()
-  await expect(page.locator('tbody tr')).toHaveCount(20)
-  await expect(page.locator('tbody tr').first().locator('td')).toHaveCount(
-    LEAF_HEADERS.length,
-  )
+  await expect(basicTable(page)).toBeVisible()
+  await expect(nestedTable(page)).toBeVisible()
+  await expect(placeholderTable(page)).toBeVisible()
+  await expect(rowSpanTable(page)).toBeVisible()
+
+  await expect(nestedTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    nestedTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(basicTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    basicTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    placeholderTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(rowSpanTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    rowSpanTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(5)
 
   expect(errors).toEqual([])
 })
@@ -110,49 +148,121 @@ test('regenerates table data', async ({ page }) => {
     name: /^Regenerate Data$/i,
   })
 
-  await expect(page.locator('tbody tr').first()).toBeVisible()
+  await expect(placeholderTable(page).locator('tbody tr').first()).toBeVisible()
 
-  const firstRowBefore = await getFirstBodyRowText(page)
+  const firstRowBefore = await getFirstBodyRowText(placeholderTable(page))
 
   await regenerateButton.click()
 
-  await expect.poll(() => getFirstBodyRowText(page)).not.toBe(firstRowBefore)
-  await expect(page.locator('tbody tr')).toHaveCount(20)
+  await expect
+    .poll(() => getFirstBodyRowText(placeholderTable(page)))
+    .not.toBe(firstRowBefore)
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+
+  expect(errors).toEqual([])
+})
+
+test('groups leaf headers evenly with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = basicTable(page)
+
+  // Every leaf column belongs to a top-level group, so the tree is even: two
+  // header rows and no empty placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(2)
+
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Stats', 'Profile'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 2, 2])
+  // An even tree never produces spanning chains, so every rowSpan is 1.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1, 1])
+
+  // Only the leaf columns declare footers and the render loop skips footer
+  // rows without content, so the group row never renders in the tfoot.
+  await expect(table.locator('tfoot tr')).toHaveCount(1)
+  await expect(footerRow(table, 0)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(errors).toEqual([])
+})
+
+test('nests groups inside groups with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = nestedTable(page)
+
+  // Groups inside groups, every leaf at the same depth: three header rows and
+  // still no placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  await expect(headerRow(table, 0)).toHaveText(['Person', 'Activity'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'Name',
+    'Demographics',
+    'Engagement',
+    'Progress',
+  ])
+  await expect(headerRow(table, 2)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  // Each group spans the sum of its descendants.
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([3, 3])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([2, 1, 2, 1])
+  // An even tree never produces spanning chains.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1])
 
   expect(errors).toEqual([])
 })
 
 test('nests the header groups three rows deep', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Two top level groups, one of which nests a further group, so the deepest
   // leaf needs three header rows.
-  await expect(page.locator('thead tr')).toHaveCount(3)
+  await expect(table.locator('thead tr')).toHaveCount(3)
 
-  await expect(headerRow(page, 0)).toHaveText(['Name', 'Info'])
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Info'])
   // Row two is mostly placeholders for the columns that have no middle group.
-  await expect(headerRow(page, 1)).toHaveText(['', '', '', 'More Info'])
-  await expect(headerRow(page, 2)).toHaveText(LEAF_HEADERS)
+  await expect(headerRow(table, 1)).toHaveText(['', '', '', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(LEAF_HEADERS)
 
   expect(errors).toEqual([])
 })
 
 test('spans each group across the columns beneath it', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // `Hello` covers two leaves, `Info` covers the other four.
-  expect(await readColSpans(page, 'thead tr:nth-child(1) th')).toEqual([2, 4])
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 4])
   // `More Info` covers the last three of `Info`'s four leaves.
-  expect(await readColSpans(page, 'thead tr:nth-child(2) th')).toEqual([
-    1, 1, 1, 3,
-  ])
-  expect(await readColSpans(page, 'thead tr:nth-child(3) th')).toEqual([
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 1, 1, 3])
+  expect(await readSpans(headerRow(table, 2), 'colspan')).toEqual([
     1, 1, 1, 1, 1, 1,
   ])
 
   // Every header row must cover the same total width as the body rows.
-  for (const row of [1, 2, 3]) {
-    const spans = await readColSpans(page, `thead tr:nth-child(${row}) th`)
+  for (const row of [0, 1, 2]) {
+    const spans = await readSpans(headerRow(table, row), 'colspan')
     expect(spans.reduce((total, span) => total + span, 0)).toBe(
       LEAF_HEADERS.length,
     )
@@ -163,15 +273,44 @@ test('spans each group across the columns beneath it', async ({ page }) => {
 
 test('mirrors the header groups in the footer', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Footer groups are the header groups reversed, so leaves come first.
-  await expect(page.locator('tfoot tr')).toHaveCount(3)
-  await expect(footerRow(page, 0)).toHaveText(LEAF_FOOTERS)
+  await expect(table.locator('tfoot tr')).toHaveCount(3)
+  await expect(footerRow(table, 0)).toHaveText(LEAF_FOOTERS)
 
-  // Both groups declare a footer, and each still spans its own columns, which
-  // is what keeps the footer aligned with the body.
-  await expect(footerRow(page, 2)).toHaveText(['Name', 'Info'])
-  expect(await readColSpans(page, 'tfoot tr:nth-child(3) th')).toEqual([2, 4])
+  // Both groups declare a footer, and each still spans its own
+  // columns, which is what keeps the footer aligned with the body.
+  await expect(footerRow(table, 2)).toHaveText(['Name', 'Info'])
+  expect(await readSpans(footerRow(table, 2), 'colspan')).toEqual([2, 4])
+
+  expect(errors).toEqual([])
+})
+
+test('spans shallow leaf headers across rows in the second table', async ({
+  page,
+}) => {
+  const errors = await openExample(page)
+  const table = rowSpanTable(page)
+
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  // Placeholder headers are skipped, so each row only renders real headers.
+  await expect(headerRow(table, 0)).toHaveText([
+    'Full Name',
+    'Info',
+    'Profile Progress',
+  ])
+  await expect(headerRow(table, 1)).toHaveText(['Age', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(['Visits', 'Status'])
+
+  // Top-level leaves span all three rows, `Age` spans the bottom two.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([3, 1, 3])
+  expect(await readSpans(headerRow(table, 1), 'rowspan')).toEqual([2, 1])
+  expect(await readSpans(headerRow(table, 2), 'rowspan')).toEqual([1, 1])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([1, 3, 1])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 2])
 
   expect(errors).toEqual([])
 })

--- a/examples/octane/header-groups/src/index.css
+++ b/examples/octane/header-groups/src/index.css
@@ -363,3 +363,15 @@ tfoot th {
   font-size: 1.875rem;
   font-weight: 700;
 }
+
+/* Lays the header group examples side by side when the viewport allows it. */
+.example-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem 1.5rem;
+}
+
+.example-panel {
+  flex: 0 1 auto;
+}

--- a/examples/octane/header-groups/src/main.tsrx
+++ b/examples/octane/header-groups/src/main.tsrx
@@ -13,6 +13,107 @@ const features = tableFeatures({})
 
 const columnHelper = createColumnHelper<typeof features, Person>()
 
+// A traditional header group setup: every leaf column sits under a top-level
+// group, so the tree is even (2 header rows) and no placeholder headers are
+// created.
+const basicColumns = columnHelper.columns([
+  columnHelper.group({
+    header: 'Name',
+    columns: columnHelper.columns([
+      columnHelper.accessor('firstName', {
+        header: 'First Name',
+        footer: 'First Name',
+      }),
+      columnHelper.accessor((row) => row.lastName, {
+        id: 'lastName',
+        header: 'Last Name',
+        footer: 'Last Name',
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    header: 'Stats',
+    columns: columnHelper.columns([
+      columnHelper.accessor('age', {
+        header: 'Age',
+        footer: 'Age',
+      }),
+      columnHelper.accessor('visits', {
+        header: 'Visits',
+        footer: 'Visits',
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    header: 'Profile',
+    columns: columnHelper.columns([
+      columnHelper.accessor('status', {
+        header: 'Status',
+        footer: 'Status',
+      }),
+      columnHelper.accessor('progress', {
+        header: 'Profile Progress',
+        footer: 'Profile Progress',
+      }),
+    ]),
+  }),
+])
+
+// Groups nested inside groups, with every leaf column at the same depth. The
+// tree stays even, so there are three header rows and still no placeholders,
+// and each group's colSpan is the sum of its descendants.
+const nestedColumns = columnHelper.columns([
+  columnHelper.group({
+    header: 'Person',
+    columns: columnHelper.columns([
+      columnHelper.group({
+        header: 'Name',
+        columns: columnHelper.columns([
+          columnHelper.accessor('firstName', {
+            header: 'First Name',
+          }),
+          columnHelper.accessor((row) => row.lastName, {
+            id: 'lastName',
+            header: 'Last Name',
+          }),
+        ]),
+      }),
+      columnHelper.group({
+        header: 'Demographics',
+        columns: columnHelper.columns([
+          columnHelper.accessor('age', {
+            header: 'Age',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    header: 'Activity',
+    columns: columnHelper.columns([
+      columnHelper.group({
+        header: 'Engagement',
+        columns: columnHelper.columns([
+          columnHelper.accessor('visits', {
+            header: 'Visits',
+          }),
+          columnHelper.accessor('status', {
+            header: 'Status',
+          }),
+        ]),
+      }),
+      columnHelper.group({
+        header: 'Progress',
+        columns: columnHelper.columns([
+          columnHelper.accessor('progress', {
+            header: 'Profile Progress',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+])
+
 // use new columnHelper.columns method to create columns with the same TValue generic so TypeScript doesn't complain when passing columns to useTable
 const columns = columnHelper.columns([
   columnHelper.group({
@@ -60,10 +161,68 @@ const columns = columnHelper.columns([
   }),
 ])
 
+// An uneven column tree: `fullName` and `progress` are top-level leaf columns
+// while their siblings nest two and three levels deep. The placeholder at the
+// top of each column's placeholder chain carries the chain's full
+// `header.rowSpan`, and the headers it covers report a rowSpan of 0 so the
+// renderer can skip them.
+const unevenColumns = columnHelper.columns([
+  columnHelper.accessor(
+    (row) => [row.firstName, row.lastName].filter(Boolean).join(' '),
+    {
+      id: 'fullName',
+      header: 'Full Name',
+      cell: (info) => info.getValue(),
+    },
+  ),
+  columnHelper.group({
+    header: 'Info',
+    columns: columnHelper.columns([
+      columnHelper.accessor('age', {
+        header: () => 'Age',
+      }),
+      columnHelper.group({
+        header: 'More Info',
+        columns: columnHelper.columns([
+          columnHelper.accessor('visits', {
+            header: () => <span>Visits</span>,
+          }),
+          columnHelper.accessor('status', {
+            header: 'Status',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+  columnHelper.accessor('progress', {
+    header: 'Profile Progress',
+  }),
+])
+
 function App() @{
-  const [data, setData] = useState(() => makeData(20))
-  const refreshData = () => setData(makeData(20))
+  const [data, setData] = useState(() => makeData(5))
+  const refreshData = () => setData(makeData(5))
   const stressTest = () => setData(makeData(1_000))
+
+  const basicTable = useTable(
+    {
+      debugTable: true,
+      features,
+      columns: basicColumns,
+      data,
+    },
+    (state) => state, // default selector
+  )
+
+  const nestedTable = useTable(
+    {
+      debugTable: true,
+      features,
+      columns: nestedColumns,
+      data,
+    },
+    (state) => state, // default selector
+  )
 
   const table = useTable(
     {
@@ -75,50 +234,184 @@ function App() @{
     (state) => state, // default selector
   )
 
-  <div className="demo-root">
+  const unevenTable = useTable(
+    {
+      debugTable: true,
+      features,
+      columns: unevenColumns,
+      data,
+    },
+    (state) => state, // default selector
+  )
+
+      <div className="demo-root">
       <div>
-        <button onClick={() => refreshData()}>Regenerate Data</button>
-        <button onClick={() => stressTest()}>Stress Test (1k rows)</button>
+        <button onClick={() => refreshData()} className="demo-button">
+          Regenerate Data
+        </button>
+        <button onClick={() => stressTest()} className="demo-button">
+          Stress Test (1k rows)
+        </button>
       </div>
-      <table>
-        <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <th key={header.id} colSpan={header.colSpan}>
-                  {header.isPlaceholder ? null : (
-                    <table.FlexRender header={header} />
+      <div className="spacer-md" />
+      {/* The panels wrap into a grid whenever the viewport is wide enough. */}
+      <div className="example-grid">
+        <section className="example-panel">
+          <h2 className="section-title">Basic Header Groups</h2>
+          <table>
+            <thead>
+              {basicTable.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      <basicTable.FlexRender header={header} />
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {basicTable.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <basicTable.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              {basicTable
+                .getFooterGroups()
+                .filter((footerGroup) =>
+                  // Only the leaf columns declare footers, so skip the group
+                  // row instead of rendering a blank one.
+                  footerGroup.headers.some(
+                    (header) =>
+                      !header.isPlaceholder && header.column.columnDef.footer,
+                  ),
+                )
+                .map((footerGroup) => (
+                  <tr key={footerGroup.id}>
+                    {footerGroup.headers.map((header) => (
+                      <th key={header.id} colSpan={header.colSpan}>
+                        {header.isPlaceholder ? null : (
+                          <basicTable.FlexRender footer={header} />
+                        )}
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+            </tfoot>
+          </table>
+        </section>
+
+        <section className="example-panel">
+          <h2 className="section-title">Nested Header Groups</h2>
+          <table>
+            <thead>
+              {nestedTable.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      <nestedTable.FlexRender header={header} />
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {nestedTable.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <nestedTable.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section className="example-panel">
+          <h2 className="section-title">Placeholder Headers</h2>
+          <table>
+            <thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {table.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              {table.getFooterGroups().map((footerGroup) => (
+                <tr key={footerGroup.id}>
+                  {footerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender footer={header} />
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </tfoot>
+          </table>
+        </section>
+
+        <section className="example-panel">
+          <h2 className="section-title">Header Row Spanning</h2>
+          <table>
+            <thead>
+              {unevenTable.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) =>
+                    header.rowSpan === 0 ? null : (
+                      <th
+                        key={header.id}
+                        colSpan={header.colSpan}
+                        rowSpan={header.rowSpan}
+                      >
+                        <unevenTable.FlexRender header={header} />
+                      </th>
+                    ),
                   )}
-                </th>
+                </tr>
               ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {table.getRowModel().rows.map((row) => (
-            <tr key={row.id}>
-              {row.getAllCells().map((cell) => (
-                <td key={cell.id}>
-                  <table.FlexRender cell={cell} />
-                </td>
+            </thead>
+            <tbody>
+              {unevenTable.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <unevenTable.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
               ))}
-            </tr>
-          ))}
-        </tbody>
-        <tfoot>
-          {table.getFooterGroups().map((footerGroup) => (
-            <tr key={footerGroup.id}>
-              {footerGroup.headers.map((header) => (
-                <th key={header.id} colSpan={header.colSpan}>
-                  {header.isPlaceholder ? null : (
-                    <table.FlexRender footer={header} />
-                  )}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </tfoot>
-      </table>
+            </tbody>
+          </table>
+        </section>
+      </div>
       <div className="spacer-md" />
     </div>
 }

--- a/examples/octane/header-groups/tests/e2e/smoke.spec.ts
+++ b/examples/octane/header-groups/tests/e2e/smoke.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { expect, test } from '@playwright/test'
 import { startExampleServer } from '../../../../../tests/e2e/helpers/startExampleServer'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 const exampleDir = path.resolve()
 
@@ -56,41 +56,88 @@ async function openExample(page: Page) {
 
   const errors = collectPageErrors(page)
 
+  await page.route(
+    'https://unpkg.com/react-scan/dist/auto.global.js',
+    (route) =>
+      route.fulfill({
+        contentType: 'application/javascript',
+        body: '',
+      }),
+  )
+
   await page.goto(server.url)
 
   return errors
 }
 
-function headerRow(page: Page, index: number) {
-  return page.locator('thead tr').nth(index).locator('th')
+// The example renders four tables: an even tree with no placeholders, an even
+// tree of nested groups, an uneven tree that keeps placeholder headers as
+// empty cells, and an uneven tree that merges headers vertically via
+// `header.rowSpan`.
+function basicTable(page: Page) {
+  return page.locator('table').nth(0)
 }
 
-function footerRow(page: Page, index: number) {
-  return page.locator('tfoot tr').nth(index).locator('th')
+function nestedTable(page: Page) {
+  return page.locator('table').nth(1)
 }
 
-async function readColSpans(page: Page, selector: string) {
-  return page
-    .locator(selector)
-    .evaluateAll((cells) =>
-      cells.map((cell) => Number(cell.getAttribute('colspan') ?? '1')),
+function placeholderTable(page: Page) {
+  return page.locator('table').nth(2)
+}
+
+function rowSpanTable(page: Page) {
+  return page.locator('table').nth(3)
+}
+
+function headerRow(table: Locator, index: number) {
+  return table.locator('thead tr').nth(index).locator('th')
+}
+
+function footerRow(table: Locator, index: number) {
+  return table.locator('tfoot tr').nth(index).locator('th')
+}
+
+async function readSpans(cells: Locator, attribute: 'colspan' | 'rowspan') {
+  return cells.evaluateAll((elements, attributeName) => {
+    return elements.map((element) =>
+      Number(element.getAttribute(attributeName) ?? '1'),
     )
+  }, attribute)
 }
 
-async function getFirstBodyRowText(page: Page) {
-  const text = await page.locator('tbody tr').first().textContent()
+async function getFirstBodyRowText(table: Locator) {
+  const text = await table.locator('tbody tr').first().textContent()
   return text?.replace(/\s+/g, ' ').trim() ?? ''
 }
 
-test('renders the table without crashing', async ({ page }) => {
+test('renders all four tables without crashing', async ({ page }) => {
   const errors = await openExample(page)
-  const table = page.locator('table').first()
 
-  await expect(table).toBeVisible()
-  await expect(page.locator('tbody tr')).toHaveCount(20)
-  await expect(page.locator('tbody tr').first().locator('td')).toHaveCount(
-    LEAF_HEADERS.length,
-  )
+  await expect(basicTable(page)).toBeVisible()
+  await expect(nestedTable(page)).toBeVisible()
+  await expect(placeholderTable(page)).toBeVisible()
+  await expect(rowSpanTable(page)).toBeVisible()
+
+  await expect(nestedTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    nestedTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(basicTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    basicTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    placeholderTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(rowSpanTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    rowSpanTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(5)
 
   expect(errors).toEqual([])
 })
@@ -101,49 +148,121 @@ test('regenerates table data', async ({ page }) => {
     name: /^Regenerate Data$/i,
   })
 
-  await expect(page.locator('tbody tr').first()).toBeVisible()
+  await expect(placeholderTable(page).locator('tbody tr').first()).toBeVisible()
 
-  const firstRowBefore = await getFirstBodyRowText(page)
+  const firstRowBefore = await getFirstBodyRowText(placeholderTable(page))
 
   await regenerateButton.click()
 
-  await expect.poll(() => getFirstBodyRowText(page)).not.toBe(firstRowBefore)
-  await expect(page.locator('tbody tr')).toHaveCount(20)
+  await expect
+    .poll(() => getFirstBodyRowText(placeholderTable(page)))
+    .not.toBe(firstRowBefore)
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+
+  expect(errors).toEqual([])
+})
+
+test('groups leaf headers evenly with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = basicTable(page)
+
+  // Every leaf column belongs to a top-level group, so the tree is even: two
+  // header rows and no empty placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(2)
+
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Stats', 'Profile'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 2, 2])
+  // An even tree never produces spanning chains, so every rowSpan is 1.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1, 1])
+
+  // Only the leaf columns declare footers and the render loop skips footer
+  // rows without content, so the group row never renders in the tfoot.
+  await expect(table.locator('tfoot tr')).toHaveCount(1)
+  await expect(footerRow(table, 0)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(errors).toEqual([])
+})
+
+test('nests groups inside groups with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = nestedTable(page)
+
+  // Groups inside groups, every leaf at the same depth: three header rows and
+  // still no placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  await expect(headerRow(table, 0)).toHaveText(['Person', 'Activity'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'Name',
+    'Demographics',
+    'Engagement',
+    'Progress',
+  ])
+  await expect(headerRow(table, 2)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  // Each group spans the sum of its descendants.
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([3, 3])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([2, 1, 2, 1])
+  // An even tree never produces spanning chains.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1])
 
   expect(errors).toEqual([])
 })
 
 test('nests the header groups three rows deep', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Two top level groups, one of which nests a further group, so the deepest
   // leaf needs three header rows.
-  await expect(page.locator('thead tr')).toHaveCount(3)
+  await expect(table.locator('thead tr')).toHaveCount(3)
 
-  await expect(headerRow(page, 0)).toHaveText(['Hello', 'Info'])
+  await expect(headerRow(table, 0)).toHaveText(['Hello', 'Info'])
   // Row two is mostly placeholders for the columns that have no middle group.
-  await expect(headerRow(page, 1)).toHaveText(['', '', '', 'More Info'])
-  await expect(headerRow(page, 2)).toHaveText(LEAF_HEADERS)
+  await expect(headerRow(table, 1)).toHaveText(['', '', '', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(LEAF_HEADERS)
 
   expect(errors).toEqual([])
 })
 
 test('spans each group across the columns beneath it', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // `Hello` covers two leaves, `Info` covers the other four.
-  expect(await readColSpans(page, 'thead tr:nth-child(1) th')).toEqual([2, 4])
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 4])
   // `More Info` covers the last three of `Info`'s four leaves.
-  expect(await readColSpans(page, 'thead tr:nth-child(2) th')).toEqual([
-    1, 1, 1, 3,
-  ])
-  expect(await readColSpans(page, 'thead tr:nth-child(3) th')).toEqual([
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 1, 1, 3])
+  expect(await readSpans(headerRow(table, 2), 'colspan')).toEqual([
     1, 1, 1, 1, 1, 1,
   ])
 
   // Every header row must cover the same total width as the body rows.
-  for (const row of [1, 2, 3]) {
-    const spans = await readColSpans(page, `thead tr:nth-child(${row}) th`)
+  for (const row of [0, 1, 2]) {
+    const spans = await readSpans(headerRow(table, row), 'colspan')
     expect(spans.reduce((total, span) => total + span, 0)).toBe(
       LEAF_HEADERS.length,
     )
@@ -154,16 +273,45 @@ test('spans each group across the columns beneath it', async ({ page }) => {
 
 test('mirrors the header groups in the footer', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Footer groups are the header groups reversed, so leaves come first.
-  await expect(page.locator('tfoot tr')).toHaveCount(3)
-  await expect(footerRow(page, 0)).toHaveText(LEAF_FOOTERS)
+  await expect(table.locator('tfoot tr')).toHaveCount(3)
+  await expect(footerRow(table, 0)).toHaveText(LEAF_FOOTERS)
 
   // The `hello` group declares a header but no footer, so its footer cell is
   // empty, while `Info` declares both. The cell is still rendered and still
   // spans its columns, which is what keeps the footer aligned with the body.
-  await expect(footerRow(page, 2)).toHaveText(['', 'Info'])
-  expect(await readColSpans(page, 'tfoot tr:nth-child(3) th')).toEqual([2, 4])
+  await expect(footerRow(table, 2)).toHaveText(['', 'Info'])
+  expect(await readSpans(footerRow(table, 2), 'colspan')).toEqual([2, 4])
+
+  expect(errors).toEqual([])
+})
+
+test('spans shallow leaf headers across rows in the second table', async ({
+  page,
+}) => {
+  const errors = await openExample(page)
+  const table = rowSpanTable(page)
+
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  // Placeholder headers are skipped, so each row only renders real headers.
+  await expect(headerRow(table, 0)).toHaveText([
+    'Full Name',
+    'Info',
+    'Profile Progress',
+  ])
+  await expect(headerRow(table, 1)).toHaveText(['Age', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(['Visits', 'Status'])
+
+  // Top-level leaves span all three rows, `Age` spans the bottom two.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([3, 1, 3])
+  expect(await readSpans(headerRow(table, 1), 'rowspan')).toEqual([2, 1])
+  expect(await readSpans(headerRow(table, 2), 'rowspan')).toEqual([1, 1])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([1, 3, 1])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 2])
 
   expect(errors).toEqual([])
 })

--- a/examples/preact/header-groups/src/index.css
+++ b/examples/preact/header-groups/src/index.css
@@ -363,3 +363,15 @@ tfoot th {
   font-size: 1.875rem;
   font-weight: 700;
 }
+
+/* Lays the header group examples side by side when the viewport allows it. */
+.example-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem 1.5rem;
+}
+
+.example-panel {
+  flex: 0 1 auto;
+}

--- a/examples/preact/header-groups/src/main.tsx
+++ b/examples/preact/header-groups/src/main.tsx
@@ -13,6 +13,107 @@ const features = tableFeatures({})
 
 const columnHelper = createColumnHelper<typeof features, Person>()
 
+// A traditional header group setup: every leaf column sits under a top-level
+// group, so the tree is even (2 header rows) and no placeholder headers are
+// created.
+const basicColumns = columnHelper.columns([
+  columnHelper.group({
+    header: 'Name',
+    columns: columnHelper.columns([
+      columnHelper.accessor('firstName', {
+        header: 'First Name',
+        footer: 'First Name',
+      }),
+      columnHelper.accessor((row) => row.lastName, {
+        id: 'lastName',
+        header: 'Last Name',
+        footer: 'Last Name',
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    header: 'Stats',
+    columns: columnHelper.columns([
+      columnHelper.accessor('age', {
+        header: 'Age',
+        footer: 'Age',
+      }),
+      columnHelper.accessor('visits', {
+        header: 'Visits',
+        footer: 'Visits',
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    header: 'Profile',
+    columns: columnHelper.columns([
+      columnHelper.accessor('status', {
+        header: 'Status',
+        footer: 'Status',
+      }),
+      columnHelper.accessor('progress', {
+        header: 'Profile Progress',
+        footer: 'Profile Progress',
+      }),
+    ]),
+  }),
+])
+
+// Groups nested inside groups, with every leaf column at the same depth. The
+// tree stays even, so there are three header rows and still no placeholders,
+// and each group's colSpan is the sum of its descendants.
+const nestedColumns = columnHelper.columns([
+  columnHelper.group({
+    header: 'Person',
+    columns: columnHelper.columns([
+      columnHelper.group({
+        header: 'Name',
+        columns: columnHelper.columns([
+          columnHelper.accessor('firstName', {
+            header: 'First Name',
+          }),
+          columnHelper.accessor((row) => row.lastName, {
+            id: 'lastName',
+            header: 'Last Name',
+          }),
+        ]),
+      }),
+      columnHelper.group({
+        header: 'Demographics',
+        columns: columnHelper.columns([
+          columnHelper.accessor('age', {
+            header: 'Age',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    header: 'Activity',
+    columns: columnHelper.columns([
+      columnHelper.group({
+        header: 'Engagement',
+        columns: columnHelper.columns([
+          columnHelper.accessor('visits', {
+            header: 'Visits',
+          }),
+          columnHelper.accessor('status', {
+            header: 'Status',
+          }),
+        ]),
+      }),
+      columnHelper.group({
+        header: 'Progress',
+        columns: columnHelper.columns([
+          columnHelper.accessor('progress', {
+            header: 'Profile Progress',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+])
+
 // use new columnHelper.columns method to create columns with the same TValue generic so TypeScript doesn't complain when passing columns to useTable
 const columns = columnHelper.columns([
   columnHelper.group({
@@ -60,10 +161,68 @@ const columns = columnHelper.columns([
   }),
 ])
 
+// An uneven column tree: `fullName` and `progress` are top-level leaf columns
+// while their siblings nest two and three levels deep. The placeholder at the
+// top of each column's placeholder chain carries the chain's full
+// `header.rowSpan`, and the headers it covers report a rowSpan of 0 so the
+// renderer can skip them.
+const unevenColumns = columnHelper.columns([
+  columnHelper.accessor(
+    (row) => [row.firstName, row.lastName].filter(Boolean).join(' '),
+    {
+      id: 'fullName',
+      header: 'Full Name',
+      cell: (info) => info.getValue(),
+    },
+  ),
+  columnHelper.group({
+    header: 'Info',
+    columns: columnHelper.columns([
+      columnHelper.accessor('age', {
+        header: () => 'Age',
+      }),
+      columnHelper.group({
+        header: 'More Info',
+        columns: columnHelper.columns([
+          columnHelper.accessor('visits', {
+            header: () => <span>Visits</span>,
+          }),
+          columnHelper.accessor('status', {
+            header: 'Status',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+  columnHelper.accessor('progress', {
+    header: 'Profile Progress',
+  }),
+])
+
 function App() {
-  const [data, setData] = useState(() => makeData(20))
-  const refreshData = () => setData(makeData(20))
+  const [data, setData] = useState(() => makeData(5))
+  const refreshData = () => setData(makeData(5))
   const stressTest = () => setData(makeData(1_000))
+
+  const basicTable = useTable(
+    {
+      debugTable: true,
+      features,
+      columns: basicColumns,
+      data,
+    },
+    (state) => state, // default selector
+  )
+
+  const nestedTable = useTable(
+    {
+      debugTable: true,
+      features,
+      columns: nestedColumns,
+      data,
+    },
+    (state) => state, // default selector
+  )
 
   const table = useTable(
     {
@@ -75,51 +234,185 @@ function App() {
     (state) => state, // default selector
   )
 
+  const unevenTable = useTable(
+    {
+      debugTable: true,
+      features,
+      columns: unevenColumns,
+      data,
+    },
+    (state) => state, // default selector
+  )
+
   return (
     <div className="demo-root">
       <div>
-        <button onClick={() => refreshData()}>Regenerate Data</button>
-        <button onClick={() => stressTest()}>Stress Test (1k rows)</button>
+        <button onClick={() => refreshData()} className="demo-button">
+          Regenerate Data
+        </button>
+        <button onClick={() => stressTest()} className="demo-button">
+          Stress Test (1k rows)
+        </button>
       </div>
-      <table>
-        <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <th key={header.id} colSpan={header.colSpan}>
-                  {header.isPlaceholder ? null : (
-                    <table.FlexRender header={header} />
+      <div className="spacer-md" />
+      {/* The panels wrap into a grid whenever the viewport is wide enough. */}
+      <div className="example-grid">
+        <section className="example-panel">
+          <h2 className="section-title">Basic Header Groups</h2>
+          <table>
+            <thead>
+              {basicTable.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      <basicTable.FlexRender header={header} />
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {basicTable.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <basicTable.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              {basicTable
+                .getFooterGroups()
+                .filter((footerGroup) =>
+                  // Only the leaf columns declare footers, so skip the group
+                  // row instead of rendering a blank one.
+                  footerGroup.headers.some(
+                    (header) =>
+                      !header.isPlaceholder && header.column.columnDef.footer,
+                  ),
+                )
+                .map((footerGroup) => (
+                  <tr key={footerGroup.id}>
+                    {footerGroup.headers.map((header) => (
+                      <th key={header.id} colSpan={header.colSpan}>
+                        {header.isPlaceholder ? null : (
+                          <basicTable.FlexRender footer={header} />
+                        )}
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+            </tfoot>
+          </table>
+        </section>
+
+        <section className="example-panel">
+          <h2 className="section-title">Nested Header Groups</h2>
+          <table>
+            <thead>
+              {nestedTable.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      <nestedTable.FlexRender header={header} />
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {nestedTable.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <nestedTable.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section className="example-panel">
+          <h2 className="section-title">Placeholder Headers</h2>
+          <table>
+            <thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {table.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              {table.getFooterGroups().map((footerGroup) => (
+                <tr key={footerGroup.id}>
+                  {footerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender footer={header} />
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </tfoot>
+          </table>
+        </section>
+
+        <section className="example-panel">
+          <h2 className="section-title">Header Row Spanning</h2>
+          <table>
+            <thead>
+              {unevenTable.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) =>
+                    header.rowSpan === 0 ? null : (
+                      <th
+                        key={header.id}
+                        colSpan={header.colSpan}
+                        rowSpan={header.rowSpan}
+                      >
+                        <unevenTable.FlexRender header={header} />
+                      </th>
+                    ),
                   )}
-                </th>
+                </tr>
               ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {table.getRowModel().rows.map((row) => (
-            <tr key={row.id}>
-              {row.getAllCells().map((cell) => (
-                <td key={cell.id}>
-                  <table.FlexRender cell={cell} />
-                </td>
+            </thead>
+            <tbody>
+              {unevenTable.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <unevenTable.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
               ))}
-            </tr>
-          ))}
-        </tbody>
-        <tfoot>
-          {table.getFooterGroups().map((footerGroup) => (
-            <tr key={footerGroup.id}>
-              {footerGroup.headers.map((header) => (
-                <th key={header.id} colSpan={header.colSpan}>
-                  {header.isPlaceholder ? null : (
-                    <table.FlexRender footer={header} />
-                  )}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </tfoot>
-      </table>
+            </tbody>
+          </table>
+        </section>
+      </div>
       <div className="spacer-md" />
     </div>
   )

--- a/examples/preact/header-groups/tests/e2e/smoke.spec.ts
+++ b/examples/preact/header-groups/tests/e2e/smoke.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { expect, test } from '@playwright/test'
 import { startExampleServer } from '../../../../../tests/e2e/helpers/startExampleServer'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 const exampleDir = path.resolve()
 
@@ -70,36 +70,74 @@ async function openExample(page: Page) {
   return errors
 }
 
-function headerRow(page: Page, index: number) {
-  return page.locator('thead tr').nth(index).locator('th')
+// The example renders four tables: an even tree with no placeholders, an even
+// tree of nested groups, an uneven tree that keeps placeholder headers as
+// empty cells, and an uneven tree that merges headers vertically via
+// `header.rowSpan`.
+function basicTable(page: Page) {
+  return page.locator('table').nth(0)
 }
 
-function footerRow(page: Page, index: number) {
-  return page.locator('tfoot tr').nth(index).locator('th')
+function nestedTable(page: Page) {
+  return page.locator('table').nth(1)
 }
 
-async function readColSpans(page: Page, selector: string) {
-  return page
-    .locator(selector)
-    .evaluateAll((cells) =>
-      cells.map((cell) => Number(cell.getAttribute('colspan') ?? '1')),
+function placeholderTable(page: Page) {
+  return page.locator('table').nth(2)
+}
+
+function rowSpanTable(page: Page) {
+  return page.locator('table').nth(3)
+}
+
+function headerRow(table: Locator, index: number) {
+  return table.locator('thead tr').nth(index).locator('th')
+}
+
+function footerRow(table: Locator, index: number) {
+  return table.locator('tfoot tr').nth(index).locator('th')
+}
+
+async function readSpans(cells: Locator, attribute: 'colspan' | 'rowspan') {
+  return cells.evaluateAll((elements, attributeName) => {
+    return elements.map((element) =>
+      Number(element.getAttribute(attributeName) ?? '1'),
     )
+  }, attribute)
 }
 
-async function getFirstBodyRowText(page: Page) {
-  const text = await page.locator('tbody tr').first().textContent()
+async function getFirstBodyRowText(table: Locator) {
+  const text = await table.locator('tbody tr').first().textContent()
   return text?.replace(/\s+/g, ' ').trim() ?? ''
 }
 
-test('renders the table without crashing', async ({ page }) => {
+test('renders all four tables without crashing', async ({ page }) => {
   const errors = await openExample(page)
-  const table = page.locator('table').first()
 
-  await expect(table).toBeVisible()
-  await expect(page.locator('tbody tr')).toHaveCount(20)
-  await expect(page.locator('tbody tr').first().locator('td')).toHaveCount(
-    LEAF_HEADERS.length,
-  )
+  await expect(basicTable(page)).toBeVisible()
+  await expect(nestedTable(page)).toBeVisible()
+  await expect(placeholderTable(page)).toBeVisible()
+  await expect(rowSpanTable(page)).toBeVisible()
+
+  await expect(nestedTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    nestedTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(basicTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    basicTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    placeholderTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(rowSpanTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    rowSpanTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(5)
 
   expect(errors).toEqual([])
 })
@@ -110,49 +148,121 @@ test('regenerates table data', async ({ page }) => {
     name: /^Regenerate Data$/i,
   })
 
-  await expect(page.locator('tbody tr').first()).toBeVisible()
+  await expect(placeholderTable(page).locator('tbody tr').first()).toBeVisible()
 
-  const firstRowBefore = await getFirstBodyRowText(page)
+  const firstRowBefore = await getFirstBodyRowText(placeholderTable(page))
 
   await regenerateButton.click()
 
-  await expect.poll(() => getFirstBodyRowText(page)).not.toBe(firstRowBefore)
-  await expect(page.locator('tbody tr')).toHaveCount(20)
+  await expect
+    .poll(() => getFirstBodyRowText(placeholderTable(page)))
+    .not.toBe(firstRowBefore)
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+
+  expect(errors).toEqual([])
+})
+
+test('groups leaf headers evenly with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = basicTable(page)
+
+  // Every leaf column belongs to a top-level group, so the tree is even: two
+  // header rows and no empty placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(2)
+
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Stats', 'Profile'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 2, 2])
+  // An even tree never produces spanning chains, so every rowSpan is 1.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1, 1])
+
+  // Only the leaf columns declare footers and the render loop skips footer
+  // rows without content, so the group row never renders in the tfoot.
+  await expect(table.locator('tfoot tr')).toHaveCount(1)
+  await expect(footerRow(table, 0)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(errors).toEqual([])
+})
+
+test('nests groups inside groups with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = nestedTable(page)
+
+  // Groups inside groups, every leaf at the same depth: three header rows and
+  // still no placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  await expect(headerRow(table, 0)).toHaveText(['Person', 'Activity'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'Name',
+    'Demographics',
+    'Engagement',
+    'Progress',
+  ])
+  await expect(headerRow(table, 2)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  // Each group spans the sum of its descendants.
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([3, 3])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([2, 1, 2, 1])
+  // An even tree never produces spanning chains.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1])
 
   expect(errors).toEqual([])
 })
 
 test('nests the header groups three rows deep', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Two top level groups, one of which nests a further group, so the deepest
   // leaf needs three header rows.
-  await expect(page.locator('thead tr')).toHaveCount(3)
+  await expect(table.locator('thead tr')).toHaveCount(3)
 
-  await expect(headerRow(page, 0)).toHaveText(['Hello', 'Info'])
+  await expect(headerRow(table, 0)).toHaveText(['Hello', 'Info'])
   // Row two is mostly placeholders for the columns that have no middle group.
-  await expect(headerRow(page, 1)).toHaveText(['', '', '', 'More Info'])
-  await expect(headerRow(page, 2)).toHaveText(LEAF_HEADERS)
+  await expect(headerRow(table, 1)).toHaveText(['', '', '', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(LEAF_HEADERS)
 
   expect(errors).toEqual([])
 })
 
 test('spans each group across the columns beneath it', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // `Hello` covers two leaves, `Info` covers the other four.
-  expect(await readColSpans(page, 'thead tr:nth-child(1) th')).toEqual([2, 4])
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 4])
   // `More Info` covers the last three of `Info`'s four leaves.
-  expect(await readColSpans(page, 'thead tr:nth-child(2) th')).toEqual([
-    1, 1, 1, 3,
-  ])
-  expect(await readColSpans(page, 'thead tr:nth-child(3) th')).toEqual([
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 1, 1, 3])
+  expect(await readSpans(headerRow(table, 2), 'colspan')).toEqual([
     1, 1, 1, 1, 1, 1,
   ])
 
   // Every header row must cover the same total width as the body rows.
-  for (const row of [1, 2, 3]) {
-    const spans = await readColSpans(page, `thead tr:nth-child(${row}) th`)
+  for (const row of [0, 1, 2]) {
+    const spans = await readSpans(headerRow(table, row), 'colspan')
     expect(spans.reduce((total, span) => total + span, 0)).toBe(
       LEAF_HEADERS.length,
     )
@@ -163,16 +273,45 @@ test('spans each group across the columns beneath it', async ({ page }) => {
 
 test('mirrors the header groups in the footer', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Footer groups are the header groups reversed, so leaves come first.
-  await expect(page.locator('tfoot tr')).toHaveCount(3)
-  await expect(footerRow(page, 0)).toHaveText(LEAF_FOOTERS)
+  await expect(table.locator('tfoot tr')).toHaveCount(3)
+  await expect(footerRow(table, 0)).toHaveText(LEAF_FOOTERS)
 
   // The `hello` group declares a header but no footer, so its footer cell is
   // empty, while `Info` declares both. The cell is still rendered and still
   // spans its columns, which is what keeps the footer aligned with the body.
-  await expect(footerRow(page, 2)).toHaveText(['', 'Info'])
-  expect(await readColSpans(page, 'tfoot tr:nth-child(3) th')).toEqual([2, 4])
+  await expect(footerRow(table, 2)).toHaveText(['', 'Info'])
+  expect(await readSpans(footerRow(table, 2), 'colspan')).toEqual([2, 4])
+
+  expect(errors).toEqual([])
+})
+
+test('spans shallow leaf headers across rows in the second table', async ({
+  page,
+}) => {
+  const errors = await openExample(page)
+  const table = rowSpanTable(page)
+
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  // Placeholder headers are skipped, so each row only renders real headers.
+  await expect(headerRow(table, 0)).toHaveText([
+    'Full Name',
+    'Info',
+    'Profile Progress',
+  ])
+  await expect(headerRow(table, 1)).toHaveText(['Age', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(['Visits', 'Status'])
+
+  // Top-level leaves span all three rows, `Age` spans the bottom two.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([3, 1, 3])
+  expect(await readSpans(headerRow(table, 1), 'rowspan')).toEqual([2, 1])
+  expect(await readSpans(headerRow(table, 2), 'rowspan')).toEqual([1, 1])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([1, 3, 1])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 2])
 
   expect(errors).toEqual([])
 })

--- a/examples/react/header-groups/src/index.css
+++ b/examples/react/header-groups/src/index.css
@@ -363,3 +363,15 @@ tfoot th {
   font-size: 1.875rem;
   font-weight: 700;
 }
+
+/* Lays the header group examples side by side when the viewport allows it. */
+.example-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem 1.5rem;
+}
+
+.example-panel {
+  flex: 0 1 auto;
+}

--- a/examples/react/header-groups/src/main.tsx
+++ b/examples/react/header-groups/src/main.tsx
@@ -13,6 +13,107 @@ const features = tableFeatures({})
 
 const columnHelper = createColumnHelper<typeof features, Person>()
 
+// A traditional header group setup: every leaf column sits under a top-level
+// group, so the tree is even (2 header rows) and no placeholder headers are
+// created.
+const basicColumns = columnHelper.columns([
+  columnHelper.group({
+    header: 'Name',
+    columns: columnHelper.columns([
+      columnHelper.accessor('firstName', {
+        header: 'First Name',
+        footer: 'First Name',
+      }),
+      columnHelper.accessor((row) => row.lastName, {
+        id: 'lastName',
+        header: 'Last Name',
+        footer: 'Last Name',
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    header: 'Stats',
+    columns: columnHelper.columns([
+      columnHelper.accessor('age', {
+        header: 'Age',
+        footer: 'Age',
+      }),
+      columnHelper.accessor('visits', {
+        header: 'Visits',
+        footer: 'Visits',
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    header: 'Profile',
+    columns: columnHelper.columns([
+      columnHelper.accessor('status', {
+        header: 'Status',
+        footer: 'Status',
+      }),
+      columnHelper.accessor('progress', {
+        header: 'Profile Progress',
+        footer: 'Profile Progress',
+      }),
+    ]),
+  }),
+])
+
+// Groups nested inside groups, with every leaf column at the same depth. The
+// tree stays even, so there are three header rows and still no placeholders,
+// and each group's colSpan is the sum of its descendants.
+const nestedColumns = columnHelper.columns([
+  columnHelper.group({
+    header: 'Person',
+    columns: columnHelper.columns([
+      columnHelper.group({
+        header: 'Name',
+        columns: columnHelper.columns([
+          columnHelper.accessor('firstName', {
+            header: 'First Name',
+          }),
+          columnHelper.accessor((row) => row.lastName, {
+            id: 'lastName',
+            header: 'Last Name',
+          }),
+        ]),
+      }),
+      columnHelper.group({
+        header: 'Demographics',
+        columns: columnHelper.columns([
+          columnHelper.accessor('age', {
+            header: 'Age',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+  columnHelper.group({
+    header: 'Activity',
+    columns: columnHelper.columns([
+      columnHelper.group({
+        header: 'Engagement',
+        columns: columnHelper.columns([
+          columnHelper.accessor('visits', {
+            header: 'Visits',
+          }),
+          columnHelper.accessor('status', {
+            header: 'Status',
+          }),
+        ]),
+      }),
+      columnHelper.group({
+        header: 'Progress',
+        columns: columnHelper.columns([
+          columnHelper.accessor('progress', {
+            header: 'Profile Progress',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+])
+
 // use new columnHelper.columns method to create columns with the same TValue generic so TypeScript doesn't complain when passing columns to useTable
 const columns = columnHelper.columns([
   columnHelper.group({
@@ -60,16 +161,84 @@ const columns = columnHelper.columns([
   }),
 ])
 
+// An uneven column tree: `fullName` and `progress` are top-level leaf columns
+// while their siblings nest two and three levels deep. The placeholder at the
+// top of each column's placeholder chain carries the chain's full
+// `header.rowSpan`, and the headers it covers report a rowSpan of 0 so the
+// renderer can skip them.
+const unevenColumns = columnHelper.columns([
+  columnHelper.accessor(
+    (row) => [row.firstName, row.lastName].filter(Boolean).join(' '),
+    {
+      id: 'fullName',
+      header: 'Full Name',
+      cell: (info) => info.getValue(),
+    },
+  ),
+  columnHelper.group({
+    header: 'Info',
+    columns: columnHelper.columns([
+      columnHelper.accessor('age', {
+        header: () => 'Age',
+      }),
+      columnHelper.group({
+        header: 'More Info',
+        columns: columnHelper.columns([
+          columnHelper.accessor('visits', {
+            header: () => <span>Visits</span>,
+          }),
+          columnHelper.accessor('status', {
+            header: 'Status',
+          }),
+        ]),
+      }),
+    ]),
+  }),
+  columnHelper.accessor('progress', {
+    header: 'Profile Progress',
+  }),
+])
+
 function App() {
-  const [data, setData] = React.useState(() => makeData(20))
-  const refreshData = () => setData(makeData(20))
+  const [data, setData] = React.useState(() => makeData(5))
+  const refreshData = () => setData(makeData(5))
   const stressTest = () => setData(makeData(1_000))
+
+  const basicTable = useTable(
+    {
+      debugTable: true,
+      features,
+      columns: basicColumns,
+      data,
+    },
+    (state) => state, // default selector
+  )
+
+  const nestedTable = useTable(
+    {
+      debugTable: true,
+      features,
+      columns: nestedColumns,
+      data,
+    },
+    (state) => state, // default selector
+  )
 
   const table = useTable(
     {
       debugTable: true,
       features,
       columns,
+      data,
+    },
+    (state) => state, // default selector
+  )
+
+  const unevenTable = useTable(
+    {
+      debugTable: true,
+      features,
+      columns: unevenColumns,
       data,
     },
     (state) => state, // default selector
@@ -86,45 +255,164 @@ function App() {
         </button>
       </div>
       <div className="spacer-md" />
-      <table>
-        <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <th key={header.id} colSpan={header.colSpan}>
-                  {header.isPlaceholder ? null : (
-                    <table.FlexRender header={header} />
+      {/* The panels wrap into a grid whenever the viewport is wide enough. */}
+      <div className="example-grid">
+        <section className="example-panel">
+          <h2 className="section-title">Basic Header Groups</h2>
+          <table>
+            <thead>
+              {basicTable.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      <basicTable.FlexRender header={header} />
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {basicTable.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <basicTable.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              {basicTable
+                .getFooterGroups()
+                .filter((footerGroup) =>
+                  // Only the leaf columns declare footers, so skip the group
+                  // row instead of rendering a blank one.
+                  footerGroup.headers.some(
+                    (header) =>
+                      !header.isPlaceholder && header.column.columnDef.footer,
+                  ),
+                )
+                .map((footerGroup) => (
+                  <tr key={footerGroup.id}>
+                    {footerGroup.headers.map((header) => (
+                      <th key={header.id} colSpan={header.colSpan}>
+                        {header.isPlaceholder ? null : (
+                          <basicTable.FlexRender footer={header} />
+                        )}
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+            </tfoot>
+          </table>
+        </section>
+
+        <section className="example-panel">
+          <h2 className="section-title">Nested Header Groups</h2>
+          <table>
+            <thead>
+              {nestedTable.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      <nestedTable.FlexRender header={header} />
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {nestedTable.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <nestedTable.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section className="example-panel">
+          <h2 className="section-title">Placeholder Headers</h2>
+          <table>
+            <thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender header={header} />
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {table.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              {table.getFooterGroups().map((footerGroup) => (
+                <tr key={footerGroup.id}>
+                  {footerGroup.headers.map((header) => (
+                    <th key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : (
+                        <table.FlexRender footer={header} />
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </tfoot>
+          </table>
+        </section>
+
+        <section className="example-panel">
+          <h2 className="section-title">Header Row Spanning</h2>
+          <table>
+            <thead>
+              {unevenTable.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) =>
+                    header.rowSpan === 0 ? null : (
+                      <th
+                        key={header.id}
+                        colSpan={header.colSpan}
+                        rowSpan={header.rowSpan}
+                      >
+                        <unevenTable.FlexRender header={header} />
+                      </th>
+                    ),
                   )}
-                </th>
+                </tr>
               ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {table.getRowModel().rows.map((row) => (
-            <tr key={row.id}>
-              {row.getAllCells().map((cell) => (
-                <td key={cell.id}>
-                  <table.FlexRender cell={cell} />
-                </td>
+            </thead>
+            <tbody>
+              {unevenTable.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getAllCells().map((cell) => (
+                    <td key={cell.id}>
+                      <unevenTable.FlexRender cell={cell} />
+                    </td>
+                  ))}
+                </tr>
               ))}
-            </tr>
-          ))}
-        </tbody>
-        <tfoot>
-          {table.getFooterGroups().map((footerGroup) => (
-            <tr key={footerGroup.id}>
-              {footerGroup.headers.map((header) => (
-                <th key={header.id} colSpan={header.colSpan}>
-                  {header.isPlaceholder ? null : (
-                    <table.FlexRender footer={header} />
-                  )}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </tfoot>
-      </table>
+            </tbody>
+          </table>
+        </section>
+      </div>
       <div className="spacer-md" />
     </div>
   )

--- a/examples/react/header-groups/tests/e2e/smoke.spec.ts
+++ b/examples/react/header-groups/tests/e2e/smoke.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { expect, test } from '@playwright/test'
 import { startExampleServer } from '../../../../../tests/e2e/helpers/startExampleServer'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 const exampleDir = path.resolve()
 
@@ -70,36 +70,74 @@ async function openExample(page: Page) {
   return errors
 }
 
-function headerRow(page: Page, index: number) {
-  return page.locator('thead tr').nth(index).locator('th')
+// The example renders four tables: an even tree with no placeholders, an even
+// tree of nested groups, an uneven tree that keeps placeholder headers as
+// empty cells, and an uneven tree that merges headers vertically via
+// `header.rowSpan`.
+function basicTable(page: Page) {
+  return page.locator('table').nth(0)
 }
 
-function footerRow(page: Page, index: number) {
-  return page.locator('tfoot tr').nth(index).locator('th')
+function nestedTable(page: Page) {
+  return page.locator('table').nth(1)
 }
 
-async function readColSpans(page: Page, selector: string) {
-  return page
-    .locator(selector)
-    .evaluateAll((cells) =>
-      cells.map((cell) => Number(cell.getAttribute('colspan') ?? '1')),
+function placeholderTable(page: Page) {
+  return page.locator('table').nth(2)
+}
+
+function rowSpanTable(page: Page) {
+  return page.locator('table').nth(3)
+}
+
+function headerRow(table: Locator, index: number) {
+  return table.locator('thead tr').nth(index).locator('th')
+}
+
+function footerRow(table: Locator, index: number) {
+  return table.locator('tfoot tr').nth(index).locator('th')
+}
+
+async function readSpans(cells: Locator, attribute: 'colspan' | 'rowspan') {
+  return cells.evaluateAll((elements, attributeName) => {
+    return elements.map((element) =>
+      Number(element.getAttribute(attributeName) ?? '1'),
     )
+  }, attribute)
 }
 
-async function getFirstBodyRowText(page: Page) {
-  const text = await page.locator('tbody tr').first().textContent()
+async function getFirstBodyRowText(table: Locator) {
+  const text = await table.locator('tbody tr').first().textContent()
   return text?.replace(/\s+/g, ' ').trim() ?? ''
 }
 
-test('renders the table without crashing', async ({ page }) => {
+test('renders all four tables without crashing', async ({ page }) => {
   const errors = await openExample(page)
-  const table = page.locator('table').first()
 
-  await expect(table).toBeVisible()
-  await expect(page.locator('tbody tr')).toHaveCount(20)
-  await expect(page.locator('tbody tr').first().locator('td')).toHaveCount(
-    LEAF_HEADERS.length,
-  )
+  await expect(basicTable(page)).toBeVisible()
+  await expect(nestedTable(page)).toBeVisible()
+  await expect(placeholderTable(page)).toBeVisible()
+  await expect(rowSpanTable(page)).toBeVisible()
+
+  await expect(nestedTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    nestedTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(basicTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    basicTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    placeholderTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(rowSpanTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    rowSpanTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(5)
 
   expect(errors).toEqual([])
 })
@@ -110,49 +148,121 @@ test('regenerates table data', async ({ page }) => {
     name: /^Regenerate Data$/i,
   })
 
-  await expect(page.locator('tbody tr').first()).toBeVisible()
+  await expect(placeholderTable(page).locator('tbody tr').first()).toBeVisible()
 
-  const firstRowBefore = await getFirstBodyRowText(page)
+  const firstRowBefore = await getFirstBodyRowText(placeholderTable(page))
 
   await regenerateButton.click()
 
-  await expect.poll(() => getFirstBodyRowText(page)).not.toBe(firstRowBefore)
-  await expect(page.locator('tbody tr')).toHaveCount(20)
+  await expect
+    .poll(() => getFirstBodyRowText(placeholderTable(page)))
+    .not.toBe(firstRowBefore)
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+
+  expect(errors).toEqual([])
+})
+
+test('groups leaf headers evenly with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = basicTable(page)
+
+  // Every leaf column belongs to a top-level group, so the tree is even: two
+  // header rows and no empty placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(2)
+
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Stats', 'Profile'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 2, 2])
+  // An even tree never produces spanning chains, so every rowSpan is 1.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1, 1])
+
+  // Only the leaf columns declare footers and the render loop skips footer
+  // rows without content, so the group row never renders in the tfoot.
+  await expect(table.locator('tfoot tr')).toHaveCount(1)
+  await expect(footerRow(table, 0)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(errors).toEqual([])
+})
+
+test('nests groups inside groups with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = nestedTable(page)
+
+  // Groups inside groups, every leaf at the same depth: three header rows and
+  // still no placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  await expect(headerRow(table, 0)).toHaveText(['Person', 'Activity'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'Name',
+    'Demographics',
+    'Engagement',
+    'Progress',
+  ])
+  await expect(headerRow(table, 2)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  // Each group spans the sum of its descendants.
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([3, 3])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([2, 1, 2, 1])
+  // An even tree never produces spanning chains.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1])
 
   expect(errors).toEqual([])
 })
 
 test('nests the header groups three rows deep', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Two top level groups, one of which nests a further group, so the deepest
   // leaf needs three header rows.
-  await expect(page.locator('thead tr')).toHaveCount(3)
+  await expect(table.locator('thead tr')).toHaveCount(3)
 
-  await expect(headerRow(page, 0)).toHaveText(['Hello', 'Info'])
+  await expect(headerRow(table, 0)).toHaveText(['Hello', 'Info'])
   // Row two is mostly placeholders for the columns that have no middle group.
-  await expect(headerRow(page, 1)).toHaveText(['', '', '', 'More Info'])
-  await expect(headerRow(page, 2)).toHaveText(LEAF_HEADERS)
+  await expect(headerRow(table, 1)).toHaveText(['', '', '', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(LEAF_HEADERS)
 
   expect(errors).toEqual([])
 })
 
 test('spans each group across the columns beneath it', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // `Hello` covers two leaves, `Info` covers the other four.
-  expect(await readColSpans(page, 'thead tr:nth-child(1) th')).toEqual([2, 4])
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 4])
   // `More Info` covers the last three of `Info`'s four leaves.
-  expect(await readColSpans(page, 'thead tr:nth-child(2) th')).toEqual([
-    1, 1, 1, 3,
-  ])
-  expect(await readColSpans(page, 'thead tr:nth-child(3) th')).toEqual([
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 1, 1, 3])
+  expect(await readSpans(headerRow(table, 2), 'colspan')).toEqual([
     1, 1, 1, 1, 1, 1,
   ])
 
   // Every header row must cover the same total width as the body rows.
-  for (const row of [1, 2, 3]) {
-    const spans = await readColSpans(page, `thead tr:nth-child(${row}) th`)
+  for (const row of [0, 1, 2]) {
+    const spans = await readSpans(headerRow(table, row), 'colspan')
     expect(spans.reduce((total, span) => total + span, 0)).toBe(
       LEAF_HEADERS.length,
     )
@@ -163,16 +273,45 @@ test('spans each group across the columns beneath it', async ({ page }) => {
 
 test('mirrors the header groups in the footer', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Footer groups are the header groups reversed, so leaves come first.
-  await expect(page.locator('tfoot tr')).toHaveCount(3)
-  await expect(footerRow(page, 0)).toHaveText(LEAF_FOOTERS)
+  await expect(table.locator('tfoot tr')).toHaveCount(3)
+  await expect(footerRow(table, 0)).toHaveText(LEAF_FOOTERS)
 
   // The `hello` group declares a header but no footer, so its footer cell is
   // empty, while `Info` declares both. The cell is still rendered and still
   // spans its columns, which is what keeps the footer aligned with the body.
-  await expect(footerRow(page, 2)).toHaveText(['', 'Info'])
-  expect(await readColSpans(page, 'tfoot tr:nth-child(3) th')).toEqual([2, 4])
+  await expect(footerRow(table, 2)).toHaveText(['', 'Info'])
+  expect(await readSpans(footerRow(table, 2), 'colspan')).toEqual([2, 4])
+
+  expect(errors).toEqual([])
+})
+
+test('spans shallow leaf headers across rows in the second table', async ({
+  page,
+}) => {
+  const errors = await openExample(page)
+  const table = rowSpanTable(page)
+
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  // Placeholder headers are skipped, so each row only renders real headers.
+  await expect(headerRow(table, 0)).toHaveText([
+    'Full Name',
+    'Info',
+    'Profile Progress',
+  ])
+  await expect(headerRow(table, 1)).toHaveText(['Age', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(['Visits', 'Status'])
+
+  // Top-level leaves span all three rows, `Age` spans the bottom two.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([3, 1, 3])
+  expect(await readSpans(headerRow(table, 1), 'rowspan')).toEqual([2, 1])
+  expect(await readSpans(headerRow(table, 2), 'rowspan')).toEqual([1, 1])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([1, 3, 1])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 2])
 
   expect(errors).toEqual([])
 })

--- a/examples/solid/header-groups/src/App.tsx
+++ b/examples/solid/header-groups/src/App.tsx
@@ -1,10 +1,104 @@
-import { For, createSignal } from 'solid-js'
+import { For, Show, createSignal } from 'solid-js'
 import { FlexRender, createTable, tableFeatures } from '@tanstack/solid-table'
 import { makeData } from './makeData'
 import type { ColumnDef } from '@tanstack/solid-table'
 import type { Person } from './makeData'
 
 const features = tableFeatures({})
+
+// A traditional header group setup: every leaf column sits under a top-level
+// group, so the tree is even (2 header rows) and no placeholder headers are
+// created.
+const basicColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    header: 'Name',
+    columns: [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+        footer: 'First Name',
+      },
+      {
+        accessorFn: (row) => row.lastName,
+        id: 'lastName',
+        header: 'Last Name',
+        footer: 'Last Name',
+      },
+    ],
+  },
+  {
+    header: 'Stats',
+    columns: [
+      {
+        accessorKey: 'age',
+        header: 'Age',
+        footer: 'Age',
+      },
+      {
+        accessorKey: 'visits',
+        header: 'Visits',
+        footer: 'Visits',
+      },
+    ],
+  },
+  {
+    header: 'Profile',
+    columns: [
+      {
+        accessorKey: 'status',
+        header: 'Status',
+        footer: 'Status',
+      },
+      {
+        accessorKey: 'progress',
+        header: 'Profile Progress',
+        footer: 'Profile Progress',
+      },
+    ],
+  },
+]
+
+// Groups nested inside groups, with every leaf column at the same depth. The
+// tree stays even, so there are three header rows and still no placeholders,
+// and each group's colSpan is the sum of its descendants.
+const nestedColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    header: 'Person',
+    columns: [
+      {
+        header: 'Name',
+        columns: [
+          { accessorKey: 'firstName', header: 'First Name' },
+          {
+            accessorFn: (row) => row.lastName,
+            id: 'lastName',
+            header: 'Last Name',
+          },
+        ],
+      },
+      {
+        header: 'Demographics',
+        columns: [{ accessorKey: 'age', header: 'Age' }],
+      },
+    ],
+  },
+  {
+    header: 'Activity',
+    columns: [
+      {
+        header: 'Engagement',
+        columns: [
+          { accessorKey: 'visits', header: 'Visits' },
+          { accessorKey: 'status', header: 'Status' },
+        ],
+      },
+      {
+        header: 'Progress',
+        columns: [{ accessorKey: 'progress', header: 'Profile Progress' }],
+      },
+    ],
+  },
+]
 
 const defaultColumns: Array<ColumnDef<typeof features, Person>> = [
   {
@@ -58,10 +152,69 @@ const defaultColumns: Array<ColumnDef<typeof features, Person>> = [
   },
 ]
 
+// An uneven column tree: `fullName` and `progress` are top-level leaf columns
+// while their siblings nest two and three levels deep. The placeholder at the
+// top of each column's placeholder chain carries the chain's full
+// `header.rowSpan`, and the headers it covers report a rowSpan of 0 so the
+// renderer can skip them.
+const unevenColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    accessorFn: (row) =>
+      [row.firstName, row.lastName].filter(Boolean).join(' '),
+    id: 'fullName',
+    header: 'Full Name',
+    cell: (info) => info.getValue(),
+  },
+  {
+    header: 'Info',
+    columns: [
+      {
+        accessorKey: 'age',
+        header: () => 'Age',
+      },
+      {
+        header: 'More Info',
+        columns: [
+          {
+            accessorKey: 'visits',
+            header: () => <span>Visits</span>,
+          },
+          {
+            accessorKey: 'status',
+            header: 'Status',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    accessorKey: 'progress',
+    header: 'Profile Progress',
+  },
+]
+
 function App() {
-  const [data, setData] = createSignal(makeData(20))
-  const refreshData = () => setData(makeData(20))
+  const [data, setData] = createSignal(makeData(5))
+  const refreshData = () => setData(makeData(5))
   const stressTest = () => setData(makeData(1_000))
+
+  const basicTable = createTable({
+    debugTable: true,
+    features,
+    get data() {
+      return data()
+    },
+    columns: basicColumns,
+  })
+
+  const nestedTable = createTable({
+    debugTable: true,
+    features,
+    get data() {
+      return data()
+    },
+    columns: nestedColumns,
+  })
 
   const table = createTable({
     debugTable: true,
@@ -72,63 +225,217 @@ function App() {
     columns: defaultColumns,
   })
 
+  const unevenTable = createTable({
+    debugTable: true,
+    features,
+    get data() {
+      return data()
+    },
+    columns: unevenColumns,
+  })
+
   return (
     <div class="demo-root">
       <div>
         <button onClick={() => refreshData()}>Regenerate Data</button>
         <button onClick={() => stressTest()}>Stress Test (1k rows)</button>
       </div>
-      <table>
-        <thead>
-          <For each={table.getHeaderGroups()}>
-            {(headerGroup) => (
-              <tr>
-                <For each={headerGroup.headers}>
-                  {(header) => (
-                    <th colSpan={header.colSpan}>
-                      {header.isPlaceholder ? null : (
-                        <FlexRender header={header} />
+      <div class="spacer-md" />
+      {/* The panels wrap into a grid whenever the viewport is wide enough. */}
+      <div class="example-grid">
+        <section class="example-panel">
+          <h2 class="section-title">Basic Header Groups</h2>
+          <table>
+            <thead>
+              <For each={basicTable.getHeaderGroups()}>
+                {(headerGroup) => (
+                  <tr>
+                    <For each={headerGroup.headers}>
+                      {(header) => (
+                        <th colSpan={header.colSpan}>
+                          <FlexRender header={header} />
+                        </th>
                       )}
-                    </th>
-                  )}
-                </For>
-              </tr>
-            )}
-          </For>
-        </thead>
-        <tbody>
-          <For each={table.getRowModel().rows}>
-            {(row) => (
-              <tr>
-                <For each={row.getAllCells()}>
-                  {(cell) => (
-                    <td>
-                      <FlexRender cell={cell} />
-                    </td>
-                  )}
-                </For>
-              </tr>
-            )}
-          </For>
-        </tbody>
-        <tfoot>
-          <For each={table.getFooterGroups()}>
-            {(footerGroup) => (
-              <tr>
-                <For each={footerGroup.headers}>
-                  {(header) => (
-                    <th colSpan={header.colSpan}>
-                      {header.isPlaceholder ? null : (
-                        <FlexRender footer={header} />
+                    </For>
+                  </tr>
+                )}
+              </For>
+            </thead>
+            <tbody>
+              <For each={basicTable.getRowModel().rows}>
+                {(row) => (
+                  <tr>
+                    <For each={row.getAllCells()}>
+                      {(cell) => (
+                        <td>
+                          <FlexRender cell={cell} />
+                        </td>
                       )}
-                    </th>
+                    </For>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+            <tfoot>
+              <For
+                each={basicTable
+                  .getFooterGroups()
+                  // Only the leaf columns declare footers, so skip the group
+                  // row instead of rendering a blank one.
+                  .filter((footerGroup) =>
+                    footerGroup.headers.some(
+                      (header) =>
+                        !header.isPlaceholder && header.column.columnDef.footer,
+                    ),
                   )}
-                </For>
-              </tr>
-            )}
-          </For>
-        </tfoot>
-      </table>
+              >
+                {(footerGroup) => (
+                  <tr>
+                    <For each={footerGroup.headers}>
+                      {(header) => (
+                        <th colSpan={header.colSpan}>
+                          <Show when={!header.isPlaceholder}>
+                            <FlexRender footer={header} />
+                          </Show>
+                        </th>
+                      )}
+                    </For>
+                  </tr>
+                )}
+              </For>
+            </tfoot>
+          </table>
+        </section>
+
+        <section class="example-panel">
+          <h2 class="section-title">Nested Header Groups</h2>
+          <table>
+            <thead>
+              <For each={nestedTable.getHeaderGroups()}>
+                {(headerGroup) => (
+                  <tr>
+                    <For each={headerGroup.headers}>
+                      {(header) => (
+                        <th colSpan={header.colSpan}>
+                          <FlexRender header={header} />
+                        </th>
+                      )}
+                    </For>
+                  </tr>
+                )}
+              </For>
+            </thead>
+            <tbody>
+              <For each={nestedTable.getRowModel().rows}>
+                {(row) => (
+                  <tr>
+                    <For each={row.getAllCells()}>
+                      {(cell) => (
+                        <td>
+                          <FlexRender cell={cell} />
+                        </td>
+                      )}
+                    </For>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="example-panel">
+          <h2 class="section-title">Placeholder Headers</h2>
+          <table>
+            <thead>
+              <For each={table.getHeaderGroups()}>
+                {(headerGroup) => (
+                  <tr>
+                    <For each={headerGroup.headers}>
+                      {(header) => (
+                        <th colSpan={header.colSpan}>
+                          {header.isPlaceholder ? null : (
+                            <FlexRender header={header} />
+                          )}
+                        </th>
+                      )}
+                    </For>
+                  </tr>
+                )}
+              </For>
+            </thead>
+            <tbody>
+              <For each={table.getRowModel().rows}>
+                {(row) => (
+                  <tr>
+                    <For each={row.getAllCells()}>
+                      {(cell) => (
+                        <td>
+                          <FlexRender cell={cell} />
+                        </td>
+                      )}
+                    </For>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+            <tfoot>
+              <For each={table.getFooterGroups()}>
+                {(footerGroup) => (
+                  <tr>
+                    <For each={footerGroup.headers}>
+                      {(header) => (
+                        <th colSpan={header.colSpan}>
+                          {header.isPlaceholder ? null : (
+                            <FlexRender footer={header} />
+                          )}
+                        </th>
+                      )}
+                    </For>
+                  </tr>
+                )}
+              </For>
+            </tfoot>
+          </table>
+        </section>
+
+        <section class="example-panel">
+          <h2 class="section-title">Header Row Spanning</h2>
+          <table>
+            <thead>
+              <For each={unevenTable.getHeaderGroups()}>
+                {(headerGroup) => (
+                  <tr>
+                    <For each={headerGroup.headers}>
+                      {(header) => (
+                        <Show when={header.rowSpan !== 0}>
+                          <th colSpan={header.colSpan} rowSpan={header.rowSpan}>
+                            <FlexRender header={header} />
+                          </th>
+                        </Show>
+                      )}
+                    </For>
+                  </tr>
+                )}
+              </For>
+            </thead>
+            <tbody>
+              <For each={unevenTable.getRowModel().rows}>
+                {(row) => (
+                  <tr>
+                    <For each={row.getAllCells()}>
+                      {(cell) => (
+                        <td>
+                          <FlexRender cell={cell} />
+                        </td>
+                      )}
+                    </For>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+          </table>
+        </section>
+      </div>
     </div>
   )
 }

--- a/examples/solid/header-groups/src/index.css
+++ b/examples/solid/header-groups/src/index.css
@@ -363,3 +363,15 @@ tfoot th {
   font-size: 1.875rem;
   font-weight: 700;
 }
+
+/* Lays the header group examples side by side when the viewport allows it. */
+.example-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem 1.5rem;
+}
+
+.example-panel {
+  flex: 0 1 auto;
+}

--- a/examples/solid/header-groups/tests/e2e/smoke.spec.ts
+++ b/examples/solid/header-groups/tests/e2e/smoke.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { expect, test } from '@playwright/test'
 import { startExampleServer } from '../../../../../tests/e2e/helpers/startExampleServer'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 const exampleDir = path.resolve()
 
@@ -70,36 +70,74 @@ async function openExample(page: Page) {
   return errors
 }
 
-function headerRow(page: Page, index: number) {
-  return page.locator('thead tr').nth(index).locator('th')
+// The example renders four tables: an even tree with no placeholders, an even
+// tree of nested groups, an uneven tree that keeps placeholder headers as
+// empty cells, and an uneven tree that merges headers vertically via
+// `header.rowSpan`.
+function basicTable(page: Page) {
+  return page.locator('table').nth(0)
 }
 
-function footerRow(page: Page, index: number) {
-  return page.locator('tfoot tr').nth(index).locator('th')
+function nestedTable(page: Page) {
+  return page.locator('table').nth(1)
 }
 
-async function readColSpans(page: Page, selector: string) {
-  return page
-    .locator(selector)
-    .evaluateAll((cells) =>
-      cells.map((cell) => Number(cell.getAttribute('colspan') ?? '1')),
+function placeholderTable(page: Page) {
+  return page.locator('table').nth(2)
+}
+
+function rowSpanTable(page: Page) {
+  return page.locator('table').nth(3)
+}
+
+function headerRow(table: Locator, index: number) {
+  return table.locator('thead tr').nth(index).locator('th')
+}
+
+function footerRow(table: Locator, index: number) {
+  return table.locator('tfoot tr').nth(index).locator('th')
+}
+
+async function readSpans(cells: Locator, attribute: 'colspan' | 'rowspan') {
+  return cells.evaluateAll((elements, attributeName) => {
+    return elements.map((element) =>
+      Number(element.getAttribute(attributeName) ?? '1'),
     )
+  }, attribute)
 }
 
-async function getFirstBodyRowText(page: Page) {
-  const text = await page.locator('tbody tr').first().textContent()
+async function getFirstBodyRowText(table: Locator) {
+  const text = await table.locator('tbody tr').first().textContent()
   return text?.replace(/\s+/g, ' ').trim() ?? ''
 }
 
-test('renders the table without crashing', async ({ page }) => {
+test('renders all four tables without crashing', async ({ page }) => {
   const errors = await openExample(page)
-  const table = page.locator('table').first()
 
-  await expect(table).toBeVisible()
-  await expect(page.locator('tbody tr')).toHaveCount(20)
-  await expect(page.locator('tbody tr').first().locator('td')).toHaveCount(
-    LEAF_HEADERS.length,
-  )
+  await expect(basicTable(page)).toBeVisible()
+  await expect(nestedTable(page)).toBeVisible()
+  await expect(placeholderTable(page)).toBeVisible()
+  await expect(rowSpanTable(page)).toBeVisible()
+
+  await expect(nestedTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    nestedTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(basicTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    basicTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    placeholderTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(rowSpanTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    rowSpanTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(5)
 
   expect(errors).toEqual([])
 })
@@ -110,49 +148,121 @@ test('regenerates table data', async ({ page }) => {
     name: /^Regenerate Data$/i,
   })
 
-  await expect(page.locator('tbody tr').first()).toBeVisible()
+  await expect(placeholderTable(page).locator('tbody tr').first()).toBeVisible()
 
-  const firstRowBefore = await getFirstBodyRowText(page)
+  const firstRowBefore = await getFirstBodyRowText(placeholderTable(page))
 
   await regenerateButton.click()
 
-  await expect.poll(() => getFirstBodyRowText(page)).not.toBe(firstRowBefore)
-  await expect(page.locator('tbody tr')).toHaveCount(20)
+  await expect
+    .poll(() => getFirstBodyRowText(placeholderTable(page)))
+    .not.toBe(firstRowBefore)
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+
+  expect(errors).toEqual([])
+})
+
+test('groups leaf headers evenly with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = basicTable(page)
+
+  // Every leaf column belongs to a top-level group, so the tree is even: two
+  // header rows and no empty placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(2)
+
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Stats', 'Profile'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 2, 2])
+  // An even tree never produces spanning chains, so every rowSpan is 1.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1, 1])
+
+  // Only the leaf columns declare footers and the render loop skips footer
+  // rows without content, so the group row never renders in the tfoot.
+  await expect(table.locator('tfoot tr')).toHaveCount(1)
+  await expect(footerRow(table, 0)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(errors).toEqual([])
+})
+
+test('nests groups inside groups with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = nestedTable(page)
+
+  // Groups inside groups, every leaf at the same depth: three header rows and
+  // still no placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  await expect(headerRow(table, 0)).toHaveText(['Person', 'Activity'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'Name',
+    'Demographics',
+    'Engagement',
+    'Progress',
+  ])
+  await expect(headerRow(table, 2)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  // Each group spans the sum of its descendants.
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([3, 3])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([2, 1, 2, 1])
+  // An even tree never produces spanning chains.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1])
 
   expect(errors).toEqual([])
 })
 
 test('nests the header groups three rows deep', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Two top level groups, one of which nests a further group, so the deepest
   // leaf needs three header rows.
-  await expect(page.locator('thead tr')).toHaveCount(3)
+  await expect(table.locator('thead tr')).toHaveCount(3)
 
-  await expect(headerRow(page, 0)).toHaveText(['Name', 'Info'])
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Info'])
   // Row two is mostly placeholders for the columns that have no middle group.
-  await expect(headerRow(page, 1)).toHaveText(['', '', '', 'More Info'])
-  await expect(headerRow(page, 2)).toHaveText(LEAF_HEADERS)
+  await expect(headerRow(table, 1)).toHaveText(['', '', '', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(LEAF_HEADERS)
 
   expect(errors).toEqual([])
 })
 
 test('spans each group across the columns beneath it', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // `Hello` covers two leaves, `Info` covers the other four.
-  expect(await readColSpans(page, 'thead tr:nth-child(1) th')).toEqual([2, 4])
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 4])
   // `More Info` covers the last three of `Info`'s four leaves.
-  expect(await readColSpans(page, 'thead tr:nth-child(2) th')).toEqual([
-    1, 1, 1, 3,
-  ])
-  expect(await readColSpans(page, 'thead tr:nth-child(3) th')).toEqual([
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 1, 1, 3])
+  expect(await readSpans(headerRow(table, 2), 'colspan')).toEqual([
     1, 1, 1, 1, 1, 1,
   ])
 
   // Every header row must cover the same total width as the body rows.
-  for (const row of [1, 2, 3]) {
-    const spans = await readColSpans(page, `thead tr:nth-child(${row}) th`)
+  for (const row of [0, 1, 2]) {
+    const spans = await readSpans(headerRow(table, row), 'colspan')
     expect(spans.reduce((total, span) => total + span, 0)).toBe(
       LEAF_HEADERS.length,
     )
@@ -163,16 +273,44 @@ test('spans each group across the columns beneath it', async ({ page }) => {
 
 test('mirrors the header groups in the footer', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Footer groups are the header groups reversed, so leaves come first.
-  await expect(page.locator('tfoot tr')).toHaveCount(3)
-  await expect(footerRow(page, 0)).toHaveText(LEAF_FOOTERS)
+  await expect(table.locator('tfoot tr')).toHaveCount(3)
+  await expect(footerRow(table, 0)).toHaveText(LEAF_FOOTERS)
 
-  // The `hello` group declares a header but no footer, so its footer cell is
-  // empty, while `Info` declares both. The cell is still rendered and still
-  // spans its columns, which is what keeps the footer aligned with the body.
-  await expect(footerRow(page, 2)).toHaveText(['Name', 'Info'])
-  expect(await readColSpans(page, 'tfoot tr:nth-child(3) th')).toEqual([2, 4])
+  // Both groups declare a footer, and each still spans its own
+  // columns, which is what keeps the footer aligned with the body.
+  await expect(footerRow(table, 2)).toHaveText(['Name', 'Info'])
+  expect(await readSpans(footerRow(table, 2), 'colspan')).toEqual([2, 4])
+
+  expect(errors).toEqual([])
+})
+
+test('spans shallow leaf headers across rows in the second table', async ({
+  page,
+}) => {
+  const errors = await openExample(page)
+  const table = rowSpanTable(page)
+
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  // Placeholder headers are skipped, so each row only renders real headers.
+  await expect(headerRow(table, 0)).toHaveText([
+    'Full Name',
+    'Info',
+    'Profile Progress',
+  ])
+  await expect(headerRow(table, 1)).toHaveText(['Age', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(['Visits', 'Status'])
+
+  // Top-level leaves span all three rows, `Age` spans the bottom two.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([3, 1, 3])
+  expect(await readSpans(headerRow(table, 1), 'rowspan')).toEqual([2, 1])
+  expect(await readSpans(headerRow(table, 2), 'rowspan')).toEqual([1, 1])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([1, 3, 1])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 2])
 
   expect(errors).toEqual([])
 })

--- a/examples/solid/spreadsheet/src/SpreadsheetGrid.tsx
+++ b/examples/solid/spreadsheet/src/SpreadsheetGrid.tsx
@@ -670,17 +670,13 @@ interface HeaderRowProps {
   onOpenMenu: (column: SpreadsheetTableColumn, rect: DOMRect) => void
 }
 
-function HeaderRow({
-  table,
-  virtualColumns,
-  centerHeaders,
-  startHeaders,
-  endHeaders,
-  onStartSelection,
-  onExtendSelection,
-  onOpenMenu,
-}: HeaderRowProps) {
-  const rowCount = table.getRowsInDisplayOrder().length
+// Do not destructure these props. The header row is created once, so reading a
+// prop here instead of inside the JSX would freeze it at its mount-time value:
+// column pinning is applied in an effect after mount, so `startHeaders` would
+// stay empty and `centerHeaders` would keep every column, leaving the pinned
+// column with no header and shifting every letter one column to the left.
+function HeaderRow(props: HeaderRowProps) {
+  const rowCount = () => props.table.getRowsInDisplayOrder().length
 
   return (
     <div
@@ -692,44 +688,46 @@ function HeaderRow({
         type="button"
         class="corner-header"
         aria-label="Select all cells"
-        onClick={() => table.selectAllCells()}
+        onClick={() => props.table.selectAllCells()}
       >
         <span />
       </button>
-      {startHeaders.map((header) => (
+      {props.startHeaders.map((header) => (
         <HeaderCell
           header={header}
           pinned="start"
-          table={table}
-          rowCount={rowCount}
-          onStartSelection={onStartSelection}
-          onExtendSelection={onExtendSelection}
-          onOpenMenu={onOpenMenu}
+          table={props.table}
+          rowCount={rowCount()}
+          onStartSelection={props.onStartSelection}
+          onExtendSelection={props.onExtendSelection}
+          onOpenMenu={props.onOpenMenu}
         />
       ))}
-      {virtualColumns.map((virtualColumn) => {
-        const header = centerHeaders[virtualColumn.index]
-        return (
+      {props.virtualColumns.map((virtualColumn) => {
+        // The virtualizer's item count trails a column swap by a tick, so an
+        // index can briefly point past the end of the header list.
+        const header = props.centerHeaders.at(virtualColumn.index)
+        return header ? (
           <HeaderCell
             header={header}
             left={virtualColumn.start}
-            table={table}
-            rowCount={rowCount}
-            onStartSelection={onStartSelection}
-            onExtendSelection={onExtendSelection}
-            onOpenMenu={onOpenMenu}
+            table={props.table}
+            rowCount={rowCount()}
+            onStartSelection={props.onStartSelection}
+            onExtendSelection={props.onExtendSelection}
+            onOpenMenu={props.onOpenMenu}
           />
-        )
+        ) : null
       })}
-      {endHeaders.map((header) => (
+      {props.endHeaders.map((header) => (
         <HeaderCell
           header={header}
           pinned="end"
-          table={table}
-          rowCount={rowCount}
-          onStartSelection={onStartSelection}
-          onExtendSelection={onExtendSelection}
-          onOpenMenu={onOpenMenu}
+          table={props.table}
+          rowCount={rowCount()}
+          onStartSelection={props.onStartSelection}
+          onExtendSelection={props.onExtendSelection}
+          onOpenMenu={props.onOpenMenu}
         />
       ))}
     </div>

--- a/examples/svelte/header-groups/src/App.svelte
+++ b/examples/svelte/header-groups/src/App.svelte
@@ -8,11 +8,93 @@
   import { makeData, type Person } from './makeData'
   import './index.css'
 
-  let data = $state(makeData(20))
-  const refreshData = () => { data = makeData(20) }
+  let data = $state(makeData(5))
+  const refreshData = () => { data = makeData(5) }
   const stressTest = () => { data = makeData(1_000) }
 
   const features = tableFeatures({})
+
+  // A traditional header group setup: every leaf column sits under a top-level
+  // group, so the tree is even (2 header rows) and no placeholder headers are
+  // created.
+  const basicColumns: ColumnDef<typeof features, Person>[] = [
+    {
+      header: 'Name',
+      columns: [
+        {
+          accessorKey: 'firstName',
+          header: 'First Name',
+          footer: 'First Name',
+        },
+        {
+          accessorFn: (row) => row.lastName,
+          id: 'lastName',
+          header: 'Last Name',
+          footer: 'Last Name',
+        },
+      ],
+    },
+    {
+      header: 'Stats',
+      columns: [
+        { accessorKey: 'age', header: 'Age', footer: 'Age' },
+        { accessorKey: 'visits', header: 'Visits', footer: 'Visits' },
+      ],
+    },
+    {
+      header: 'Profile',
+      columns: [
+        { accessorKey: 'status', header: 'Status', footer: 'Status' },
+        {
+          accessorKey: 'progress',
+          header: 'Profile Progress',
+          footer: 'Profile Progress',
+        },
+      ],
+    },
+  ]
+
+  // Groups nested inside groups, with every leaf column at the same depth. The
+  // tree stays even, so there are three header rows and still no placeholders,
+  // and each group's colSpan is the sum of its descendants.
+  const nestedColumns: ColumnDef<typeof features, Person>[] = [
+    {
+      header: 'Person',
+      columns: [
+        {
+          header: 'Name',
+          columns: [
+            { accessorKey: 'firstName', header: 'First Name' },
+            {
+              accessorFn: (row) => row.lastName,
+              id: 'lastName',
+              header: 'Last Name',
+            },
+          ],
+        },
+        {
+          header: 'Demographics',
+          columns: [{ accessorKey: 'age', header: 'Age' }],
+        },
+      ],
+    },
+    {
+      header: 'Activity',
+      columns: [
+        {
+          header: 'Engagement',
+          columns: [
+            { accessorKey: 'visits', header: 'Visits' },
+            { accessorKey: 'status', header: 'Status' },
+          ],
+        },
+        {
+          header: 'Progress',
+          columns: [{ accessorKey: 'progress', header: 'Profile Progress' }],
+        },
+      ],
+    },
+  ]
 
   const defaultColumns: ColumnDef<typeof features, Person>[] = [
     {
@@ -66,14 +148,48 @@
     },
   ]
 
-  const table = createTable({
+  // An uneven column tree: `fullName` and `progress` are top-level leaf columns
+  // while their siblings nest two and three levels deep. The placeholder at the
+  // top of each column's placeholder chain carries the chain's full
+  // `header.rowSpan`, and the headers it covers report a rowSpan of 0 so the
+  // renderer can skip them.
+  const unevenColumns: ColumnDef<typeof features, Person>[] = [
+    {
+      accessorFn: (row) =>
+        [row.firstName, row.lastName].filter(Boolean).join(' '),
+      id: 'fullName',
+      header: 'Full Name',
+      cell: (info) => info.getValue(),
+    },
+    {
+      header: 'Info',
+      columns: [
+        { accessorKey: 'age', header: () => 'Age' },
+        {
+          header: 'More Info',
+          columns: [
+            { accessorKey: 'visits', header: () => 'Visits' },
+            { accessorKey: 'status', header: 'Status' },
+          ],
+        },
+      ],
+    },
+    { accessorKey: 'progress', header: 'Profile Progress' },
+  ]
+
+  const tableOptions = (columns: ColumnDef<typeof features, Person>[]) => ({
     debugTable: true,
     features,
     get data() {
       return data
     },
-    columns: defaultColumns,
+    columns,
   })
+
+  const basicTable = createTable(tableOptions(basicColumns))
+  const nestedTable = createTable(tableOptions(nestedColumns))
+  const table = createTable(tableOptions(defaultColumns))
+  const unevenTable = createTable(tableOptions(unevenColumns))
 </script>
 
 <div class="demo-root">
@@ -81,45 +197,153 @@
     <button onclick={() => refreshData()}>Regenerate Data</button>
     <button onclick={() => stressTest()}>Stress Test (1k rows)</button>
   </div>
-  <table>
-    <thead>
-      {#each table.getHeaderGroups() as headerGroup (headerGroup.id)
-      }
-        <tr>
-          {#each headerGroup.headers as header (header.id)}
-            <th colSpan={header.colSpan}>
-              {#if !header.isPlaceholder}
-                <FlexRender header={header} />
-              {/if}
-            </th>
-          {/each}
-        </tr>
-      {/each}
-    </thead>
-    <tbody>
-      {#each table.getRowModel().rows as row (row.id)}
-        <tr>
-          {#each row.getAllCells() as cell (cell.id)}
-            <td>
-              <FlexRender cell={cell} />
-            </td>
-          {/each}
-        </tr>
-      {/each}
-    </tbody>
-    <tfoot>
-      {#each table.getFooterGroups() as footerGroup (footerGroup.id)}
-        <tr>
-          {#each footerGroup.headers as header (header.id)}
-            <th colSpan={header.colSpan}>
-              {#if !header.isPlaceholder}
-                <FlexRender footer={header} />
-              {/if}
-            </th>
-          {/each}
-        </tr>
-      {/each}
-    </tfoot>
-  </table>
   <div class="spacer-md"></div>
+  <!-- The panels wrap into a grid whenever the viewport is wide enough. -->
+  <div class="example-grid">
+    <section class="example-panel">
+      <h2 class="section-title">Basic Header Groups</h2>
+      <table>
+        <thead>
+          {#each basicTable.getHeaderGroups() as headerGroup (headerGroup.id)}
+            <tr>
+              {#each headerGroup.headers as header (header.id)}
+                <th colSpan={header.colSpan}>
+                  <FlexRender header={header} />
+                </th>
+              {/each}
+            </tr>
+          {/each}
+        </thead>
+        <tbody>
+          {#each basicTable.getRowModel().rows as row (row.id)}
+            <tr>
+              {#each row.getAllCells() as cell (cell.id)}
+                <td>
+                  <FlexRender cell={cell} />
+                </td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+        <tfoot>
+          <!-- Only the leaf columns declare footers, so skip the group row
+               instead of rendering a blank one. -->
+          {#each basicTable
+            .getFooterGroups()
+            .filter((footerGroup) => footerGroup.headers.some((header) => !header.isPlaceholder && header.column.columnDef.footer)) as footerGroup (footerGroup.id)}
+            <tr>
+              {#each footerGroup.headers as header (header.id)}
+                <th colSpan={header.colSpan}>
+                  {#if !header.isPlaceholder}
+                    <FlexRender footer={header} />
+                  {/if}
+                </th>
+              {/each}
+            </tr>
+          {/each}
+        </tfoot>
+      </table>
+    </section>
+
+    <section class="example-panel">
+      <h2 class="section-title">Nested Header Groups</h2>
+      <table>
+        <thead>
+          {#each nestedTable.getHeaderGroups() as headerGroup (headerGroup.id)}
+            <tr>
+              {#each headerGroup.headers as header (header.id)}
+                <th colSpan={header.colSpan}>
+                  <FlexRender header={header} />
+                </th>
+              {/each}
+            </tr>
+          {/each}
+        </thead>
+        <tbody>
+          {#each nestedTable.getRowModel().rows as row (row.id)}
+            <tr>
+              {#each row.getAllCells() as cell (cell.id)}
+                <td>
+                  <FlexRender cell={cell} />
+                </td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </section>
+
+    <section class="example-panel">
+      <h2 class="section-title">Placeholder Headers</h2>
+      <table>
+        <thead>
+          {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
+            <tr>
+              {#each headerGroup.headers as header (header.id)}
+                <th colSpan={header.colSpan}>
+                  {#if !header.isPlaceholder}
+                    <FlexRender header={header} />
+                  {/if}
+                </th>
+              {/each}
+            </tr>
+          {/each}
+        </thead>
+        <tbody>
+          {#each table.getRowModel().rows as row (row.id)}
+            <tr>
+              {#each row.getAllCells() as cell (cell.id)}
+                <td>
+                  <FlexRender cell={cell} />
+                </td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+        <tfoot>
+          {#each table.getFooterGroups() as footerGroup (footerGroup.id)}
+            <tr>
+              {#each footerGroup.headers as header (header.id)}
+                <th colSpan={header.colSpan}>
+                  {#if !header.isPlaceholder}
+                    <FlexRender footer={header} />
+                  {/if}
+                </th>
+              {/each}
+            </tr>
+          {/each}
+        </tfoot>
+      </table>
+    </section>
+
+    <section class="example-panel">
+      <h2 class="section-title">Header Row Spanning</h2>
+      <table>
+        <thead>
+          {#each unevenTable.getHeaderGroups() as headerGroup (headerGroup.id)}
+            <tr>
+              {#each headerGroup.headers as header (header.id)}
+                {#if header.rowSpan !== 0}
+                  <th colSpan={header.colSpan} rowSpan={header.rowSpan}>
+                    <FlexRender header={header} />
+                  </th>
+                {/if}
+              {/each}
+            </tr>
+          {/each}
+        </thead>
+        <tbody>
+          {#each unevenTable.getRowModel().rows as row (row.id)}
+            <tr>
+              {#each row.getAllCells() as cell (cell.id)}
+                <td>
+                  <FlexRender cell={cell} />
+                </td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </section>
+  </div>
 </div>

--- a/examples/svelte/header-groups/src/index.css
+++ b/examples/svelte/header-groups/src/index.css
@@ -363,3 +363,15 @@ tfoot th {
   font-size: 1.875rem;
   font-weight: 700;
 }
+
+/* Lays the header group examples side by side when the viewport allows it. */
+.example-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem 1.5rem;
+}
+
+.example-panel {
+  flex: 0 1 auto;
+}

--- a/examples/svelte/header-groups/tests/e2e/smoke.spec.ts
+++ b/examples/svelte/header-groups/tests/e2e/smoke.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { expect, test } from '@playwright/test'
 import { startExampleServer } from '../../../../../tests/e2e/helpers/startExampleServer'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 const exampleDir = path.resolve()
 
@@ -70,36 +70,74 @@ async function openExample(page: Page) {
   return errors
 }
 
-function headerRow(page: Page, index: number) {
-  return page.locator('thead tr').nth(index).locator('th')
+// The example renders four tables: an even tree with no placeholders, an even
+// tree of nested groups, an uneven tree that keeps placeholder headers as
+// empty cells, and an uneven tree that merges headers vertically via
+// `header.rowSpan`.
+function basicTable(page: Page) {
+  return page.locator('table').nth(0)
 }
 
-function footerRow(page: Page, index: number) {
-  return page.locator('tfoot tr').nth(index).locator('th')
+function nestedTable(page: Page) {
+  return page.locator('table').nth(1)
 }
 
-async function readColSpans(page: Page, selector: string) {
-  return page
-    .locator(selector)
-    .evaluateAll((cells) =>
-      cells.map((cell) => Number(cell.getAttribute('colspan') ?? '1')),
+function placeholderTable(page: Page) {
+  return page.locator('table').nth(2)
+}
+
+function rowSpanTable(page: Page) {
+  return page.locator('table').nth(3)
+}
+
+function headerRow(table: Locator, index: number) {
+  return table.locator('thead tr').nth(index).locator('th')
+}
+
+function footerRow(table: Locator, index: number) {
+  return table.locator('tfoot tr').nth(index).locator('th')
+}
+
+async function readSpans(cells: Locator, attribute: 'colspan' | 'rowspan') {
+  return cells.evaluateAll((elements, attributeName) => {
+    return elements.map((element) =>
+      Number(element.getAttribute(attributeName) ?? '1'),
     )
+  }, attribute)
 }
 
-async function getFirstBodyRowText(page: Page) {
-  const text = await page.locator('tbody tr').first().textContent()
+async function getFirstBodyRowText(table: Locator) {
+  const text = await table.locator('tbody tr').first().textContent()
   return text?.replace(/\s+/g, ' ').trim() ?? ''
 }
 
-test('renders the table without crashing', async ({ page }) => {
+test('renders all four tables without crashing', async ({ page }) => {
   const errors = await openExample(page)
-  const table = page.locator('table').first()
 
-  await expect(table).toBeVisible()
-  await expect(page.locator('tbody tr')).toHaveCount(20)
-  await expect(page.locator('tbody tr').first().locator('td')).toHaveCount(
-    LEAF_HEADERS.length,
-  )
+  await expect(basicTable(page)).toBeVisible()
+  await expect(nestedTable(page)).toBeVisible()
+  await expect(placeholderTable(page)).toBeVisible()
+  await expect(rowSpanTable(page)).toBeVisible()
+
+  await expect(nestedTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    nestedTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(basicTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    basicTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    placeholderTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(rowSpanTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    rowSpanTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(5)
 
   expect(errors).toEqual([])
 })
@@ -110,49 +148,121 @@ test('regenerates table data', async ({ page }) => {
     name: /^Regenerate Data$/i,
   })
 
-  await expect(page.locator('tbody tr').first()).toBeVisible()
+  await expect(placeholderTable(page).locator('tbody tr').first()).toBeVisible()
 
-  const firstRowBefore = await getFirstBodyRowText(page)
+  const firstRowBefore = await getFirstBodyRowText(placeholderTable(page))
 
   await regenerateButton.click()
 
-  await expect.poll(() => getFirstBodyRowText(page)).not.toBe(firstRowBefore)
-  await expect(page.locator('tbody tr')).toHaveCount(20)
+  await expect
+    .poll(() => getFirstBodyRowText(placeholderTable(page)))
+    .not.toBe(firstRowBefore)
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+
+  expect(errors).toEqual([])
+})
+
+test('groups leaf headers evenly with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = basicTable(page)
+
+  // Every leaf column belongs to a top-level group, so the tree is even: two
+  // header rows and no empty placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(2)
+
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Stats', 'Profile'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 2, 2])
+  // An even tree never produces spanning chains, so every rowSpan is 1.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1, 1])
+
+  // Only the leaf columns declare footers and the render loop skips footer
+  // rows without content, so the group row never renders in the tfoot.
+  await expect(table.locator('tfoot tr')).toHaveCount(1)
+  await expect(footerRow(table, 0)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(errors).toEqual([])
+})
+
+test('nests groups inside groups with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = nestedTable(page)
+
+  // Groups inside groups, every leaf at the same depth: three header rows and
+  // still no placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  await expect(headerRow(table, 0)).toHaveText(['Person', 'Activity'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'Name',
+    'Demographics',
+    'Engagement',
+    'Progress',
+  ])
+  await expect(headerRow(table, 2)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  // Each group spans the sum of its descendants.
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([3, 3])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([2, 1, 2, 1])
+  // An even tree never produces spanning chains.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1])
 
   expect(errors).toEqual([])
 })
 
 test('nests the header groups three rows deep', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Two top level groups, one of which nests a further group, so the deepest
   // leaf needs three header rows.
-  await expect(page.locator('thead tr')).toHaveCount(3)
+  await expect(table.locator('thead tr')).toHaveCount(3)
 
-  await expect(headerRow(page, 0)).toHaveText(['Name', 'Info'])
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Info'])
   // Row two is mostly placeholders for the columns that have no middle group.
-  await expect(headerRow(page, 1)).toHaveText(['', '', '', 'More Info'])
-  await expect(headerRow(page, 2)).toHaveText(LEAF_HEADERS)
+  await expect(headerRow(table, 1)).toHaveText(['', '', '', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(LEAF_HEADERS)
 
   expect(errors).toEqual([])
 })
 
 test('spans each group across the columns beneath it', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // `Hello` covers two leaves, `Info` covers the other four.
-  expect(await readColSpans(page, 'thead tr:nth-child(1) th')).toEqual([2, 4])
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 4])
   // `More Info` covers the last three of `Info`'s four leaves.
-  expect(await readColSpans(page, 'thead tr:nth-child(2) th')).toEqual([
-    1, 1, 1, 3,
-  ])
-  expect(await readColSpans(page, 'thead tr:nth-child(3) th')).toEqual([
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 1, 1, 3])
+  expect(await readSpans(headerRow(table, 2), 'colspan')).toEqual([
     1, 1, 1, 1, 1, 1,
   ])
 
   // Every header row must cover the same total width as the body rows.
-  for (const row of [1, 2, 3]) {
-    const spans = await readColSpans(page, `thead tr:nth-child(${row}) th`)
+  for (const row of [0, 1, 2]) {
+    const spans = await readSpans(headerRow(table, row), 'colspan')
     expect(spans.reduce((total, span) => total + span, 0)).toBe(
       LEAF_HEADERS.length,
     )
@@ -163,15 +273,44 @@ test('spans each group across the columns beneath it', async ({ page }) => {
 
 test('mirrors the header groups in the footer', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Footer groups are the header groups reversed, so leaves come first.
-  await expect(page.locator('tfoot tr')).toHaveCount(3)
-  await expect(footerRow(page, 0)).toHaveText(LEAF_FOOTERS)
+  await expect(table.locator('tfoot tr')).toHaveCount(3)
+  await expect(footerRow(table, 0)).toHaveText(LEAF_FOOTERS)
 
-  // Both groups declare a footer, and each still spans its own columns, which
-  // is what keeps the footer aligned with the body.
-  await expect(footerRow(page, 2)).toHaveText(['Name', 'Info'])
-  expect(await readColSpans(page, 'tfoot tr:nth-child(3) th')).toEqual([2, 4])
+  // Both groups declare a footer, and each still spans its own
+  // columns, which is what keeps the footer aligned with the body.
+  await expect(footerRow(table, 2)).toHaveText(['Name', 'Info'])
+  expect(await readSpans(footerRow(table, 2), 'colspan')).toEqual([2, 4])
+
+  expect(errors).toEqual([])
+})
+
+test('spans shallow leaf headers across rows in the second table', async ({
+  page,
+}) => {
+  const errors = await openExample(page)
+  const table = rowSpanTable(page)
+
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  // Placeholder headers are skipped, so each row only renders real headers.
+  await expect(headerRow(table, 0)).toHaveText([
+    'Full Name',
+    'Info',
+    'Profile Progress',
+  ])
+  await expect(headerRow(table, 1)).toHaveText(['Age', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(['Visits', 'Status'])
+
+  // Top-level leaves span all three rows, `Age` spans the bottom two.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([3, 1, 3])
+  expect(await readSpans(headerRow(table, 1), 'rowspan')).toEqual([2, 1])
+  expect(await readSpans(headerRow(table, 2), 'rowspan')).toEqual([1, 1])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([1, 3, 1])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 2])
 
   expect(errors).toEqual([])
 })

--- a/examples/vue/header-groups/src/App.tsx
+++ b/examples/vue/header-groups/src/App.tsx
@@ -12,6 +12,100 @@ import type { Person } from './makeData'
 
 const features = tableFeatures({})
 
+// A traditional header group setup: every leaf column sits under a top-level
+// group, so the tree is even (2 header rows) and no placeholder headers are
+// created.
+const basicColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    header: 'Name',
+    columns: [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+        footer: 'First Name',
+      },
+      {
+        accessorFn: (row) => row.lastName,
+        id: 'lastName',
+        header: 'Last Name',
+        footer: 'Last Name',
+      },
+    ],
+  },
+  {
+    header: 'Stats',
+    columns: [
+      {
+        accessorKey: 'age',
+        header: 'Age',
+        footer: 'Age',
+      },
+      {
+        accessorKey: 'visits',
+        header: 'Visits',
+        footer: 'Visits',
+      },
+    ],
+  },
+  {
+    header: 'Profile',
+    columns: [
+      {
+        accessorKey: 'status',
+        header: 'Status',
+        footer: 'Status',
+      },
+      {
+        accessorKey: 'progress',
+        header: 'Profile Progress',
+        footer: 'Profile Progress',
+      },
+    ],
+  },
+]
+
+// Groups nested inside groups, with every leaf column at the same depth. The
+// tree stays even, so there are three header rows and still no placeholders,
+// and each group's colSpan is the sum of its descendants.
+const nestedColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    header: 'Person',
+    columns: [
+      {
+        header: 'Name',
+        columns: [
+          { accessorKey: 'firstName', header: 'First Name' },
+          {
+            accessorFn: (row) => row.lastName,
+            id: 'lastName',
+            header: 'Last Name',
+          },
+        ],
+      },
+      {
+        header: 'Demographics',
+        columns: [{ accessorKey: 'age', header: 'Age' }],
+      },
+    ],
+  },
+  {
+    header: 'Activity',
+    columns: [
+      {
+        header: 'Engagement',
+        columns: [
+          { accessorKey: 'visits', header: 'Visits' },
+          { accessorKey: 'status', header: 'Status' },
+        ],
+      },
+      {
+        header: 'Progress',
+        columns: [{ accessorKey: 'progress', header: 'Profile Progress' }],
+      },
+    ],
+  },
+]
+
 const columns: Array<ColumnDef<typeof features, Person>> = [
   {
     header: 'Name',
@@ -64,27 +158,99 @@ const columns: Array<ColumnDef<typeof features, Person>> = [
   },
 ]
 
+// An uneven column tree: `fullName` and `progress` are top-level leaf columns
+// while their siblings nest two and three levels deep. The placeholder at the
+// top of each column's placeholder chain carries the chain's full
+// `header.rowSpan`, and the headers it covers report a rowSpan of 0 so the
+// renderer can skip them.
+const unevenColumns: Array<ColumnDef<typeof features, Person>> = [
+  {
+    accessorFn: (row) =>
+      [row.firstName, row.lastName].filter(Boolean).join(' '),
+    id: 'fullName',
+    header: 'Full Name',
+    cell: (info) => info.getValue(),
+  },
+  {
+    header: 'Info',
+    columns: [
+      {
+        accessorKey: 'age',
+        header: () => 'Age',
+      },
+      {
+        header: 'More Info',
+        columns: [
+          {
+            accessorKey: 'visits',
+            header: () => <span>Visits</span>,
+          },
+          {
+            accessorKey: 'status',
+            header: 'Status',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    accessorKey: 'progress',
+    header: 'Profile Progress',
+  },
+]
+
 export default defineComponent({
   name: 'HeaderGroupsExample',
   setup() {
-    const data = ref(makeData(20))
+    const data = ref(makeData(5))
 
     const refreshData = () => {
-      data.value = makeData(20)
+      data.value = makeData(5)
     }
 
     const stressTest = () => {
       data.value = makeData(1_000)
     }
 
-    const table = useTable({
+    const tableOptions = (
+      tableColumns: Array<ColumnDef<typeof features, Person>>,
+    ) => ({
       debugTable: true,
       features,
-      columns,
+      columns: tableColumns,
       get data() {
         return data.value
       },
     })
+
+    const basicTable = useTable(tableOptions(basicColumns))
+    const nestedTable = useTable(tableOptions(nestedColumns))
+    const table = useTable(tableOptions(columns))
+    const unevenTable = useTable(tableOptions(unevenColumns))
+
+    const renderBody = (
+      bodyTable:
+        | typeof basicTable
+        | typeof nestedTable
+        | typeof table
+        | typeof unevenTable,
+    ) => (
+      <tbody>
+        {bodyTable
+          .getRowModel()
+          .rows.map((row: Row<typeof features, Person>) => (
+            <tr key={row.id}>
+              {row
+                .getAllCells()
+                .map((cell: Cell<typeof features, Person, unknown>) => (
+                  <td key={cell.id}>
+                    <FlexRender cell={cell} />
+                  </td>
+                ))}
+            </tr>
+          ))}
+      </tbody>
+    )
 
     return () => (
       <div class="demo-root">
@@ -97,57 +263,145 @@ export default defineComponent({
           </button>
         </div>
         <div class="spacer-md" />
-        <table>
-          <thead>
-            {table
-              .getHeaderGroups()
-              .map((headerGroup: HeaderGroup<typeof features, Person>) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map(
-                    (header: Header<typeof features, Person, unknown>) => (
-                      <th key={header.id} colspan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <FlexRender header={header} />
-                        )}
-                      </th>
+        {/* The panels wrap into a grid whenever the viewport is wide enough. */}
+        <div class="example-grid">
+          <section class="example-panel">
+            <h2 class="section-title">Basic Header Groups</h2>
+            <table>
+              <thead>
+                {basicTable
+                  .getHeaderGroups()
+                  .map((headerGroup: HeaderGroup<typeof features, Person>) => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map(
+                        (header: Header<typeof features, Person, unknown>) => (
+                          <th key={header.id} colspan={header.colSpan}>
+                            <FlexRender header={header} />
+                          </th>
+                        ),
+                      )}
+                    </tr>
+                  ))}
+              </thead>
+              {renderBody(basicTable)}
+              <tfoot>
+                {basicTable
+                  .getFooterGroups()
+                  // Only the leaf columns declare footers, so skip the group
+                  // row instead of rendering a blank one.
+                  .filter((footerGroup: HeaderGroup<typeof features, Person>) =>
+                    footerGroup.headers.some(
+                      (header: Header<typeof features, Person, unknown>) =>
+                        !header.isPlaceholder && header.column.columnDef.footer,
                     ),
-                  )}
-                </tr>
-              ))}
-          </thead>
-          <tbody>
-            {table
-              .getRowModel()
-              .rows.map((row: Row<typeof features, Person>) => (
-                <tr key={row.id}>
-                  {row
-                    .getAllCells()
-                    .map((cell: Cell<typeof features, Person, unknown>) => (
-                      <td key={cell.id}>
-                        <FlexRender cell={cell} />
-                      </td>
-                    ))}
-                </tr>
-              ))}
-          </tbody>
-          <tfoot>
-            {table
-              .getFooterGroups()
-              .map((footerGroup: HeaderGroup<typeof features, Person>) => (
-                <tr key={footerGroup.id}>
-                  {footerGroup.headers.map(
-                    (header: Header<typeof features, Person, unknown>) => (
-                      <th key={header.id} colspan={header.colSpan}>
-                        {header.isPlaceholder ? null : (
-                          <FlexRender footer={header} />
-                        )}
-                      </th>
-                    ),
-                  )}
-                </tr>
-              ))}
-          </tfoot>
-        </table>
+                  )
+                  .map((footerGroup: HeaderGroup<typeof features, Person>) => (
+                    <tr key={footerGroup.id}>
+                      {footerGroup.headers.map(
+                        (header: Header<typeof features, Person, unknown>) => (
+                          <th key={header.id} colspan={header.colSpan}>
+                            {header.isPlaceholder ? null : (
+                              <FlexRender footer={header} />
+                            )}
+                          </th>
+                        ),
+                      )}
+                    </tr>
+                  ))}
+              </tfoot>
+            </table>
+          </section>
+
+          <section class="example-panel">
+            <h2 class="section-title">Nested Header Groups</h2>
+            <table>
+              <thead>
+                {nestedTable
+                  .getHeaderGroups()
+                  .map((headerGroup: HeaderGroup<typeof features, Person>) => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map(
+                        (header: Header<typeof features, Person, unknown>) => (
+                          <th key={header.id} colspan={header.colSpan}>
+                            <FlexRender header={header} />
+                          </th>
+                        ),
+                      )}
+                    </tr>
+                  ))}
+              </thead>
+              {renderBody(nestedTable)}
+            </table>
+          </section>
+
+          <section class="example-panel">
+            <h2 class="section-title">Placeholder Headers</h2>
+            <table>
+              <thead>
+                {table
+                  .getHeaderGroups()
+                  .map((headerGroup: HeaderGroup<typeof features, Person>) => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map(
+                        (header: Header<typeof features, Person, unknown>) => (
+                          <th key={header.id} colspan={header.colSpan}>
+                            {header.isPlaceholder ? null : (
+                              <FlexRender header={header} />
+                            )}
+                          </th>
+                        ),
+                      )}
+                    </tr>
+                  ))}
+              </thead>
+              {renderBody(table)}
+              <tfoot>
+                {table
+                  .getFooterGroups()
+                  .map((footerGroup: HeaderGroup<typeof features, Person>) => (
+                    <tr key={footerGroup.id}>
+                      {footerGroup.headers.map(
+                        (header: Header<typeof features, Person, unknown>) => (
+                          <th key={header.id} colspan={header.colSpan}>
+                            {header.isPlaceholder ? null : (
+                              <FlexRender footer={header} />
+                            )}
+                          </th>
+                        ),
+                      )}
+                    </tr>
+                  ))}
+              </tfoot>
+            </table>
+          </section>
+
+          <section class="example-panel">
+            <h2 class="section-title">Header Row Spanning</h2>
+            <table>
+              <thead>
+                {unevenTable
+                  .getHeaderGroups()
+                  .map((headerGroup: HeaderGroup<typeof features, Person>) => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map(
+                        (header: Header<typeof features, Person, unknown>) =>
+                          header.rowSpan === 0 ? null : (
+                            <th
+                              key={header.id}
+                              colspan={header.colSpan}
+                              rowspan={header.rowSpan}
+                            >
+                              <FlexRender header={header} />
+                            </th>
+                          ),
+                      )}
+                    </tr>
+                  ))}
+              </thead>
+              {renderBody(unevenTable)}
+            </table>
+          </section>
+        </div>
       </div>
     )
   },

--- a/examples/vue/header-groups/src/index.css
+++ b/examples/vue/header-groups/src/index.css
@@ -363,3 +363,15 @@ tfoot th {
   font-size: 1.875rem;
   font-weight: 700;
 }
+
+/* Lays the header group examples side by side when the viewport allows it. */
+.example-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem 1.5rem;
+}
+
+.example-panel {
+  flex: 0 1 auto;
+}

--- a/examples/vue/header-groups/tests/e2e/smoke.spec.ts
+++ b/examples/vue/header-groups/tests/e2e/smoke.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { expect, test } from '@playwright/test'
 import { startExampleServer } from '../../../../../tests/e2e/helpers/startExampleServer'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 const exampleDir = path.resolve()
 
@@ -70,36 +70,74 @@ async function openExample(page: Page) {
   return errors
 }
 
-function headerRow(page: Page, index: number) {
-  return page.locator('thead tr').nth(index).locator('th')
+// The example renders four tables: an even tree with no placeholders, an even
+// tree of nested groups, an uneven tree that keeps placeholder headers as
+// empty cells, and an uneven tree that merges headers vertically via
+// `header.rowSpan`.
+function basicTable(page: Page) {
+  return page.locator('table').nth(0)
 }
 
-function footerRow(page: Page, index: number) {
-  return page.locator('tfoot tr').nth(index).locator('th')
+function nestedTable(page: Page) {
+  return page.locator('table').nth(1)
 }
 
-async function readColSpans(page: Page, selector: string) {
-  return page
-    .locator(selector)
-    .evaluateAll((cells) =>
-      cells.map((cell) => Number(cell.getAttribute('colspan') ?? '1')),
+function placeholderTable(page: Page) {
+  return page.locator('table').nth(2)
+}
+
+function rowSpanTable(page: Page) {
+  return page.locator('table').nth(3)
+}
+
+function headerRow(table: Locator, index: number) {
+  return table.locator('thead tr').nth(index).locator('th')
+}
+
+function footerRow(table: Locator, index: number) {
+  return table.locator('tfoot tr').nth(index).locator('th')
+}
+
+async function readSpans(cells: Locator, attribute: 'colspan' | 'rowspan') {
+  return cells.evaluateAll((elements, attributeName) => {
+    return elements.map((element) =>
+      Number(element.getAttribute(attributeName) ?? '1'),
     )
+  }, attribute)
 }
 
-async function getFirstBodyRowText(page: Page) {
-  const text = await page.locator('tbody tr').first().textContent()
+async function getFirstBodyRowText(table: Locator) {
+  const text = await table.locator('tbody tr').first().textContent()
   return text?.replace(/\s+/g, ' ').trim() ?? ''
 }
 
-test('renders the table without crashing', async ({ page }) => {
+test('renders all four tables without crashing', async ({ page }) => {
   const errors = await openExample(page)
-  const table = page.locator('table').first()
 
-  await expect(table).toBeVisible()
-  await expect(page.locator('tbody tr')).toHaveCount(20)
-  await expect(page.locator('tbody tr').first().locator('td')).toHaveCount(
-    LEAF_HEADERS.length,
-  )
+  await expect(basicTable(page)).toBeVisible()
+  await expect(nestedTable(page)).toBeVisible()
+  await expect(placeholderTable(page)).toBeVisible()
+  await expect(rowSpanTable(page)).toBeVisible()
+
+  await expect(nestedTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    nestedTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(basicTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    basicTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    placeholderTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(LEAF_HEADERS.length)
+
+  await expect(rowSpanTable(page).locator('tbody tr')).toHaveCount(5)
+  await expect(
+    rowSpanTable(page).locator('tbody tr').first().locator('td'),
+  ).toHaveCount(5)
 
   expect(errors).toEqual([])
 })
@@ -110,49 +148,121 @@ test('regenerates table data', async ({ page }) => {
     name: /^Regenerate Data$/i,
   })
 
-  await expect(page.locator('tbody tr').first()).toBeVisible()
+  await expect(placeholderTable(page).locator('tbody tr').first()).toBeVisible()
 
-  const firstRowBefore = await getFirstBodyRowText(page)
+  const firstRowBefore = await getFirstBodyRowText(placeholderTable(page))
 
   await regenerateButton.click()
 
-  await expect.poll(() => getFirstBodyRowText(page)).not.toBe(firstRowBefore)
-  await expect(page.locator('tbody tr')).toHaveCount(20)
+  await expect
+    .poll(() => getFirstBodyRowText(placeholderTable(page)))
+    .not.toBe(firstRowBefore)
+  await expect(placeholderTable(page).locator('tbody tr')).toHaveCount(5)
+
+  expect(errors).toEqual([])
+})
+
+test('groups leaf headers evenly with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = basicTable(page)
+
+  // Every leaf column belongs to a top-level group, so the tree is even: two
+  // header rows and no empty placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(2)
+
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Stats', 'Profile'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 2, 2])
+  // An even tree never produces spanning chains, so every rowSpan is 1.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1, 1])
+
+  // Only the leaf columns declare footers and the render loop skips footer
+  // rows without content, so the group row never renders in the tfoot.
+  await expect(table.locator('tfoot tr')).toHaveCount(1)
+  await expect(footerRow(table, 0)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  expect(errors).toEqual([])
+})
+
+test('nests groups inside groups with no placeholders', async ({ page }) => {
+  const errors = await openExample(page)
+  const table = nestedTable(page)
+
+  // Groups inside groups, every leaf at the same depth: three header rows and
+  // still no placeholder cells.
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  await expect(headerRow(table, 0)).toHaveText(['Person', 'Activity'])
+  await expect(headerRow(table, 1)).toHaveText([
+    'Name',
+    'Demographics',
+    'Engagement',
+    'Progress',
+  ])
+  await expect(headerRow(table, 2)).toHaveText([
+    'First Name',
+    'Last Name',
+    'Age',
+    'Visits',
+    'Status',
+    'Profile Progress',
+  ])
+
+  // Each group spans the sum of its descendants.
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([3, 3])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([2, 1, 2, 1])
+  // An even tree never produces spanning chains.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([1, 1])
 
   expect(errors).toEqual([])
 })
 
 test('nests the header groups three rows deep', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Two top level groups, one of which nests a further group, so the deepest
   // leaf needs three header rows.
-  await expect(page.locator('thead tr')).toHaveCount(3)
+  await expect(table.locator('thead tr')).toHaveCount(3)
 
-  await expect(headerRow(page, 0)).toHaveText(['Name', 'Info'])
+  await expect(headerRow(table, 0)).toHaveText(['Name', 'Info'])
   // Row two is mostly placeholders for the columns that have no middle group.
-  await expect(headerRow(page, 1)).toHaveText(['', '', '', 'More Info'])
-  await expect(headerRow(page, 2)).toHaveText(LEAF_HEADERS)
+  await expect(headerRow(table, 1)).toHaveText(['', '', '', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(LEAF_HEADERS)
 
   expect(errors).toEqual([])
 })
 
 test('spans each group across the columns beneath it', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // `Hello` covers two leaves, `Info` covers the other four.
-  expect(await readColSpans(page, 'thead tr:nth-child(1) th')).toEqual([2, 4])
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([2, 4])
   // `More Info` covers the last three of `Info`'s four leaves.
-  expect(await readColSpans(page, 'thead tr:nth-child(2) th')).toEqual([
-    1, 1, 1, 3,
-  ])
-  expect(await readColSpans(page, 'thead tr:nth-child(3) th')).toEqual([
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 1, 1, 3])
+  expect(await readSpans(headerRow(table, 2), 'colspan')).toEqual([
     1, 1, 1, 1, 1, 1,
   ])
 
   // Every header row must cover the same total width as the body rows.
-  for (const row of [1, 2, 3]) {
-    const spans = await readColSpans(page, `thead tr:nth-child(${row}) th`)
+  for (const row of [0, 1, 2]) {
+    const spans = await readSpans(headerRow(table, row), 'colspan')
     expect(spans.reduce((total, span) => total + span, 0)).toBe(
       LEAF_HEADERS.length,
     )
@@ -163,15 +273,44 @@ test('spans each group across the columns beneath it', async ({ page }) => {
 
 test('mirrors the header groups in the footer', async ({ page }) => {
   const errors = await openExample(page)
+  const table = placeholderTable(page)
 
   // Footer groups are the header groups reversed, so leaves come first.
-  await expect(page.locator('tfoot tr')).toHaveCount(3)
-  await expect(footerRow(page, 0)).toHaveText(LEAF_FOOTERS)
+  await expect(table.locator('tfoot tr')).toHaveCount(3)
+  await expect(footerRow(table, 0)).toHaveText(LEAF_FOOTERS)
 
-  // Both groups declare a footer, and each still spans its own columns, which
-  // is what keeps the footer aligned with the body.
-  await expect(footerRow(page, 2)).toHaveText(['Name', 'Info'])
-  expect(await readColSpans(page, 'tfoot tr:nth-child(3) th')).toEqual([2, 4])
+  // Both groups declare a footer, and each still spans its own
+  // columns, which is what keeps the footer aligned with the body.
+  await expect(footerRow(table, 2)).toHaveText(['Name', 'Info'])
+  expect(await readSpans(footerRow(table, 2), 'colspan')).toEqual([2, 4])
+
+  expect(errors).toEqual([])
+})
+
+test('spans shallow leaf headers across rows in the second table', async ({
+  page,
+}) => {
+  const errors = await openExample(page)
+  const table = rowSpanTable(page)
+
+  await expect(table.locator('thead tr')).toHaveCount(3)
+
+  // Placeholder headers are skipped, so each row only renders real headers.
+  await expect(headerRow(table, 0)).toHaveText([
+    'Full Name',
+    'Info',
+    'Profile Progress',
+  ])
+  await expect(headerRow(table, 1)).toHaveText(['Age', 'More Info'])
+  await expect(headerRow(table, 2)).toHaveText(['Visits', 'Status'])
+
+  // Top-level leaves span all three rows, `Age` spans the bottom two.
+  expect(await readSpans(headerRow(table, 0), 'rowspan')).toEqual([3, 1, 3])
+  expect(await readSpans(headerRow(table, 1), 'rowspan')).toEqual([2, 1])
+  expect(await readSpans(headerRow(table, 2), 'rowspan')).toEqual([1, 1])
+
+  expect(await readSpans(headerRow(table, 0), 'colspan')).toEqual([1, 3, 1])
+  expect(await readSpans(headerRow(table, 1), 'colspan')).toEqual([1, 2])
 
   expect(errors).toEqual([])
 })

--- a/packages/ember-table/src/FlexRender.gts
+++ b/packages/ember-table/src/FlexRender.gts
@@ -167,7 +167,11 @@ export class FlexRenderHeader<
   @cached
   get result(): HeaderRenderResult<TFeatures, TData, TValue> {
     const header = this.args.header
-    if (header.isPlaceholder) return null
+    // Placeholder headers are not skipped here. Whether a placeholder renders
+    // is the template's decision: the usual pattern wraps this component in
+    // `{{#unless header.isPlaceholder}}`, but merging headers vertically with
+    // `header.rowSpan` requires the spanning placeholder to render its
+    // column's header content. This matches every other framework adapter.
     return flexRender(
       header.column.columnDef.header,
       header.getContext(),
@@ -238,7 +242,8 @@ export class FlexRenderFooter<
   @cached
   get result(): HeaderRenderResult<TFeatures, TData, TValue> {
     const footer = this.args.footer
-    if (footer.isPlaceholder) return null
+    // Placeholder footers are not skipped here; see `FlexRenderHeader`. The
+    // template decides, which matches every other framework adapter.
     return flexRender(
       footer.column.columnDef.footer,
       footer.getContext(),

--- a/packages/ember-table/tests/integration/flex-render.test.gts
+++ b/packages/ember-table/tests/integration/flex-render.test.gts
@@ -620,4 +620,87 @@ module('Integration | FlexRender', function (hooks) {
       .hasText('My Header', 'renders a string header')
     assert.dom('[data-test-header-badge]').exists('renders a component header')
   })
+
+  // Placeholder headers must render their column's header content. Skipping
+  // them is the template's job (`{{#unless header.isPlaceholder}}`), which is
+  // what makes `header.rowSpan` usable for merging header cells vertically.
+  // Every other framework adapter behaves this way.
+  test('renders placeholder headers instead of suppressing them', async (assert) => {
+    const unevenColumns: Array<ColumnDef<typeof stockFeatures, Person>> = [
+      {
+        id: 'shallow',
+        accessorKey: 'firstName',
+        header: 'Shallow',
+      },
+      {
+        id: 'group',
+        header: 'Group',
+        columns: [
+          {
+            id: 'deep',
+            accessorKey: 'firstName',
+            header: 'Deep',
+          },
+        ],
+      },
+    ]
+
+    class TableComponent extends Component {
+      table = useTable(() => ({
+        data: defaultData,
+        features: stockFeatures,
+        columns: unevenColumns,
+      }))
+
+      get headerGroups() {
+        return this.table.getHeaderGroups()
+      }
+
+      <template>
+        <table>
+          <thead>
+            {{#each this.headerGroups as |headerGroup|}}
+              <tr data-test-row={{headerGroup.depth}}>
+                {{#each headerGroup.headers as |header|}}
+                  <th
+                    data-test-cell='{{headerGroup.depth}}-{{header.column.id}}'
+                    data-test-placeholder={{header.isPlaceholder}}
+                  ><FlexRenderHeader @header={{header}} /></th>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </thead>
+        </table>
+      </template>
+    }
+
+    await render(<template><TableComponent /></template>)
+
+    // `shallow` is a leaf one level above the deepest leaf, so the top row
+    // holds its spanning placeholder.
+    // Glimmer serializes a `true` attribute value as an empty string, so
+    // assert presence rather than value.
+    assert
+      .dom('[data-test-cell="0-shallow"]')
+      .hasAttribute(
+        'data-test-placeholder',
+        '',
+        'the top cell is a placeholder',
+      )
+    assert
+      .dom('[data-test-cell="0-group"]')
+      .doesNotHaveAttribute(
+        'data-test-placeholder',
+        'the group header is not a placeholder',
+      )
+    assert
+      .dom('[data-test-cell="0-shallow"]')
+      .hasText('Shallow', 'the placeholder still renders its column header')
+    assert
+      .dom('[data-test-cell="0-group"]')
+      .hasText('Group', 'real group headers are unaffected')
+    assert
+      .dom('[data-test-cell="1-deep"]')
+      .hasText('Deep', 'leaf headers are unaffected')
+  })
 })

--- a/packages/table-core/src/core/headers/buildHeaderGroups.ts
+++ b/packages/table-core/src/core/headers/buildHeaderGroups.ts
@@ -175,7 +175,6 @@ function updateHeaderSpans<
     }
 
     let colSpan = 0
-    let minChildRowSpan = Infinity
 
     if (header.subHeaders.length) {
       updateHeaderSpans(header.subHeaders)
@@ -189,17 +188,42 @@ function updateHeaderSpans<
         }
 
         colSpan += child.colSpan
-        if (child.rowSpan < minChildRowSpan) {
-          minChildRowSpan = child.rowSpan
-        }
       }
     } else {
       colSpan = 1
-      minChildRowSpan = 0
     }
 
     header.colSpan = colSpan
-    header.rowSpan = minChildRowSpan
+
+    // A shallow leaf column produces a chain of same-column headers: the
+    // placeholder at the column's own depth, more placeholders below it, and
+    // the real leaf header in the bottom row. The top of the chain carries the
+    // full rowSpan and renders the column's header content when merging
+    // vertically; every header it covers gets a rowSpan of 0 so rowSpan-aware
+    // renderers can skip it. All other headers span a single row.
+    if (
+      header.isPlaceholder &&
+      header.subHeaders.length === 1 &&
+      header.subHeaders[0]!.column === header.column
+    ) {
+      let rowSpan = 1
+      let chainChild: Header<TFeatures, TData, TValue> | undefined =
+        header.subHeaders[0]
+      while (chainChild) {
+        chainChild.rowSpan = 0
+        rowSpan++
+        chainChild =
+          chainChild.subHeaders.length === 1 &&
+          chainChild.subHeaders[0]!.column === header.column
+            ? chainChild.subHeaders[0]
+            : undefined
+      }
+      header.rowSpan = rowSpan
+    } else {
+      // Chain members are visited before their chain top, so this default is
+      // overwritten with 0 when the chain top claims them.
+      header.rowSpan = 1
+    }
   }
 }
 

--- a/packages/table-core/src/core/headers/coreHeadersFeature.types.ts
+++ b/packages/table-core/src/core/headers/coreHeadersFeature.types.ts
@@ -78,7 +78,11 @@ export interface Header_CoreProperties<
    */
   index: number
   /**
-   * A boolean denoting if the header is a placeholder header.
+   * A boolean denoting if the header is a placeholder header. Placeholder
+   * headers fill the rows above a shallow leaf column's real header so that
+   * every header group row accounts for every visible column. Render them as
+   * empty cells, or use `header.rowSpan` to merge each chain of placeholders
+   * into one vertically spanning header cell.
    */
   isPlaceholder: boolean
   /**
@@ -86,7 +90,15 @@ export interface Header_CoreProperties<
    */
   placeholderId?: string
   /**
-   * The row-span for the header.
+   * The number of header group rows the header should span when merging header
+   * cells vertically. A leaf column that is shallower than the deepest leaf
+   * column produces a chain of placeholder headers above its real header; the
+   * placeholder at the top of the chain reports the chain's full span, and
+   * every header it covers (including the real leaf header in the bottom row)
+   * reports 0. To merge vertically, skip headers with a rowSpan of 0 and
+   * render every other header with the `rowSpan` attribute and its column's
+   * header content, even when it is a placeholder. Headers in even column
+   * trees always report 1.
    */
   rowSpan: number
   /**

--- a/packages/table-core/src/flex-render.ts
+++ b/packages/table-core/src/flex-render.ts
@@ -49,9 +49,40 @@ export function FlexRender<
   TValue extends CellData = CellData,
 >(props: FlexRenderProps<TFeatures, TData, TValue>): unknown | null {
   if ('cell' in props && props.cell) {
-    return flexRender(props.cell.column.columnDef.cell, props.cell.getContext())
+    const cell = props.cell
+    const def = cell.column.columnDef
+    // When the column-grouping feature is registered, a cell can be in one of
+    // three special modes that should not render `columnDef.cell` directly:
+    //   - aggregated: render `columnDef.aggregatedCell` (falling back to
+    //     `columnDef.cell` if the column did not define one)
+    //   - placeholder: a duplicate value within a group — render nothing
+    //   - grouped: the group header cell — fall through to `columnDef.cell`;
+    //     consumers that want a custom group header typically branch on
+    //     `cell.getIsGrouped()` themselves first
+    // The optional-chaining + cast keeps this safe when the grouping feature
+    // is not registered (the methods are absent at the type level then).
+    const groupingCell = cell as typeof cell & {
+      getIsAggregated?: () => boolean
+      getIsPlaceholder?: () => boolean
+    }
+    const groupingDef = def as typeof def & {
+      aggregatedCell?: typeof def.cell
+    }
+    if (groupingCell.getIsAggregated?.()) {
+      return flexRender(
+        groupingDef.aggregatedCell ?? def.cell,
+        cell.getContext(),
+      )
+    }
+    if (groupingCell.getIsPlaceholder?.()) {
+      return null
+    }
+    return flexRender(def.cell, cell.getContext())
   }
 
+  // Placeholder headers and footers are not skipped here. Whether a
+  // placeholder renders is the caller's decision, which is what makes
+  // `header.rowSpan` usable for merging header cells vertically.
   if ('header' in props && props.header) {
     return flexRender(
       props.header.column.columnDef.header,

--- a/packages/table-core/tests/unit/core/headers/coreHeadersFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/core/headers/coreHeadersFeature.utils.test.ts
@@ -131,8 +131,9 @@ describe('table_getHeaderGroups', () => {
         header.rowSpan,
       ]),
     ).toEqual([
-      ['a', 1, 0],
-      ['b', 1, 0],
+      ['a', 1, 1],
+      ['b', 1, 1],
+      // c is covered by the spanning placeholder in the row above it.
       ['c', 1, 0],
     ])
 
@@ -149,6 +150,152 @@ describe('table_getHeaderGroups', () => {
     expect(
       hiddenHeaderGroups[2]!.headers.map((header) => header.column.id),
     ).toEqual(['a', 'c'])
+  })
+})
+
+describe('header rowSpan for uneven column trees', () => {
+  it('should give the top placeholder of a chain the full span and cover the leaf', () => {
+    // group[a, b] is two levels deep while c is a top-level leaf, so c gets a
+    // placeholder above its real header. The placeholder carries the rowSpan
+    // and the covered real header reports 0 so renderers can skip it.
+    const table = makeTable()
+    const headerGroups = table_getHeaderGroups(table)
+
+    expect(headerGroups).toHaveLength(2)
+
+    const topRow = headerGroups[0]!.headers
+    expect(
+      topRow.map((header) => [
+        header.column.id,
+        header.isPlaceholder,
+        header.colSpan,
+        header.rowSpan,
+      ]),
+    ).toEqual([
+      ['group', false, 2, 1],
+      ['c', true, 1, 2],
+    ])
+
+    const leafRow = headerGroups[1]!.headers
+    expect(
+      leafRow.map((header) => [
+        header.id,
+        header.column.id,
+        header.isPlaceholder,
+        header.colSpan,
+        header.rowSpan,
+      ]),
+    ).toEqual([
+      ['a', 'a', false, 1, 1],
+      ['b', 'b', false, 1, 1],
+      // The real leaf header stays in the bottom row with its plain column id,
+      // covered by the spanning placeholder above it.
+      ['c', 'c', false, 1, 0],
+    ])
+  })
+
+  it('should give every rowSpan length in a three-level mixed tree', () => {
+    const mixedColumns: Array<ColumnDef<typeof features, Item, any>> = [
+      { accessorKey: 'a', id: 'a' },
+      {
+        id: 'group',
+        header: 'Group',
+        columns: [
+          { accessorKey: 'b', id: 'b' },
+          {
+            id: 'nested',
+            header: 'Nested',
+            columns: [{ accessorKey: 'c', id: 'c' }],
+          },
+        ],
+      },
+    ]
+    const table = constructTable<typeof features, Item>({
+      features,
+      columns: mixedColumns,
+      data,
+    })
+    const headerGroups = table_getHeaderGroups(table)
+
+    expect(headerGroups).toHaveLength(3)
+
+    const spansByRow = headerGroups.map((headerGroup) =>
+      headerGroup.headers.map((header) => [
+        header.column.id,
+        header.isPlaceholder,
+        header.rowSpan,
+      ]),
+    )
+    expect(spansByRow).toEqual([
+      [
+        // a spans all three rows from its top placeholder.
+        ['a', true, 3],
+        ['group', false, 1],
+      ],
+      [
+        ['a', true, 0],
+        // b spans the bottom two rows from its own top placeholder.
+        ['b', true, 2],
+        ['nested', false, 1],
+      ],
+      [
+        ['a', false, 0],
+        ['b', false, 0],
+        ['c', false, 1],
+      ],
+    ])
+
+    // Every row still covers the full leaf width.
+    for (const headerGroup of headerGroups) {
+      const totalColSpan = headerGroup.headers.reduce(
+        (total, header) => total + header.colSpan,
+        0,
+      )
+      expect(totalColSpan).toBe(3)
+    }
+  })
+
+  it('should shrink rowSpans when hiding columns flattens the tree', () => {
+    // Hiding both leaves of the group removes the second header row entirely,
+    // so c no longer needs a spanning placeholder.
+    const table = makeTable({
+      initialState: { columnVisibility: { a: false, b: false } },
+    })
+    const headerGroups = table_getHeaderGroups(table)
+
+    expect(headerGroups).toHaveLength(1)
+    expect(
+      headerGroups[0]!.headers.map((header) => [
+        header.column.id,
+        header.isPlaceholder,
+        header.rowSpan,
+      ]),
+    ).toEqual([['c', false, 1]])
+  })
+
+  it('should keep rowSpans consistent through the pin partitioning path', () => {
+    const table = makeTable({
+      initialState: { columnPinning: { start: ['c'], end: [] } },
+    })
+    const headerGroups = table_getHeaderGroups(table)
+
+    const spanningPlaceholder = headerGroups[0]!.headers.find(
+      (header) => header.column.id === 'c',
+    )!
+    expect(spanningPlaceholder.isPlaceholder).toBe(true)
+    expect(spanningPlaceholder.rowSpan).toBe(2)
+
+    expect(
+      headerGroups[1]!.headers.map((header) => [
+        header.column.id,
+        header.isPlaceholder,
+        header.rowSpan,
+      ]),
+    ).toEqual([
+      ['c', false, 0],
+      ['a', false, 1],
+      ['b', false, 1],
+    ])
   })
 })
 

--- a/packages/table-core/tests/unit/flex-render.test.ts
+++ b/packages/table-core/tests/unit/flex-render.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+import {
+  aggregationFns,
+  columnGroupingFeature,
+  constructTable,
+  createGroupedRowModel,
+  rowAggregationFeature,
+} from '../../src'
+import { FlexRender, flexRender } from '../../src/flex-render'
+import { testFeatures } from '../fixtures/features'
+import type { ColumnDef } from '../../src'
+
+type Person = {
+  id: string
+  region: string
+  team: string
+  amount: number
+}
+
+const data: Array<Person> = [
+  { id: '1', region: 'Europe', team: 'Blue', amount: 1 },
+  { id: '2', region: 'Europe', team: 'Green', amount: 2 },
+]
+
+describe('flexRender', () => {
+  it('should return null for nullish templates', () => {
+    expect(flexRender(null, {})).toBeNull()
+    expect(flexRender(undefined, {})).toBeNull()
+  })
+
+  it('should call function templates with the props and pass through values', () => {
+    expect(
+      flexRender((props: { value: string }) => props.value, {
+        value: 'called',
+      }),
+    ).toBe('called')
+    expect(flexRender('static', {})).toBe('static')
+    // Falsey non-nullish values still render.
+    expect(flexRender(0, {})).toBe(0)
+  })
+})
+
+describe('FlexRender', () => {
+  const features = testFeatures({})
+
+  const unevenColumns: Array<ColumnDef<typeof features, Person, any>> = [
+    { id: 'shallow', accessorKey: 'region', header: 'Shallow' },
+    {
+      id: 'group',
+      header: 'Group',
+      columns: [{ id: 'deep', accessorKey: 'team', header: 'Deep' }],
+    },
+  ]
+
+  function makeUnevenTable() {
+    return constructTable({ features, columns: unevenColumns, data })
+  }
+
+  it('should render header and footer templates', () => {
+    const table = constructTable({
+      features,
+      data,
+      columns: [
+        {
+          id: 'region',
+          accessorKey: 'region',
+          header: 'Region',
+          footer: 'Sum',
+        },
+      ],
+    })
+    const header = table.getHeaderGroups()[0]!.headers[0]!
+
+    expect(FlexRender({ header })).toBe('Region')
+    expect(FlexRender({ footer: header })).toBe('Sum')
+  })
+
+  // Skipping placeholders is the caller's decision, which is what makes
+  // `header.rowSpan` usable for merging header cells vertically. Every
+  // framework adapter behaves this way.
+  it('should render a placeholder header instead of suppressing it', () => {
+    const headerGroups = makeUnevenTable().getHeaderGroups()
+    const topRow = headerGroups[0]!.headers
+    const spanningHeader = topRow.find(
+      (header) => header.column.id === 'shallow',
+    )!
+
+    expect(spanningHeader.isPlaceholder).toBe(true)
+    expect(spanningHeader.rowSpan).toBe(2)
+    expect(FlexRender({ header: spanningHeader })).toBe('Shallow')
+
+    // The real leaf header it covers still renders too; the template decides
+    // which of the two to skip.
+    const coveredHeader = headerGroups[1]!.headers.find(
+      (header) => header.column.id === 'shallow',
+    )!
+    expect(coveredHeader.rowSpan).toBe(0)
+    expect(FlexRender({ header: coveredHeader })).toBe('Shallow')
+  })
+
+  it('should render a placeholder footer instead of suppressing it', () => {
+    const table = constructTable({
+      features,
+      data,
+      columns: [
+        { id: 'shallow', accessorKey: 'region', footer: 'Shallow Footer' },
+        {
+          id: 'group',
+          header: 'Group',
+          columns: [{ id: 'deep', accessorKey: 'team' }],
+        },
+      ],
+    })
+    const spanningFooter = table
+      .getFooterGroups()
+      .flatMap((footerGroup) => footerGroup.headers)
+      .find((header) => header.column.id === 'shallow' && header.isPlaceholder)!
+
+    expect(FlexRender({ footer: spanningFooter })).toBe('Shallow Footer')
+  })
+
+  it('should return null when no cell, header, or footer is passed', () => {
+    expect(FlexRender({} as any)).toBeNull()
+  })
+})
+
+describe('FlexRender with the column grouping feature', () => {
+  const groupingFeatures = testFeatures({
+    aggregationFns,
+    columnGroupingFeature,
+    groupedRowModel: createGroupedRowModel(),
+    rowAggregationFeature,
+  })
+
+  const groupingColumns: Array<
+    ColumnDef<typeof groupingFeatures, Person, any>
+  > = [
+    {
+      id: 'region',
+      accessorKey: 'region',
+      cell: (context) => `Region ${String(context.getValue())}`,
+    },
+    {
+      id: 'team',
+      accessorKey: 'team',
+      cell: (context) => `Team ${String(context.getValue())}`,
+    },
+    {
+      id: 'amount',
+      accessorKey: 'amount',
+      aggregationFn: 'sum',
+      cell: (context) => `Amount ${String(context.getValue())}`,
+      aggregatedCell: (context) => `Total ${String(context.getValue())}`,
+    },
+  ]
+
+  function makeGroupedTable() {
+    return constructTable({
+      features: groupingFeatures,
+      columns: groupingColumns,
+      data,
+      initialState: { grouping: ['region', 'team'] },
+    })
+  }
+
+  // These three modes match every framework adapter's FlexRender.
+  it('should render aggregated cells with aggregatedCell', () => {
+    const row = makeGroupedTable().getRowModel().rows[0]!
+    const cell = row.getAllCells().find((c) => c.column.id === 'amount')!
+
+    expect(cell.getIsAggregated()).toBe(true)
+    expect(FlexRender({ cell })).toBe('Total 3')
+  })
+
+  it('should render nothing for grouping placeholder cells', () => {
+    const row = makeGroupedTable().getRowModel().rows[0]!
+    const cell = row.getAllCells().find((c) => c.column.id === 'team')!
+
+    expect(cell.getIsPlaceholder()).toBe(true)
+    expect(FlexRender({ cell })).toBeNull()
+  })
+
+  it('should render the active grouping cell with its own cell template', () => {
+    const row = makeGroupedTable().getRowModel().rows[0]!
+    const cell = row.getAllCells().find((c) => c.column.id === 'region')!
+
+    expect(cell.getIsGrouped()).toBe(true)
+    expect(FlexRender({ cell })).toBe('Region Europe')
+  })
+
+  // `rowAggregationFeature` supplies a default `aggregatedCell`, so a column
+  // that declares none still renders the formatted aggregate rather than
+  // falling through to its `cell` template.
+  it('should use the feature default when a column defines no aggregatedCell', () => {
+    const table = constructTable({
+      features: groupingFeatures,
+      data,
+      columns: [
+        { id: 'region', accessorKey: 'region' },
+        {
+          id: 'amount',
+          accessorKey: 'amount',
+          aggregationFn: 'sum',
+          cell: (context) => `Amount ${String(context.getValue())}`,
+        },
+      ],
+      initialState: { grouping: ['region'] },
+    })
+    const row = table.getRowModel().rows[0]!
+    const cell = row.getAllCells().find((c) => c.column.id === 'amount')!
+
+    expect(cell.getIsAggregated()).toBe(true)
+    expect(FlexRender({ cell })).toBe('3')
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm test:pr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved grouped table headers with correct vertical spanning, including nested and uneven header structures.
  * Placeholder headers now preserve their configured content while rendering appropriately.
  * Expanded header-group examples across supported frameworks with responsive layouts and four demonstrated configurations.

* **Bug Fixes**
  * Improved grouped and aggregated cell rendering, including fallback behavior.
  * Enhanced header rendering reliability during column pinning, visibility changes, and reordering.

* **Documentation**
  * Added guidance and a recipe for header row spanning and placeholder-header behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->