### PR TITLE
feat: add opt-in sorting auto-reset

### DIFF
--- a/docs/framework/alpine/guide/sorting.md
+++ b/docs/framework/alpine/guide/sorting.md
@@ -580,6 +580,14 @@ Because Alpine does not initialize directives inside content set with `x-html`, 
 </th>
 ```
 
+### Reset Sorting When Data Changes
+
+Sorting state is preserved when the `data` option changes by default. Set `autoResetSorting: true` to reset sorting whenever a new data reference is processed. The reset restores `initialState.sorting`, or an empty sorting state when no initial value was provided.
+
+This option responds only to data changes. Changing sorting, filters, or grouping does not trigger it. The global `autoResetAll` option overrides `autoResetSorting` when explicitly set.
+
+Be careful when combining this option with manual/server-side sorting: a server response normally replaces `data`, so enabling the reset can immediately clear the sorting state that requested that response.
+
 ### Sorting APIs
 
 There are a lot of sorting related APIs that you can use to hook up to your UI or other logic. Here is a list of all of the sorting APIs and some of their use-cases.

--- a/docs/framework/angular/guide/sorting.md
+++ b/docs/framework/angular/guide/sorting.md
@@ -542,6 +542,14 @@ readonly table = injectTable(() => ({
 }))
 ```
 
+### Reset Sorting When Data Changes
+
+Sorting state is preserved when the `data` option changes by default. Set `autoResetSorting: true` to reset sorting whenever a new data reference is processed. The reset restores `initialState.sorting`, or an empty sorting state when no initial value was provided.
+
+This option responds only to data changes. Changing sorting, filters, or grouping does not trigger it. The global `autoResetAll` option overrides `autoResetSorting` when explicitly set.
+
+Be careful when combining this option with manual/server-side sorting: a server response normally replaces `data`, so enabling the reset can immediately clear the sorting state that requested that response.
+
 ### Sorting APIs
 
 There are a lot of sorting related APIs that you can use to hook up to your UI or other logic. Here is a list of all of the sorting APIs and some of their use-cases.

--- a/docs/framework/ember/guide/sorting.md
+++ b/docs/framework/ember/guide/sorting.md
@@ -532,6 +532,14 @@ table = useTable(() => ({
 }))
 ```
 
+### Reset Sorting When Data Changes
+
+Sorting state is preserved when the `data` option changes by default. Set `autoResetSorting: true` to reset sorting whenever a new data reference is processed. The reset restores `initialState.sorting`, or an empty sorting state when no initial value was provided.
+
+This option responds only to data changes. Changing sorting, filters, or grouping does not trigger it. The global `autoResetAll` option overrides `autoResetSorting` when explicitly set.
+
+Be careful when combining this option with manual/server-side sorting: a server response normally replaces `data`, so enabling the reset can immediately clear the sorting state that requested that response.
+
 ### Sorting APIs
 
 There are a lot of sorting related APIs that you can use to hook up to your UI or other logic. Here is a list of all of the sorting APIs and some of their use-cases.

--- a/docs/framework/lit/guide/sorting.md
+++ b/docs/framework/lit/guide/sorting.md
@@ -559,6 +559,14 @@ const table = this.tableController.table({
 })
 ```
 
+### Reset Sorting When Data Changes
+
+Sorting state is preserved when the `data` option changes by default. Set `autoResetSorting: true` to reset sorting whenever a new data reference is processed. The reset restores `initialState.sorting`, or an empty sorting state when no initial value was provided.
+
+This option responds only to data changes. Changing sorting, filters, or grouping does not trigger it. The global `autoResetAll` option overrides `autoResetSorting` when explicitly set.
+
+Be careful when combining this option with manual/server-side sorting: a server response normally replaces `data`, so enabling the reset can immediately clear the sorting state that requested that response.
+
 ### Sorting APIs
 
 There are a lot of sorting related APIs that you can use to hook up to your UI or other logic. Here is a list of all of the sorting APIs and some of their use-cases.

--- a/docs/framework/octane/guide/sorting.md
+++ b/docs/framework/octane/guide/sorting.md
@@ -535,6 +535,14 @@ const table = useTable({
 })
 ```
 
+### Reset Sorting When Data Changes
+
+Sorting state is preserved when the `data` option changes by default. Set `autoResetSorting: true` to reset sorting whenever a new data reference is processed. The reset restores `initialState.sorting`, or an empty sorting state when no initial value was provided.
+
+This option responds only to data changes. Changing sorting, filters, or grouping does not trigger it. The global `autoResetAll` option overrides `autoResetSorting` when explicitly set.
+
+Be careful when combining this option with manual/server-side sorting: a server response normally replaces `data`, so enabling the reset can immediately clear the sorting state that requested that response.
+
 ### Sorting APIs
 
 There are a lot of sorting related APIs that you can use to hook up to your UI or other logic. Here is a list of all of the sorting APIs and some of their use-cases.

--- a/docs/framework/preact/guide/sorting.md
+++ b/docs/framework/preact/guide/sorting.md
@@ -535,6 +535,14 @@ const table = useTable({
 })
 ```
 
+### Reset Sorting When Data Changes
+
+Sorting state is preserved when the `data` option changes by default. Set `autoResetSorting: true` to reset sorting whenever a new data reference is processed. The reset restores `initialState.sorting`, or an empty sorting state when no initial value was provided.
+
+This option responds only to data changes. Changing sorting, filters, or grouping does not trigger it. The global `autoResetAll` option overrides `autoResetSorting` when explicitly set.
+
+Be careful when combining this option with manual/server-side sorting: a server response normally replaces `data`, so enabling the reset can immediately clear the sorting state that requested that response.
+
 ### Sorting APIs
 
 There are a lot of sorting related APIs that you can use to hook up to your UI or other logic. Here is a list of all of the sorting APIs and some of their use-cases.

--- a/docs/framework/react/guide/sorting.md
+++ b/docs/framework/react/guide/sorting.md
@@ -535,6 +535,14 @@ const table = useTable({
 })
 ```
 
+### Reset Sorting When Data Changes
+
+Sorting state is preserved when the `data` option changes by default. Set `autoResetSorting: true` to reset sorting whenever a new data reference is processed. The reset restores `initialState.sorting`, or an empty sorting state when no initial value was provided.
+
+This option responds only to data changes. Changing sorting, filters, or grouping does not trigger it. The global `autoResetAll` option overrides `autoResetSorting` when explicitly set.
+
+Be careful when combining this option with manual/server-side sorting: a server response normally replaces `data`, so enabling the reset can immediately clear the sorting state that requested that response.
+
 ### Sorting APIs
 
 There are a lot of sorting related APIs that you can use to hook up to your UI or other logic. Here is a list of all of the sorting APIs and some of their use-cases.

--- a/docs/framework/solid/guide/sorting.md
+++ b/docs/framework/solid/guide/sorting.md
@@ -534,6 +534,14 @@ const table = createTable({
 })
 ```
 
+### Reset Sorting When Data Changes
+
+Sorting state is preserved when the `data` option changes by default. Set `autoResetSorting: true` to reset sorting whenever a new data reference is processed. The reset restores `initialState.sorting`, or an empty sorting state when no initial value was provided.
+
+This option responds only to data changes. Changing sorting, filters, or grouping does not trigger it. The global `autoResetAll` option overrides `autoResetSorting` when explicitly set.
+
+Be careful when combining this option with manual/server-side sorting: a server response normally replaces `data`, so enabling the reset can immediately clear the sorting state that requested that response.
+
 ### Sorting APIs
 
 There are a lot of sorting related APIs that you can use to hook up to your UI or other logic. Here is a list of all of the sorting APIs and some of their use-cases.

--- a/docs/framework/svelte/guide/sorting.md
+++ b/docs/framework/svelte/guide/sorting.md
@@ -553,6 +553,14 @@ const table = createTable({
 })
 ```
 
+### Reset Sorting When Data Changes
+
+Sorting state is preserved when the `data` option changes by default. Set `autoResetSorting: true` to reset sorting whenever a new data reference is processed. The reset restores `initialState.sorting`, or an empty sorting state when no initial value was provided.
+
+This option responds only to data changes. Changing sorting, filters, or grouping does not trigger it. The global `autoResetAll` option overrides `autoResetSorting` when explicitly set.
+
+Be careful when combining this option with manual/server-side sorting: a server response normally replaces `data`, so enabling the reset can immediately clear the sorting state that requested that response.
+
 ### Sorting APIs
 
 There are a lot of sorting related APIs that you can use to hook up to your UI or other logic. Here is a list of all of the sorting APIs and some of their use-cases.

--- a/docs/framework/vue/guide/sorting.md
+++ b/docs/framework/vue/guide/sorting.md
@@ -542,6 +542,14 @@ const table = useTable({
 })
 ```
 
+### Reset Sorting When Data Changes
+
+Sorting state is preserved when the `data` option changes by default. Set `autoResetSorting: true` to reset sorting whenever a new data reference is processed. The reset restores `initialState.sorting`, or an empty sorting state when no initial value was provided.
+
+This option responds only to data changes. Changing sorting, filters, or grouping does not trigger it. The global `autoResetAll` option overrides `autoResetSorting` when explicitly set.
+
+Be careful when combining this option with manual/server-side sorting: a server response normally replaces `data`, so enabling the reset can immediately clear the sorting state that requested that response.
+
 ### Sorting APIs
 
 There are a lot of sorting related APIs that you can use to hook up to your UI or other logic. Here is a list of all of the sorting APIs and some of their use-cases.

--- a/docs/reference/index/interfaces/TableOptions_RowSorting.md
+++ b/docs/reference/index/interfaces/TableOptions_RowSorting.md
@@ -9,13 +9,28 @@ Defined in: [features/row-sorting/rowSortingFeature.types.ts:210](https://github
 
 ## Properties
 
+### autoResetSorting?
+
+```ts
+optional autoResetSorting: boolean;
+```
+
+Defined in: [features/row-sorting/rowSortingFeature.types.ts:217](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L217)
+
+Resets sorting to its initial state when the `data` option changes.
+
+This is disabled by default. `autoResetAll` overrides this option when it
+is explicitly set.
+
+***
+
 ### enableMultiRemove?
 
 ```ts
 optional enableMultiRemove: boolean;
 ```
 
-Defined in: [features/row-sorting/rowSortingFeature.types.ts:214](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L214)
+Defined in: [features/row-sorting/rowSortingFeature.types.ts:221](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L221)
 
 Allows multi-sort toggles to remove a column from sorting state.
 
@@ -27,7 +42,7 @@ Allows multi-sort toggles to remove a column from sorting state.
 optional enableMultiSort: boolean;
 ```
 
-Defined in: [features/row-sorting/rowSortingFeature.types.ts:218](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L218)
+Defined in: [features/row-sorting/rowSortingFeature.types.ts:225](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L225)
 
 Enables/Disables multi-sorting for the table.
 
@@ -39,7 +54,7 @@ Enables/Disables multi-sorting for the table.
 optional enableSorting: boolean;
 ```
 
-Defined in: [features/row-sorting/rowSortingFeature.types.ts:222](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L222)
+Defined in: [features/row-sorting/rowSortingFeature.types.ts:229](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L229)
 
 Enables/Disables sorting for the table.
 
@@ -51,7 +66,7 @@ Enables/Disables sorting for the table.
 optional enableSortingRemoval: boolean;
 ```
 
-Defined in: [features/row-sorting/rowSortingFeature.types.ts:228](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L228)
+Defined in: [features/row-sorting/rowSortingFeature.types.ts:235](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L235)
 
 Enables/Disables the ability to remove sorting for the table.
 - If `true` then changing sort order will circle like: 'none' -> 'desc' -> 'asc' -> 'none' -> ...
@@ -65,7 +80,7 @@ Enables/Disables the ability to remove sorting for the table.
 optional isMultiSortEvent: (e) => boolean;
 ```
 
-Defined in: [features/row-sorting/rowSortingFeature.types.ts:232](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L232)
+Defined in: [features/row-sorting/rowSortingFeature.types.ts:239](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L239)
 
 Pass a custom function that will be used to determine if a multi-sort event should be triggered. It is passed the event from the sort toggle handler and should return `true` if the event should trigger a multi-sort.
 
@@ -87,7 +102,7 @@ Pass a custom function that will be used to determine if a multi-sort event shou
 optional manualSorting: boolean;
 ```
 
-Defined in: [features/row-sorting/rowSortingFeature.types.ts:236](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L236)
+Defined in: [features/row-sorting/rowSortingFeature.types.ts:243](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L243)
 
 Enables manual sorting for the table. If this is `true`, you will be expected to sort your data before it is passed to the table. This is useful if you are doing server-side sorting.
 
@@ -99,7 +114,7 @@ Enables manual sorting for the table. If this is `true`, you will be expected to
 optional maxMultiSortColCount: number;
 ```
 
-Defined in: [features/row-sorting/rowSortingFeature.types.ts:240](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L240)
+Defined in: [features/row-sorting/rowSortingFeature.types.ts:247](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L247)
 
 Set a maximum number of columns that can be multi-sorted.
 
@@ -111,7 +126,7 @@ Set a maximum number of columns that can be multi-sorted.
 optional onSortingChange: OnChangeFn<SortingState>;
 ```
 
-Defined in: [features/row-sorting/rowSortingFeature.types.ts:246](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L246)
+Defined in: [features/row-sorting/rowSortingFeature.types.ts:253](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L253)
 
 Called with an updater when sorting state changes. Pair this with
 `state.sorting` when using external state; external atoms can own the slice
@@ -125,6 +140,6 @@ without this callback.
 optional sortDescFirst: boolean;
 ```
 
-Defined in: [features/row-sorting/rowSortingFeature.types.ts:250](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L250)
+Defined in: [features/row-sorting/rowSortingFeature.types.ts:257](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts#L257)
 
 If `true`, all sorts will default to descending as their first toggle state.

--- a/docs/reference/static-functions/functions/table_autoResetSorting.md
+++ b/docs/reference/static-functions/functions/table_autoResetSorting.md
@@ -1,0 +1,43 @@
+---
+id: table_autoResetSorting
+title: table_autoResetSorting
+---
+
+# Function: table\_autoResetSorting()
+
+```ts
+function table_autoResetSorting<TFeatures, TData>(table): void;
+```
+
+Defined in: [features/row-sorting/rowSortingFeature.utils.ts:81](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-sorting/rowSortingFeature.utils.ts#L81)
+
+Resets sorting after the table data changes when explicitly enabled.
+
+Unlike other auto-reset behaviors, sorting is preserved by default. An
+explicit `autoResetAll` value takes precedence over `autoResetSorting`.
+
+## Type Parameters
+
+### TFeatures
+
+`TFeatures` *extends* [`TableFeatures`](../../index/interfaces/TableFeatures.md)
+
+### TData
+
+`TData` *extends* [`RowData`](../../index/type-aliases/RowData.md)
+
+## Parameters
+
+### table
+
+[`Table_Internal`](../../index/interfaces/Table_Internal.md)\<`TFeatures`, `TData`\>
+
+## Returns
+
+`void`
+
+## Example
+
+```ts
+table_autoResetSorting(table)
+```

--- a/docs/reference/static-functions/index.md
+++ b/docs/reference/static-functions/index.md
@@ -136,6 +136,7 @@ title: static-functions
 - [table\_autoResetCellSelection](functions/table_autoResetCellSelection.md)
 - [table\_autoResetExpanded](functions/table_autoResetExpanded.md)
 - [table\_autoResetPageIndex](functions/table_autoResetPageIndex.md)
+- [table\_autoResetSorting](functions/table_autoResetSorting.md)
 - [table\_extendCellSelection](functions/table_extendCellSelection.md)
 - [table\_firstPage](functions/table_firstPage.md)
 - [table\_getAllColumns](functions/table_getAllColumns.md)

--- a/packages/table-core/src/core/row-models/createCoreRowModel.ts
+++ b/packages/table-core/src/core/row-models/createCoreRowModel.ts
@@ -2,6 +2,7 @@ import { constructRow } from '../rows/constructRow'
 import { makeObjectMap, tableMemo } from '../../utils'
 import { table_autoResetCellSelection } from '../../features/cell-selection/cellSelectionFeature.utils'
 import { table_autoResetPageIndex } from '../../features/row-pagination/rowPaginationFeature.utils'
+import { table_autoResetSorting } from '../../features/row-sorting/rowSortingFeature.utils'
 import type { Table_Internal } from '../../types/Table'
 import type { RowModel } from './coreRowModelsFeature.types'
 import type { TableFeatures } from '../../types/TableFeatures'
@@ -28,8 +29,7 @@ export function createCoreRowModel<
       fn: () => _createCoreRowModel(table, table.options.data),
       onAfterUpdate: () => {
         table_autoResetPageIndex(table)
-        // this memo recomputes only when `options.data` changes, which is
-        // exactly when id-keyed cell ranges stop being meaningful
+        table_autoResetSorting(table)
         table_autoResetCellSelection(table)
       },
     })

--- a/packages/table-core/src/features/row-sorting/rowSortingFeature.ts
+++ b/packages/table-core/src/features/row-sorting/rowSortingFeature.ts
@@ -42,6 +42,7 @@ export const rowSortingFeature: TableFeature = {
 
   getDefaultTableOptions(table) {
     return {
+      autoResetSorting: false,
       onSortingChange: makeStateUpdater('sorting', table),
       isMultiSortEvent: (e: unknown) => {
         return (e as MouseEvent).shiftKey

--- a/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts
+++ b/packages/table-core/src/features/row-sorting/rowSortingFeature.types.ts
@@ -209,6 +209,13 @@ export interface Column_RowSorting<
 
 export interface TableOptions_RowSorting {
   /**
+   * Resets sorting to its initial state when the `data` option changes.
+   *
+   * This is disabled by default. `autoResetAll` overrides this option when it
+   * is explicitly set.
+   */
+  autoResetSorting?: boolean
+  /**
    * Allows multi-sort toggles to remove a column from sorting state.
    */
   enableMultiRemove?: boolean

--- a/packages/table-core/src/features/row-sorting/rowSortingFeature.utils.ts
+++ b/packages/table-core/src/features/row-sorting/rowSortingFeature.utils.ts
@@ -67,6 +67,30 @@ export function table_resetSorting<
   )
 }
 
+/**
+ * Resets sorting after the table data changes when explicitly enabled.
+ *
+ * Unlike other auto-reset behaviors, sorting is preserved by default. An
+ * explicit `autoResetAll` value takes precedence over `autoResetSorting`.
+ *
+ * @example
+ * ```ts
+ * table_autoResetSorting(table)
+ * ```
+ */
+export function table_autoResetSorting<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>(table: Table_Internal<TFeatures, TData>) {
+  // The core row model is available without the sorting feature. Avoid
+  // routing an update when this table has no sorting state to reset.
+  if (!table.atoms.sorting) return
+
+  if (table.options.autoResetAll ?? table.options.autoResetSorting ?? false) {
+    table_resetSorting(table)
+  }
+}
+
 // Column Utils
 
 /**

--- a/packages/table-core/tests/implementation/core/autoReset.test.ts
+++ b/packages/table-core/tests/implementation/core/autoReset.test.ts
@@ -16,7 +16,12 @@ import {
   sortFns,
 } from '../../../src'
 import { testFeatures } from '../../fixtures/features'
-import type { ColumnDef, ExpandedState, TableOptions } from '../../../src'
+import type {
+  ColumnDef,
+  ExpandedState,
+  SortingState,
+  TableOptions,
+} from '../../../src'
 
 /**
  * End-to-end tests for the autoReset wiring.
@@ -73,9 +78,11 @@ function makeTable(
   options?: Partial<TableOptions<typeof features, Person>> & {
     initialExpanded?: ExpandedState
     initialPageIndex?: number
+    initialSorting?: SortingState
   },
 ) {
-  const { initialExpanded, initialPageIndex, ...rest } = options ?? {}
+  const { initialExpanded, initialPageIndex, initialSorting, ...rest } =
+    options ?? {}
   return constructTable<typeof features, Person>({
     features,
     columns,
@@ -84,6 +91,7 @@ function makeTable(
     initialState: {
       pagination: { pageIndex: initialPageIndex ?? 0, pageSize: 2 },
       ...(initialExpanded ? { expanded: initialExpanded } : {}),
+      ...(initialSorting ? { sorting: initialSorting } : {}),
     },
     ...rest,
   })
@@ -252,6 +260,117 @@ describe('autoResetPageIndex end-to-end wiring', () => {
       await triggerReset(table)
       expect(table.atoms.pagination.get().pageIndex).toBe(2)
     })
+  })
+})
+
+describe('autoResetSorting end-to-end wiring', () => {
+  const ageSorting: SortingState = [{ id: 'age', desc: true }]
+  const nameSorting: SortingState = [{ id: 'name', desc: false }]
+
+  async function replaceData(table: ReturnType<typeof makeTable>) {
+    table.setOptions((old) => ({ ...old, data: makeData() }))
+    table.getRowModel()
+    await flushMicrotasks()
+  }
+
+  it('should preserve sorting by default when data changes', async () => {
+    const table = makeTable()
+    await primeTable(table)
+
+    expect(table.options.autoResetSorting).toBe(false)
+
+    table.setSorting(ageSorting)
+    await replaceData(table)
+
+    expect(table.atoms.sorting.get()).toEqual(ageSorting)
+  })
+
+  it('should reset sorting when data changes and autoResetSorting is true', async () => {
+    const table = makeTable({ autoResetSorting: true })
+    await primeTable(table)
+
+    table.setSorting(ageSorting)
+    await replaceData(table)
+
+    expect(table.atoms.sorting.get()).toEqual([])
+  })
+
+  it('should reset sorting to initialState.sorting', async () => {
+    const table = makeTable({
+      autoResetSorting: true,
+      initialSorting: ageSorting,
+    })
+    await primeTable(table)
+
+    expect(table.atoms.sorting.get()).toEqual(ageSorting)
+
+    table.setSorting(nameSorting)
+    await replaceData(table)
+
+    expect(table.atoms.sorting.get()).toEqual(ageSorting)
+  })
+
+  it('should not reset sorting when the sorting state itself changes', async () => {
+    const table = makeTable({ autoResetSorting: true })
+    await primeTable(table)
+
+    table.setSorting(ageSorting)
+    table.getRowModel()
+    await flushMicrotasks()
+
+    expect(table.atoms.sorting.get()).toEqual(ageSorting)
+  })
+
+  it('should not reset sorting when filters or grouping change', async () => {
+    const table = makeTable({ autoResetSorting: true })
+    await primeTable(table)
+
+    table.setSorting(ageSorting)
+    table.setColumnFilters([{ id: 'group', value: 'even' }])
+    table.getRowModel()
+    await flushMicrotasks()
+    expect(table.atoms.sorting.get()).toEqual(ageSorting)
+
+    table.setGrouping(['group'])
+    table.getRowModel()
+    await flushMicrotasks()
+    expect(table.atoms.sorting.get()).toEqual(ageSorting)
+  })
+
+  it('should allow autoResetAll to enable the reset', async () => {
+    const table = makeTable({ autoResetAll: true })
+    await primeTable(table)
+
+    table.setSorting(ageSorting)
+    await replaceData(table)
+
+    expect(table.atoms.sorting.get()).toEqual([])
+  })
+
+  it('should allow autoResetAll to disable an explicit sorting reset', async () => {
+    const table = makeTable({
+      autoResetAll: false,
+      autoResetSorting: true,
+    })
+    await primeTable(table)
+
+    table.setSorting(ageSorting)
+    await replaceData(table)
+
+    expect(table.atoms.sorting.get()).toEqual(ageSorting)
+  })
+
+  it('should honor an explicit reset with manual sorting', async () => {
+    const table = makeTable({
+      autoResetSorting: true,
+      manualSorting: true,
+    })
+    await primeTable(table)
+
+    table.setSorting(ageSorting)
+    await replaceData(table)
+
+    expect(table.atoms.sorting.get()).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary

- add an autoResetSorting table option that is explicitly disabled by default
- reset sorting only when the data reference changes
- restore initialState.sorting, falling back to an empty sorting state
- keep autoResetAll as the global override
- document the behavior and manual/server-side sorting caveat across framework guides

This reimplements the intent of #5414 for the v9 beta architecture and co-authors the original contributor.

## Why

The original implementation attached the reset to the sorted-row-model memo. That memo also depends on sorting and upstream row models, so sorting, filtering, or grouping changes could incorrectly clear sorting. It also effectively enabled the option by default for client-side sorting.

In v9, the reset is attached to the core-row memo, whose relevant dependency is options.data. This gives the option a precise data-change-only boundary while preserving sorting by default.

## Behavior

- omitted or false: preserve sorting when data changes
- true: reset to initialState.sorting, or an empty state
- autoResetAll: overrides the feature option when explicitly set
- sorting, filtering, and grouping changes do not trigger a reset
- explicit opt-in is honored with manual sorting, with the server-response caveat documented

## Validation

- 62 table-core test files / 1,203 tests
- TypeScript and declaration emit
- ESLint
- table-core build and strict publint
- documentation link verification
- size limit: 23.97 kB / 25 kB
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `autoResetSorting` to control whether sorting resets when table data changes.
  * Sorting remains preserved by default, with support for restoring initial sorting or clearing it.
  * Added `autoResetAll` precedence and compatibility with manual/server-side sorting.

* **Documentation**
  * Added framework guides and API reference documentation, including usage examples.

* **Tests**
  * Added coverage for data changes, initial sorting, configuration overrides, unrelated state changes, and manual sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->