### PR TITLE
fix: ensure isSubRowSelected returns false if no subRows are selectable

### DIFF
--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
@@ -907,6 +907,7 @@ export function isSubRowSelected<
 
   let someSelected = false
   let allChildrenSelected = true
+  let someSelectable = false
 
   for (let i = 0; i < row.subRows.length; i++) {
     const subRow = row.subRows[i]!
@@ -917,6 +918,7 @@ export function isSubRowSelected<
     }
 
     if (row_getCanSelect(subRow)) {
+      someSelectable = true
       if (isRowSelected(subRow, rowSelection)) {
         someSelected = true
       } else {
@@ -929,14 +931,19 @@ export function isSubRowSelected<
       const subRowChildrenSelected = isSubRowSelected(subRow)
       if (subRowChildrenSelected === 'all') {
         someSelected = true
+        someSelectable = true
       } else if (subRowChildrenSelected === 'some') {
         someSelected = true
         allChildrenSelected = false
+        someSelectable = true
       } else {
         allChildrenSelected = false
       }
     }
   }
+
+  // A row with no selectable descendants can never be in a selected state
+  if (!someSelectable) return false
 
   return allChildrenSelected ? 'all' : someSelected ? 'some' : false
 }

--- a/packages/table-core/tests/implementation/features/row-selection/rowSelectionFeature.test.ts
+++ b/packages/table-core/tests/implementation/features/row-selection/rowSelectionFeature.test.ts
@@ -416,6 +416,52 @@ describe('rowSelectionFeature', () => {
       expect(result).toEqual(false)
     })
 
+    it('should return false if no sub-rows are selectable', () => {
+      const data = generateTestData(3, 2)
+      const columns = generateColumnDefs(data)
+
+      const table = constructTable<typeof features, Person>({
+        features,
+        enableRowSelection: false,
+        renderFallbackValue: '',
+        data,
+        getSubRows: (originalRow: Person, _idx: number) => originalRow.subRows,
+        initialState: {
+          rowSelection: {},
+        },
+        columns,
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]!
+
+      const result = RowSelectionUtils.isSubRowSelected(firstRow)
+
+      expect(result).toEqual(false)
+    })
+
+    it('should return some if no children are selectable, but a grand-child is and is selected', () => {
+      const data = generateTestData(3, 2, 2)
+      const columns = generateColumnDefs(data)
+
+      const table = constructTable<typeof features, Person>({
+        features,
+        enableRowSelection: (row) => row.id === '0.0.1',
+        renderFallbackValue: '',
+        data,
+        getSubRows: (originalRow: Person, _idx: number) => originalRow.subRows,
+        initialState: {
+          rowSelection: { '0.0.1': true },
+        },
+        columns,
+      })
+
+      const firstRow = table.getCoreRowModel().rows[0]!
+
+      const result = RowSelectionUtils.isSubRowSelected(firstRow)
+
+      expect(result).toEqual('some')
+    })
+
     it('should return some if some sub-rows are selected', () => {
       const data = generateTestData(3, 2)
       const columns = generateColumnDefs(data)

--- a/packages/table-core/tests/unit/features/row-selection/rowSelectionFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/row-selection/rowSelectionFeature.utils.test.ts
@@ -399,6 +399,14 @@ describe('row_getIsSomeSelected / row_getIsAllSubRowsSelected', () => {
     expect(row_getIsSomeSelected(row)).toBe(false)
     expect(row_getIsAllSubRowsSelected(row)).toBe(false)
   })
+
+  it('should report nothing when no sub-rows are selectable', () => {
+    const table = makeTable({ enableRowSelection: false }, [3, 2])
+    const parent = table.getRow('0')
+
+    expect(row_getIsSomeSelected(parent)).toBe(false)
+    expect(row_getIsAllSubRowsSelected(parent)).toBe(false)
+  })
 })
 
 describe('row selection flags', () => {


### PR DESCRIPTION
Fixes #5173. Rewrite of #5790 against the v9 `beta` branch, with co-author credit to @remleduff.

## Problem

`isSubRowSelected` only flips `allChildrenSelected` to `false` when it encounters a selectable-but-unselected sub-row or a nested level that isn't fully selected. A parent whose sub-rows are all unselectable (e.g. `enableRowSelection: false` or a row predicate that disables the whole subtree) never hits either condition, so `allChildrenSelected` stays `true` and the function returns `'all'` with nothing selected. `row.getIsAllSubRowsSelected()` then reports `true` and indeterminate/checked parent checkbox UI renders incorrectly.

## Fix

Track whether any selectable descendant was seen (`someSelectable`) and return `false` when none were, same approach as #5790. Rows with only unselectable descendants now report no selection state, and a selected grand-child under unselectable children correctly reports `'some'` instead of `'all'`.

## Tests

- `isSubRowSelected` returns `false` when no sub-rows are selectable (previously `'all'`)
- `isSubRowSelected` returns `'some'` when children are unselectable but a selected grand-child exists (previously `'all'`)
- `row_getIsSomeSelected` / `row_getIsAllSubRowsSelected` both report `false` when no sub-rows are selectable

All 1206 table-core tests and type checks pass.

Co-authored-by: Joel 'Aaron' Cohen <acohen@deepsig.ai>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected nested row-selection states when rows or descendants are not selectable.
  - Parent rows no longer appear partially or fully selected when no selectable descendants exist.
  - Preserved accurate partial-selection indicators when selectable nested descendants are selected.

- **Tests**
  - Added coverage for disabled row selection and mixed selectable/unselectable nested rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->