### PR TITLE
fix row pinning after ungrouping

### DIFF
--- a/packages/table-core/src/features/row-pinning/rowPinningFeature.utils.ts
+++ b/packages/table-core/src/features/row-pinning/rowPinningFeature.utils.ts
@@ -123,8 +123,10 @@ function table_getPinnedRows<
     if (keepPinnedRows) {
       // get all rows that are pinned even if they would not be otherwise
       // visible; account for expanded parent rows, but not pagination/filtering
-      const fullRow = table.getRow(rowId, true)
-      if (row_getIsAllParentsExpanded(fullRow)) row = fullRow
+      const fullRow =
+        table.getPrePaginatedRowModel().rowsById[rowId] ??
+        table.getCoreRowModel().rowsById[rowId]
+      if (fullRow && row_getIsAllParentsExpanded(fullRow)) row = fullRow
     } else {
       // else get only visible rows that are pinned
       row = visibleRows.find((r) => r.id === rowId)

--- a/packages/table-core/tests/implementation/features/row-pinning/rowPinningFeature.test.ts
+++ b/packages/table-core/tests/implementation/features/row-pinning/rowPinningFeature.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  columnGroupingFeature,
   constructTable,
+  createGroupedRowModel,
   createPaginatedRowModel,
   rowPaginationFeature,
   rowPinningFeature,
@@ -19,6 +21,12 @@ const featuresWithPagination = testFeatures({
   rowPaginationFeature,
   rowPinningFeature,
   paginatedRowModel: createPaginatedRowModel(),
+})
+
+const featuresWithGrouping = testFeatures({
+  columnGroupingFeature,
+  rowPinningFeature,
+  groupedRowModel: createGroupedRowModel(),
 })
 
 function makeTable(
@@ -137,6 +145,31 @@ describe('table methods', () => {
   })
 
   describe('getTopRows/getBottomRows/getCenterRows', () => {
+    it('does not throw when a pinned grouped row disappears after ungrouping', () => {
+      const data = generateTestData(3)
+      const table = constructTable({
+        features: featuresWithGrouping,
+        data,
+        columns: generateTestColumnDefs<typeof featuresWithGrouping>(data),
+        initialState: {
+          grouping: ['status'],
+        },
+      })
+      const groupedRow = table.getRowModel().rows[0]!
+
+      groupedRow.pin('top')
+      expect(table.getTopRows()).toEqual([groupedRow])
+
+      table.setGrouping([])
+
+      expect(table.getTopRows()).toEqual([])
+      expect(table.atoms.rowPinning.get().top).toEqual([groupedRow.id])
+
+      table.setGrouping(['status'])
+
+      expect(table.getTopRows().map((row) => row.id)).toEqual([groupedRow.id])
+    })
+
     it('should return correct rows for each section', () => {
       const table = makeTable({
         initialState: {


### PR DESCRIPTION
## What changed

Resolve pinned rows directly from the pre-pagination and core row-model maps instead of calling the throwing `table.getRow(id, true)` API. Add a regression test covering grouping, pinning a synthetic group row, ungrouping, and regrouping.

Fixes #5822.

## Why

Ungrouping removes synthetic group rows from the active row models while their IDs may remain in row-pinning state. `getTopRows()` and `getBottomRows()` treated those temporarily absent IDs as exceptional and crashed. The previous proposed fix in #5823 used `try`/`catch` for this expected lookup miss.

An absent synthetic row is now omitted without exception-driven control flow. The pinned ID remains in state, so the correct grouped row is restored if the same grouping is applied again.

## Validation

- `pnpm --filter @tanstack/table-core test:lib --run tests/implementation/features/row-pinning/rowPinningFeature.test.ts`
- `pnpm exec eslint packages/table-core/src/features/row-pinning/rowPinningFeature.utils.ts packages/table-core/tests/implementation/features/row-pinning/rowPinningFeature.test.ts`
- `pnpm --filter @tanstack/table-core test:types`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pinned-row retention when pagination or grouping changes.
  * Preserved pinning state safely when grouped rows are temporarily ungrouped and later restored.
  * Ensured pinned rows appear only when their parent rows are expanded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->