### PR TITLE
fix(table-core): wire expansion auto-reset into the core row model and guard first runs

### DIFF
--- a/examples/alpine/aggregation/src/main.ts
+++ b/examples/alpine/aggregation/src/main.ts
@@ -103,6 +103,7 @@ Alpine.data('table', () => {
       return { rowSource: local.rowSource }
     },
     initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+    // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
     debugTable: true,
     debugColumns: true,
   })

--- a/examples/alpine/basic-create-table/index.html
+++ b/examples/alpine/basic-create-table/index.html
@@ -6,7 +6,7 @@
     <title>TanStack Alpine Table - Basic Create Table</title>
   </head>
   <body>
-    <!-- 7. Render your table markup from the table instance APIs -->
+    <!-- 6. Render your table markup from the table instance APIs -->
     <div id="root" class="demo-root" x-data="table">
       <div class="button-row">
         <button @click="refreshData()">Regenerate Data</button>

--- a/examples/alpine/basic-create-table/src/main.ts
+++ b/examples/alpine/basic-create-table/src/main.ts
@@ -1,8 +1,12 @@
 import Alpine from 'alpinejs'
-import { FlexRender, createTable, tableFeatures } from '@tanstack/alpine-table'
+import {
+  FlexRender,
+  createColumnHelper,
+  createTable,
+  tableFeatures,
+} from '@tanstack/alpine-table'
 import { makeData } from './makeData'
 import './index.css'
-import type { ColumnDef } from '@tanstack/alpine-table'
 import type { Person } from './makeData'
 
 // This example uses the standalone `createTable` function to create a table without the `createTableHook` util.
@@ -10,46 +14,42 @@ import type { Person } from './makeData'
 // 1. New in V9! Tell the table which features and row models we want to use. In this case, this will be a basic table with no additional features
 const features = tableFeatures({}) // util method to create sharable TFeatures object/type
 
-// 4. Define the columns for your table. This uses the new `ColumnDef` type to define columns.
-//    Alternatively, check out the createTableHook/createAppColumnHelper util for an even more type-safe way to define columns.
-const columns: Array<ColumnDef<typeof features, Person>> = [
-  {
-    accessorKey: 'firstName', // accessorKey method (most common for simple use-cases)
+// 2. Create a column helper with the table features and row type
+const columnHelper = createColumnHelper<typeof features, Person>()
+
+// 3. Define the columns for your table with the column helper
+const columns = columnHelper.columns([
+  columnHelper.accessor('firstName', {
     header: 'First Name',
     cell: (info) => info.getValue(),
-  },
-  {
-    accessorFn: (row) => row.lastName, // accessorFn used (alternative) along with a custom id
+  }),
+  columnHelper.accessor((row) => row.lastName, {
     id: 'lastName',
     header: () => 'Last Name',
     cell: (info) => info.getValue(),
-  },
-  {
-    accessorFn: (row) => Number(row.age), // accessorFn used to transform the data
+  }),
+  columnHelper.accessor((row) => Number(row.age), {
     id: 'age',
     header: () => 'Age',
     cell: (info) => info.renderValue(),
-  },
-  {
-    accessorKey: 'visits',
+  }),
+  columnHelper.accessor('visits', {
     header: () => 'Visits',
-  },
-  {
-    accessorKey: 'status',
+  }),
+  columnHelper.accessor('status', {
     header: 'Status',
-  },
-  {
-    accessorKey: 'progress',
+  }),
+  columnHelper.accessor('progress', {
     header: 'Profile Progress',
-  },
-]
+  }),
+])
 
-// 5. Register the Alpine component. Store data in Alpine-reactive state so the
+// 4. Register the Alpine component. Store data in Alpine-reactive state so the
 //    buttons can swap it out and the table re-renders.
 Alpine.data('table', () => {
   const local = Alpine.reactive({ data: makeData(20) })
 
-  // 6. Create the table instance with required features, columns, and data
+  // 5. Create the table instance with required features, columns, and data
   const table = createTable({
     debugTable: true, // optionally, enable console logging debug messages
     features, // new required option in V9. Tell the table which features you are importing and using (better tree-shaking)

--- a/examples/alpine/column-sizing/src/main.ts
+++ b/examples/alpine/column-sizing/src/main.ts
@@ -64,6 +64,7 @@ Alpine.data('table', () => {
     },
     columnResizeMode: 'onChange',
     columnResizeDirection: 'ltr',
+    // defaultColumn: { size: 150, minSize: 50, maxSize: 500 }, // set sizing defaults for every column
     // initialState: { columnSizing: { firstName: 200 } }, // set column sizes on first render
     // atoms: { columnSizing: columnSizingAtom }, // preferred: own sizing state with an external atom
     // state: { columnSizing }, // classic controlled state; pair with onColumnSizingChange

--- a/examples/alpine/expanding/src/main.ts
+++ b/examples/alpine/expanding/src/main.ts
@@ -98,7 +98,11 @@ Alpine.data('table', () => {
     get data() {
       return local.data
     },
-    getSubRows: (row) => row.subRows,
+    getSubRows: (row) => row.subRows, // tell the table where nested rows live
+    // enableRowSelection: row => row.original.age > 18, // enable selection conditionally; default true
+    // enableMultiRowSelection: false, // allow only one selected row at a time; default true
+    // enableSubRowSelection: false, // disable sub-row selection; default true
+    // enableRowRangeSelection: false, // disable shift-click range selection; default true
     // initialState: { expanded: { '0': true } }, // expand rows on first render
     // atoms: { expanded: expandedAtom }, // preferred: own expanded state with an external atom
     // state: { expanded }, // classic controlled state; pair with onExpandedChange
@@ -110,8 +114,11 @@ Alpine.data('table', () => {
     // paginateExpandedRows: false, // keep expanded children on their parent page; default true
     // autoResetExpanded: false, // keep expanded rows after page-altering changes; default true
     // autoResetAll: false, // turn off every feature's automatic reset, including expansion
+    // enableFilters: false, // disable all column and global filtering; default true
+    // enableColumnFilters: false, // disable per-column filters; default true
     // filterFromLeafRows: true, // with filtering, keep parents whose descendants match
     // maxLeafRowFilterDepth: 0, // with filtering, only filter root rows
+    // manualFiltering: true, // pass data that is already filtered, for example from a server
     debugTable: true,
   })
 

--- a/examples/alpine/row-pinning/src/main.ts
+++ b/examples/alpine/row-pinning/src/main.ts
@@ -99,6 +99,7 @@ Alpine.data('table', () => {
     },
     initialState: {
       pagination: { pageSize: 20, pageIndex: 0 },
+      // rowPinning: { top: ['0'], bottom: ['1'] }, // pin rows on first render
     },
     getSubRows: (row) => row.subRows,
     keepPinnedRows: true,

--- a/examples/alpine/row-selection/src/main.ts
+++ b/examples/alpine/row-selection/src/main.ts
@@ -82,6 +82,7 @@ Alpine.data('table', () => {
       return local.data
     },
     enableRowSelection: true,
+    // enableRowSelection: row => row.original.age > 18, // or enable selection conditionally
     // initialState: { rowSelection: { '0': true } }, // select rows on first render
     // atoms: { rowSelection: rowSelectionAtom }, // preferred: own selection state with an external atom
     // state: { rowSelection }, // classic controlled state; pair with onRowSelectionChange

--- a/examples/angular/aggregation/src/app/app.ts
+++ b/examples/angular/aggregation/src/app/app.ts
@@ -101,6 +101,7 @@ export class App {
     data: this.data(),
     meta: { rowSource: this.rowSource() },
     initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+    // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
     debugTable: true,
     debugColumns: true,
   }))

--- a/examples/angular/basic-inject-table/src/app/app.ts
+++ b/examples/angular/basic-inject-table/src/app/app.ts
@@ -5,9 +5,13 @@ import {
   inject,
   signal,
 } from '@angular/core'
-import { FlexRender, injectTable, tableFeatures } from '@tanstack/angular-table'
+import {
+  FlexRender,
+  createColumnHelper,
+  injectTable,
+  tableFeatures,
+} from '@tanstack/angular-table'
 import { injectTanStackTableDevtools } from '@tanstack/angular-table-devtools'
-import type { ColumnDef } from '@tanstack/angular-table'
 
 // This example uses the Angular standalone `injectTable` helper to create a table without the `createTableHook` util.
 
@@ -61,39 +65,35 @@ const defaultData: Array<Person> = [
 // In this case, this will be a basic table with no additional features
 const features = tableFeatures({})
 
-// 4. Define the columns for your table. This uses the new `ColumnDef` type to define columns.
-// Alternatively, check out the createTableHook/createColumnHelper util for an even more type-safe way to define columns.
-const columns: Array<ColumnDef<typeof features, Person>> = [
-  {
-    accessorKey: 'firstName',
+// 4. Create a column helper with the table features and row type
+const columnHelper = createColumnHelper<typeof features, Person>()
+
+// 5. Define the columns for your table with the column helper
+const columns = columnHelper.columns([
+  columnHelper.accessor('firstName', {
     header: 'First Name',
     cell: (info) => info.getValue(),
-  },
-  {
-    accessorFn: (row) => row.lastName,
+  }),
+  columnHelper.accessor((row) => row.lastName, {
     id: 'lastName',
     header: () => 'Last Name',
-    cell: (info) => info.getValue<string>(),
-  },
-  {
-    accessorFn: (row) => Number(row.age),
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor((row) => Number(row.age), {
     id: 'age',
     header: () => 'Age',
     cell: (info) => info.renderValue(),
-  },
-  {
-    accessorKey: 'visits',
+  }),
+  columnHelper.accessor('visits', {
     header: () => 'Visits',
-  },
-  {
-    accessorKey: 'status',
+  }),
+  columnHelper.accessor('status', {
     header: 'Status',
-  },
-  {
-    accessorKey: 'progress',
+  }),
+  columnHelper.accessor('progress', {
     header: 'Profile Progress',
-  },
-]
+  }),
+])
 
 @Component({
   selector: 'app-root',
@@ -104,10 +104,10 @@ const columns: Array<ColumnDef<typeof features, Person>> = [
 export class App {
   private readonly injector = inject(Injector)
 
-  // 5. Store data with a stable reference
+  // 6. Store data with a stable reference
   readonly data = signal<Array<Person>>([...defaultData])
 
-  // 6. Create the table instance with required features, columns, and data
+  // 7. Create the table instance with required features, columns, and data
   readonly table = injectTable(() => ({
     key: 'basic-inject-table', // needed for devtools
     debugTable: true,

--- a/examples/angular/column-sizing/src/app/app.ts
+++ b/examples/angular/column-sizing/src/app/app.ts
@@ -65,6 +65,7 @@ export class App {
     features,
     columns,
     data: this.data(),
+    // defaultColumn: { size: 150, minSize: 50, maxSize: 500 }, // set sizing defaults for every column
     // initialState: { columnSizing: { firstName: 200 } }, // set column sizes on first render
     // atoms: { columnSizing: columnSizingAtom }, // preferred: own sizing state with an external atom
     // state: { columnSizing }, // classic controlled state; pair with onColumnSizingChange

--- a/examples/angular/expanding/src/app/app.html
+++ b/examples/angular/expanding/src/app/app.html
@@ -22,6 +22,32 @@
                   >
                     <div [innerHTML]="header"></div>
                   </ng-container>
+
+                  @if (header.column.getCanFilter()) {
+                    <div>
+                      @if (isNumberColumn(header.column)) {
+                        <input
+                          type="number"
+                          placeholder="Min"
+                          [value]="getNumberFilterValue(header.column, 0)"
+                          (input)="setNumberFilter(header.column, $event, 0)"
+                        />
+                        <input
+                          type="number"
+                          placeholder="Max"
+                          [value]="getNumberFilterValue(header.column, 1)"
+                          (input)="setNumberFilter(header.column, $event, 1)"
+                        />
+                      } @else {
+                        <input
+                          type="text"
+                          placeholder="Search..."
+                          [value]="header.column.getFilterValue() ?? ''"
+                          (input)="setTextFilter(header.column, $event)"
+                        />
+                      }
+                    </div>
+                  }
                 }
               </th>
             }

--- a/examples/angular/expanding/src/app/app.ts
+++ b/examples/angular/expanding/src/app/app.ts
@@ -1,8 +1,12 @@
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core'
 import {
   FlexRender,
+  columnFilteringFeature,
   createExpandedRowModel,
+  createFilteredRowModel,
   createPaginatedRowModel,
+  filterFn_inNumberRange,
+  filterFn_includesString,
   flexRenderComponent,
   injectTable,
   rowExpandingFeature,
@@ -17,14 +21,20 @@ import {
   ExpandableHeaderCell,
 } from './expandable-cell/expandable-cell'
 import type { Person } from './makeData'
-import type { ColumnDef, ExpandedState } from '@tanstack/angular-table'
+import type { Column, ColumnDef, ExpandedState } from '@tanstack/angular-table'
 
 export const features = tableFeatures({
+  columnFilteringFeature,
   rowExpandingFeature: rowExpandingFeature,
   rowPaginationFeature: rowPaginationFeature,
   rowSelectionFeature: rowSelectionFeature,
+  filteredRowModel: createFilteredRowModel(),
   paginatedRowModel: createPaginatedRowModel(),
   expandedRowModel: createExpandedRowModel(),
+  filterFns: {
+    includesString: filterFn_includesString,
+    inNumberRange: filterFn_inNumberRange,
+  },
 })
 
 const defaultColumns: Array<ColumnDef<typeof features, Person>> = [
@@ -93,7 +103,11 @@ export class App {
       typeof updater === 'function'
         ? this.expanded.update(updater)
         : this.expanded.set(updater),
-    getSubRows: (row) => row.subRows,
+    getSubRows: (row) => row.subRows, // tell the table where nested rows live
+    // enableRowSelection: row => row.original.age > 18, // enable selection conditionally; default true
+    // enableMultiRowSelection: false, // allow only one selected row at a time; default true
+    // enableSubRowSelection: false, // disable sub-row selection; default true
+    // enableRowRangeSelection: false, // disable shift-click range selection; default true
     // initialState: { expanded: { '0': true } }, // expand rows on first render
     // atoms: { expanded: expandedAtom }, // preferred: own expanded state with an external atom
     // enableExpanding: false, // disable expanding for every row; default true
@@ -103,8 +117,11 @@ export class App {
     // paginateExpandedRows: false, // keep expanded children on their parent page; default true
     // autoResetExpanded: false, // keep expanded rows after page-altering changes; default true
     // autoResetAll: false, // turn off every feature's automatic reset, including expansion
+    // enableFilters: false, // disable all column and global filtering; default true
+    // enableColumnFilters: false, // disable per-column filters; default true
     // filterFromLeafRows: true, // with filtering, keep parents whose descendants match
     // maxLeafRowFilterDepth: 0, // with filtering, only filter root rows
+    // manualFiltering: true, // pass data that is already filtered, for example from a server
     debugTable: true,
   }))
 
@@ -120,6 +137,38 @@ export class App {
 
   onPageSizeChange(event: any): void {
     this.table.setPageSize(Number(event.target.value))
+  }
+
+  isNumberColumn(column: Column<typeof features, Person>): boolean {
+    const firstValue = this.table
+      .getPreFilteredRowModel()
+      .flatRows[0]?.getValue(column.id)
+    return typeof firstValue === 'number'
+  }
+
+  setTextFilter(column: Column<typeof features, Person>, event: Event): void {
+    column.setFilterValue((event.target as HTMLInputElement).value)
+  }
+
+  getNumberFilterValue(
+    column: Column<typeof features, Person>,
+    index: 0 | 1,
+  ): number | '' {
+    const value = column.getFilterValue() as [number?, number?] | undefined
+    return value?.[index] ?? ''
+  }
+
+  setNumberFilter(
+    column: Column<typeof features, Person>,
+    event: Event,
+    index: 0 | 1,
+  ): void {
+    const value = (event.target as HTMLInputElement).value
+    column.setFilterValue((old: [number?, number?] | undefined) => {
+      const next: [number?, number?] = [...(old ?? [])]
+      next[index] = value === '' ? undefined : Number(value)
+      return next
+    })
   }
 
   refreshData = () => this.data.set(makeData(100, 5, 3))

--- a/examples/angular/row-pinning/src/app/app.ts
+++ b/examples/angular/row-pinning/src/app/app.ts
@@ -73,7 +73,10 @@ export class App {
     features,
     columns,
     data: this.data(),
-    initialState: { pagination: { pageSize: 20, pageIndex: 0 } },
+    initialState: {
+      pagination: { pageSize: 20, pageIndex: 0 },
+      // rowPinning: { top: ['0'], bottom: ['1'] }, // pin rows on first render
+    },
     state: { expanded: this.expanded(), rowPinning: this.rowPinning() },
     onExpandedChange: (updater: Updater<ExpandedState>) =>
       isFunction(updater)

--- a/examples/angular/row-selection/src/app/app.ts
+++ b/examples/angular/row-selection/src/app/app.ts
@@ -102,6 +102,7 @@ export class App {
     },
 
     enableRowSelection: this.enableRowSelection(), // enable row selection for all rows
+    // enableRowSelection: row => row.original.age > 18, // or enable selection conditionally
     onRowSelectionChange: (updaterOrValue) => {
       this.rowSelection.set(
         typeof updaterOrValue === 'function'

--- a/examples/ember/aggregation/app/templates/application.gts
+++ b/examples/ember/aggregation/app/templates/application.gts
@@ -121,6 +121,7 @@ export default class PaginationTable extends Component {
     data: this.data,
     meta: { rowSource: this.rowSource },
     initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+    // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
     // initialState: { pagination: { pageIndex: 1, pageSize: 20 } }, // set the initial page once
     // atoms: { pagination: paginationAtom }, // preferred: own pagination state with an external atom
     // state: { pagination }, // classic controlled state; pair with onPaginationChange

--- a/examples/ember/column-sizing/app/templates/application.gts
+++ b/examples/ember/column-sizing/app/templates/application.gts
@@ -82,6 +82,7 @@ export default class ColumnSizingTable extends Component {
     features,
     columns,
     data: this.data,
+    // defaultColumn: { size: 150, minSize: 50, maxSize: 500 }, // set sizing defaults for every column
     // initialState: { columnSizing: { firstName: 200 } }, // set column sizes on first render
     // atoms: { columnSizing: columnSizingAtom }, // preferred: own sizing state with an external atom
     // state: { columnSizing }, // classic controlled state; pair with onColumnSizingChange

--- a/examples/ember/expanding/app/templates/application.gts
+++ b/examples/ember/expanding/app/templates/application.gts
@@ -231,8 +231,12 @@ export default class ExpandingTable extends Component {
     features,
     columns,
     data: this.data,
-    getSubRows: (row: Person) => row.subRows,
+    getSubRows: (row: Person) => row.subRows, // tell the table where nested rows live
     getRowCanExpand: () => true,
+    // enableRowSelection: row => row.original.age > 18, // enable selection conditionally; default true
+    // enableMultiRowSelection: false, // allow only one selected row at a time; default true
+    // enableSubRowSelection: false, // disable sub-row selection; default true
+    // enableRowRangeSelection: false, // disable shift-click range selection; default true
     // initialState: { expanded: { '0': true } }, // expand rows on first render
     // atoms: { expanded: expandedAtom }, // preferred: own expanded state with an external atom
     // state: { expanded }, // classic controlled state; pair with onExpandedChange
@@ -243,8 +247,11 @@ export default class ExpandingTable extends Component {
     // paginateExpandedRows: false, // keep expanded children on their parent page; default true
     // autoResetExpanded: false, // keep expanded rows after page-altering changes; default true
     // autoResetAll: false, // turn off every feature's automatic reset, including expansion
+    // enableFilters: false, // disable all column and global filtering; default true
+    // enableColumnFilters: false, // disable per-column filters; default true
     // filterFromLeafRows: true, // with filtering, keep parents whose descendants match
     // maxLeafRowFilterDepth: 0, // with filtering, only filter root rows
+    // manualFiltering: true, // pass data that is already filtered, for example from a server
   }))
 
   get headerGroups() {

--- a/examples/ember/row-pinning/app/templates/application.gts
+++ b/examples/ember/row-pinning/app/templates/application.gts
@@ -114,7 +114,10 @@ export default class RowPinningTable extends Component {
     getRowId: (row: Person, index: number) =>
       `${row.firstName}-${row.lastName}-${index}`,
     getSubRows: (row: Person) => row.subRows,
-    initialState: { pagination: { pageSize: 20, pageIndex: 0 } },
+    initialState: {
+      pagination: { pageSize: 20, pageIndex: 0 },
+      // rowPinning: { top: ['0'], bottom: ['1'] }, // pin rows on first render
+    },
     state: {
       rowPinning: this.rowPinning,
     },

--- a/examples/ember/row-selection/app/templates/application.gts
+++ b/examples/ember/row-selection/app/templates/application.gts
@@ -180,6 +180,7 @@ export default class RowSelectionTable extends Component {
       rowSelection: this.rowSelection,
     },
     enableRowSelection: true,
+    // enableRowSelection: row => row.original.age > 18, // or enable selection conditionally
     onRowSelectionChange: (updater) => {
       this.rowSelection =
         typeof updater === 'function' ? updater(this.rowSelection) : updater

--- a/examples/lit/aggregation/src/main.ts
+++ b/examples/lit/aggregation/src/main.ts
@@ -113,6 +113,7 @@ class LitTableExample extends LitElement {
         data: this._data,
         meta: { rowSource: this._rowSource },
         initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+        // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
         // initialState: { pagination: { pageIndex: 1, pageSize: 20 } }, // set the initial page once
         // atoms: { pagination: paginationAtom }, // preferred: own pagination state with an external atom
         // state: { pagination }, // classic controlled state; pair with onPaginationChange

--- a/examples/lit/column-sizing/src/main.ts
+++ b/examples/lit/column-sizing/src/main.ts
@@ -68,6 +68,7 @@ class LitTableExample extends LitElement {
         columns,
         columnResizeMode: 'onChange',
         columnResizeDirection: 'ltr',
+        // defaultColumn: { size: 150, minSize: 50, maxSize: 500 }, // set sizing defaults for every column
         // initialState: { columnSizing: { firstName: 200 } }, // set column sizes on first render
         // atoms: { columnSizing: columnSizingAtom }, // preferred: own sizing state with an external atom
         // state: { columnSizing }, // classic controlled state; pair with onColumnSizingChange

--- a/examples/lit/expanding/src/main.ts
+++ b/examples/lit/expanding/src/main.ts
@@ -201,7 +201,11 @@ class LitTableExample extends LitElement {
         features,
         columns,
         data: this._data,
-        getSubRows: (row) => row.subRows,
+        getSubRows: (row) => row.subRows, // tell the table where nested rows live
+        // enableRowSelection: row => row.original.age > 18, // enable selection conditionally; default true
+        // enableMultiRowSelection: false, // allow only one selected row at a time; default true
+        // enableSubRowSelection: false, // disable sub-row selection; default true
+        // enableRowRangeSelection: false, // disable shift-click range selection; default true
         // initialState: { expanded: { '0': true } }, // expand rows on first render
         // atoms: { expanded: expandedAtom }, // preferred: own expanded state with an external atom
         // state: { expanded }, // classic controlled state; pair with onExpandedChange
@@ -213,8 +217,11 @@ class LitTableExample extends LitElement {
         // paginateExpandedRows: false, // keep expanded children on their parent page; default true
         // autoResetExpanded: false, // keep expanded rows after page-altering changes; default true
         // autoResetAll: false, // turn off every feature's automatic reset, including expansion
+        // enableFilters: false, // disable all column and global filtering; default true
+        // enableColumnFilters: false, // disable per-column filters; default true
         // filterFromLeafRows: true, // with filtering, keep parents whose descendants match
         // maxLeafRowFilterDepth: 0, // with filtering, only filter root rows
+        // manualFiltering: true, // pass data that is already filtered, for example from a server
         debugTable: true,
       },
       (state) => ({

--- a/examples/lit/row-pinning/src/main.ts
+++ b/examples/lit/row-pinning/src/main.ts
@@ -191,6 +191,7 @@ class LitTableExample extends LitElement {
         data: this._data,
         initialState: {
           pagination: { pageSize: 20, pageIndex: 0 },
+          // rowPinning: { top: ['0'], bottom: ['1'] }, // pin rows on first render
         },
         getSubRows: (row) => row.subRows,
         keepPinnedRows: true,

--- a/examples/lit/row-selection/src/main.ts
+++ b/examples/lit/row-selection/src/main.ts
@@ -100,6 +100,7 @@ class LitTableExample extends LitElement {
         data: this._data,
         columns,
         enableRowSelection: true,
+        // enableRowSelection: row => row.original.age > 18, // or enable selection conditionally
         // initialState: { rowSelection: { '0': true } }, // select rows on first render
         // atoms: { rowSelection: rowSelectionAtom }, // preferred: own selection state with an external atom
         // state: { rowSelection }, // classic controlled state; pair with onRowSelectionChange

--- a/examples/octane/aggregation/src/main.tsrx
+++ b/examples/octane/aggregation/src/main.tsrx
@@ -128,6 +128,7 @@ function App() @{
       data,
       meta: { rowSource },
       initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+      // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
       debugTable: true,
       debugColumns: true,
     },

--- a/examples/octane/basic-use-table/src/main.tsrx
+++ b/examples/octane/basic-use-table/src/main.tsrx
@@ -1,6 +1,9 @@
 import { createRoot, useState } from 'octane'
-import { tableFeatures, useTable } from '@tanstack/octane-table'
-import type { ColumnDef } from '@tanstack/octane-table'
+import {
+  createColumnHelper,
+  tableFeatures,
+  useTable,
+} from '@tanstack/octane-table'
 import './index.css'
 
 // This example uses the classic standalone `useTable` hook to create a table without the new `createTableHelper` util.
@@ -26,41 +29,37 @@ const defaultData: Array<Person> = [
 // 3. New in V9! Tell the table which features and row models we want to use. In this case, this will be a basic table with no additional features
 const features = tableFeatures({})
 
-// 4. Define the columns for your table. This uses the new `ColumnDef` type to define columns. Alternatively, check out the createTableHelper/createColumnHelper util for an even more type-safe way to define columns.
-const columns: Array<ColumnDef<typeof features, Person>> = [
-  {
-    // accessorKey method (most common for simple use-cases)
-    accessorKey: 'firstName',
+// 4. Create a column helper with the table features and row type
+const columnHelper = createColumnHelper<typeof features, Person>()
+
+// 5. Define the columns for your table with the column helper
+const columns = columnHelper.columns([
+  columnHelper.accessor('firstName', {
     header: 'First Name',
     cell: (info) => String(info.getValue()),
-  },
-  {
-    // accessorFn used (alternative) along with a custom id
-    accessorFn: (row) => row.lastName,
+  }),
+  columnHelper.accessor((row) => row.lastName, {
     id: 'lastName',
     header: () => <span>Last Name</span>,
-    cell: (info) => <i>{String(info.getValue<string>())}</i>,
-  },
-  {
-    // accessorFn used to transform the data
-    accessorFn: (row) => Number(row.age),
+    cell: (info) => <i>{String(info.getValue())}</i>,
+  }),
+  columnHelper.accessor((row) => Number(row.age), {
     id: 'age',
     header: () => 'Age',
     cell: (info) => String(info.renderValue()),
-  },
-  {
-    accessorKey: 'visits',
+  }),
+  columnHelper.accessor('visits', {
     header: () => <span>Visits</span>,
-  },
-  { accessorKey: 'status', header: 'Status' },
-  { accessorKey: 'progress', header: 'Profile Progress' },
-]
+  }),
+  columnHelper.accessor('status', { header: 'Status' }),
+  columnHelper.accessor('progress', { header: 'Profile Progress' }),
+])
 
 function App() @{
-  // 5. Store data with a stable reference
+  // 6. Store data with a stable reference
   const [data] = useState(() => [...defaultData])
 
-  // 6. Create the table instance with required features, columns, and data
+  // 7. Create the table instance with required features, columns, and data
   const table = useTable(
     {
       debugTable: true, // optionally, enable console logging debug messages
@@ -72,7 +71,7 @@ function App() @{
     (state) => state, // default selector
   )
 
-  // 7. Render your table markup from the table instance APIs
+  // 8. Render your table markup from the table instance APIs
   <div className="demo-root">
     <table>
       <thead>

--- a/examples/octane/column-sizing/src/main.tsrx
+++ b/examples/octane/column-sizing/src/main.tsrx
@@ -64,6 +64,7 @@ function App() @{
       features,
       columns,
       data,
+      // defaultColumn: { size: 150, minSize: 50, maxSize: 500 }, // set sizing defaults for every column
       // initialState: { columnSizing: { firstName: 200 } }, // set column sizes on first render
       // atoms: { columnSizing: columnSizingAtom }, // preferred: own sizing state with an external atom
       // state: { columnSizing }, // classic controlled state; pair with onColumnSizingChange

--- a/examples/octane/expanding/src/main.tsrx
+++ b/examples/octane/expanding/src/main.tsrx
@@ -144,7 +144,11 @@ function App() @{
       features,
       columns,
       data,
-      getSubRows: (row) => row.subRows,
+      getSubRows: (row) => row.subRows, // tell the table where nested rows live
+      // enableRowSelection: row => row.original.age > 18, // enable selection conditionally; default true
+      // enableMultiRowSelection: false, // allow only one selected row at a time; default true
+      // enableSubRowSelection: false, // disable sub-row selection; default true
+      // enableRowRangeSelection: false, // disable shift-click range selection; default true
       // initialState: { expanded: { '0': true } }, // expand rows on first render
       // atoms: { expanded: expandedAtom }, // preferred: own expanded state with an external atom
       // state: { expanded }, // classic controlled state; pair with onExpandedChange
@@ -156,8 +160,11 @@ function App() @{
       // paginateExpandedRows: false, // keep expanded children on their parent page; default true
       // autoResetExpanded: false, // keep expanded rows after page-altering changes; default true
       // autoResetAll: false, // turn off every feature's automatic reset, including expansion
+      // enableFilters: false, // disable all column and global filtering; default true
+      // enableColumnFilters: false, // disable per-column filters; default true
       // filterFromLeafRows: true, // with filtering, keep parents whose descendants match
       // maxLeafRowFilterDepth: 0, // with filtering, only filter root rows
+      // manualFiltering: true, // pass data that is already filtered, for example from a server
       debugTable: true,
     },
     (state) => state, // default selector

--- a/examples/octane/row-pinning/src/main.tsrx
+++ b/examples/octane/row-pinning/src/main.tsrx
@@ -159,7 +159,10 @@ function App() @{
       features,
       columns,
       data,
-      initialState: { pagination: { pageSize: 20, pageIndex: 0 } },
+      initialState: {
+        pagination: { pageSize: 20, pageIndex: 0 },
+        // rowPinning: { top: ['0'], bottom: ['1'] }, // pin rows on first render
+      },
       state: {
         expanded,
         rowPinning,

--- a/examples/octane/row-selection/src/main.tsrx
+++ b/examples/octane/row-selection/src/main.tsrx
@@ -113,6 +113,7 @@ function App() @{
       data,
       getRowId: (row) => row.id,
       enableRowSelection: true, // enable row selection for all rows
+      // enableRowSelection: row => row.original.age > 18, // or enable selection conditionally
       // initialState: { rowSelection: { '0': true } }, // select rows on first render
       // state: { rowSelection }, // classic controlled state; pair with onRowSelectionChange
       // onRowSelectionChange: setRowSelection,

--- a/examples/preact/aggregation/src/main.tsx
+++ b/examples/preact/aggregation/src/main.tsx
@@ -128,6 +128,7 @@ function App() {
       data,
       meta: { rowSource },
       initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+      // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
       debugTable: true,
       debugColumns: true,
     },

--- a/examples/preact/basic-use-table/src/main.tsx
+++ b/examples/preact/basic-use-table/src/main.tsx
@@ -1,12 +1,15 @@
 import { render } from 'preact'
 import { TanStackDevtools } from '@tanstack/preact-devtools'
 import { useState } from 'preact/hooks'
-import { tableFeatures, useTable } from '@tanstack/preact-table'
+import {
+  createColumnHelper,
+  tableFeatures,
+  useTable,
+} from '@tanstack/preact-table'
 import {
   tableDevtoolsPlugin,
   useTanStackTableDevtools,
 } from '@tanstack/preact-table-devtools'
-import type { ColumnDef } from '@tanstack/preact-table'
 import './index.css'
 
 // This example uses the classic standalone `useTable` hook to create a table without the new `createTableHelper` util.
@@ -60,46 +63,43 @@ const defaultData: Array<Person> = [
 // 3. New in V9! Tell the table which features and row models we want to use. In this case, this will be a basic table with no additional features
 const features = tableFeatures({}) // util method to create sharable TFeatures object/type
 
-// 4. Define the columns for your table. This uses the new `ColumnDef` type to define columns. Alternatively, check out the createTableHelper/createColumnHelper util for an even more type-safe way to define columns.
-const columns: Array<ColumnDef<typeof features, Person>> = [
-  {
-    accessorKey: 'firstName', // accessorKey method (most common for simple use-cases)
+// 4. Create a column helper with the table features and row type
+const columnHelper = createColumnHelper<typeof features, Person>()
+
+// 5. Define the columns for your table with the column helper
+const columns = columnHelper.columns([
+  columnHelper.accessor('firstName', {
     header: 'First Name',
     cell: (info) => info.getValue(),
-  },
-  {
-    accessorFn: (row) => row.lastName, // accessorFn used (alternative) along with a custom id
+  }),
+  columnHelper.accessor((row) => row.lastName, {
     id: 'lastName',
     header: () => <span>Last Name</span>,
-    cell: (info) => <i>{info.getValue<string>()}</i>,
-  },
-  {
-    accessorFn: (row) => Number(row.age), // accessorFn used to transform the data
+    cell: (info) => <i>{info.getValue()}</i>,
+  }),
+  columnHelper.accessor((row) => Number(row.age), {
     id: 'age',
     header: () => 'Age',
     cell: (info) => {
       return info.renderValue()
     },
-  },
-  {
-    accessorKey: 'visits',
+  }),
+  columnHelper.accessor('visits', {
     header: () => <span>Visits</span>,
-  },
-  {
-    accessorKey: 'status',
+  }),
+  columnHelper.accessor('status', {
     header: 'Status',
-  },
-  {
-    accessorKey: 'progress',
+  }),
+  columnHelper.accessor('progress', {
     header: 'Profile Progress',
-  },
-]
+  }),
+])
 
 function App() {
-  // 5. Store data with a stable reference
+  // 6. Store data with a stable reference
   const [data, _setData] = useState(() => [...defaultData])
 
-  // 6. Create the table instance with required features, columns, and data
+  // 7. Create the table instance with required features, columns, and data
   const table = useTable(
     {
       key: 'basic-use-table', // needed for devtools
@@ -114,7 +114,7 @@ function App() {
 
   useTanStackTableDevtools(table)
 
-  // 7. Render your table markup from the table instance APIs
+  // 8. Render your table markup from the table instance APIs
   return (
     <div className="demo-root">
       <table>

--- a/examples/preact/column-sizing/src/main.tsx
+++ b/examples/preact/column-sizing/src/main.tsx
@@ -64,6 +64,7 @@ function App() {
       features,
       columns,
       data,
+      // defaultColumn: { size: 150, minSize: 50, maxSize: 500 }, // set sizing defaults for every column
       // initialState: { columnSizing: { firstName: 200 } }, // set column sizes on first render
       // atoms: { columnSizing: columnSizingAtom }, // preferred: own sizing state with an external atom
       // state: { columnSizing }, // classic controlled state; pair with onColumnSizingChange

--- a/examples/preact/expanding/src/main.tsx
+++ b/examples/preact/expanding/src/main.tsx
@@ -144,7 +144,11 @@ function App() {
       features,
       columns,
       data,
-      getSubRows: (row) => row.subRows,
+      getSubRows: (row) => row.subRows, // tell the table where nested rows live
+      // enableRowSelection: row => row.original.age > 18, // enable selection conditionally; default true
+      // enableMultiRowSelection: false, // allow only one selected row at a time; default true
+      // enableSubRowSelection: false, // disable sub-row selection; default true
+      // enableRowRangeSelection: false, // disable shift-click range selection; default true
       // initialState: { expanded: { '0': true } }, // expand rows on first render
       // atoms: { expanded: expandedAtom }, // preferred: own expanded state with an external atom
       // state: { expanded }, // classic controlled state; pair with onExpandedChange
@@ -156,8 +160,11 @@ function App() {
       // paginateExpandedRows: false, // keep expanded children on their parent page; default true
       // autoResetExpanded: false, // keep expanded rows after page-altering changes; default true
       // autoResetAll: false, // turn off every feature's automatic reset, including expansion
+      // enableFilters: false, // disable all column and global filtering; default true
+      // enableColumnFilters: false, // disable per-column filters; default true
       // filterFromLeafRows: true, // with filtering, keep parents whose descendants match
       // maxLeafRowFilterDepth: 0, // with filtering, only filter root rows
+      // manualFiltering: true, // pass data that is already filtered, for example from a server
       debugTable: true,
     },
     (state) => state, // default selector

--- a/examples/preact/row-pinning/src/main.tsx
+++ b/examples/preact/row-pinning/src/main.tsx
@@ -159,7 +159,10 @@ function App() {
       features,
       columns,
       data,
-      initialState: { pagination: { pageSize: 20, pageIndex: 0 } },
+      initialState: {
+        pagination: { pageSize: 20, pageIndex: 0 },
+        // rowPinning: { top: ['0'], bottom: ['1'] }, // pin rows on first render
+      },
       state: {
         expanded,
         rowPinning,

--- a/examples/preact/row-selection/src/main.tsx
+++ b/examples/preact/row-selection/src/main.tsx
@@ -121,6 +121,7 @@ function App() {
       data,
       getRowId: (row) => row.id,
       enableRowSelection: true, // enable row selection for all rows
+      // enableRowSelection: row => row.original.age > 18, // or enable selection conditionally
       // initialState: { rowSelection: { '0': true } }, // select rows on first render
       // state: { rowSelection }, // classic controlled state; pair with onRowSelectionChange
       // onRowSelectionChange: setRowSelection,

--- a/examples/react/aggregation/src/main.tsx
+++ b/examples/react/aggregation/src/main.tsx
@@ -106,6 +106,8 @@ function App() {
         columnHelper.accessor('amount', {
           header: 'Amount',
           aggregationFn: 'sum',
+          // maxAggregationDepth: 1, // include one level of descendants in this column's aggregate
+          // getAggregationValue: () => ({ value: 0 }), // provide a precomputed value and skip local fallback
           cell: ({ getValue }) => getValue<number>().toLocaleString(),
           footer: ({ column, table }) =>
             formatValue(
@@ -141,6 +143,7 @@ function App() {
       data,
       meta: { rowSource },
       initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+      // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
       debugTable: true,
       debugColumns: true,
     },

--- a/examples/react/basic-use-table/src/main.tsx
+++ b/examples/react/basic-use-table/src/main.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react'
 import { TanStackDevtools } from '@tanstack/react-devtools'
 import ReactDOM from 'react-dom/client'
-import { tableFeatures, useTable } from '@tanstack/react-table'
+import {
+  createColumnHelper,
+  tableFeatures,
+  useTable,
+} from '@tanstack/react-table'
 import {
   tableDevtoolsPlugin,
   useTanStackTableDevtools,
 } from '@tanstack/react-table-devtools'
-import type { ColumnDef } from '@tanstack/react-table'
 import './index.css'
 
 // This example uses the classic standalone `useTable` hook to create a table without the new `createTableHelper` util.
@@ -60,46 +63,43 @@ const defaultData: Array<Person> = [
 // 3. New in V9! Tell the table which features and row models we want to use. In this case, this will be a basic table with no additional features
 const features = tableFeatures({}) // util method to create sharable TFeatures object/type
 
-// 4. Define the columns for your table. This uses the new `ColumnDef` type to define columns. Alternatively, check out the createTableHelper/createColumnHelper util for an even more type-safe way to define columns.
-const columns: Array<ColumnDef<typeof features, Person>> = [
-  {
-    accessorKey: 'firstName', // accessorKey method (most common for simple use-cases)
+// 4. Create a column helper with the table features and row type
+const columnHelper = createColumnHelper<typeof features, Person>()
+
+// 5. Define the columns for your table with the column helper
+const columns = columnHelper.columns([
+  columnHelper.accessor('firstName', {
     header: 'First Name',
     cell: (info) => info.getValue(),
-  },
-  {
-    accessorFn: (row) => row.lastName, // accessorFn used (alternative) along with a custom id
+  }),
+  columnHelper.accessor((row) => row.lastName, {
     id: 'lastName',
     header: () => <span>Last Name</span>,
-    cell: (info) => <i>{info.getValue<string>()}</i>,
-  },
-  {
-    accessorFn: (row) => Number(row.age), // accessorFn used to transform the data
+    cell: (info) => <i>{info.getValue()}</i>,
+  }),
+  columnHelper.accessor((row) => Number(row.age), {
     id: 'age',
     header: () => 'Age',
     cell: (info) => {
       return info.renderValue()
     },
-  },
-  {
-    accessorKey: 'visits',
+  }),
+  columnHelper.accessor('visits', {
     header: () => <span>Visits</span>,
-  },
-  {
-    accessorKey: 'status',
+  }),
+  columnHelper.accessor('status', {
     header: 'Status',
-  },
-  {
-    accessorKey: 'progress',
+  }),
+  columnHelper.accessor('progress', {
     header: 'Profile Progress',
-  },
-]
+  }),
+])
 
 function App() {
-  // 5. Store data with a stable reference
+  // 6. Store data with a stable reference
   const [data, _setData] = React.useState(() => [...defaultData])
 
-  // 6. Create the table instance with required features, columns, and data
+  // 7. Create the table instance with required features, columns, and data
   const table = useTable(
     {
       key: 'basic-use-table', // needed for devtools, omit if you don't want to use the devtools
@@ -115,7 +115,7 @@ function App() {
   // optionally, add this table instance to the devtools
   useTanStackTableDevtools(table)
 
-  // 7. Render your table markup from the table instance APIs
+  // 8. Render your table markup from the table instance APIs
   return (
     <div className="demo-root">
       <table>

--- a/examples/react/column-pinning/src/main.tsx
+++ b/examples/react/column-pinning/src/main.tsx
@@ -38,6 +38,7 @@ const columns = columnHelper.columns([
       }),
       columnHelper.accessor((row) => row.lastName, {
         id: 'lastName',
+        // enablePinning: false, // prevent this column from being pinned
         cell: (info) => info.getValue(),
         header: () => <span>Last Name</span>,
         footer: (props) => props.column.id,

--- a/examples/react/column-resizing/src/main.tsx
+++ b/examples/react/column-resizing/src/main.tsx
@@ -25,6 +25,8 @@ const columns = columnHelper.columns([
     footer: (props) => props.column.id,
     columns: columnHelper.columns([
       columnHelper.accessor('firstName', {
+        // enableResizing: false, // prevent this column from being resized
+        // size: 180, minSize: 80, maxSize: 400, // override sizing defaults for this column
         cell: (info) => info.getValue(),
         footer: (props) => props.column.id,
       }),

--- a/examples/react/column-sizing/src/main.tsx
+++ b/examples/react/column-sizing/src/main.tsx
@@ -64,6 +64,7 @@ function App() {
       features,
       columns,
       data,
+      // defaultColumn: { size: 150, minSize: 50, maxSize: 500 }, // set sizing defaults for every column
       // initialState: { columnSizing: { firstName: 200 } }, // set column sizes on first render
       // atoms: { columnSizing: columnSizingAtom }, // preferred: own sizing state with an external atom
       // state: { columnSizing }, // classic controlled state; pair with onColumnSizingChange

--- a/examples/react/column-visibility/src/main.tsx
+++ b/examples/react/column-visibility/src/main.tsx
@@ -20,6 +20,7 @@ const columns = columnHelper.columns([
     footer: (props) => props.column.id,
     columns: columnHelper.columns([
       columnHelper.accessor('firstName', {
+        // enableHiding: false, // keep this column visible
         cell: (info) => info.getValue(),
         footer: (props) => props.column.id,
       }),

--- a/examples/react/expanding/src/main.tsx
+++ b/examples/react/expanding/src/main.tsx
@@ -7,9 +7,9 @@ import {
   createFilteredRowModel,
   createPaginatedRowModel,
   createSortedRowModel,
+  filterFn_between,
   filterFn_inNumberRange,
   filterFn_includesString,
-  filterFns,
   rowExpandingFeature,
   rowPaginationFeature,
   rowSelectionFeature,
@@ -37,7 +37,7 @@ const features = tableFeatures({
   paginatedRowModel: createPaginatedRowModel(),
   sortedRowModel: createSortedRowModel(),
   filterFns: {
-    between: filterFns.between, // no individual export for this fn (yet)
+    between: filterFn_between,
     includesString: filterFn_includesString,
     inNumberRange: filterFn_inNumberRange,
   },
@@ -146,7 +146,10 @@ function App() {
       columns,
       data,
       getSubRows: (row) => row.subRows, // tell the table where nested rows live
-      // enableSubRowSelection: false,
+      // enableRowSelection: row => row.original.age > 18, // enable selection conditionally; default true
+      // enableMultiRowSelection: false, // allow only one selected row at a time; default true
+      // enableSubRowSelection: false, // disable sub-row selection; default true
+      // enableRowRangeSelection: false, // disable shift-click range selection; default true
       // initialState: { expanded: { '0': true } }, // expand rows on first render
       // atoms: { expanded: expandedAtom }, // preferred: own expanded state with an external atom
       // state: { expanded }, // classic controlled state; pair with onExpandedChange
@@ -158,8 +161,11 @@ function App() {
       // paginateExpandedRows: false, // keep expanded children on their parent page; default true
       // autoResetExpanded: false, // keep expanded rows after page-altering changes; default true
       // autoResetAll: false, // turn off every feature's automatic reset, including expansion
+      // enableFilters: false, // disable all column and global filtering; default true
+      // enableColumnFilters: false, // disable per-column filters; default true
       // filterFromLeafRows: true, // with filtering, keep parents whose descendants match
       // maxLeafRowFilterDepth: 0, // with filtering, only filter root rows
+      // manualFiltering: true, // pass data that is already filtered, for example from a server
       debugTable: true,
       debugRows: true,
     },

--- a/examples/react/filters/src/main.tsx
+++ b/examples/react/filters/src/main.tsx
@@ -50,6 +50,7 @@ function App() {
         }),
         columnHelper.accessor('firstName', {
           cell: (info) => info.getValue(),
+          // enableColumnFilter: false, // disable filtering for this column
         }),
         columnHelper.accessor((row) => row.lastName, {
           id: 'lastName',

--- a/examples/react/grouping/src/main.tsx
+++ b/examples/react/grouping/src/main.tsx
@@ -67,6 +67,7 @@ function App() {
         }),
         columnHelper.accessor('age', {
           header: () => 'Age',
+          // enableGrouping: false, // prevent grouping by this column
         }),
         columnHelper.accessor('visits', {
           header: () => <span>Visits</span>,

--- a/examples/react/row-pinning/src/main.tsx
+++ b/examples/react/row-pinning/src/main.tsx
@@ -160,7 +160,10 @@ function App() {
       features,
       columns,
       data,
-      initialState: { pagination: { pageSize: 20, pageIndex: 0 } },
+      initialState: {
+        pagination: { pageSize: 20, pageIndex: 0 },
+        // rowPinning: { top: ['0'], bottom: ['1'] }, // pin rows on first render
+      },
       state: {
         expanded,
         rowPinning,

--- a/examples/react/row-selection/src/main.tsx
+++ b/examples/react/row-selection/src/main.tsx
@@ -118,6 +118,7 @@ function App() {
       data,
       getRowId: (row) => row.id,
       enableRowSelection: true, // enable row selection for all rows
+      // enableRowSelection: row => row.original.age > 18, // or enable selection conditionally
       // initialState: { rowSelection: { '0': true } }, // select rows on first render
       // state: { rowSelection }, // classic controlled state; pair with onRowSelectionChange
       // onRowSelectionChange: setRowSelection,

--- a/examples/solid/aggregation/src/App.tsx
+++ b/examples/solid/aggregation/src/App.tsx
@@ -125,6 +125,7 @@ function App() {
       return { rowSource: rowSource() }
     },
     initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+    // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
     debugTable: true,
     debugColumns: true,
   })

--- a/examples/solid/basic-use-table/src/App.tsx
+++ b/examples/solid/basic-use-table/src/App.tsx
@@ -1,7 +1,11 @@
-import { FlexRender, createTable, tableFeatures } from '@tanstack/solid-table'
+import {
+  FlexRender,
+  createColumnHelper,
+  createTable,
+  tableFeatures,
+} from '@tanstack/solid-table'
 import { useTanStackTableDevtools } from '@tanstack/solid-table-devtools'
 import { For, createSignal } from 'solid-js'
-import type { ColumnDef } from '@tanstack/solid-table'
 
 // This example uses the standalone `createTable` function to create a table without the `createTableHook` util.
 
@@ -54,44 +58,41 @@ const defaultData: Array<Person> = [
 // 3. New in V9! Tell the table which features and row models we want to use. In this case, this will be a basic table with no additional features
 const features = tableFeatures({}) // util method to create sharable TFeatures object/type
 
-// 4. Define the columns for your table. This uses the new `ColumnDef` type to define columns. Alternatively, check out the createTableHook/createAppColumnHelper util for an even more type-safe way to define columns.
-const columns: Array<ColumnDef<typeof features, Person>> = [
-  {
-    accessorKey: 'firstName', // accessorKey method (most common for simple use-cases)
+// 4. Create a column helper with the table features and row type
+const columnHelper = createColumnHelper<typeof features, Person>()
+
+// 5. Define the columns for your table with the column helper
+const columns = columnHelper.columns([
+  columnHelper.accessor('firstName', {
     header: 'First Name',
     cell: (info) => info.getValue(),
-  },
-  {
-    accessorFn: (row) => row.lastName, // accessorFn used (alternative) along with a custom id
+  }),
+  columnHelper.accessor((row) => row.lastName, {
     id: 'lastName',
     header: () => <span>Last Name</span>,
-    cell: (info) => <i>{info.getValue<string>()}</i>,
-  },
-  {
-    accessorFn: (row) => Number(row.age), // accessorFn used to transform the data
+    cell: (info) => <i>{info.getValue()}</i>,
+  }),
+  columnHelper.accessor((row) => Number(row.age), {
     id: 'age',
     header: () => 'Age',
     cell: (info) => info.renderValue(),
-  },
-  {
-    accessorKey: 'visits',
+  }),
+  columnHelper.accessor('visits', {
     header: () => <span>Visits</span>,
-  },
-  {
-    accessorKey: 'status',
+  }),
+  columnHelper.accessor('status', {
     header: 'Status',
-  },
-  {
-    accessorKey: 'progress',
+  }),
+  columnHelper.accessor('progress', {
     header: 'Profile Progress',
-  },
-]
+  }),
+])
 
 function App() {
-  // 5. Store data with a reactive reference
+  // 6. Store data with a reactive reference
   const [data] = createSignal([...defaultData])
 
-  // 6. Create the table instance with required features, columns, and data
+  // 7. Create the table instance with required features, columns, and data
   const table = createTable({
     key: 'basic-use-table', // needed for devtools
     debugTable: true,
@@ -104,7 +105,7 @@ function App() {
 
   useTanStackTableDevtools(table)
 
-  // 7. Render your table markup from the table instance APIs
+  // 8. Render your table markup from the table instance APIs
   return (
     <div class="demo-root">
       <table>

--- a/examples/solid/column-sizing/src/App.tsx
+++ b/examples/solid/column-sizing/src/App.tsx
@@ -58,6 +58,7 @@ function App() {
     get data() {
       return data()
     },
+    // defaultColumn: { size: 150, minSize: 50, maxSize: 500 }, // set sizing defaults for every column
     // initialState: { columnSizing: { firstName: 200 } }, // set column sizes on first render
     // atoms: { columnSizing: columnSizingAtom }, // preferred: own sizing state with an external atom
     // state: { columnSizing }, // classic controlled state; pair with onColumnSizingChange

--- a/examples/solid/expanding/src/App.tsx
+++ b/examples/solid/expanding/src/App.tsx
@@ -130,7 +130,11 @@ function App() {
     get data() {
       return data()
     },
-    getSubRows: (row) => row.subRows,
+    getSubRows: (row) => row.subRows, // tell the table where nested rows live
+    // enableRowSelection: row => row.original.age > 18, // enable selection conditionally; default true
+    // enableMultiRowSelection: false, // allow only one selected row at a time; default true
+    // enableSubRowSelection: false, // disable sub-row selection; default true
+    // enableRowRangeSelection: false, // disable shift-click range selection; default true
     // initialState: { expanded: { '0': true } }, // expand rows on first render
     // atoms: { expanded: expandedAtom }, // preferred: own expanded state with an external atom
     // state: { expanded }, // classic controlled state; pair with onExpandedChange
@@ -142,8 +146,11 @@ function App() {
     // paginateExpandedRows: false, // keep expanded children on their parent page; default true
     // autoResetExpanded: false, // keep expanded rows after page-altering changes; default true
     // autoResetAll: false, // turn off every feature's automatic reset, including expansion
+    // enableFilters: false, // disable all column and global filtering; default true
+    // enableColumnFilters: false, // disable per-column filters; default true
     // filterFromLeafRows: true, // with filtering, keep parents whose descendants match
     // maxLeafRowFilterDepth: 0, // with filtering, only filter root rows
+    // manualFiltering: true, // pass data that is already filtered, for example from a server
     debugTable: true,
   })
 

--- a/examples/solid/row-pinning/src/App.tsx
+++ b/examples/solid/row-pinning/src/App.tsx
@@ -138,7 +138,10 @@ function App() {
     get data() {
       return data()
     },
-    initialState: { pagination: { pageSize: 20, pageIndex: 0 } },
+    initialState: {
+      pagination: { pageSize: 20, pageIndex: 0 },
+      // rowPinning: { top: ['0'], bottom: ['1'] }, // pin rows on first render
+    },
     get state() {
       return {
         expanded: expanded(),

--- a/examples/solid/row-selection/src/App.tsx
+++ b/examples/solid/row-selection/src/App.tsx
@@ -131,6 +131,7 @@ function App() {
     get enableRowSelection() {
       return enableRowSelection()
     },
+    // enableRowSelection: row => row.original.age > 18, // or enable selection conditionally
     // initialState: { rowSelection: { '0': true } }, // select rows on first render
     // atoms: { rowSelection: rowSelectionAtom }, // preferred: own selection state with an external atom
     // state: { rowSelection }, // classic controlled state; pair with onRowSelectionChange

--- a/examples/svelte/aggregation/src/App.svelte
+++ b/examples/svelte/aggregation/src/App.svelte
@@ -41,7 +41,9 @@
     features, columns,
     get data() { return data },
     get meta() { return { rowSource } },
-    initialState: { pagination: { pageIndex: 0, pageSize: 10 } }, debugTable: true, debugColumns: true,
+    initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+    // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
+    debugTable: true, debugColumns: true,
   })
   const pagination = $derived(table.atoms.pagination.get())
   function changeRowSource(value: RowSource) {

--- a/examples/svelte/basic-create-table/src/App.svelte
+++ b/examples/svelte/basic-create-table/src/App.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   // This example uses the standalone `createTable` function to create a table without the `createTableHook` util.
 
-  import { createTable, FlexRender, tableFeatures
+  import { createColumnHelper, createTable, FlexRender, tableFeatures
   } from '@tanstack/svelte-table'
-  import type { ColumnDef } from '@tanstack/svelte-table'
   import { makeData, type Person } from './makeData'
   import './index.css'
 
@@ -11,46 +10,42 @@
   const features = tableFeatures({
   }) // util method to create sharable TFeatures object/type
 
-  // 4. Define the columns for your table. This uses the new `ColumnDef` type to define columns.
-  //    Alternatively, check out the createTableHook/createAppColumnHelper util for an even more type-safe way to define columns.
-  const columns: Array<ColumnDef<typeof features, Person>> = [
-    {
-      accessorKey: 'firstName', // accessorKey method (most common for simple use-cases)
+  // 2. Create a column helper with the table features and row type
+  const columnHelper = createColumnHelper<typeof features, Person>()
+
+  // 3. Define the columns for your table with the column helper
+  const columns = columnHelper.columns([
+    columnHelper.accessor('firstName', {
       header: 'First Name',
       cell: (info) => info.getValue(),
-    },
-    {
-      accessorFn: (row) => row.lastName, // accessorFn used (alternative) along with a custom id
+    }),
+    columnHelper.accessor((row) => row.lastName, {
       id: 'lastName',
       header: () => 'Last Name',
       cell: (info) => info.getValue(),
-    },
-    {
-      accessorFn: (row) => Number(row.age), // accessorFn used to transform the data
+    }),
+    columnHelper.accessor((row) => Number(row.age), {
       id: 'age',
       header: () => 'Age',
       cell: (info) => info.renderValue(),
-    },
-    {
-      accessorKey: 'visits',
+    }),
+    columnHelper.accessor('visits', {
       header: () => 'Visits',
-    },
-    {
-      accessorKey: 'status',
+    }),
+    columnHelper.accessor('status', {
       header: 'Status',
-    },
-    {
-      accessorKey: 'progress',
+    }),
+    columnHelper.accessor('progress', {
       header: 'Profile Progress',
-    },
-  ]
+    }),
+  ])
 
-  // 5. Store data with a $state rune for reactivity
+  // 4. Store data with a $state rune for reactivity
   let data = $state(makeData(20))
   const refreshData = () => { data = makeData(20) }
   const stressTest = () => { data = makeData(1_000) }
 
-  // 6. Create the table instance with required features, columns, and data
+  // 5. Create the table instance with required features, columns, and data
   const table = createTable({
     debugTable: true,
     features, // new required option in V9. Tell the table which features you are importing and using (better tree-shaking)
@@ -62,7 +57,7 @@
   })
 </script>
 
-<!-- 7. Render your table markup from the table instance APIs -->
+<!-- 6. Render your table markup from the table instance APIs -->
 <div class="demo-root">
   <div>
     <button onclick={() => refreshData()

--- a/examples/svelte/column-sizing/src/App.svelte
+++ b/examples/svelte/column-sizing/src/App.svelte
@@ -59,6 +59,7 @@
       get data() {
         return data
       },
+      // defaultColumn: { size: 150, minSize: 50, maxSize: 500 }, // set sizing defaults for every column
       // initialState: { columnSizing: { firstName: 200 } }, // set column sizes on first render
       // atoms: { columnSizing: columnSizingAtom }, // preferred: own sizing state with an external atom
       // state: { columnSizing }, // classic controlled state; pair with onColumnSizingChange

--- a/examples/svelte/expanding/src/App.svelte
+++ b/examples/svelte/expanding/src/App.svelte
@@ -102,7 +102,11 @@
       get data() {
         return data
       },
-      getSubRows: (row) => row.subRows,
+      getSubRows: (row) => row.subRows, // tell the table where nested rows live
+      // enableRowSelection: row => row.original.age > 18, // enable selection conditionally; default true
+      // enableMultiRowSelection: false, // allow only one selected row at a time; default true
+      // enableSubRowSelection: false, // disable sub-row selection; default true
+      // enableRowRangeSelection: false, // disable shift-click range selection; default true
       // initialState: { expanded: { '0': true } }, // expand rows on first render
       // atoms: { expanded: expandedAtom }, // preferred: own expanded state with an external atom
       // state: { expanded }, // classic controlled state; pair with onExpandedChange
@@ -114,8 +118,11 @@
       // paginateExpandedRows: false, // keep expanded children on their parent page; default true
       // autoResetExpanded: false, // keep expanded rows after page-altering changes; default true
       // autoResetAll: false, // turn off every feature's automatic reset, including expansion
+      // enableFilters: false, // disable all column and global filtering; default true
+      // enableColumnFilters: false, // disable per-column filters; default true
       // filterFromLeafRows: true, // with filtering, keep parents whose descendants match
       // maxLeafRowFilterDepth: 0, // with filtering, only filter root rows
+      // manualFiltering: true, // pass data that is already filtered, for example from a server
       debugTable: true,
     },
   )

--- a/examples/svelte/row-pinning/src/App.svelte
+++ b/examples/svelte/row-pinning/src/App.svelte
@@ -89,7 +89,10 @@
       get data() {
         return data
       },
-      initialState: { pagination: { pageSize: 20, pageIndex: 0 } },
+      initialState: {
+        pagination: { pageSize: 20, pageIndex: 0 },
+        // rowPinning: { top: ['0'], bottom: ['1'] }, // pin rows on first render
+      },
       get state() {
         return {
           expanded: expanded(),

--- a/examples/svelte/row-selection/src/App.svelte
+++ b/examples/svelte/row-selection/src/App.svelte
@@ -113,6 +113,7 @@
       ],
       getRowId: (row) => row.id,
       enableRowSelection: true,
+      // enableRowSelection: row => row.original.age > 18, // or enable selection conditionally
       // initialState: { rowSelection: { '0': true } }, // select rows on first render
       // atoms: { rowSelection: rowSelectionAtom }, // preferred: own selection state with an external atom
       // state: { rowSelection }, // classic controlled state; pair with onRowSelectionChange

--- a/examples/vanilla/aggregation/src/main.ts
+++ b/examples/vanilla/aggregation/src/main.ts
@@ -258,6 +258,7 @@ const table = constructTable({
   columns,
   meta: { rowSource },
   initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+  // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
   debugTable: true,
   debugColumns: true,
 })

--- a/examples/vue/aggregation/src/App.vue
+++ b/examples/vue/aggregation/src/App.vue
@@ -97,6 +97,7 @@ const table = useTable({
     return { rowSource: rowSource.value }
   },
   initialState: { pagination: { pageIndex: 0, pageSize: 10 } },
+  // manualAggregation: true, // supply aggregate values yourself instead of calculating them locally
   debugTable: true,
   debugColumns: true,
 })

--- a/examples/vue/basic-use-table/src/App.tsx
+++ b/examples/vue/basic-use-table/src/App.tsx
@@ -1,13 +1,12 @@
 import { defineComponent, ref } from 'vue'
-import { FlexRender, tableFeatures, useTable } from '@tanstack/vue-table'
-import { useTanStackTableDevtools } from '@tanstack/vue-table-devtools'
-import type {
-  Cell,
-  ColumnDef,
-  Header,
-  HeaderGroup,
-  Row,
+import {
+  FlexRender,
+  createColumnHelper,
+  tableFeatures,
+  useTable,
 } from '@tanstack/vue-table'
+import { useTanStackTableDevtools } from '@tanstack/vue-table-devtools'
+import type { Cell, Header, HeaderGroup, Row } from '@tanstack/vue-table'
 
 type Person = {
   firstName: string
@@ -55,37 +54,33 @@ const defaultData: Array<Person> = [
 
 const features = tableFeatures({})
 
-const columns: Array<ColumnDef<typeof features, Person>> = [
-  {
-    accessorKey: 'firstName',
+const columnHelper = createColumnHelper<typeof features, Person>()
+
+const columns = columnHelper.columns([
+  columnHelper.accessor('firstName', {
     header: 'First Name',
     cell: (info) => info.getValue(),
-  },
-  {
-    accessorFn: (row) => row.lastName,
+  }),
+  columnHelper.accessor((row) => row.lastName, {
     id: 'lastName',
     header: () => <span>Last Name</span>,
-    cell: (info) => <i>{info.getValue<string>()}</i>,
-  },
-  {
-    accessorFn: (row) => Number(row.age),
+    cell: (info) => <i>{info.getValue()}</i>,
+  }),
+  columnHelper.accessor((row) => Number(row.age), {
     id: 'age',
     header: () => 'Age',
     cell: (info) => info.renderValue(),
-  },
-  {
-    accessorKey: 'visits',
+  }),
+  columnHelper.accessor('visits', {
     header: () => <span>Visits</span>,
-  },
-  {
-    accessorKey: 'status',
+  }),
+  columnHelper.accessor('status', {
     header: 'Status',
-  },
-  {
-    accessorKey: 'progress',
+  }),
+  columnHelper.accessor('progress', {
     header: 'Profile Progress',
-  },
-]
+  }),
+])
 
 export default defineComponent({
   name: 'BasicUseTableExample',

--- a/examples/vue/column-sizing/src/App.vue
+++ b/examples/vue/column-sizing/src/App.vue
@@ -61,6 +61,7 @@ const table = useTable({
   get columns() {
     return columns.value
   },
+  // defaultColumn: { size: 150, minSize: 50, maxSize: 500 }, // set sizing defaults for every column
   // initialState: { columnSizing: { firstName: 200 } }, // set column sizes on first render
   // atoms: { columnSizing: columnSizingAtom }, // preferred: own sizing state with an external atom
   // state: { columnSizing }, // classic controlled state; pair with onColumnSizingChange

--- a/examples/vue/expanding/src/App.tsx
+++ b/examples/vue/expanding/src/App.tsx
@@ -219,7 +219,11 @@ export default defineComponent({
       get data() {
         return data.value
       },
-      getSubRows: (row: Person) => row.subRows,
+      getSubRows: (row: Person) => row.subRows, // tell the table where nested rows live
+      // enableRowSelection: row => row.original.age > 18, // enable selection conditionally; default true
+      // enableMultiRowSelection: false, // allow only one selected row at a time; default true
+      // enableSubRowSelection: false, // disable sub-row selection; default true
+      // enableRowRangeSelection: false, // disable shift-click range selection; default true
       // initialState: { expanded: { '0': true } }, // expand rows on first render
       // atoms: { expanded: expandedAtom }, // preferred: own expanded state with an external atom
       // state: { expanded }, // classic controlled state; pair with onExpandedChange
@@ -231,8 +235,11 @@ export default defineComponent({
       // paginateExpandedRows: false, // keep expanded children on their parent page; default true
       // autoResetExpanded: false, // keep expanded rows after page-altering changes; default true
       // autoResetAll: false, // turn off every feature's automatic reset, including expansion
+      // enableFilters: false, // disable all column and global filtering; default true
+      // enableColumnFilters: false, // disable per-column filters; default true
       // filterFromLeafRows: true, // with filtering, keep parents whose descendants match
       // maxLeafRowFilterDepth: 0, // with filtering, only filter root rows
+      // manualFiltering: true, // pass data that is already filtered, for example from a server
       debugTable: true,
     })
 

--- a/examples/vue/row-pinning/src/App.tsx
+++ b/examples/vue/row-pinning/src/App.tsx
@@ -234,7 +234,10 @@ export default defineComponent({
         return data.value
       },
       getSubRows: (row: Person) => row.subRows,
-      initialState: { pagination: { pageSize: 20, pageIndex: 0 } },
+      initialState: {
+        pagination: { pageSize: 20, pageIndex: 0 },
+        // rowPinning: { top: ['0'], bottom: ['1'] }, // pin rows on first render
+      },
       get keepPinnedRows() {
         return keepPinnedRows.value
       },

--- a/examples/vue/row-selection/src/App.vue
+++ b/examples/vue/row-selection/src/App.vue
@@ -115,6 +115,7 @@ const table = useTable({
   get enableRowSelection() {
     return enableRowSelection.value
   },
+  // enableRowSelection: row => row.original.age > 18, // or enable selection conditionally
   // initialState: { rowSelection: { '0': true } }, // select rows on first render
   // atoms: { rowSelection: rowSelectionAtom }, // preferred: own selection state with an external atom
   // state: { rowSelection }, // classic controlled state; pair with onRowSelectionChange

--- a/packages/table-core/src/core/row-models/createCoreRowModel.ts
+++ b/packages/table-core/src/core/row-models/createCoreRowModel.ts
@@ -1,6 +1,7 @@
 import { constructRow } from '../rows/constructRow'
-import { makeObjectMap, tableMemo } from '../../utils'
+import { makeObjectMap, skipFirstRun, tableMemo } from '../../utils'
 import { table_autoResetCellSelection } from '../../features/cell-selection/cellSelectionFeature.utils'
+import { table_autoResetExpanded } from '../../features/row-expanding/rowExpandingFeature.utils'
 import { table_autoResetPageIndex } from '../../features/row-pagination/rowPaginationFeature.utils'
 import { table_autoResetSorting } from '../../features/row-sorting/rowSortingFeature.utils'
 import type { Table_Internal } from '../../types/Table'
@@ -27,11 +28,12 @@ export function createCoreRowModel<
       fnName: 'table.getCoreRowModel',
       memoDeps: () => [table.options.data],
       fn: () => _createCoreRowModel(table, table.options.data),
-      onAfterUpdate: () => {
+      onAfterUpdate: skipFirstRun(() => {
+        table_autoResetExpanded(table)
         table_autoResetPageIndex(table)
         table_autoResetSorting(table)
         table_autoResetCellSelection(table)
-      },
+      }),
     })
   }
 }

--- a/packages/table-core/src/features/column-filtering/createFilteredRowModel.ts
+++ b/packages/table-core/src/features/column-filtering/createFilteredRowModel.ts
@@ -1,4 +1,4 @@
-import { makeObjectMap, tableMemo } from '../../utils'
+import { makeObjectMap, skipFirstRun, tableMemo } from '../../utils'
 import { table_getColumn } from '../../core/columns/coreColumnsFeature.utils'
 import {
   column_getCanGlobalFilter,
@@ -45,7 +45,7 @@ export function createFilteredRowModel<
         table.atoms.globalFilter?.get(),
       ],
       fn: () => _createFilteredRowModel(table),
-      onAfterUpdate: () => table_autoResetPageIndex(table),
+      onAfterUpdate: skipFirstRun(() => table_autoResetPageIndex(table)),
     })
   }
 }

--- a/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
+++ b/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
@@ -46,10 +46,12 @@ export function createGroupedRowModel<
       onAfterUpdate: () => {
         const grouping = table.atoms.grouping?.get()
         const preGroupedRowModel = table.getPreGroupedRowModel()
+        // The first computation is not a change; auto-resets fire only once
+        // a previously observed grouping or pre-grouped row model differs.
         const rowInputsChanged =
-          !hasAutoResetDependencies ||
-          grouping !== previousGrouping ||
-          preGroupedRowModel !== previousPreGroupedRowModel
+          hasAutoResetDependencies &&
+          (grouping !== previousGrouping ||
+            preGroupedRowModel !== previousPreGroupedRowModel)
 
         previousGrouping = grouping
         previousPreGroupedRowModel = preGroupedRowModel

--- a/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
+++ b/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
@@ -39,6 +39,10 @@ export function table_autoResetExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table_Internal<TFeatures, TData>) {
+  // The core row model is available without the expanding feature. Avoid
+  // routing an update when this table has no expanded state to reset.
+  if (!table.atoms.expanded) return
+
   if (
     table.options.autoResetAll ??
     table.options.autoResetExpanded ??

--- a/packages/table-core/src/features/row-sorting/createSortedRowModel.ts
+++ b/packages/table-core/src/features/row-sorting/createSortedRowModel.ts
@@ -1,4 +1,8 @@
-import { copyInstancePropertiesWithoutMemos, tableMemo } from '../../utils'
+import {
+  copyInstancePropertiesWithoutMemos,
+  skipFirstRun,
+  tableMemo,
+} from '../../utils'
 import { table_autoResetPageIndex } from '../row-pagination/rowPaginationFeature.utils'
 import { column_getCanSort, column_getSortFn } from './rowSortingFeature.utils'
 import type { Column_Internal } from '../../types/Column'
@@ -36,7 +40,7 @@ export function createSortedRowModel<
         table.getPreSortedRowModel(),
       ],
       fn: () => _createSortedRowModel(table),
-      onAfterUpdate: () => table_autoResetPageIndex(table),
+      onAfterUpdate: skipFirstRun(() => table_autoResetPageIndex(table)),
     })
   }
 }

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -206,6 +206,25 @@ export const memo = <TDeps extends ReadonlyArray<any>, TDepArgs, TResult>({
   return memoizedFn
 }
 
+/**
+ * Wraps a callback so that its first invocation is skipped.
+ *
+ * Row-model `onAfterUpdate` hooks schedule auto-resets when their inputs
+ * change. The initial computation of a row model is not a change, so state
+ * resets must not fire for it — otherwise merely reading a row model on mount
+ * would wipe initial or controlled state.
+ */
+export function skipFirstRun(fn: () => void): () => void {
+  let hasRun = false
+  return () => {
+    if (!hasRun) {
+      hasRun = true
+      return
+    }
+    fn()
+  }
+}
+
 interface TableMemoOptions<
   TFeatures extends TableFeatures,
   TDeps extends ReadonlyArray<any>,

--- a/packages/table-core/src/worker/createTableWorker.ts
+++ b/packages/table-core/src/worker/createTableWorker.ts
@@ -72,6 +72,8 @@ export interface TableWorkerBridge {
   results: { [K in TableWorkerStage]?: TableWorkerDataPayload }
   /** Bumped per stage only when that stage's payload actually changed. */
   stageVersions: { [K in TableWorkerStage]?: number }
+  /** The first applied result is not a change; auto-resets skip it. */
+  hasAppliedResults: boolean
 }
 
 type AnyTable = Table_Internal<any, any>
@@ -157,6 +159,7 @@ export function getTableWorkerBridge(
       lastState: {},
       results: {},
       stageVersions: {},
+      hasAppliedResults: false,
     }
     tableWorker._bridges.set(table, bridge)
   }
@@ -250,8 +253,11 @@ function handleResult(
   // The async equivalent of the sync models' `onAfterUpdate` hooks. The
   // worker's unchanged-detection is its memo identity, so `groupedChanged`
   // mirrors exactly when the sync grouped model would have recomputed (and
-  // reset expansion).
-  if (anyChanged) {
+  // reset expansion). Like the sync models, the first applied result is not
+  // a change and must not fire auto-resets.
+  const isFirstAppliedResult = !bridge.hasAppliedResults
+  bridge.hasAppliedResults = true
+  if (anyChanged && !isFirstAppliedResult) {
     table._reactivity.schedule(() =>
       table._reactivity.untrack(() => {
         if (groupedChanged) {

--- a/packages/table-core/tests/implementation/core/autoReset.test.ts
+++ b/packages/table-core/tests/implementation/core/autoReset.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   columnFilteringFeature,
   columnGroupingFeature,
@@ -97,9 +97,10 @@ function makeTable(
   })
 }
 
-// Pull the row model once and flush so the initial memo runs (which itself
-// schedules autoReset callbacks) do not interfere with the test assertions.
-async function primeTable(table: ReturnType<typeof makeTable>) {
+// Pull the row model once and flush so each stage memo records its initial
+// inputs. Auto-resets skip the first computation (it is not a change), so a
+// table must be primed before a change can trigger a reset.
+async function primeTable(table: { getRowModel: () => unknown }) {
   table.getRowModel()
   await flushMicrotasks()
   await flushMicrotasks()
@@ -375,6 +376,27 @@ describe('autoResetSorting end-to-end wiring', () => {
 })
 
 describe('autoResetExpanded end-to-end wiring', () => {
+  it('should reset expanded when data changes without the grouping feature', async () => {
+    const expandingOnlyFeatures = testFeatures({ rowExpandingFeature })
+    const table = constructTable<typeof expandingOnlyFeatures, Person>({
+      features: expandingOnlyFeatures,
+      columns: [{ accessorKey: 'name', id: 'name' }],
+      data: makeData(),
+      getSubRows: (row) => row.subRows,
+    })
+    await primeTable(table)
+
+    table.getRow('1').toggleExpanded(true)
+    expect(table.atoms.expanded.get()).toEqual({ '1': true })
+
+    table.setOptions((old) => ({ ...old, data: makeData() }))
+    table.getRowModel()
+    await flushMicrotasks()
+    await flushMicrotasks()
+
+    expect(table.atoms.expanded.get()).toEqual({})
+  })
+
   it('should reset expanded to an empty map when grouping changes', async () => {
     const table = makeTable()
     await primeTable(table)
@@ -422,10 +444,11 @@ describe('autoResetExpanded end-to-end wiring', () => {
     await flushMicrotasks()
     await flushMicrotasks()
 
-    // Only createGroupedRowModel wires table_autoResetExpanded, and the
-    // pipeline order is core -> filtered -> grouped -> sorted -> expanded ->
-    // paginated. Sorting is downstream of grouping, so a sorting change never
-    // recomputes the grouped memo and expanded state is preserved.
+    // table_autoResetExpanded is wired from createCoreRowModel (data changes)
+    // and createGroupedRowModel. The pipeline order is core -> filtered ->
+    // grouped -> sorted -> expanded -> paginated. Sorting is downstream of
+    // grouping and does not touch data, so a sorting change never recomputes
+    // either wiring stage and expanded state is preserved.
     expect(table.atoms.expanded.get()).toEqual({ '1': true })
   })
 
@@ -439,8 +462,7 @@ describe('autoResetExpanded end-to-end wiring', () => {
     await flushMicrotasks()
     await flushMicrotasks()
 
-    // Pinned CURRENT behavior: even though table_autoResetExpanded is wired
-    // only from createGroupedRowModel, the grouped memo depends on
+    // Pinned CURRENT behavior: the grouped memo depends on
     // getPreGroupedRowModel() (the filtered model). Any upstream change
     // (data or filters) recomputes the grouped memo even when no grouping is
     // active, so filter changes also reset expanded state.
@@ -489,5 +511,51 @@ describe('autoResetExpanded end-to-end wiring', () => {
       await triggerReset(table)
       expect(table.atoms.expanded.get()).toEqual({ '1': true })
     })
+  })
+})
+
+describe('first-run guard', () => {
+  it('should not reset initialState.pageIndex on the first row model read', async () => {
+    const table = makeTable({ initialPageIndex: 1 })
+    expect(table.atoms.pagination.get().pageIndex).toBe(1)
+
+    table.getRowModel()
+    await flushMicrotasks()
+    await flushMicrotasks()
+
+    expect(table.atoms.pagination.get().pageIndex).toBe(1)
+  })
+
+  it('should not push controlled-state resets to the consumer on mount', async () => {
+    const onExpandedChange = vi.fn()
+    const onPaginationChange = vi.fn()
+    const table = makeTable({
+      state: {
+        expanded: { '0': true },
+        pagination: { pageIndex: 2, pageSize: 2 },
+      },
+      onExpandedChange,
+      onPaginationChange,
+    })
+
+    table.getRowModel()
+    await flushMicrotasks()
+    await flushMicrotasks()
+
+    expect(onExpandedChange).not.toHaveBeenCalled()
+    expect(onPaginationChange).not.toHaveBeenCalled()
+  })
+
+  it('should still auto-reset on the first change after mount', async () => {
+    const table = makeTable({ initialPageIndex: 1 })
+    await primeTable(table)
+
+    table.setPageIndex(2)
+    table.setColumnFilters([{ id: 'group', value: 'even' }])
+    table.getRowModel()
+    await flushMicrotasks()
+    await flushMicrotasks()
+
+    expect(table.atoms.pagination.get().pageIndex).toBe(0)
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Auto-resets are `onAfterUpdate` hooks on the row model stage memos. Two related defects made them fire in the wrong places.

### Expansion auto-reset was wired to the wrong stage (#5801)

`table_autoResetExpanded` was only called from `createGroupedRowModel`, so `autoResetExpanded` silently did nothing for tables that use expansion without grouping. It is now wired from `createCoreRowModel` alongside the existing pageIndex, sorting, and cell-selection resets, so a data reference change resets expansion regardless of which features are installed.

`table_autoResetExpanded` gained the same `if (!table.atoms.expanded) return` guard that the sorting and cell-selection resets already use, since the core row model also runs on tables without the expanding feature.

### Auto-resets fired on first render (#5968)

`memo` seeds its dependency list to `[]`, so the first computation of every stage always compares as changed. Merely reading a row model on mount scheduled resets for pageIndex, sorting, cell selection, and (for grouped tables) expansion.

For uncontrolled tables this was self-cancelling, since the reset targets `initialState` — which is why it was hard to reproduce and why the examples all looked fine. It was visible in two cases:

- a seeded `initialState.pagination.pageIndex` was wiped to 0 on mount
- controlled consumers received unsolicited `onExpandedChange` / `onPaginationChange` calls on mount, clobbering state restored from a URL or storage

v7 and v8 suppressed the first run with a `registered` flag inside each feature's `createTable` closure. The v9 rewrite dropped it. A new `skipFirstRun` util restores that suppression:

```ts
export function skipFirstRun(fn: () => void): () => void {
  let hasRun = false
  return () => {
    if (!hasRun) {
      hasRun = true
      return
    }
    fn()
  }
}
```

It is applied in the row model factories, which already run once per table, so each table instance gets its own flag. The grouped row model already tracked its previous inputs and only needed its first-run condition inverted. The worker bridge reports every stage as changed in its first response, so it carries an equivalent `hasAppliedResults` flag.

### Landing order

These ship together deliberately. Wiring expansion into the core row model without the first-run guard would extend the mount-time wipe from grouped tables to *every* table using expansion — which is why #6443 was held back. This PR supersedes that one and includes an equivalent regression test.

## Changes

- wire `table_autoResetExpanded` into `createCoreRowModel` (#5801)
- add `skipFirstRun` util; apply to the core, filtered, and sorted row models (#5968)
- invert the grouped row model's first-run condition
- guard `table_autoResetExpanded` when the expanding feature is absent
- skip auto-resets on the worker bridge's first applied result
- tests: expansion reset without the grouping feature, plus a first-run guard suite covering seeded initial state and controlled-state consumers

`table_autoResetPageIndex` continues to reset to page 0 rather than `initialState.pageIndex`; that semantic is unchanged and now pinned by test.

### Examples

Bundled from parallel work on the same tree:

- migrate the basic examples to `createColumnHelper` across all 10 framework adapters
- document more table options inline as commented-out defaults across the expanding, row-pinning, row-selection, aggregation, and column-sizing examples
- replace the `filterFns.between` workaround in the React expanding example with the `filterFn_between` individual export, which already existed

## Verification

- table-core: 62 files, 1,236 tests passed
- `pnpm test:pr`: eslint, sherif, knip, test:lib, test:types, test:build, build across 405 projects passed
- rebased onto latest `beta` and re-verified

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

Closes #5801
Closes #5968
Supersedes #6443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic pagination and expanded-row resets during a table’s initial load.
  * Preserved initial state and avoided triggering controlled callbacks on mount, while retaining resets after subsequent data or feature changes.
  * Improved behavior for worker-driven table updates and tables without expanded-row state.

* **Documentation**
  * Expanded examples across supported frameworks with guidance for filtering, aggregation, row selection, row pinning, column sizing, visibility, resizing, and grouping.
  * Updated basic table examples to demonstrate typed column helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->