### PR TITLE
docs: use the dynamic README header endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png"
+      alt="TanStack Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/alpine-table/README.md
+++ b/packages/alpine-table/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=alpine&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=alpine"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=alpine"
+      alt="TanStack Alpine Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/angular-table/README.md
+++ b/packages/angular-table/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=angular&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=angular"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=angular"
+      alt="TanStack Angular Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/ember-table/README.md
+++ b/packages/ember-table/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=ember&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=ember"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=ember"
+      alt="TanStack Ember Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/lit-table/README.md
+++ b/packages/lit-table/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=lit&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=lit"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=lit"
+      alt="TanStack Lit Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/match-sorter-utils/README.md
+++ b/packages/match-sorter-utils/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png"
+      alt="TanStack Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/octane-table/README.md
+++ b/packages/octane-table/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=octane&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=octane"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=octane"
+      alt="TanStack Octane Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/preact-table-devtools/README.md
+++ b/packages/preact-table-devtools/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=preact&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=preact"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=preact"
+      alt="TanStack Preact Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/preact-table/README.md
+++ b/packages/preact-table/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=preact&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=preact"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=preact"
+      alt="TanStack Preact Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/react-table-devtools/README.md
+++ b/packages/react-table-devtools/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=react&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=react"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=react"
+      alt="TanStack React Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/react-table/README.md
+++ b/packages/react-table/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=react&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=react"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=react"
+      alt="TanStack React Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/solid-table-devtools/README.md
+++ b/packages/solid-table-devtools/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=solid&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=solid"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=solid"
+      alt="TanStack Solid Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/solid-table/README.md
+++ b/packages/solid-table/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=solid&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=solid"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=solid"
+      alt="TanStack Solid Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/svelte-table/README.md
+++ b/packages/svelte-table/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=svelte&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=svelte"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=svelte"
+      alt="TanStack Svelte Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/table-core/README.md
+++ b/packages/table-core/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png"
+      alt="TanStack Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/table-devtools/README.md
+++ b/packages/table-devtools/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png"
+      alt="TanStack Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/vue-table-devtools/README.md
+++ b/packages/vue-table-devtools/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=vue&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=vue"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=vue"
+      alt="TanStack Vue Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />

--- a/packages/vue-table/README.md
+++ b/packages/vue-table/README.md
@@ -1,5 +1,19 @@
 <div align="center">
-  <img src="./media/header_table.png" alt="TanStack Table">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=vue&theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/table.png?framework=vue"
+    />
+    <img
+      src="https://tanstack.com/api/readme/table.png?framework=vue"
+      alt="TanStack Vue Table"
+      width="900"
+    />
+  </picture>
 </div>
 
 <br />


### PR DESCRIPTION
Adopts the dynamic README header endpoint added in TanStack/tanstack.com#1076,
which is merged and live.

Every README banner in this repo now points a `<picture>` at
`https://tanstack.com/api/readme/` instead of a committed PNG. The endpoint
renders 1800x450 in light and dark, so a branding change lands in every README
at once and dark-mode readers get a dark banner.

## What changed

- 18 README(s) updated.
- Light and dark served through `<picture>`, per [GitHub's guidance](https://github.blog/developer-skills/github/how-to-make-your-images-in-markdown-on-github-adjust-for-dark-mode-and-light-mode/). The trailing `<img>` stays the light variant, as the fallback for renderers that ignore `<picture>` (npm, most editors).
- Per-package READMEs pass `?framework=` so each banner shows its own package name instead of the generic library name.


There is no `media/header_table.png` on `beta`, so **every one of these 18 READMEs was showing a broken image**. This fixes that.

## Verification

Every generated URL in this diff was requested against the live endpoint and
returned `200 image/png` at 1800x450. `git grep` confirms no README still
references the old `media/header_*.png` path.

Heads up: deleting the committed PNG means npm pages for **already-published**
versions that embed the `raw.githubusercontent.com/.../main/media/header_*.png`
link will show a broken image, since that link is branch-pinned. New releases
pick up the endpoint URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project and package README headers with responsive images that adapt to light and dark themes.
  * Added accessible image descriptions and consistent display sizing.
  * Updated framework-specific branding and fallback images across package documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->