### PR TITLE
feat: implement and export `getAriaSort`

### DIFF
--- a/examples/react/kitchen-sink-hero-ui/src/main.tsx
+++ b/examples/react/kitchen-sink-hero-ui/src/main.tsx
@@ -18,6 +18,7 @@ import {
   tableDevtoolsPlugin,
   useTanStackTableDevtools,
 } from '@tanstack/react-table-devtools'
+import { getAriaSort } from '@tanstack/react-table'
 import type { Column } from '@tanstack/react-table'
 import type { ExtendedColumnFilter } from '@/types'
 import type { Person } from '@/lib/make-data'
@@ -26,12 +27,6 @@ import { makeData } from '@/lib/make-data'
 import { useAppTable } from '@/hooks/table'
 import { columns } from '@/columns'
 import './styles/globals.css'
-
-function getAriaSort(sortDirection: false | 'asc' | 'desc') {
-  if (sortDirection === 'asc') return 'ascending'
-  if (sortDirection === 'desc') return 'descending'
-  return 'none'
-}
 
 function getCommonPinningStyles(
   column: Column<typeof features, Person>,

--- a/examples/react/kitchen-sink-material-ui/src/main.tsx
+++ b/examples/react/kitchen-sink-material-ui/src/main.tsx
@@ -31,6 +31,7 @@ import DarkModeIcon from '@mui/icons-material/DarkMode'
 import LightModeIcon from '@mui/icons-material/LightMode'
 import SearchIcon from '@mui/icons-material/Search'
 import { useTanStackTableDevtools } from '@tanstack/react-table-devtools'
+import { getAriaSort } from '@tanstack/react-table'
 import type { Column } from '@tanstack/react-table'
 import type { ExtendedColumnFilter } from '@/types'
 import type { Person } from '@/lib/make-data'
@@ -40,14 +41,6 @@ import { useAppTable } from '@/hooks/table'
 import { columns } from '@/columns'
 import { toSentenceCase } from '@/components/data-table/shared'
 import './styles/globals.css'
-
-function getAriaSort(
-  sortDirection: false | 'asc' | 'desc',
-): 'ascending' | 'descending' | 'none' {
-  if (sortDirection === 'asc') return 'ascending'
-  if (sortDirection === 'desc') return 'descending'
-  return 'none'
-}
 
 function getCommonPinningStyles(
   column: Column<typeof features, Person>,

--- a/examples/react/kitchen-sink-react-aria/src/main.tsx
+++ b/examples/react/kitchen-sink-react-aria/src/main.tsx
@@ -21,6 +21,7 @@ import {
   tableDevtoolsPlugin,
   useTanStackTableDevtools,
 } from '@tanstack/react-table-devtools'
+import { getAriaSort } from '@tanstack/react-table'
 import type { Column } from '@tanstack/react-table'
 import type { ExtendedColumnFilter } from '@/types'
 import type { Person } from '@/lib/make-data'
@@ -30,12 +31,6 @@ import { useAppTable } from '@/hooks/table'
 import { columns } from '@/columns'
 import { cx } from '@/components/data-table/shared'
 import './styles/globals.css'
-
-function getAriaSort(sortDirection: false | 'asc' | 'desc') {
-  if (sortDirection === 'asc') return 'ascending'
-  if (sortDirection === 'desc') return 'descending'
-  return 'none'
-}
 
 function getCommonPinningStyles(
   column: Column<typeof features, Person>,

--- a/examples/react/lib-chakra-ui/src/main.tsx
+++ b/examples/react/lib-chakra-ui/src/main.tsx
@@ -26,6 +26,7 @@ import {
   createPaginatedRowModel,
   createSortedRowModel,
   filterFn_includesString,
+  getAriaSort,
   globalFilteringFeature,
   rowPaginationFeature,
   rowSortingFeature,
@@ -56,11 +57,6 @@ const features = tableFeatures({
 })
 
 const columnHelper = createColumnHelper<typeof features, Person>()
-function getAriaSort(sortDirection: false | 'asc' | 'desc') {
-  if (sortDirection === 'asc') return 'ascending'
-  if (sortDirection === 'desc') return 'descending'
-  return 'none'
-}
 
 const columns = columnHelper.columns([
   columnHelper.accessor('firstName', {

--- a/examples/react/lib-mantine/src/main.tsx
+++ b/examples/react/lib-mantine/src/main.tsx
@@ -29,6 +29,7 @@ import {
   createPaginatedRowModel,
   createSortedRowModel,
   filterFn_includesString,
+  getAriaSort,
   globalFilteringFeature,
   rowPaginationFeature,
   rowSortingFeature,
@@ -59,11 +60,6 @@ const features = tableFeatures({
 })
 
 const columnHelper = createColumnHelper<typeof features, Person>()
-function getAriaSort(sortDirection: false | 'asc' | 'desc') {
-  if (sortDirection === 'asc') return 'ascending'
-  if (sortDirection === 'desc') return 'descending'
-  return 'none'
-}
 
 const columns = columnHelper.columns([
   columnHelper.accessor('firstName', {

--- a/examples/react/lib-material-ui/src/main.tsx
+++ b/examples/react/lib-material-ui/src/main.tsx
@@ -30,6 +30,7 @@ import {
   createPaginatedRowModel,
   createSortedRowModel,
   filterFn_includesString,
+  getAriaSort,
   globalFilteringFeature,
   rowPaginationFeature,
   rowSortingFeature,
@@ -60,11 +61,6 @@ const features = tableFeatures({
 })
 
 const columnHelper = createColumnHelper<typeof features, Person>()
-function getAriaSort(sortDirection: false | 'asc' | 'desc') {
-  if (sortDirection === 'asc') return 'ascending'
-  if (sortDirection === 'desc') return 'descending'
-  return 'none'
-}
 
 const columns = columnHelper.columns([
   columnHelper.accessor('firstName', {

--- a/packages/table-core/src/features/row-sorting/ariaSort.ts
+++ b/packages/table-core/src/features/row-sorting/ariaSort.ts
@@ -1,0 +1,21 @@
+import type { SortDirection } from './rowSortingFeature.types'
+
+/**
+ * Maps a column's sort state to a valid `aria-sort` attribute value.
+ *
+ * Pass the result of `column.getIsSorted()` directly: an ascending sort becomes
+ * `'ascending'`, a descending sort becomes `'descending'`, and the unsorted
+ * state (`false`) becomes `'none'`.
+ *
+ * @example
+ * ```tsx
+ * <th aria-sort={getAriaSort(header.column.getIsSorted())}>…</th>
+ * ```
+ */
+export function getAriaSort(
+  sorted: false | SortDirection,
+): 'ascending' | 'descending' | 'none' {
+  if (sorted === 'asc') return 'ascending'
+  if (sorted === 'desc') return 'descending'
+  return 'none'
+}

--- a/packages/table-core/src/index.ts
+++ b/packages/table-core/src/index.ts
@@ -142,5 +142,6 @@ export * from './features/row-sorting/rowSortingFeature'
 export * from './features/row-sorting/rowSortingFeature.types'
 export * from './features/row-sorting/createSortedRowModel'
 export * from './features/row-sorting/sortFns'
+export * from './features/row-sorting/ariaSort'
 
 // force

--- a/packages/table-core/tests/unit/features/row-sorting/ariaSort.test.ts
+++ b/packages/table-core/tests/unit/features/row-sorting/ariaSort.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { getAriaSort } from '../../../../src'
+
+describe('getAriaSort', () => {
+  it('maps an ascending sort to "ascending"', () => {
+    expect(getAriaSort('asc')).toBe('ascending')
+  })
+
+  it('maps a descending sort to "descending"', () => {
+    expect(getAriaSort('desc')).toBe('descending')
+  })
+
+  it('maps the unsorted state (false) to "none"', () => {
+    expect(getAriaSort(false)).toBe('none')
+  })
+})


### PR DESCRIPTION
This function was placed in a lot of examples and we just introduced it into our codebase. I think this would be value to be placed in the library as this needs to be used anyway all the time if you want to have an accesible table.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

The commit message already tells the story, we needed to add this function to our codebase and while reviewing the PR I've thought this function should be exposed by the library in order to create easily accessible tables.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved table sorting announcements for assistive technologies by providing valid `aria-sort` values for ascending, descending, and unsorted columns.
* **Consistency**
  * Standardized sorting accessibility behavior across table examples and UI integrations.
* **Tests**
  * Added coverage for all supported sorting states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->