### PR TITLE
hotfix: Fixes TableDevtoolsPanel rendering while using as a standalone component in TanStack Devtools

### DIFF
--- a/.changeset/silent-planets-learn.md
+++ b/.changeset/silent-planets-learn.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/angular-table-devtools': patch
+'@tanstack/preact-table-devtools': patch
+'@tanstack/react-table-devtools': patch
+'@tanstack/solid-table-devtools': patch
+'@tanstack/vue-table-devtools': patch
+'@tanstack/table-devtools': patch
+---
+
+Hotfix: Fixes TableDevtoolsPanel rendering while using as a standalone component in TanStack Devtools

--- a/packages/angular-table-devtools/src/TableDevtools.ts
+++ b/packages/angular-table-devtools/src/TableDevtools.ts
@@ -4,12 +4,12 @@ import type { DevtoolsPanelProps } from '@tanstack/devtools-utils/angular'
 
 export interface TableDevtoolsAngularInit extends Partial<DevtoolsPanelProps> {}
 
-function resolvePanelProps(
+export function resolvePanelProps(
   props?: TableDevtoolsAngularInit,
 ): DevtoolsPanelProps {
   return {
     theme: props?.theme ?? 'dark',
-    devtoolsOpen: props?.devtoolsOpen ?? false,
+    devtoolsOpen: props?.devtoolsOpen ?? true,
   }
 }
 

--- a/packages/angular-table-devtools/src/production/TableDevtools.ts
+++ b/packages/angular-table-devtools/src/production/TableDevtools.ts
@@ -3,12 +3,12 @@ import { TableDevtoolsCore } from '@tanstack/table-devtools/production'
 import type { DevtoolsPanelProps } from '@tanstack/devtools-utils/angular'
 import type { TableDevtoolsAngularInit } from '../TableDevtools'
 
-function resolvePanelProps(
+export function resolvePanelProps(
   props?: TableDevtoolsAngularInit,
 ): DevtoolsPanelProps {
   return {
     theme: props?.theme ?? 'dark',
-    devtoolsOpen: props?.devtoolsOpen ?? false,
+    devtoolsOpen: props?.devtoolsOpen ?? true,
   }
 }
 

--- a/packages/angular-table-devtools/src/production/TableDevtools.ts
+++ b/packages/angular-table-devtools/src/production/TableDevtools.ts
@@ -3,7 +3,7 @@ import { TableDevtoolsCore } from '@tanstack/table-devtools/production'
 import type { DevtoolsPanelProps } from '@tanstack/devtools-utils/angular'
 import type { TableDevtoolsAngularInit } from '../TableDevtools'
 
-export function resolvePanelProps(
+function resolvePanelProps(
   props?: TableDevtoolsAngularInit,
 ): DevtoolsPanelProps {
   return {

--- a/packages/angular-table-devtools/tests/panel-props.test.ts
+++ b/packages/angular-table-devtools/tests/panel-props.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePanelProps } from '../src/TableDevtools'
+
+describe('TableDevtoolsPanel props', () => {
+  it('treats a standalone panel without devtools props as open', () => {
+    expect(resolvePanelProps()).toEqual({
+      theme: 'dark',
+      devtoolsOpen: true,
+    })
+  })
+
+  it('preserves an explicit closed state from the devtools plugin', () => {
+    expect(resolvePanelProps({ devtoolsOpen: false })).toEqual({
+      theme: 'dark',
+      devtoolsOpen: false,
+    })
+  })
+})

--- a/packages/preact-table-devtools/src/PreactTableDevtools.tsx
+++ b/packages/preact-table-devtools/src/PreactTableDevtools.tsx
@@ -19,7 +19,7 @@ function resolvePanelProps(
 ): DevtoolsPanelProps {
   return {
     theme: props?.theme ?? 'dark',
-    devtoolsOpen: props?.devtoolsOpen ?? false,
+    devtoolsOpen: props?.devtoolsOpen ?? true,
   }
 }
 

--- a/packages/preact-table-devtools/src/production/PreactTableDevtools.tsx
+++ b/packages/preact-table-devtools/src/production/PreactTableDevtools.tsx
@@ -17,7 +17,7 @@ function resolvePanelProps(
 ): DevtoolsPanelProps {
   return {
     theme: props?.theme ?? 'dark',
-    devtoolsOpen: props?.devtoolsOpen ?? false,
+    devtoolsOpen: props?.devtoolsOpen ?? true,
   }
 }
 

--- a/packages/react-table-devtools/src/ReactTableDevtools.tsx
+++ b/packages/react-table-devtools/src/ReactTableDevtools.tsx
@@ -16,7 +16,7 @@ const [TableDevtoolsPanelBase, TableDevtoolsPanelNoOpBase] =
 function resolvePanelProps(props?: TableDevtoolsReactInit): DevtoolsPanelProps {
   return {
     theme: props?.theme ?? 'dark',
-    devtoolsOpen: props?.devtoolsOpen ?? false,
+    devtoolsOpen: props?.devtoolsOpen ?? true,
   }
 }
 

--- a/packages/react-table-devtools/src/production/ReactTableDevtools.tsx
+++ b/packages/react-table-devtools/src/production/ReactTableDevtools.tsx
@@ -14,7 +14,7 @@ const [TableDevtoolsPanelBase] = createReactPanel(TableDevtoolsCore)
 function resolvePanelProps(props?: TableDevtoolsReactInit): DevtoolsPanelProps {
   return {
     theme: props?.theme ?? 'dark',
-    devtoolsOpen: props?.devtoolsOpen ?? false,
+    devtoolsOpen: props?.devtoolsOpen ?? true,
   }
 }
 

--- a/packages/solid-table-devtools/src/TableDevtools.tsx
+++ b/packages/solid-table-devtools/src/TableDevtools.tsx
@@ -18,7 +18,7 @@ function resolvePanelProps(props?: TableDevtoolsSolidInit): DevtoolsPanelProps {
       return props?.theme ?? 'dark'
     },
     get devtoolsOpen() {
-      return props?.devtoolsOpen ?? false
+      return props?.devtoolsOpen ?? true
     },
   }
 }

--- a/packages/solid-table-devtools/src/production/TableDevtools.tsx
+++ b/packages/solid-table-devtools/src/production/TableDevtools.tsx
@@ -18,7 +18,7 @@ function resolvePanelProps(props?: TableDevtoolsSolidInit): DevtoolsPanelProps {
       return props?.theme ?? 'dark'
     },
     get devtoolsOpen() {
-      return props?.devtoolsOpen ?? false
+      return props?.devtoolsOpen ?? true
     },
   }
 }

--- a/packages/table-devtools/src/TableDevtools.tsx
+++ b/packages/table-devtools/src/TableDevtools.tsx
@@ -6,11 +6,11 @@ import type { TanStackDevtoolsTheme } from '@tanstack/devtools-ui'
 
 export default function TableDevtools(props: {
   theme: TanStackDevtoolsTheme
-  devtoolsOpen: boolean
+  devtoolsOpen?: boolean
 }) {
   return (
     <ThemeContextProvider theme={props.theme}>
-      <Show when={props.devtoolsOpen}>
+      <Show when={props.devtoolsOpen ?? true}>
         <TableContextProvider>
           <Shell />
         </TableContextProvider>

--- a/packages/table-devtools/tests/panel-lifecycle.test.tsx
+++ b/packages/table-devtools/tests/panel-lifecycle.test.tsx
@@ -39,6 +39,21 @@ afterEach(() => {
 })
 
 describe('TableDevtools panel lifecycle', () => {
+  it('treats a standalone panel without devtools props as open', async () => {
+    const { subscribe, table } = createDevtoolsTable()
+    const cleanupTarget = upsertTableDevtoolsTarget({
+      table: table as never,
+    })
+    const element = document.createElement('div')
+    const dispose = render(() => <TableDevtools theme="dark" />, element)
+
+    await Promise.resolve()
+    expect(subscribe).toHaveBeenCalledTimes(1)
+
+    dispose()
+    cleanupTarget?.()
+  })
+
   it('subscribes only while the devtools panel is open', async () => {
     const { subscribe, table, unsubscribe } = createDevtoolsTable()
     const cleanupTarget = upsertTableDevtoolsTarget({

--- a/packages/vue-table-devtools/src/VueTableDevtools.tsx
+++ b/packages/vue-table-devtools/src/VueTableDevtools.tsx
@@ -14,7 +14,7 @@ class TableDevtoolsVueCore {
   mount(el: HTMLElement, props?: DevtoolsPanelProps) {
     void this.core.mount(el, {
       theme: props?.theme ?? 'dark',
-      devtoolsOpen: props?.devtoolsOpen ?? false,
+      devtoolsOpen: props?.devtoolsOpen ?? true,
     })
   }
 
@@ -39,7 +39,7 @@ function createPanelWrapper(
       return () => {
         const devtoolsProps = {
           theme: props.theme ?? 'dark',
-          devtoolsOpen: props.devtoolsOpen ?? false,
+          devtoolsOpen: props.devtoolsOpen ?? true,
         }
         return h(Component, {
           key: `${devtoolsProps.theme}:${devtoolsProps.devtoolsOpen}`,

--- a/packages/vue-table-devtools/src/production/VueTableDevtools.tsx
+++ b/packages/vue-table-devtools/src/production/VueTableDevtools.tsx
@@ -13,7 +13,7 @@ class TableDevtoolsVueCore {
   mount(el: HTMLElement, props?: DevtoolsPanelProps) {
     void this.core.mount(el, {
       theme: props?.theme ?? 'dark',
-      devtoolsOpen: props?.devtoolsOpen ?? false,
+      devtoolsOpen: props?.devtoolsOpen ?? true,
     })
   }
 
@@ -34,7 +34,7 @@ export const TableDevtoolsPanel = defineComponent({
     return () => {
       const devtoolsProps = {
         theme: props.theme ?? 'dark',
-        devtoolsOpen: props.devtoolsOpen ?? false,
+        devtoolsOpen: props.devtoolsOpen ?? true,
       }
       return h(TableDevtoolsPanelBase, {
         key: `${devtoolsProps.theme}:${devtoolsProps.devtoolsOpen}`,


### PR DESCRIPTION
This pull request implements a hotfix to ensure that the `TableDevtoolsPanel` renders as open by default when used as a standalone component across all supported frameworks in TanStack Devtools. The default value for the `devtoolsOpen` prop is changed from `false` to `true`, and new tests are added to verify this behavior. This update improves the developer experience by making the panel visible out-of-the-box unless explicitly closed.

**Default open state for TableDevtoolsPanel:**

* Changed the default value of the `devtoolsOpen` prop from `false` to `true` in all framework-specific `resolvePanelProps` functions and component mounts, including Angular, React, Preact, Solid, and Vue implementations (`TableDevtools.ts`, `ReactTableDevtools.tsx`, `PreactTableDevtools.tsx`, `VueTableDevtools.tsx`, etc.). [[1]](diffhunk://#diff-4863e134db6b6e859deba1017c68f93d223fa616f2513037b825a0940a5f84f1L7-R12) [[2]](diffhunk://#diff-a2ecbf0fe05aa39606ffd5500d1c73cae5b7a52fb107a09dbee552aa0e15b176L6-R11) [[3]](diffhunk://#diff-2f7fa5c6e0a33f41296752383addb1b97205e9e7933e11a358ddca2d5f62bc12L22-R22) [[4]](diffhunk://#diff-0b5e53a6cc1f93fc85180eca3ec151ae6a5f3e44b23bad75064d26f7c368a1b4L20-R20) [[5]](diffhunk://#diff-3fab9e59760988eac1aa441b4a1bbf40853f862d8cf0e70089fc718da13115abL19-R19) [[6]](diffhunk://#diff-bce42c3e66ffab57f52935274ff40d9ba3e35220f970426e8366d3ba6e465e87L17-R17) [[7]](diffhunk://#diff-c4c34b6a5d1e7096adf007b660d93b51c7a75422bc41d48eb378b66d9bf7344aL21-R21) [[8]](diffhunk://#diff-b4ffc3def8653a40f0cbbf4a091568458f01307cadd06bdc7095badbefe7da8fL21-R21) [[9]](diffhunk://#diff-7db61f7515fafca9cb31c1883307a46bad75e4e83483e9c8c0a41ab970db40b4L17-R17) [[10]](diffhunk://#diff-7db61f7515fafca9cb31c1883307a46bad75e4e83483e9c8c0a41ab970db40b4L42-R42) [[11]](diffhunk://#diff-92bb179290d60882d9ecd2674c8cd5c8ce2fde2a670a61609ba504abdd405c96L16-R16) [[12]](diffhunk://#diff-92bb179290d60882d9ecd2674c8cd5c8ce2fde2a670a61609ba504abdd405c96L37-R37)

* Updated the core `TableDevtools` component to treat `devtoolsOpen` as `true` by default if not provided.

**Testing improvements:**

* Added tests in Angular and core packages to verify that the panel is open by default when used standalone, and that explicit closed state is preserved. [[1]](diffhunk://#diff-f85378cb2c46d60892fa23e3489e9dbbcc2a23d8255436ec430e7dd507ee4084R1-R18) [[2]](diffhunk://#diff-dca6548c27341cb190cc5647eb5a1e119bad9492fe3ccc424c3b3911a697d291R42-R56)

**Documentation and release:**

* Added a changeset describing the hotfix and affected packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed standalone Table Devtools panels so they open by default across Angular, Preact, React, Solid, Vue, and core integrations.
  * Preserved the ability to explicitly keep Devtools closed.
  * Improved standalone panel lifecycle behavior, including proper table connection and cleanup.

* **Tests**
  * Added coverage for default panel visibility and lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->