### PR TITLE
fix(table-core): don't fire onExpandedChange when resetExpanded is a no-op

### DIFF
--- a/.changeset/reset-expanded-noop.md
+++ b/.changeset/reset-expanded-noop.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Make `table.resetExpanded()` a no-op when the target state already matches the current expanded state, so it no longer fires `onExpandedChange` with a new-but-equal map. `row.toggleExpanded()` and `table.toggleAllRowsExpanded()` already early-return this way. Because the core row model auto-resets `expanded` on every `data` reference change, the unguarded write could drive a controlled table with an unstable `data` reference into an unbounded render loop.

--- a/docs/reference/static-functions/functions/getDefaultExpandedState.md
+++ b/docs/reference/static-functions/functions/getDefaultExpandedState.md
@@ -9,7 +9,7 @@ title: getDefaultExpandedState
 function getDefaultExpandedState(): ExpandedState;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:22](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L22)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:23](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L23)
 
 Creates the default expanded state.
 

--- a/docs/reference/static-functions/functions/row_getCanExpand.md
+++ b/docs/reference/static-functions/functions/row_getCanExpand.md
@@ -9,7 +9,7 @@ title: row_getCanExpand
 function row_getCanExpand<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:399](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L399)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:385](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L385)
 
 Checks whether this row can be expanded.
 

--- a/docs/reference/static-functions/functions/row_getCanExpand.md
+++ b/docs/reference/static-functions/functions/row_getCanExpand.md
@@ -9,7 +9,7 @@ title: row_getCanExpand
 function row_getCanExpand<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:378](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L378)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:399](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L399)
 
 Checks whether this row can be expanded.
 

--- a/docs/reference/static-functions/functions/row_getIsAllParentsExpanded.md
+++ b/docs/reference/static-functions/functions/row_getIsAllParentsExpanded.md
@@ -9,7 +9,7 @@ title: row_getIsAllParentsExpanded
 function row_getIsAllParentsExpanded<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:398](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L398)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:419](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L419)
 
 Checks whether every ancestor of this row is expanded.
 

--- a/docs/reference/static-functions/functions/row_getIsAllParentsExpanded.md
+++ b/docs/reference/static-functions/functions/row_getIsAllParentsExpanded.md
@@ -9,7 +9,7 @@ title: row_getIsAllParentsExpanded
 function row_getIsAllParentsExpanded<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:419](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L419)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:405](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L405)
 
 Checks whether every ancestor of this row is expanded.
 

--- a/docs/reference/static-functions/functions/row_getIsExpanded.md
+++ b/docs/reference/static-functions/functions/row_getIsExpanded.md
@@ -9,7 +9,7 @@ title: row_getIsExpanded
 function row_getIsExpanded<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:364](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L364)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:350](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L350)
 
 Checks whether this row is expanded.
 

--- a/docs/reference/static-functions/functions/row_getIsExpanded.md
+++ b/docs/reference/static-functions/functions/row_getIsExpanded.md
@@ -9,7 +9,7 @@ title: row_getIsExpanded
 function row_getIsExpanded<TFeatures, TData>(row): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:343](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L343)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:364](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L364)
 
 Checks whether this row is expanded.
 

--- a/docs/reference/static-functions/functions/row_getToggleExpandedHandler.md
+++ b/docs/reference/static-functions/functions/row_getToggleExpandedHandler.md
@@ -9,7 +9,7 @@ title: row_getToggleExpandedHandler
 function row_getToggleExpandedHandler<TFeatures, TData>(row): () => void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:444](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L444)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:430](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L430)
 
 Creates a row control handler that toggles this row's expanded state.
 

--- a/docs/reference/static-functions/functions/row_getToggleExpandedHandler.md
+++ b/docs/reference/static-functions/functions/row_getToggleExpandedHandler.md
@@ -9,7 +9,7 @@ title: row_getToggleExpandedHandler
 function row_getToggleExpandedHandler<TFeatures, TData>(row): () => void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:423](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L423)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:444](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L444)
 
 Creates a row control handler that toggles this row's expanded state.
 

--- a/docs/reference/static-functions/functions/row_toggleExpanded.md
+++ b/docs/reference/static-functions/functions/row_toggleExpanded.md
@@ -9,7 +9,7 @@ title: row_toggleExpanded
 function row_toggleExpanded<TFeatures, TData>(row, expanded?): void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:284](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L284)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:305](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L305)
 
 Expands or collapses this row.
 

--- a/docs/reference/static-functions/functions/row_toggleExpanded.md
+++ b/docs/reference/static-functions/functions/row_toggleExpanded.md
@@ -9,7 +9,7 @@ title: row_toggleExpanded
 function row_toggleExpanded<TFeatures, TData>(row, expanded?): void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:305](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L305)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:291](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L291)
 
 Expands or collapses this row.
 

--- a/docs/reference/static-functions/functions/table_autoResetExpanded.md
+++ b/docs/reference/static-functions/functions/table_autoResetExpanded.md
@@ -9,7 +9,7 @@ title: table_autoResetExpanded
 function table_autoResetExpanded<TFeatures, TData>(table): void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:38](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L38)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:39](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L39)
 
 Schedules an expanded-state reset after row-structure changes.
 

--- a/docs/reference/static-functions/functions/table_getCanSomeRowsExpand.md
+++ b/docs/reference/static-functions/functions/table_getCanSomeRowsExpand.md
@@ -9,7 +9,7 @@ title: table_getCanSomeRowsExpand
 function table_getCanSomeRowsExpand<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:166](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L166)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:152](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L152)
 
 Checks whether at least one pre-paginated row can expand.
 

--- a/docs/reference/static-functions/functions/table_getCanSomeRowsExpand.md
+++ b/docs/reference/static-functions/functions/table_getCanSomeRowsExpand.md
@@ -9,7 +9,7 @@ title: table_getCanSomeRowsExpand
 function table_getCanSomeRowsExpand<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:145](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L145)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:166](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L166)
 
 Checks whether at least one pre-paginated row can expand.
 

--- a/docs/reference/static-functions/functions/table_getExpandedDepth.md
+++ b/docs/reference/static-functions/functions/table_getExpandedDepth.md
@@ -9,7 +9,7 @@ title: table_getExpandedDepth
 function table_getExpandedDepth<TFeatures, TData>(table): number;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:266](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L266)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:252](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L252)
 
 Computes the deepest expanded row id depth.
 

--- a/docs/reference/static-functions/functions/table_getExpandedDepth.md
+++ b/docs/reference/static-functions/functions/table_getExpandedDepth.md
@@ -9,7 +9,7 @@ title: table_getExpandedDepth
 function table_getExpandedDepth<TFeatures, TData>(table): number;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:245](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L245)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:266](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L266)
 
 Computes the deepest expanded row id depth.
 

--- a/docs/reference/static-functions/functions/table_getIsAllRowsExpanded.md
+++ b/docs/reference/static-functions/functions/table_getIsAllRowsExpanded.md
@@ -9,7 +9,7 @@ title: table_getIsAllRowsExpanded
 function table_getIsAllRowsExpanded<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:223](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L223)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:209](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L209)
 
 Checks whether every expandable row in the current row model is expanded.
 

--- a/docs/reference/static-functions/functions/table_getIsAllRowsExpanded.md
+++ b/docs/reference/static-functions/functions/table_getIsAllRowsExpanded.md
@@ -9,7 +9,7 @@ title: table_getIsAllRowsExpanded
 function table_getIsAllRowsExpanded<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:202](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L202)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:223](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L223)
 
 Checks whether every expandable row in the current row model is expanded.
 

--- a/docs/reference/static-functions/functions/table_getIsSomeRowsExpanded.md
+++ b/docs/reference/static-functions/functions/table_getIsSomeRowsExpanded.md
@@ -9,7 +9,7 @@ title: table_getIsSomeRowsExpanded
 function table_getIsSomeRowsExpanded<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:202](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L202)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:188](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L188)
 
 Checks whether any row is expanded.
 

--- a/docs/reference/static-functions/functions/table_getIsSomeRowsExpanded.md
+++ b/docs/reference/static-functions/functions/table_getIsSomeRowsExpanded.md
@@ -9,7 +9,7 @@ title: table_getIsSomeRowsExpanded
 function table_getIsSomeRowsExpanded<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:181](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L181)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:202](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L202)
 
 Checks whether any row is expanded.
 

--- a/docs/reference/static-functions/functions/table_getToggleAllRowsExpandedHandler.md
+++ b/docs/reference/static-functions/functions/table_getToggleAllRowsExpandedHandler.md
@@ -9,7 +9,7 @@ title: table_getToggleAllRowsExpandedHandler
 function table_getToggleAllRowsExpandedHandler<TFeatures, TData>(table): (_e) => void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:183](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L183)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:169](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L169)
 
 Creates an event handler that toggles all rows expanded.
 

--- a/docs/reference/static-functions/functions/table_getToggleAllRowsExpandedHandler.md
+++ b/docs/reference/static-functions/functions/table_getToggleAllRowsExpandedHandler.md
@@ -9,7 +9,7 @@ title: table_getToggleAllRowsExpandedHandler
 function table_getToggleAllRowsExpandedHandler<TFeatures, TData>(table): (_e) => void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:162](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L162)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:183](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L183)
 
 Creates an event handler that toggles all rows expanded.
 

--- a/docs/reference/static-functions/functions/table_resetExpanded.md
+++ b/docs/reference/static-functions/functions/table_resetExpanded.md
@@ -9,7 +9,7 @@ title: table_resetExpanded
 function table_resetExpanded<TFeatures, TData>(table, defaultState?): void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:120](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L120)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:121](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L121)
 
 Resets `expanded` to the configured initial state or feature default.
 

--- a/docs/reference/static-functions/functions/table_resetExpanded.md
+++ b/docs/reference/static-functions/functions/table_resetExpanded.md
@@ -9,12 +9,16 @@ title: table_resetExpanded
 function table_resetExpanded<TFeatures, TData>(table, defaultState?): void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:116](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L116)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:120](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L120)
 
 Resets `expanded` to the configured initial state or feature default.
 
 With no argument, the reset clones `table.initialState.expanded` when it
 exists. Passing `true` ignores initial state and resets to `{}`.
+
+The call is a no-op (no `onExpandedChange`) when the target state already
+matches the current state, so an auto-reset on a table with nothing expanded
+does not publish a new-but-equal map.
 
 ## Type Parameters
 

--- a/docs/reference/static-functions/functions/table_setExpanded.md
+++ b/docs/reference/static-functions/functions/table_setExpanded.md
@@ -9,7 +9,7 @@ title: table_setExpanded
 function table_setExpanded<TFeatures, TData>(table, updater): void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:66](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L66)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:67](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L67)
 
 Routes an expanded-state updater through the table's expanded change handler.
 

--- a/docs/reference/static-functions/functions/table_toggleAllRowsExpanded.md
+++ b/docs/reference/static-functions/functions/table_toggleAllRowsExpanded.md
@@ -9,7 +9,7 @@ title: table_toggleAllRowsExpanded
 function table_toggleAllRowsExpanded<TFeatures, TData>(table, expanded?): void;
 ```
 
-Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:88](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L88)
+Defined in: [features/row-expanding/rowExpandingFeature.utils.ts:89](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts#L89)
 
 Expands or collapses every row.
 

--- a/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
+++ b/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
@@ -107,6 +107,10 @@ export function table_toggleAllRowsExpanded<
  * With no argument, the reset clones `table.initialState.expanded` when it
  * exists. Passing `true` ignores initial state and resets to `{}`.
  *
+ * The call is a no-op (no `onExpandedChange`) when the target state already
+ * matches the current state, so an auto-reset on a table with nothing expanded
+ * does not publish a new-but-equal map.
+ *
  * @example
  * ```ts
  * table_resetExpanded(table)
@@ -117,18 +121,35 @@ export function table_resetExpanded<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(table: Table_Internal<TFeatures, TData>, defaultState?: boolean) {
+  const currentExpanded = table.atoms.expanded?.get() ?? {}
   const initialExpanded = table.initialState.expanded
-  table_setExpanded(
-    table,
-    defaultState
-      ? makeObjectMap()
-      : initialExpanded === true
-        ? true
-        : Object.assign(
-            makeObjectMap<boolean | undefined>(),
-            cloneState(initialExpanded ?? {}),
-          ),
-  )
+  const newExpanded: ExpandedState = defaultState
+    ? makeObjectMap()
+    : initialExpanded === true
+      ? true
+      : Object.assign(
+          makeObjectMap<boolean | undefined>(),
+          cloneState(initialExpanded ?? {}),
+        )
+
+  if (isSameExpandedState(currentExpanded, newExpanded)) return
+
+  table_setExpanded(table, newExpanded)
+}
+
+function isSameExpandedState(a: ExpandedState, b: ExpandedState): boolean {
+  if (a === true || b === true) return a === b
+
+  const aKeys = Object.keys(a)
+
+  if (aKeys.length !== Object.keys(b).length) return false
+
+  for (let i = 0; i < aKeys.length; i++) {
+    const key = aKeys[i]!
+    if (!hasOwn(b, key) || a[key] !== b[key]) return false
+  }
+
+  return true
 }
 
 /**

--- a/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
+++ b/packages/table-core/src/features/row-expanding/rowExpandingFeature.utils.ts
@@ -1,3 +1,4 @@
+import { shallow } from '@tanstack/store'
 import { cloneState, hasOwn, makeObjectMap } from '../../utils'
 import type { RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
@@ -132,24 +133,9 @@ export function table_resetExpanded<
           cloneState(initialExpanded ?? {}),
         )
 
-  if (isSameExpandedState(currentExpanded, newExpanded)) return
+  if (shallow(currentExpanded, newExpanded)) return
 
   table_setExpanded(table, newExpanded)
-}
-
-function isSameExpandedState(a: ExpandedState, b: ExpandedState): boolean {
-  if (a === true || b === true) return a === b
-
-  const aKeys = Object.keys(a)
-
-  if (aKeys.length !== Object.keys(b).length) return false
-
-  for (let i = 0; i < aKeys.length; i++) {
-    const key = aKeys[i]!
-    if (!hasOwn(b, key) || a[key] !== b[key]) return false
-  }
-
-  return true
 }
 
 /**

--- a/packages/table-core/tests/unit/features/row-expanding/rowExpandingFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/row-expanding/rowExpandingFeature.utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   constructTable,
   createExpandedRowModel,
+  functionalUpdate,
   rowExpandingFeature,
 } from '../../../../src'
 import {
@@ -25,7 +26,12 @@ import { testFeatures } from '../../../fixtures/features'
 import { generateTestColumnDefs } from '../../../fixtures/data/generateTestColumnDefs'
 import { generateTestData } from '../../../fixtures/data/generateTestData'
 import { getUpdaterResult } from '../../../helpers/testUtils'
-import type { ExpandedState, Table, TableOptions } from '../../../../src'
+import type {
+  ExpandedState,
+  Table,
+  TableOptions,
+  Updater,
+} from '../../../../src'
 import type { Person } from '../../../fixtures/data/types'
 
 const features = testFeatures({
@@ -88,6 +94,7 @@ describe('table_resetExpanded', () => {
       onExpandedChange,
       initialState: { expanded: { '0': true } },
     })
+    table.baseAtoms.expanded.set({ '0': true, '1': true })
 
     table_resetExpanded(table)
 
@@ -100,10 +107,66 @@ describe('table_resetExpanded', () => {
       onExpandedChange,
       initialState: { expanded: true },
     })
+    table.baseAtoms.expanded.set({ '0': true })
 
     table_resetExpanded(table)
 
     expect(onExpandedChange).toHaveBeenCalledWith(true)
+  })
+
+  it('should reset when the expanded ids differ at the same count', () => {
+    const onExpandedChange = vi.fn()
+    const table = makeTable({
+      onExpandedChange,
+      initialState: { expanded: { '0': true } },
+    })
+    table.baseAtoms.expanded.set({ '1': true })
+
+    table_resetExpanded(table)
+
+    expect(onExpandedChange).toHaveBeenCalledWith({ '0': true })
+  })
+
+  it('should be a no-op when nothing is expanded', () => {
+    const onExpandedChange = vi.fn()
+    const table = makeTable({ onExpandedChange })
+
+    table_resetExpanded(table)
+
+    expect(onExpandedChange).not.toHaveBeenCalled()
+  })
+
+  it('should be a no-op when the expanded map is already at the target', () => {
+    const onExpandedChange = vi.fn()
+    const table = makeTable({
+      onExpandedChange,
+      initialState: { expanded: { '0': true } },
+    })
+
+    table_resetExpanded(table)
+
+    expect(onExpandedChange).not.toHaveBeenCalled()
+  })
+
+  it('should be a no-op when already in the expanded-all initial state', () => {
+    const onExpandedChange = vi.fn()
+    const table = makeTable({
+      onExpandedChange,
+      initialState: { expanded: true },
+    })
+
+    table_resetExpanded(table)
+
+    expect(onExpandedChange).not.toHaveBeenCalled()
+  })
+
+  it('should be a no-op when defaultState is true and nothing is expanded', () => {
+    const onExpandedChange = vi.fn()
+    const table = makeTable({ onExpandedChange })
+
+    table_resetExpanded(table, true)
+
+    expect(onExpandedChange).not.toHaveBeenCalled()
   })
 })
 
@@ -534,6 +597,34 @@ describe('table_autoResetExpanded', () => {
     const table = makeTable({ onExpandedChange, manualExpanding: true })
 
     table_autoResetExpanded(table)
+    await flushMicrotasks()
+
+    expect(onExpandedChange).not.toHaveBeenCalled()
+  })
+
+  it('should not loop when a data identity change resets controlled state that already matches', async () => {
+    // Stands in for a framework render loop: the auto-reset publishes expanded
+    // state, the consumer re-renders with a fresh `data` reference, and the core
+    // row model recomputes and auto-resets again
+    let expanded: ExpandedState = {}
+    let table: Table<typeof features, Person>
+    const onExpandedChange = vi.fn((updater: Updater<ExpandedState>) => {
+      expanded = functionalUpdate(updater, expanded)
+      // stop feeding the loop so a regression fails the assertion below
+      // instead of hanging the suite
+      if (onExpandedChange.mock.calls.length > 5) return
+      table.setOptions((prev) => ({
+        ...prev,
+        data: [...prev.data],
+        state: { ...prev.state, expanded },
+      }))
+      table.getCoreRowModel()
+    })
+    table = makeTable({ state: { expanded }, onExpandedChange })
+    table.getCoreRowModel()
+
+    table.setOptions((prev) => ({ ...prev, data: [...prev.data] }))
+    table.getCoreRowModel()
     await flushMicrotasks()
 
     expect(onExpandedChange).not.toHaveBeenCalled()


### PR DESCRIPTION
`table_resetExpanded` builds a fresh state object and always calls `onExpandedChange`, without comparing against the current state. Every sibling compares first:

- `table_resetPageIndex` / `table_resetPageSize` — early-return when the value already matches
- `row_toggleExpanded` / `table_toggleAllRowsExpanded` — early-return, added in #6501
- `table_resetExpanded` — no guard

Since #6499 wired the expansion auto-reset into `createCoreRowModel`, that unguarded write fires on every `data` reference change:

`data` identity changes → core row model recomputes → `table_autoResetExpanded` → `table_resetExpanded` → `onExpandedChange(newEmptyMap)` → consumer re-renders → new `data` reference → repeat.

Measured with this repo's `react-table` on React 19.2, controlled `expanded` via `useState`, `getRowCanExpand: () => true`, and one row-model read during render, capped at 50 renders:

| `data` | renders | `onExpandedChange` calls |
| --- | --- | --- |
| `items ?? []` | 50 (capped) | 48 |
| `items ?? []` + this fix | 2 | 0 |
| `items ?? STABLE_EMPTY_ARRAY` | 2 | 0 |
| `items ?? []` + `autoResetExpanded: false` | 2 | 0 |

Stable `data` is documented, and the loop needs an unstable reference — this is a user mistake in the first instance. The case for guarding anyway is that the punishment is disproportionate and near-undiagnosable: nothing in the stack points at expansion, and the tab is too unresponsive to profile. The pagination resets already absorb exactly this mistake, and v8 absorbed it too — it passed `table.initialState?.expanded` through by reference, so `setExpanded(sameRef)` hit the identity check in `useState`. v9 clones it, so the reference is always new.

## Change

`table_resetExpanded` compares its target against `table.atoms.expanded?.get()` (as `row_toggleExpanded` already does) and returns early when they match — `true` by identity, maps key-by-key, both `defaultState` branches.

Two existing tests asserted that the reset fires when the current state already equals the target. They now diverge the state first, so they still cover the reset value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant expanded-state updates when resetting a table whose expanded state is already synchronized.
  * Avoided unnecessary change callbacks and potential render loops when data references change.
  * Preserved correct reset behavior when expanded rows differ.

* **Documentation**
  * Updated expansion API source links and documented the no-op reset behavior.

* **Tests**
  * Added coverage for synchronized resets, changed expanded-row states, and controlled-state reset scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->