### PR TITLE
fix: skip non-numeric values in median aggregation

### DIFF
--- a/packages/table-core/src/features/row-aggregation/aggregationFns.ts
+++ b/packages/table-core/src/features/row-aggregation/aggregationFns.ts
@@ -256,8 +256,9 @@ export const aggregationFn_mean = constructAggregationFn<
 })
 
 /**
- * Computes the median when every row value is a number. Returns `undefined`
- * for empty inputs or when any value is non-numeric.
+ * Computes the median of the numeric row values. Non-numeric values are
+ * ignored, matching the `sum`/`min`/`max`/`mean` aggregations. Returns
+ * `undefined` when no numeric values remain.
  */
 export const aggregationFn_median = constructAggregationFn<
   any,
@@ -267,13 +268,12 @@ export const aggregationFn_median = constructAggregationFn<
 >({
   aggregate: (context) => {
     const rows = context.rows
-    if (!rows.length) return undefined
-    const values = new Array<number>(rows.length)
+    const values: Array<number> = []
     for (let i = 0; i < rows.length; i++) {
       const value = context.getValue(rows[i]!)
-      if (typeof value !== 'number') return undefined
-      values[i] = value
+      if (typeof value === 'number') values.push(value)
     }
+    if (!values.length) return undefined
     values.sort((a, b) => a - b)
     const mid = Math.floor(values.length / 2)
     return values.length % 2

--- a/packages/table-core/tests/unit/fns/aggregationFns.test.ts
+++ b/packages/table-core/tests/unit/fns/aggregationFns.test.ts
@@ -69,18 +69,34 @@ describe('aggregation function definitions', () => {
     ])
   })
 
-  it('preserves mean coercion and all-number median validation', () => {
+  it('preserves mean coercion and median numeric-only behavior', () => {
     expect(
       aggregationFn_mean.aggregate(context([null, undefined, '', '2', 4, 'x'])),
     ).toBe(2)
-    expect(
-      aggregationFn_median.aggregate(context([3, '2', 1, 2])),
-    ).toBeUndefined()
+    // Non-numeric values are skipped, not treated as a reason to bail out,
+    // so the median is computed from the remaining numeric values (1, 2, 3).
+    expect(aggregationFn_median.aggregate(context([3, '2', 1, 2]))).toBe(2)
     expect(aggregationFn_median.aggregate(context([3, 1, 2]))).toBe(2)
     expect(aggregationFn_mean.aggregate(context([]))).toBeUndefined()
     expect(aggregationFn_median.aggregate(context([]))).toBeUndefined()
     expect(aggregationFn_mean.merge).toBeUndefined()
     expect(aggregationFn_median.merge).toBeUndefined()
+  })
+
+  it('skips null/non-numeric values in median, like sum/min/max/mean', () => {
+    // A null in the group should not discard the whole aggregation.
+    expect(aggregationFn_median.aggregate(context([1, null, 2, 3]))).toBe(2)
+    expect(
+      aggregationFn_median.aggregate(context([null, undefined, 4, '5', 6])),
+    ).toBe(5)
+    // Even-length numeric result still averages the two middle values.
+    expect(aggregationFn_median.aggregate(context([1, null, 2, 3, 4]))).toBe(
+      2.5,
+    )
+    // Only when there are no numeric values left does it fall back to undefined.
+    expect(
+      aggregationFn_median.aggregate(context([null, undefined, 'x', 'y'])),
+    ).toBeUndefined()
   })
 
   it('uses Set semantics for unique values', () => {


### PR DESCRIPTION
## Changes

`aggregationFn_median` bailed out and returned `undefined` for the whole group the moment it hit a single non-numeric value (e.g. `null`). That's inconsistent with every other built-in aggregation function — `sum`, `min`, `max`, and `mean` all skip non-numeric/nullish values and aggregate over whatever numeric values remain instead of discarding the group.

This brings `median` in line with its siblings: it now filters out non-numeric values first, computes the median from what's left, and only returns `undefined` when no numeric values remain at all.

Fixes #5008

## Note on behavior change

This does change the previously-asserted result for groups that contain non-numeric values. The existing test had:

```ts
expect(aggregationFn_median.aggregate(context([3, '2', 1, 2]))).toBeUndefined()
```

That assertion documented the buggy early-return behavior, not an intentional design choice — there's no rationale for it in the aggregation-overhaul PRs, and it directly contradicts how `sum`/`min`/`max`/`mean` already handle the same situation. I updated it to reflect the fixed behavior (median of the numeric values `[3, 1, 2]` -> `2`) and added a dedicated regression test covering: a `null` inside a group, a mix of `null`/`undefined`/non-numeric-string, an even-length numeric result, and the all-non-numeric -> `undefined` fallback case.

## Testing
- `pnpm --filter @tanstack/table-core test:lib` — 62 files / 1272 tests passing
- `pnpm --filter @tanstack/table-core test:eslint` — clean
- `pnpm --filter @tanstack/table-core test:types` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Median aggregation now ignores null, missing, and non-numeric values.
  - Median results are calculated from the remaining numeric values, including fractional results for even-sized datasets.
  - Returns no result only when there are no numeric values to aggregate.

- **Tests**
  - Added coverage for mixed, invalid, and empty aggregation inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->