### PR TITLE
fix(angular): ensure table options updates are not missed during first mount window

### DIFF
--- a/.changeset/early-tips-matter.md
+++ b/.changeset/early-tips-matter.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-table': patch
+---
+
+Ensure options updates are not missed during first mount

--- a/packages/angular-table/src/injectTable.ts
+++ b/packages/angular-table/src/injectTable.ts
@@ -97,44 +97,46 @@ export function injectTable<
   assertInInjectionContext(injectTable)
   const injector = inject(Injector)
   const ngZone = inject(NgZone)
+  const destroyRef = inject(DestroyRef)
   const options = computed(() => _options())
+  const coreReactivityFeature = angularReactivity(injector)
 
-  return ngZone.runOutsideAngular(() =>
+  const lazyTable = ngZone.runOutsideAngular(() =>
     lazyInit(() => {
-      // Explicit type arguments skip generic inference from the spread object
-      // (a type-check hot spot); the spread only adds the angular reactivity
-      // binding to `features`.
-      const table = constructTable<TFeatures, TData>({
-        ...options(),
-        features: {
-          coreReactivityFeature: angularReactivity(injector),
-          ...options().features,
-        },
+      const currentOptions = options()
+      const features = {
+        coreReactivityFeature,
+        ...currentOptions.features,
+      } satisfies TableFeatures
+      return constructTable<TFeatures, TData>({
+        ...currentOptions,
+        features,
       })
-
-      injector.get(DestroyRef).onDestroy(() => {
-        table._reactivity.unmount?.()
-      })
-
-      let previousOptions = options()
-      effect(
-        () => {
-          const currentOptions = options()
-          if (previousOptions === currentOptions) {
-            return
-          }
-          untracked(() =>
-            table.setOptions((previous) => ({
-              ...previous,
-              ...currentOptions,
-            })),
-          )
-          previousOptions = currentOptions
-        },
-        { injector, debugName: 'tableOptionsUpdate' },
-      )
-
-      return table
     }),
   )
+
+  destroyRef.onDestroy(() => {
+    if (lazyTable.initialized) {
+      lazyTable.value._reactivity.unmount?.()
+    }
+  })
+
+  let previousOptions: TableOptions<TFeatures, TData> | undefined = undefined
+  effect(
+    () => {
+      const currentOptions = options()
+      const tableInstance = lazyTable.rawValue
+      if (previousOptions === currentOptions) return
+      untracked(() =>
+        tableInstance.setOptions((previous) => ({
+          ...previous,
+          ...currentOptions,
+        })),
+      )
+      previousOptions = currentOptions
+    },
+    { injector, debugName: 'tableOptionsUpdate' },
+  )
+
+  return lazyTable.value
 }

--- a/packages/angular-table/src/injectTable.ts
+++ b/packages/angular-table/src/injectTable.ts
@@ -3,6 +3,7 @@ import {
   Injector,
   NgZone,
   assertInInjectionContext,
+  computed,
   effect,
   inject,
   untracked,
@@ -91,11 +92,12 @@ export function injectTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  options: () => TableOptions<TFeatures, TData>,
+  _options: () => TableOptions<TFeatures, TData>,
 ): AngularTable<TFeatures, TData> {
   assertInInjectionContext(injectTable)
   const injector = inject(Injector)
   const ngZone = inject(NgZone)
+  const options = computed(() => _options())
 
   return ngZone.runOutsideAngular(() =>
     lazyInit(() => {
@@ -114,20 +116,20 @@ export function injectTable<
         table._reactivity.unmount?.()
       })
 
-      let isMount = true
+      let previousOptions = options()
       effect(
         () => {
-          const newOptions = options()
-          if (isMount) {
-            isMount = false
+          const currentOptions = options()
+          if (previousOptions === currentOptions) {
             return
           }
           untracked(() =>
             table.setOptions((previous) => ({
               ...previous,
-              ...newOptions,
+              ...currentOptions,
             })),
           )
+          previousOptions = currentOptions
         },
         { injector, debugName: 'tableOptionsUpdate' },
       )

--- a/packages/angular-table/src/injectTable.ts
+++ b/packages/angular-table/src/injectTable.ts
@@ -92,13 +92,13 @@ export function injectTable<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
-  _options: () => TableOptions<TFeatures, TData>,
+  optionsFactory: () => TableOptions<TFeatures, TData>,
 ): AngularTable<TFeatures, TData> {
-  assertInInjectionContext(injectTable)
-  const injector = inject(Injector)
-  const ngZone = inject(NgZone)
+assertInInjectionContext(injectTable)
+const injector = inject(Injector)
+const ngZone = inject(NgZone)
   const destroyRef = inject(DestroyRef)
-  const options = computed(() => _options())
+  const options = computed(() => optionsFactory())
   const coreReactivityFeature = angularReactivity(injector)
 
   const lazyTable = ngZone.runOutsideAngular(() =>

--- a/packages/angular-table/src/injectTable.ts
+++ b/packages/angular-table/src/injectTable.ts
@@ -125,7 +125,8 @@ const ngZone = inject(NgZone)
   effect(
     () => {
       const currentOptions = options()
-      const tableInstance = lazyTable.rawValue
+      // rawValue will be always valued here due to internal lazyInit effect
+      const tableInstance = lazyTable.rawValue
       if (previousOptions === currentOptions) return
       untracked(() =>
         tableInstance.setOptions((previous) => ({

--- a/packages/angular-table/src/injectTable.ts
+++ b/packages/angular-table/src/injectTable.ts
@@ -94,9 +94,9 @@ export function injectTable<
 >(
   optionsFactory: () => TableOptions<TFeatures, TData>,
 ): AngularTable<TFeatures, TData> {
-assertInInjectionContext(injectTable)
-const injector = inject(Injector)
-const ngZone = inject(NgZone)
+  assertInInjectionContext(injectTable)
+  const injector = inject(Injector)
+  const ngZone = inject(NgZone)
   const destroyRef = inject(DestroyRef)
   const options = computed(() => optionsFactory())
   const coreReactivityFeature = angularReactivity(injector)
@@ -126,7 +126,7 @@ const ngZone = inject(NgZone)
     () => {
       const currentOptions = options()
       // rawValue will be always valued here due to internal lazyInit effect
-      const tableInstance = lazyTable.rawValue
+      const tableInstance = lazyTable.rawValue
       if (previousOptions === currentOptions) return
       untracked(() =>
         tableInstance.setOptions((previous) => ({

--- a/packages/angular-table/src/lazySignalInitializer.ts
+++ b/packages/angular-table/src/lazySignalInitializer.ts
@@ -1,10 +1,13 @@
-import { untracked } from '@angular/core'
+import { assertInInjectionContext, effect, untracked } from '@angular/core'
 
-/**
- * Implementation from @tanstack/angular-query
- * {https://github.com/TanStack/query/blob/main/packages/angular-query-experimental/src/util/lazy-init/lazy-init.ts}
- */
-export function lazyInit<T extends object>(initializer: () => T): T {
+export function lazyInit<T extends object>(
+  initializer: () => T,
+): {
+  readonly rawValue: T
+  readonly value: T
+  readonly initialized: boolean
+} {
+  assertInInjectionContext(lazyInit)
   let object: T | null = null
 
   const initializeObject = () => {
@@ -13,11 +16,13 @@ export function lazyInit<T extends object>(initializer: () => T): T {
     }
   }
 
-  queueMicrotask(() => initializeObject())
+  effect(() => initializeObject(), {
+    debugName: 'tableLazyInitEffect',
+  })
 
   const table = () => {}
 
-  return new Proxy<T>(table as T, {
+  const proxy = new Proxy<T>(table as T, {
     apply(target: T, thisArg: any, argArray: Array<any>): any {
       initializeObject()
       if (typeof object === 'function') {
@@ -44,4 +49,14 @@ export function lazyInit<T extends object>(initializer: () => T): T {
       }
     },
   })
+
+  return {
+    value: proxy,
+    get rawValue() {
+      return object as T
+    },
+    get initialized() {
+      return !!object
+    },
+  }
 }

--- a/packages/angular-table/tests/angularReactivityFeature.test.ts
+++ b/packages/angular-table/tests/angularReactivityFeature.test.ts
@@ -28,7 +28,7 @@ describe('angularReactivityFeature', () => {
     return TestBed.runInInjectionContext(() =>
       injectTable(() => ({
         data: _data(),
-        features: { ...stockFeatures },
+        features: stockFeatures,
         columns: columns,
         getRowId: (row) => row.id,
       })),

--- a/packages/angular-table/tests/injectTable.test.ts
+++ b/packages/angular-table/tests/injectTable.test.ts
@@ -147,4 +147,29 @@ describe('injectTable', () => {
       })
     })
   })
+
+  // Fixes https://github.com/TanStack/table/issues/6530
+  test('does not drop an options update before the effect first runs', () => {
+    type Data = { id: string }
+
+    const initialData: Array<Data> = []
+    const updatedData: Array<Data> = [{ id: '1' }]
+    const data = signal(initialData)
+
+    const table = TestBed.runInInjectionContext(() =>
+      injectTable(() => ({
+        data: data(),
+        columns: [],
+        features: stockFeatures,
+        getRowId: (row) => row.id,
+      })),
+    )
+
+    expect(table.options.data).toBe(initialData)
+
+    data.set(updatedData)
+    TestBed.tick()
+
+    expect(table.options.data).toBe(updatedData)
+  })
 })

--- a/packages/angular-table/tests/lazy-init.test.ts
+++ b/packages/angular-table/tests/lazy-init.test.ts
@@ -13,23 +13,27 @@ import { flushQueue, setFixtureSignalInputs } from './test-utils'
 import type { WritableSignal } from '@angular/core'
 
 describe('lazyInit', () => {
-  test('should init lazily in next tick when not accessing manually', async () => {
+  test('should init lazily in next tick when not accessing manually', () => {
     const mockFn = vi.fn()
 
     TestBed.runInInjectionContext(() => {
-      lazyInit(() => {
+      const proxy = lazyInit(() => {
         mockFn()
         return {
           data: signal(true),
         }
       })
+
+      expect(mockFn).not.toHaveBeenCalled()
+      expect(proxy.initialized).toEqual(false)
+      expect(proxy.rawValue).toBeNullable()
+
+      TestBed.tick()
+
+      expect(proxy.initialized).toEqual(true)
+      expect(proxy.rawValue).not.toBeNullable()
+      expect(mockFn).toHaveBeenCalled()
     })
-
-    expect(mockFn).not.toHaveBeenCalled()
-
-    await new Promise(setImmediate)
-
-    expect(mockFn).toHaveBeenCalled()
   })
 
   test('should init eagerly accessing manually', () => {
@@ -43,7 +47,7 @@ describe('lazyInit', () => {
         }
       })
 
-      lazySignal.data()
+      lazySignal.value.data()
     })
 
     expect(mockFn).toHaveBeenCalled()
@@ -63,14 +67,14 @@ describe('lazyInit', () => {
         void outerSignal()
 
         return { data: signal(0) }
-      })
+      }).value
 
       effect(() => registerDataValue(value.data()))
     })
 
     value.data()
 
-    TestBed.flushEffects()
+    TestBed.tick()
 
     expect(outerSignal).toBeDefined()
 
@@ -102,13 +106,12 @@ describe('lazyInit', () => {
         return {
           data: computed(() => this.title()),
         }
-      })
+      }).value
     }
 
     const fixture = TestBed.createComponent(Test)
-
     setFixtureSignalInputs(fixture, { title: 'newValue' })
-    expect(fixture.debugElement.nativeElement.textContent).toBe('0 - newValue')
+    expect(fixture.debugElement.nativeElement.textContent).toBe('1 - newValue')
     await flushQueue()
 
     setFixtureSignalInputs(fixture, { title: 'updatedValue' })


### PR DESCRIPTION
This pull request addresses a key issue in the `@tanstack/angular-table` package where options updates could be missed during the initial mount of a table. The changes ensure that option updates are reliably captured from the very first render, and also refactor the lazy initialization logic to provide more robust state tracking and improved test coverage.

**Core improvements to options reactivity and initialization:**

* The `injectTable` function now uses a computed signal for options and ensures updates are not missed during the initial mount, fixing a bug where the first update could be dropped. This involves tracking previous options and applying updates only when they change.
* The `lazyInit` utility is refactored to return an object with `value`, `rawValue`, and `initialized` properties, allowing for more precise control and introspection of the lazy initialization state. [[1]](diffhunk://#diff-024c4114c19c176041be2a5e2b978534bd3890d278ccd74f7e548a7ede2bd8d7L1-R10) [[2]](diffhunk://#diff-024c4114c19c176041be2a5e2b978534bd3890d278ccd74f7e548a7ede2bd8d7L16-R25) [[3]](diffhunk://#diff-024c4114c19c176041be2a5e2b978534bd3890d278ccd74f7e548a7ede2bd8d7R52-R61)

**Testing and reliability improvements:**

* Additional and updated tests ensure that options updates are not dropped before the effect first runs, and that the new lazy initialization logic behaves correctly and is testable. [[1]](diffhunk://#diff-f0e5b4a46fb3cfb1612f5ce75e3f2d55b86c75d1e64fb79837d1f80f29ba159bR150-R174) [[2]](diffhunk://#diff-34ed57b020d139a2b9addc1cbb68a15f3ef111c4873c779c2f0f8e6199366088L16-R37) [[3]](diffhunk://#diff-34ed57b020d139a2b9addc1cbb68a15f3ef111c4873c779c2f0f8e6199366088L46-R50) [[4]](diffhunk://#diff-34ed57b020d139a2b9addc1cbb68a15f3ef111c4873c779c2f0f8e6199366088L66-R77) [[5]](diffhunk://#diff-34ed57b020d139a2b9addc1cbb68a15f3ef111c4873c779c2f0f8e6199366088L105-R114)
* Minor test and type fixes, such as correcting feature spreading and updating test assertions to match the new initialization API.

**Documentation:**

* A changeset is added to document the patch release and the fix for missed options updates on first mount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Angular Table options updates during initial rendering so the latest data and configuration are preserved.
  - Improved reactive updates to apply only when table options change.
  - Ensured table cleanup is safe when initialization has not completed.

- **Behavior Updates**
  - Lazy table initialization now reports its status and provides access to the initialized value.
  - Required signal inputs can trigger initialization during rendering.

- **Release**
  - Prepared a patch release for `@tanstack/angular-table`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->