### PR TITLE
fix(table-core): skip onColumnVisibilityChange for a redundant toggle-all

### DIFF
--- a/.changeset/toggle-all-columns-visible-noop.md
+++ b/.changeset/toggle-all-columns-visible-noop.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Skip `onColumnVisibilityChange` when `table.toggleAllColumnsVisible()` is called with the visibility state every leaf column is already in. This matches the no-op guards `table.toggleAllRowsExpanded()` already has.

--- a/docs/reference/static-functions/functions/table_getIsAllColumnsVisible.md
+++ b/docs/reference/static-functions/functions/table_getIsAllColumnsVisible.md
@@ -9,7 +9,7 @@ title: table_getIsAllColumnsVisible
 function table_getIsAllColumnsVisible<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/column-visibility/columnVisibilityFeature.utils.ts:360](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts#L360)
+Defined in: [features/column-visibility/columnVisibilityFeature.utils.ts:373](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts#L373)
 
 Checks whether every leaf column is currently visible.
 

--- a/docs/reference/static-functions/functions/table_getIsSomeColumnsVisible.md
+++ b/docs/reference/static-functions/functions/table_getIsSomeColumnsVisible.md
@@ -9,7 +9,7 @@ title: table_getIsSomeColumnsVisible
 function table_getIsSomeColumnsVisible<TFeatures, TData>(table): boolean;
 ```
 
-Defined in: [features/column-visibility/columnVisibilityFeature.utils.ts:382](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts#L382)
+Defined in: [features/column-visibility/columnVisibilityFeature.utils.ts:395](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts#L395)
 
 Checks whether at least one leaf column is currently visible.
 

--- a/docs/reference/static-functions/functions/table_getToggleAllColumnsVisibilityHandler.md
+++ b/docs/reference/static-functions/functions/table_getToggleAllColumnsVisibilityHandler.md
@@ -9,7 +9,7 @@ title: table_getToggleAllColumnsVisibilityHandler
 function table_getToggleAllColumnsVisibilityHandler<TFeatures, TData>(table): (e) => void;
 ```
 
-Defined in: [features/column-visibility/columnVisibilityFeature.utils.ts:404](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts#L404)
+Defined in: [features/column-visibility/columnVisibilityFeature.utils.ts:417](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts#L417)
 
 Creates a checkbox-style handler that shows or hides all columns.
 

--- a/docs/reference/static-functions/functions/table_toggleAllColumnsVisible.md
+++ b/docs/reference/static-functions/functions/table_toggleAllColumnsVisible.md
@@ -9,11 +9,14 @@ title: table_toggleAllColumnsVisible
 function table_toggleAllColumnsVisible<TFeatures, TData>(table, value?): void;
 ```
 
-Defined in: [features/column-visibility/columnVisibilityFeature.utils.ts:333](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts#L333)
+Defined in: [features/column-visibility/columnVisibilityFeature.utils.ts:336](https://github.com/TanStack/table/blob/main/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts#L336)
 
 Shows or hides every hideable leaf column.
 
 Columns that cannot hide stay visible when toggling all columns off.
+
+The call is a no-op (no `onColumnVisibilityChange`) when every leaf column is
+already in the requested visibility state.
 
 ## Type Parameters
 

--- a/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts
+++ b/packages/table-core/src/features/column-visibility/columnVisibilityFeature.utils.ts
@@ -325,6 +325,9 @@ export function table_resetColumnVisibility<
  *
  * Columns that cannot hide stay visible when toggling all columns off.
  *
+ * The call is a no-op (no `onColumnVisibilityChange`) when every leaf column is
+ * already in the requested visibility state.
+ *
  * @example
  * ```ts
  * table_toggleAllColumnsVisible(table)
@@ -341,6 +344,16 @@ export function table_toggleAllColumnsVisible<
   for (let i = 0; i < leafColumns.length; i++) {
     const column = leafColumns[i]!
     visibility[column.id] = !value ? !column_getCanHide(column) : value
+  }
+
+  if (
+    leafColumns.every(
+      (column) =>
+        visibility[column.id] ===
+        callMemoOrStaticFn(column, 'getIsVisible', column_getIsVisible),
+    )
+  ) {
+    return
   }
 
   table_setColumnVisibility(table, visibility)

--- a/packages/table-core/tests/unit/features/column-visibility/columnVisibilityFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/column-visibility/columnVisibilityFeature.utils.test.ts
@@ -362,6 +362,11 @@ describe('columnVisibilityFeature.utils', () => {
       const onColumnVisibilityChange = vi.fn()
       const table = makeTable(1, {
         onColumnVisibilityChange,
+        initialState: {
+          columnVisibility: {
+            firstName: false,
+          },
+        },
       })
 
       table_toggleAllColumnsVisible(table, true)
@@ -388,6 +393,36 @@ describe('columnVisibilityFeature.utils', () => {
       expect(Object.entries(result)).toEqual(
         allColumnIds.map((id) => [id, false]),
       )
+    })
+
+    it('should be a no-op when all columns are already visible', () => {
+      const onColumnVisibilityChange = vi.fn()
+      const table = makeTable(1, {
+        onColumnVisibilityChange,
+      })
+
+      table_toggleAllColumnsVisible(table, true)
+
+      expect(onColumnVisibilityChange).not.toHaveBeenCalled()
+    })
+
+    it('should be a no-op when all hideable columns are already hidden', () => {
+      const onColumnVisibilityChange = vi.fn()
+      const allColumnIds = makeTable(1)
+        .getAllLeafColumns()
+        .map((col) => col.id)
+      const table = makeTable(1, {
+        onColumnVisibilityChange,
+        initialState: {
+          columnVisibility: Object.fromEntries(
+            allColumnIds.map((id) => [id, false]),
+          ),
+        },
+      })
+
+      table_toggleAllColumnsVisible(table, false)
+
+      expect(onColumnVisibilityChange).not.toHaveBeenCalled()
     })
   })
 
@@ -454,6 +489,11 @@ describe('columnVisibilityFeature.utils', () => {
       const onColumnVisibilityChange = vi.fn()
       const table = makeTable(1, {
         onColumnVisibilityChange,
+        initialState: {
+          columnVisibility: {
+            firstName: false,
+          },
+        },
       })
       const handler = table_getToggleAllColumnsVisibilityHandler(table)
 


### PR DESCRIPTION
## 🎯 Changes

`table_toggleAllColumnsVisible` rebuilds the whole visibility map and hands it to `table_setColumnVisibility` unconditionally, so asking for a state the table is already in still runs `onColumnVisibilityChange`:

```ts
table.toggleAllColumnsVisible(true) // shows every column
table.toggleAllColumnsVisible(true) // nothing left to change, the handler fires anyway
```

`setStateSlice` can't catch this one. The map it receives (`{ id: true, firstName: true, ... }`) is structurally different from the `{}` the state usually holds while every column is visible, so the two never compare equal. The fix compares the map against each leaf column's current visibility instead and returns early when they already agree, the same kind of explicit no-op check `table_toggleAllRowsExpanded` keeps.

Two existing tests toggled all columns on from a table where everything was already visible, which is now a no-op. Both start from a hidden `firstName` instead, so they still exercise the show-all path.

Fixes #6539

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

Two tests added to `columnVisibilityFeature.utils.test.ts`, both verified to fail on `main`: one for the already-all-visible case, one for the already-all-hidden case.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toggling all columns now does nothing when they already match the requested visibility state.
  * Prevented unnecessary visibility updates and change notifications in no-op scenarios.
  * Improved behavior when showing or hiding all columns from partially or fully hidden states.

* **Documentation**
  * Updated column visibility function references and documented the no-op behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->