### PR TITLE
fix(table-core): keep depth-truncated sub-rows in the leaf-up filter path

### DIFF
--- a/.changeset/leaf-up-truncated-sub-rows.md
+++ b/.changeset/leaf-up-truncated-sub-rows.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Fix `filterFromLeafRows` discarding the sub-rows of rows kept past `maxLeafRowFilterDepth`. The leaf-up filter path rebuilt those rows without their unfiltered subtree, so the truncated descendants vanished from `subRows`, `flatRows` and `rowsById` alike. They are now carried over and flattened, the way the root-down path already keeps them.

--- a/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
+++ b/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
@@ -82,11 +82,20 @@ function filterRowModelFromLeafs<
           continue
         }
       } else {
+        // Past maxLeafRowFilterDepth the subtree is never filtered, so it stays
+        // visible through row.subRows and its rows must enter flatRows and
+        // rowsById as well, like the root-down path already does
+        newRow.subRows = row.subRows
         row = newRow
         if (filterRow(row)) {
           filteredRows.push(row)
           newFilteredRowsById[row.id] = row
           newFilteredFlatRows.push(row)
+          addSubRowsToFlatArrays(
+            row.subRows,
+            newFilteredFlatRows,
+            newFilteredRowsById,
+          )
         }
       }
     }

--- a/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
+++ b/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
@@ -319,6 +319,55 @@ describe('createFilteredRowModel', () => {
       expect(model.rowsById[keepA1.id]).toBe(keepA1)
     })
 
+    it('should include unfiltered descendants of kept rows in flatRows and rowsById (from leaf, depth 0)', () => {
+      const table = makeNestedTable({
+        filterFromLeafRows: true,
+        maxLeafRowFilterDepth: 0,
+      })
+      const model = table.getFilteredRowModel()
+
+      // The subtrees of the kept rows are never filtered at depth 0, so they
+      // stay visible through subRows and belong in the flat arrays too, the
+      // same way the root-down path keeps them
+      const keepA = model.rows[0]!
+      expect(rowNames(keepA.subRows)).toEqual(['keep-a1', 'drop-a2'])
+      expect(rowNames(model.flatRows)).toEqual([
+        'keep-a',
+        'keep-a1',
+        'drop-a1a',
+        'drop-a2',
+        'keep-c',
+        'keep-d',
+        'drop-d1',
+      ])
+
+      const keepA1 = keepA.subRows[0]!
+      expect(model.rowsById[keepA1.id]).toBe(keepA1)
+    })
+
+    it('should include kept-as-is grandchildren in flatRows when maxLeafRowFilterDepth is 1 (from leaf)', () => {
+      const table = makeNestedTable({
+        filterFromLeafRows: true,
+        maxLeafRowFilterDepth: 1,
+      })
+      const model = table.getFilteredRowModel()
+
+      // Depth-1 children are still filtered (drop-a2 removed), while the
+      // depth-2 subtree of keep-a1 is kept as-is and joins flatRows
+      const keepA = model.rows[0]!
+      expect(rowNames(keepA.subRows)).toEqual(['keep-a1'])
+      expect(rowNames(keepA.subRows[0]!.subRows)).toEqual(['drop-a1a'])
+      expect(rowNames(model.flatRows)).toEqual([
+        'keep-a1',
+        'drop-a1a',
+        'keep-a',
+        'keep-b1',
+        'drop-b',
+        'keep-c',
+        'keep-d',
+      ])
+    })
+
     it('should include kept-as-is grandchildren in flatRows when maxLeafRowFilterDepth is 1 (from root)', () => {
       const table = makeNestedTable({ maxLeafRowFilterDepth: 1 })
       const model = table.getFilteredRowModel()


### PR DESCRIPTION
## 🎯 Changes

With `filterFromLeafRows: true`, a row kept at `maxLeafRowFilterDepth` loses its whole subtree. `filterRowModelFromLeafs` rebuilds every row through `constructRow`, and once the depth cap stops the recursion the rebuilt row never gets its sub-rows back, so the descendants vanish from `subRows`, `flatRows` and `rowsById` at once.

```ts
// maxLeafRowFilterDepth: 1, 'keep-a1' matches at depth 1 and owns 'drop-a1a' at depth 2
table.getFilteredRowModel().rows[0].subRows[0].subRows
// before: []
// after:  [drop-a1a]
```

The root-down path keeps the original row instead of a rebuilt one, so its unfiltered subtree stays visible, and #6503 made those descendants join the flat arrays through `addSubRowsToFlatArrays`. The leaf-up path now carries the original sub-rows onto the rebuilt row and flattens them with that same helper, which #6503 listed as the remaining follow-up.

Fixes #6537

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

Two tests added to `createFilteredRowModel.test.ts`, mirroring the root-down ones already there for depth 0 and depth 1. Both fail on `main` and pass with the fix. `@tanstack/table-core` is at 1318/1318 tests, with eslint, types and build clean. The only red target is `@tanstack/ember-table:test:lib`, where testem cannot reach a local headless Chrome, and it fails the same way without this change.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed hierarchical filtering when the maximum leaf-row filter depth is reached.
  - Retained rows now preserve their unfiltered descendants, including nested rows and flattened row results.
  - Row references and ordering remain consistent across filtered table results.

- **Tests**
  - Added coverage for filtering at multiple depth limits, including validation of nested rows and flattened results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->