### PR TITLE
fix(table-core): skip onRowSelectionChange on a no-op toggleAllRowsSelected

### DIFF
--- a/.changeset/toggle-all-rows-selected-noop.md
+++ b/.changeset/toggle-all-rows-selected-noop.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Stop `table.toggleAllRowsSelected()` from calling `onRowSelectionChange` when the requested state already matches the current one. Selecting when every selectable row is already selected, and deselecting when nothing is selected, are now no-ops, matching the O(1) guards `table.toggleAllRowsExpanded()` already has.

--- a/packages/alpine-table/tests/unit/adapterCoverage.test.ts
+++ b/packages/alpine-table/tests/unit/adapterCoverage.test.ts
@@ -230,7 +230,7 @@ describe('Alpine adapter reactivity', () => {
 
     options.onRowSelectionChange = secondHandler
     await flushEffects()
-    table.toggleAllRowsSelected(false)
+    table.toggleAllRowsSelected(true)
 
     expect(firstHandler).toHaveBeenCalledTimes(1)
     expect(secondHandler).toHaveBeenCalledTimes(1)

--- a/packages/lit-table/tests/unit/adapterLifecycle.test.ts
+++ b/packages/lit-table/tests/unit/adapterLifecycle.test.ts
@@ -369,7 +369,7 @@ describe('TableController lifecycle and option ownership', () => {
       '{"canSelect":false,"columnIds":["title"],"values":["Final"]}',
     )
 
-    element.table!.toggleAllRowsSelected(false)
+    element.table!.toggleAllRowsSelected(true)
 
     expect(firstSelectionHandler).toHaveBeenCalledOnce()
     expect(secondSelectionHandler).toHaveBeenCalledOnce()

--- a/packages/solid-table/tests/unit/adapterReactivity.test.ts
+++ b/packages/solid-table/tests/unit/adapterReactivity.test.ts
@@ -293,7 +293,7 @@ describe('Solid adapter lifecycle and option ownership', () => {
       expect(secondHandler).not.toHaveBeenCalled()
 
       setOnRowSelectionChange(() => secondHandler)
-      table.toggleAllRowsSelected(false)
+      table.toggleAllRowsSelected(true)
 
       expect(firstHandler).toHaveBeenCalledTimes(1)
       expect(secondHandler).toHaveBeenCalledTimes(1)

--- a/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
+++ b/packages/table-core/src/features/row-selection/rowSelectionFeature.utils.ts
@@ -96,6 +96,10 @@ export function table_resetRowSelection<
  * existing selection map; rows that cannot be selected keep their selection
  * unless `opts.deselectAll` is `true`.
  *
+ * The call is a no-op (no `onRowSelectionChange`) when every selectable row is
+ * already selected and selection is requested, or when nothing is selected and
+ * deselection is requested.
+ *
  * @example
  * ```ts
  * table_toggleAllRowsSelected(table)
@@ -111,6 +115,25 @@ export function table_toggleAllRowsSelected<
 ) {
   // @ts-ignore - _lastSelectedRowId is part of the RowSelection feature
   table._lastSelectedRowId = null
+
+  const isAllRowsSelected = callMemoOrStaticFn(
+    table,
+    'getIsAllRowsSelected',
+    table_getIsAllRowsSelected,
+  )
+
+  if (value ?? !isAllRowsSelected) {
+    if (isAllRowsSelected) return
+  } else if (
+    !callMemoOrStaticFn(
+      table,
+      'getIsSomeRowsSelected',
+      table_getIsSomeRowsSelected,
+    )
+  ) {
+    return
+  }
+
   table_setRowSelection(table, (old) => {
     value =
       typeof value !== 'undefined'

--- a/packages/table-core/tests/unit/features/row-selection/rowSelectionFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/row-selection/rowSelectionFeature.utils.test.ts
@@ -865,4 +865,52 @@ describe('table_toggleAllRowsSelected', () => {
       getUpdaterResult(onRowSelectionChange, { '0': true, '1': true }),
     ).toEqual({})
   })
+
+  it('should be a no-op for a redundant select all', () => {
+    const onRowSelectionChange = vi.fn()
+    const table = makeTable({
+      onRowSelectionChange,
+      state: {
+        rowSelection: {
+          '0': true,
+          '1': true,
+          '2': true,
+          '3': true,
+          '4': true,
+        },
+      },
+    })
+
+    table_toggleAllRowsSelected(table, true)
+
+    expect(onRowSelectionChange).not.toHaveBeenCalled()
+  })
+
+  it('should be a no-op for a redundant deselect all', () => {
+    const onRowSelectionChange = vi.fn()
+    const table = makeTable({ onRowSelectionChange })
+
+    table_toggleAllRowsSelected(table, false)
+    table_toggleAllRowsSelected(table, false, { deselectAll: true })
+
+    expect(onRowSelectionChange).not.toHaveBeenCalled()
+  })
+
+  it('should still select when only some selectable rows are selected', () => {
+    const onRowSelectionChange = vi.fn()
+    const table = makeTable({
+      onRowSelectionChange,
+      state: { rowSelection: { '0': true } },
+    })
+
+    table_toggleAllRowsSelected(table, true)
+
+    expect(getUpdaterResult(onRowSelectionChange, { '0': true })).toEqual({
+      '0': true,
+      '1': true,
+      '2': true,
+      '3': true,
+      '4': true,
+    })
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

`table.toggleAllRowsSelected(true)` rebuilds the whole selection map and calls `onRowSelectionChange` even when every selectable row is already selected, and `toggleAllRowsSelected(false)` does the same when nothing is selected. Consumers that mirror `rowSelection` into a URL or onto a server get a redundant write on every no-op toggle.

`toggleAllRowsExpanded` grew the equivalent guards in #6501, and #6532 kept those O(1) checks on purpose while leaving the general `setRowSelection` unguarded. This adds the matching pair: return early when selection is requested and `getIsAllRowsSelected()` is already true, and when deselection is requested and nothing is selected. Both read memoized getters, so the row-scaled map comparison that `setRowSelection` deliberately avoids stays out of the picture.

Three adapter tests drove their second `onRowSelectionChange` through `toggleAllRowsSelected(false)` with a mock handler that never writes state back, leaving the selection empty, so that call is now a no-op. They toggle selection on instead.

Fixes #6538

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

Green across all 409 projects except `@tanstack/ember-table:test:lib`, whose testem browser will not start on my machine. It fails the same way on an unmodified `main`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant row-selection updates when all selectable rows are already selected or deselected.
  * Avoided triggering selection change callbacks for no-op toggle requests.
  * Preserved selection updates when the table contains a mix of selected and unselected rows.

* **Tests**
  * Added coverage for redundant selection operations and partial-selection scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->