### PR TITLE
fix(table-core): flatten filtered parent rows ahead of their sub-rows

### DIFF
--- a/.changeset/great-pugs-sniff.md
+++ b/.changeset/great-pugs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/table-core": patch
+---
+
+Fix `getFilteredRowModel().flatRows` listing sub-rows before their parent in both `filterFromLeafRows` and `filterFromRoot` modes. This restores the parent-first order used by the core, sorted, and paginated row models, and aligns the flattened result with the filtered `rows` tree.

--- a/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
+++ b/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
@@ -65,20 +65,25 @@ function filterRowModelFromLeafs<
       newRow.columnFilters = row.columnFilters
 
       if (row.subRows.length && depth < maxDepth) {
+        // Descendants are filtered first, so in the flat list a parent must
+        // be inserted before its surviving children (pre-order) to match the
+        // readable `rows` tree and the core/sorted/paginated row models.
+        const flatIndex = newFilteredFlatRows.length
+
         newRow.subRows = recurseFilterRows(row.subRows, depth + 1)
         row = newRow
 
         if (filterRow(row) && !newRow.subRows.length) {
+          newFilteredFlatRows.splice(flatIndex, 0, row)
           filteredRows.push(row)
           newFilteredRowsById[row.id] = row
-          newFilteredFlatRows.push(row)
           continue
         }
 
         if (filterRow(row) || newRow.subRows.length) {
+          newFilteredFlatRows.splice(flatIndex, 0, row)
           filteredRows.push(row)
           newFilteredRowsById[row.id] = row
-          newFilteredFlatRows.push(row)
           continue
         }
       } else {
@@ -127,6 +132,11 @@ function filterRowModelFromRoot<
       const pass = filterRow(row)
 
       if (pass) {
+        // Take this row's slot before descending, so a parent stays ahead of
+        // its own sub-rows in flatRows (pre-order).
+        const flatIndex = newFilteredFlatRows.length
+        newFilteredFlatRows.push(row)
+
         if (row.subRows.length && depth < maxDepth) {
           const newRow = constructRow(
             table,
@@ -139,10 +149,10 @@ function filterRowModelFromRoot<
           )
           newRow.subRows = recurseFilterRows(row.subRows, depth + 1)
           row = newRow
+          newFilteredFlatRows[flatIndex] = row
         }
 
         filteredRows.push(row)
-        newFilteredFlatRows.push(row)
         newFilteredRowsById[row.id] = row
 
         // When maxLeafRowFilterDepth stops the recursion, the kept row's

--- a/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
+++ b/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
@@ -209,6 +209,20 @@ describe('createFilteredRowModel', () => {
       expect(model.rowsById[keepA.id]).toBe(keepA)
       expect(model.rowsById[keepA.subRows[0]!.id]).toBe(keepA.subRows[0])
     })
+
+    it('flattens each parent ahead of its own sub-rows (from root)', () => {
+      const table = makeNestedTable()
+      const model = table.getFilteredRowModel()
+
+      // Pre-order: a parent precedes its own surviving sub-rows in flatRows,
+      // matching the readable `rows` tree.
+      expect(rowNames(model.flatRows)).toEqual([
+        'keep-a',
+        'keep-a1',
+        'keep-c',
+        'keep-d',
+      ])
+    })
   })
 
   describe('filterFromLeafRows', () => {
@@ -270,6 +284,23 @@ describe('createFilteredRowModel', () => {
       expect(rowNames(keepA.subRows)).toEqual(['keep-a1'])
       expect(keepA.subRows[0]!.subRows).toEqual([])
     })
+
+    it('flattens each parent ahead of its own sub-rows (from leaf)', () => {
+      const table = makeNestedTable({ filterFromLeafRows: true })
+      const { rows, flatRows } = table.getFilteredRowModel()
+
+      // drop-b is retained because keep-b1 matches, and its ancestor chain
+      // must appear before its descendants in flatRows (pre-order).
+      expect(rowNames(rows)).toEqual(['keep-a', 'drop-b', 'keep-c', 'keep-d'])
+      expect(rowNames(flatRows)).toEqual([
+        'keep-a',
+        'keep-a1',
+        'drop-b',
+        'keep-b1',
+        'keep-c',
+        'keep-d',
+      ])
+    })
   })
 
   describe('maxLeafRowFilterDepth', () => {
@@ -324,13 +355,12 @@ describe('createFilteredRowModel', () => {
       const model = table.getFilteredRowModel()
 
       // Depth-1 children are still filtered (drop-a2 removed), while the
-      // depth-2 subtree of keep-a1 is kept as-is and joins flatRows. The
-      // pre-existing flatRows order pushes recursed children before their
-      // parent.
+      // depth-2 subtree of keep-a1 is kept as-is and joins flatRows. Each
+      // parent flattens ahead of its own sub-rows (pre-order).
       expect(rowNames(model.flatRows)).toEqual([
+        'keep-a',
         'keep-a1',
         'drop-a1a',
-        'keep-a',
         'keep-c',
         'keep-d',
       ])


### PR DESCRIPTION
## 🎯 Changes

`getFilteredRowModel().flatRows` has the exact same post-order problem that
[#6529](https://github.com/TanStack/table/pull/6529) fixed for
`getSortedRowModel().flatRows`.

### Root cause

Both `filterRowModelFromLeafs` (used when `filterFromLeafRows: true`) and
`filterRowModelFromRoot` (default) recurse into a row's sub-rows *before*
pushing the row itself to `flatRows`, so every descendant precedes its own
parent in the flattened list.

### Fix

- **`filterRowModelFromRoot`**: reserves the parent's flat-array slot before
  descending (same pattern as #6529's `createSortedRowModel`), then replaces
  it with the cloned row when recursion returns.
- **`filterRowModelFromLeafs`**: records the insertion point before recursion
  and splices the parent ahead of its surviving children when the parent is
  retained.

### Before

```ts
table.getCoreRowModel().flatRows.map((r) => r.original.name)
// ['keep-a', 'keep-a1', 'drop-a1a', 'drop-a2', 'drop-b', 'keep-b1',
//  'keep-c', 'keep-d', 'drop-d1']

table.getFilteredRowModel().flatRows.map((r) => r.original.name)
// before: ['keep-a1', 'keep-a', 'keep-c', 'keep-d']
// after:  ['keep-a', 'keep-a1', 'keep-c', 'keep-d']
```

### Checklist

- [x] `filterRowModelFromLeafs` fix
- [x] `filterRowModelFromRoot` fix
- [x] Update existing test expectation (the `maxLeafRowFilterDepth: 1` test
  that explicitly documented the old post-order behaviour)
- [x] Add new tests for both modes

Closes #6536


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected filtered row ordering so parent rows consistently appear before their surviving sub-rows.
  * Aligned flat row results with the displayed filtered row hierarchy across all filtering modes.

* **Tests**
  * Added coverage for hierarchical filtering and updated depth-limited filtering expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->