### PR TITLE
fix(mantine-react-table): map multi-select filterVariant to arrHas

### DIFF
--- a/examples/react/mantine-react-table/src/mantine-react-table/utils/column.utils.ts
+++ b/examples/react/mantine-react-table/src/mantine-react-table/utils/column.utils.ts
@@ -99,7 +99,10 @@ export const getDefaultColumnFilterFn = <TData extends MRT_RowData>(
   columnDef: MRT_ColumnDef<TData>,
 ): MRT_FilterOption => {
   const { filterVariant } = columnDef
-  if (filterVariant === 'multi-select') return 'arrIncludesSome'
+  // v9's arrIncludesSome requires an ARRAY cell value (v8 also matched strings via
+  // String#includes), so it filters out every row on scalar columns. arrHas
+  // ("scalar value equals at least one filter value") is the multi-select semantic.
+  if (filterVariant === 'multi-select') return 'arrHas'
   if (filterVariant?.includes('range')) return 'betweenInclusive'
   if (['checkbox', 'date', 'select'].includes(filterVariant || ''))
     return 'equals'


### PR DESCRIPTION
filterVariant: 'multi-select' resolved to the arrIncludesSome filter fn. In v8 that fn happened to work on scalar cell values because it leaned on String.prototype.includes, but the v9 implementation hard-requires an array data value (`if (!Array.isArray(dataValue)) return false`), so a multi-select filter applied to a plain string/number column filters out every row and blanks the table.

v9 added arrHas ('keeps rows whose scalar column value equals at least one filter value'), which is exactly the multi-select semantic — a cell holding one value matched against the array of selected options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering for multi-select columns to return more accurate results.
  * Updated behavior to correctly handle selected values and scalar entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->