### PR TITLE
fix(mantine-react-table): don't force manual row modes when data is empty

### DIFF
--- a/examples/react/mantine-react-table/src/mantine-react-table/hooks/useMRT_TableOptions.ts
+++ b/examples/react/mantine-react-table/src/mantine-react-table/hooks/useMRT_TableOptions.ts
@@ -171,12 +171,6 @@ export const useMRT_TableOptions: <TData extends MRT_RowData>(
     manualPagination = true
   }
 
-  if (!rest.data?.length) {
-    manualFiltering = true
-    manualGrouping = true
-    manualPagination = true
-    manualSorting = true
-  }
 
   return {
     aggregationFns,


### PR DESCRIPTION
Forcing manualFiltering/Grouping/Pagination/Sorting when `data` is empty drops the row-model factories and fns from the `features` option at construction time. table-core freezes \_rowModelFns (aggregationFns/ filterFns/sortFns) when the table is constructed, so any table that mounts before its async data arrives (data: [] on first render, rows later) permanently loses client-side grouping, sorting, and filtering — the options heal on re-render but the frozen registries never do.

The check was a v2-era perf hack; running the row-model pipelines over zero rows costs nothing, so it can simply be removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty or missing data from automatically enabling all manual table-processing modes.
  * Preserved manual pagination behavior when pagination is disabled and no explicit setting is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->