### PR TITLE
fix(mantine-react-table): expose loading state slices on table.state

### DIFF
--- a/examples/react/mantine-react-table/src/mantine-react-table/hooks/useMRT_TableInstance.ts
+++ b/examples/react/mantine-react-table/src/mantine-react-table/hooks/useMRT_TableInstance.ts
@@ -391,6 +391,17 @@ export const useMRT_TableInstance = <TData extends MRT_RowData>(
     showColumnFilters,
     showGlobalFilter,
     showToolbarDropZone,
+    // The controlled-only loading slices have no internal state — they only ever
+    // arrive via `options.state` — so they must be re-injected here too, or every
+    // component reads `isLoading: undefined` and e.g. body cells render real Cells
+    // over the blank skeleton rows instead of <Skeleton>s.
+    isLoading: statefulTableOptions.state.isLoading ?? false,
+    isSaving: statefulTableOptions.state.isSaving ?? false,
+    showLoadingOverlay: statefulTableOptions.state.showLoadingOverlay ?? false,
+    showProgressBars: statefulTableOptions.state.showProgressBars ?? false,
+    // not defaulted: `false` means "suppress skeletons even while loading"
+    // (MRT_TableBodyCell checks `showSkeletons !== false`), undefined means "auto"
+    showSkeletons: statefulTableOptions.state.showSkeletons!,
   }
 
   // v8-style `getState()` alias for any consumer that still calls it.


### PR DESCRIPTION
The post-useTable patch that re-injects MRT-only state slices onto table.state omits the controlled-only loading slices (isLoading, isSaving, showLoadingOverlay, showProgressBars, showSkeletons). Those slices have no internal useState — they only arrive via options.state — so every component that destructures them from table.state reads undefined.

Visible symptom: with state.isLoading true, the blank skeleton rows are generated, but MRT_TableBodyCell's skeleton branch never triggers, so column Cell renderers run against the null placeholder data (epoch dates, fallback strings) instead of rendering <Skeleton>s. The loading overlay and progress bars are similarly dead.

showSkeletons is intentionally not defaulted to false: MRT_TableBodyCell checks `showSkeletons !== false` — false means 'suppress skeletons even while loading', undefined means 'auto'.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading-state handling for controlled tables.
  * Loading indicators now display consistently while preserving explicitly configured skeleton visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->