### PR TITLE
docs: Fix callout formatting

### DIFF
--- a/docs/framework/alpine/guide/cell-selection.md
+++ b/docs/framework/alpine/guide/cell-selection.md
@@ -140,7 +140,8 @@ const table = createTable(
 )
 ```
 
-> Note: a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
+> [!NOTE]
+> a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
 
 ### Useful Row Ids
 
@@ -257,7 +258,8 @@ function getCellClassName(cell) {
 }
 ```
 
-> Tip: draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
+> [!TIP]
+> draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
 
 ### Keyboard Navigation
 

--- a/docs/framework/alpine/guide/column-filtering.md
+++ b/docs/framework/alpine/guide/column-filtering.md
@@ -45,7 +45,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
 
 ## Column Filtering (Alpine) Guide
 
@@ -82,7 +83,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
+> [!NOTE]
+> When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
 
 ### Client-Side Filtering
 
@@ -225,7 +227,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
+> [!NOTE]
+> Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
 
 ### FilterFns
 
@@ -256,7 +259,8 @@ You can also define your own custom filter functions, either inline as the `filt
 
 #### Custom Filter Functions
 
-> **Note:** These filter functions only run during client-side filtering.
+> [!NOTE]
+> These filter functions only run during client-side filtering.
 
 Whether you register a custom filter function in the `filterFns` slot on `tableFeatures` or pass it directly as a `filterFn` column option, it should have the following signature:
 
@@ -372,7 +376,8 @@ const includesStringIgnoreDiacritics = constructFilterFn({
 
 Register the variant by name in the `filterFns` registry or pass it directly to the `filterFn` column option, just like any other custom filter function.
 
-> **Note:** The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
+> [!NOTE]
+> The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
 
 ### Wiring up the filter UI
 

--- a/docs/framework/alpine/guide/column-ordering.md
+++ b/docs/framework/alpine/guide/column-ordering.md
@@ -44,7 +44,8 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual **Column Ordering** - A manually specified column order is applied.
 3. [Grouping](./grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
-> **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
+> [!NOTE]
+> `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 
 ### Column Order State
 
@@ -67,7 +68,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
+> [!NOTE]
+> If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
 
 #### Managing Column Order State
 

--- a/docs/framework/alpine/guide/column-pinning.md
+++ b/docs/framework/alpine/guide/column-pinning.md
@@ -132,7 +132,8 @@ const table = createTable({
 
 ### Useful Column Pinning APIs
 
-> Note: These APIs are available when using `columnPinningFeature`.
+> [!NOTE]
+> These APIs are available when using `columnPinningFeature`.
 
 There are a handful of useful Column API methods to help you implement column pinning features:
 

--- a/docs/framework/alpine/guide/column-resizing.md
+++ b/docs/framework/alpine/guide/column-resizing.md
@@ -402,6 +402,7 @@ Alpine.data('table', () => {
 </table>
 ```
 
-> Note: with the `() => ({})` selector, the `:class` binding on the resizer above will not update during a drag (the table is opted out of state-driven re-evaluation). The example instead toggles the `isResizing` class imperatively from a `table.atoms.columnResizing` subscription. Keeping the `:class` binding is fine if you accept the highlight only reflecting resize state on the next data-driven re-render.
+> [!NOTE]
+> with the `() => ({})` selector, the `:class` binding on the resizer above will not update during a drag (the table is opted out of state-driven re-evaluation). The example instead toggles the `isResizing` class imperatively from a `table.atoms.columnResizing` subscription. Keeping the `:class` binding is fine if you accept the highlight only reflecting resize state on the next data-driven re-render.
 
 If you follow these steps, you should see significant performance improvements while resizing columns.

--- a/docs/framework/alpine/guide/column-visibility.md
+++ b/docs/framework/alpine/guide/column-visibility.md
@@ -102,7 +102,8 @@ const table = createTable({
 
 Alternatively, if you don't need to manage the column visibility state outside of the table, you can still set the initial default column visibility state using the `initialState` option.
 
-> **Note**: If `columnVisibility` is provided to both `initialState` and a controlled option (`atoms` or `state`), the controlled value will take precedence and `initialState` will be ignored. Only provide `columnVisibility` in one place.
+> [!NOTE]
+> If `columnVisibility` is provided to both `initialState` and a controlled option (`atoms` or `state`), the controlled value will take precedence and `initialState` will be ignored. Only provide `columnVisibility` in one place.
 
 ```ts
 const features = tableFeatures({ columnVisibilityFeature })

--- a/docs/framework/alpine/guide/expanding.md
+++ b/docs/framework/alpine/guide/expanding.md
@@ -117,7 +117,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
+> [!NOTE]
+> You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
 
 ### Custom Expanding UI
 

--- a/docs/framework/alpine/guide/fuzzy-filtering.md
+++ b/docs/framework/alpine/guide/fuzzy-filtering.md
@@ -46,7 +46,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
+> [!NOTE]
+> The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
 
 ## Fuzzy Filtering (Alpine) Guide
 
@@ -56,7 +57,8 @@ You can implement client-side fuzzy filtering by defining a custom filter functi
 
 Fuzzy filtering is mostly used with global filtering, but you can also apply it to individual columns. We will discuss how to implement fuzzy filtering for both cases.
 
-> **Note:** You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
+> [!NOTE]
+> You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
 > TanStack Match Sorter Utils is a fork of [match-sorter](https://github.com/kentcdodds/match-sorter) by Kent C. Dodds. It was forked in order to work better with TanStack Table's row by row filtering approach.
 
 ```bash
@@ -228,4 +230,5 @@ You can then pass this sorting function directly to the `sortFn` option of the c
 }
 ```
 
-> **Note:** Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would only work if you also registered the function in the `sortFns` slot on `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips that step.
+> [!NOTE]
+> Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would only work if you also registered the function in the `sortFns` slot on `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips that step.

--- a/docs/framework/alpine/guide/global-filtering.md
+++ b/docs/framework/alpine/guide/global-filtering.md
@@ -42,7 +42,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
 
 ## Global Filtering (Alpine) Guide
 
@@ -210,7 +211,8 @@ TanStack table will not add a global filter input UI to your table. You should m
 
 If you want to use a custom global filter function, you can define the function and pass it to the `globalFilterFn` option.
 
-> **Note:** It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
+> [!NOTE]
+> It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
 
 ```ts
 const customFilterFn = (row, columnId, filterValue) => {
@@ -238,7 +240,8 @@ const table = createTable({
 })
 ```
 
-> NOTE: Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
+> [!NOTE]
+> Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
 
 ### Disable Global Filtering
 

--- a/docs/framework/alpine/guide/grouping.md
+++ b/docs/framework/alpine/guide/grouping.md
@@ -8,7 +8,8 @@ Want to skip to the implementation? Check out these Alpine examples:
 
 - [Grouping](../examples/grouping)
 
-> **Note:** `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
+> [!NOTE]
+> `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
 
 Read your reactive inputs such as `data` through a getter (for example backing them with `Alpine.reactive`) when creating the table, so the table sees updates.
 
@@ -135,7 +136,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
+> [!NOTE]
+> There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
 
 ### Controlled Grouping State
 

--- a/docs/framework/alpine/guide/pagination.md
+++ b/docs/framework/alpine/guide/pagination.md
@@ -108,7 +108,8 @@ const table = createTable({
 })
 ```
 
-> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+> [!NOTE]
+> Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
 
 ### Pagination State
 
@@ -202,7 +203,8 @@ const table = createTable({
 })
 ```
 
-> **Note**: Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
+> [!NOTE]
+> Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
 
 ### Pagination Options
 
@@ -251,7 +253,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
-> **Note**: These pagination APIs are available when using `rowPaginationFeature`.
+> [!NOTE]
+> These pagination APIs are available when using `rowPaginationFeature`.
 
 Pagination controls live on real elements so the click handlers and `:disabled` bindings stay interactive. Read the page index and page size with `table.atoms.pagination.get()`.
 

--- a/docs/framework/alpine/guide/row-selection.md
+++ b/docs/framework/alpine/guide/row-selection.md
@@ -54,7 +54,8 @@ console.log(table.getGroupedSelectedRowModel().rows) //get grouped client-side s
 
 In Alpine, the table's state atoms are reactive. `table.atoms.rowSelection.get()` is a reactive read when called inside an Alpine binding (`x-text`, `x-html`, `:value`, `x-if`, `x-for`, `x-effect`, or a getter/method on your `Alpine.data` object); in event handlers and other untracked code, the same call simply returns the current value.
 
-> Note: If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
+> [!NOTE]
+> If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
 
 ### Manage Row Selection State
 
@@ -282,7 +283,8 @@ const columns = [
 </template>
 ```
 
-> **Note:** The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
+> [!NOTE]
+> The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
 
 #### Connect Row Selection APIs to UI
 

--- a/docs/framework/alpine/guide/sorting.md
+++ b/docs/framework/alpine/guide/sorting.md
@@ -45,7 +45,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
+> [!NOTE]
+> Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
 
 ## Sorting (Alpine) Guide
 
@@ -154,7 +155,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
+> [!NOTE]
+> Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
 
 ### Client-Side vs Server-Side Sorting
 
@@ -190,7 +192,8 @@ const table = createTable({
 
 Hoisting the sorting state into your own scope (with an external atom or the `state.sorting` plus `onSortingChange` pattern) is covered in the [Controlled Sorting State](#controlled-sorting-state) section above.
 
-> **NOTE**: When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
+> [!NOTE]
+> When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
 
 ### Client-Side Sorting
 
@@ -258,7 +261,8 @@ const myCustomSortFn: SortFn<TFeatures, TData> = (
 }
 ```
 
-> Note: The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
+> [!NOTE]
+> The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
 
 Every sorting function receives 2 rows and a column ID and is expected to compare the two rows using the column ID to return `-1`, `0`, or `1` in ascending order. Here's a cheat sheet:
 
@@ -422,7 +426,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
+> [!NOTE]
+> You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
 
 #### Invert Sorting
 
@@ -451,7 +456,8 @@ If not specified, the default value for `sortUndefined` is `1`, and undefined va
 - `-1` - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
 - `1` - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
 
-> NOTE: `'first'` and `'last'` options are available in v9.
+> [!NOTE]
+> `'first'` and `'last'` options are available in v9.
 
 ```ts
 const columns = [

--- a/docs/framework/alpine/guide/table-state.md
+++ b/docs/framework/alpine/guide/table-state.md
@@ -188,7 +188,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. The precedence is `atoms[key]` > `state[key]` > internal `baseAtoms[key]`: external atoms take precedence over external `state`, and external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. The precedence is `atoms[key]` > `state[key]` > internal `baseAtoms[key]`: external atoms take precedence over external `state`, and external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/framework/angular/guide/cell-selection.md
+++ b/docs/framework/angular/guide/cell-selection.md
@@ -122,7 +122,8 @@ export class App {
 }
 ```
 
-> Note: a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
+> [!NOTE]
+> a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
 
 ### Useful Row Ids
 
@@ -241,7 +242,8 @@ function getCellClassName(cell) {
 }
 ```
 
-> Tip: draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
+> [!TIP]
+> draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
 
 ### Keyboard Navigation
 

--- a/docs/framework/angular/guide/column-filtering.md
+++ b/docs/framework/angular/guide/column-filtering.md
@@ -47,7 +47,8 @@ export class App {
 }
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
 
 ## Column Filtering (Angular) Guide
 
@@ -82,7 +83,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> **Note:** When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
+> [!NOTE]
+> When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
 
 ### Client-Side Filtering
 
@@ -214,7 +216,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> **NOTE**: Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
+> [!NOTE]
+> Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
 
 ### FilterFns
 
@@ -245,7 +248,8 @@ You can also define your own custom filter functions, either inline as the `filt
 
 #### Custom Filter Functions
 
-> **Note:** These filter functions only run during client-side filtering.
+> [!NOTE]
+> These filter functions only run during client-side filtering.
 
 Whether you register a custom filter function in the `filterFns` slot on `tableFeatures` or pass it directly as a `filterFn` column option, it should have the following signature:
 
@@ -359,7 +363,8 @@ const includesStringIgnoreDiacritics = constructFilterFn({
 
 Register the variant by name in the `filterFns` registry or pass it directly to the `filterFn` column option, just like any other custom filter function.
 
-> **Note:** The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
+> [!NOTE]
+> The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
 
 ### Customize Column Filtering
 

--- a/docs/framework/angular/guide/column-ordering.md
+++ b/docs/framework/angular/guide/column-ordering.md
@@ -45,7 +45,8 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual **Column Ordering** - A manually specified column order is applied.
 3. [Grouping](./grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
-> **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
+> [!NOTE]
+> `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 
 ### Column Order State
 
@@ -68,7 +69,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> **Note:** If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
+> [!NOTE]
+> If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
 
 #### Managing Column Order State
 

--- a/docs/framework/angular/guide/column-pinning.md
+++ b/docs/framework/angular/guide/column-pinning.md
@@ -131,7 +131,8 @@ readonly table = injectTable(() => ({
 
 ### Useful Column Pinning APIs
 
-> Note: These APIs are available when using `columnPinningFeature`.
+> [!NOTE]
+> These APIs are available when using `columnPinningFeature`.
 
 There are a handful of useful Column API methods to help you implement column pinning features:
 

--- a/docs/framework/angular/guide/column-visibility.md
+++ b/docs/framework/angular/guide/column-visibility.md
@@ -100,7 +100,8 @@ readonly table = injectTable(() => ({
 
 Alternatively, if you don't need to manage the column visibility state outside of the table, you can still set the initial default column visibility state using the `initialState` option.
 
-> **Note**: If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
+> [!NOTE]
+> If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
 
 ```ts
 const features = tableFeatures({ columnVisibilityFeature })

--- a/docs/framework/angular/guide/expanding.md
+++ b/docs/framework/angular/guide/expanding.md
@@ -117,7 +117,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> **Note:** You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
+> [!NOTE]
+> You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
 
 ### Custom Expanding UI
 

--- a/docs/framework/angular/guide/fuzzy-filtering.md
+++ b/docs/framework/angular/guide/fuzzy-filtering.md
@@ -54,7 +54,8 @@ export class App {
 }
 ```
 
-> **Note:** The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
+> [!NOTE]
+> The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
 
 ## Fuzzy Filtering (Angular) Guide
 
@@ -64,7 +65,8 @@ You can implement client-side fuzzy filtering by defining a custom filter functi
 
 Fuzzy filtering is mostly used with global filtering, but you can also apply it to individual columns. We will discuss how to implement fuzzy filtering for both cases.
 
-> **Note:** You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
+> [!NOTE]
+> You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
 > TanStack Match Sorter Utils is a fork of [match-sorter](https://github.com/kentcdodds/match-sorter) by Kent C. Dodds. It was forked in order to work better with TanStack Table's row by row filtering approach.
 
 Using the match-sorter libraries is optional, but the TanStack Match Sorter Utils library provides a great way to both fuzzy filter and sort by the rank information it returns, so that rows can be sorted by their closest matches to the search query.
@@ -216,4 +218,5 @@ You can then pass this sorting function directly to the `sortFn` option of the c
 }
 ```
 
-> **Note:** `fuzzySort` can also be referenced by the string `'fuzzy'` if it is registered in the `sortFns` slot of `tableFeatures` (as shown in the setup snippet above). Passing the function directly to `sortFn` skips the need to register it.
+> [!NOTE]
+> `fuzzySort` can also be referenced by the string `'fuzzy'` if it is registered in the `sortFns` slot of `tableFeatures` (as shown in the setup snippet above). Passing the function directly to `sortFn` skips the need to register it.

--- a/docs/framework/angular/guide/global-filtering.md
+++ b/docs/framework/angular/guide/global-filtering.md
@@ -43,7 +43,8 @@ export class App {
 }
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
 
 ## Global Filtering (Angular) Guide
 
@@ -205,7 +206,8 @@ TanStack table will not add a global filter input UI to your table. You should m
 
 If you want to use a custom global filter function, you can define the function and pass it to the `globalFilterFn` option.
 
-> **Note:** It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
+> [!NOTE]
+> It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
 
 ```ts
 const customFilterFn = (row, columnId, filterValue) => {
@@ -235,7 +237,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> NOTE: Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
+> [!NOTE]
+> Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
 
 ### Disable Global Filtering
 

--- a/docs/framework/angular/guide/grouping.md
+++ b/docs/framework/angular/guide/grouping.md
@@ -8,7 +8,8 @@ Want to skip to the implementation? Check out these Angular examples:
 
 - [Grouping](../examples/grouping)
 
-> **Note:** `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
+> [!NOTE]
+> `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
 
 ### Grouping Setup
 
@@ -136,7 +137,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> **Note:** There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
+> [!NOTE]
+> There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
 
 ### Controlled Grouping State
 

--- a/docs/framework/angular/guide/migrating.md
+++ b/docs/framework/angular/guide/migrating.md
@@ -81,7 +81,8 @@ const v9Table = injectTable(() => ({
 }))
 ```
 
-> Note: `injectTable` evaluates your initializer whenever any Angular signal read inside of it changes.
+> [!NOTE]
+> `injectTable` evaluates your initializer whenever any Angular signal read inside of it changes.
 > Keep expensive/static values (like `columns` and `features`) as stable references outside the initializer.
 
 ### New Required `features` Table Option

--- a/docs/framework/angular/guide/pagination.md
+++ b/docs/framework/angular/guide/pagination.md
@@ -111,7 +111,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+> [!NOTE]
+> Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
 
 #### Using TanStack Query
 
@@ -294,7 +295,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> **Note**: Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
+> [!NOTE]
+> Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
 
 ### Pagination Options
 
@@ -341,7 +343,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
-> **Note**: These pagination APIs are available when using `rowPaginationFeature`.
+> [!NOTE]
+> These pagination APIs are available when using `rowPaginationFeature`.
 
 ```html
 <button

--- a/docs/framework/angular/guide/row-selection.md
+++ b/docs/framework/angular/guide/row-selection.md
@@ -56,7 +56,8 @@ console.log(table.getGroupedSelectedRowModel().rows) //get grouped client-side s
 
 In Angular, table atom reads are signal reads, so reading `table.atoms.rowSelection.get()` in a template expression, `computed(...)`, or `effect(...)` automatically tracks updates.
 
-> Note: If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
+> [!NOTE]
+> If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
 
 ### Manage Row Selection State
 
@@ -250,7 +251,8 @@ If you need more granular control over these function handlers, you can always j
 />
 ```
 
-> **Note:** The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
+> [!NOTE]
+> The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
 
 #### Connect Row Selection APIs to UI
 

--- a/docs/framework/angular/guide/sorting.md
+++ b/docs/framework/angular/guide/sorting.md
@@ -46,7 +46,8 @@ export class App {
 }
 ```
 
-> **NOTE**: Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
+> [!NOTE]
+> Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
 
 ## Sorting (Angular) Guide
 
@@ -150,7 +151,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> **NOTE**: Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
+> [!NOTE]
+> Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
 
 ### Client-Side vs Server-Side Sorting
 
@@ -188,7 +190,8 @@ export class App {
 
 Hoisting the sorting state into your own scope (with an external atom or the `state.sorting` plus `onSortingChange` pattern) is covered in the [Controlled Sorting State](#controlled-sorting-state) section above.
 
-> **NOTE**: When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
+> [!NOTE]
+> When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
 
 ### Client-Side Sorting
 
@@ -254,7 +257,8 @@ const myCustomSortFn: SortFn<TFeatures, TData> = (
 }
 ```
 
-> Note: The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
+> [!NOTE]
+> The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
 
 Every sorting function receives 2 rows and a column ID and is expected to compare the two rows using the column ID to return `-1`, `0`, or `1` in ascending order. Here's a cheat sheet:
 
@@ -414,7 +418,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> **NOTE**: You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
+> [!NOTE]
+> You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
 
 #### Invert Sorting
 
@@ -443,7 +448,8 @@ If not specified, the default value for `sortUndefined` is `1`, and undefined va
 - `-1` - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
 - `1` - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
 
-> NOTE: `'first'` and `'last'` options are available in v9.
+> [!NOTE]
+> `'first'` and `'last'` options are available in v9.
 
 ```ts
 const columns = [

--- a/docs/framework/angular/guide/table-state.md
+++ b/docs/framework/angular/guide/table-state.md
@@ -178,7 +178,8 @@ readonly table = injectTable(() => ({
 }))
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/framework/ember/guide/cell-selection.md
+++ b/docs/framework/ember/guide/cell-selection.md
@@ -118,7 +118,8 @@ table = useTable(() => ({
 }))
 ```
 
-> Note: a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
+> [!NOTE]
+> a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
 
 ### Useful Row Ids
 
@@ -237,7 +238,8 @@ function getCellClassName(cell) {
 }
 ```
 
-> Tip: draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
+> [!TIP]
+> draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
 
 ### Keyboard Navigation
 

--- a/docs/framework/ember/guide/column-filtering.md
+++ b/docs/framework/ember/guide/column-filtering.md
@@ -43,7 +43,8 @@ table = useTable(() => ({
 }))
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
 
 ## Column Filtering (Ember) Guide
 
@@ -78,7 +79,8 @@ table = useTable(() => ({
 }))
 ```
 
-> **Note:** When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
+> [!NOTE]
+> When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
 
 ### Client-Side Filtering
 
@@ -212,7 +214,8 @@ table = useTable(() => ({
 }))
 ```
 
-> **NOTE**: Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
+> [!NOTE]
+> Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
 
 ### FilterFns
 
@@ -243,7 +246,8 @@ You can also define your own custom filter functions, either inline as the `filt
 
 #### Custom Filter Functions
 
-> **Note:** These filter functions only run during client-side filtering.
+> [!NOTE]
+> These filter functions only run during client-side filtering.
 
 Whether you register a custom filter function in the `filterFns` slot on `tableFeatures` or pass it directly as a `filterFn` column option, it should have the following signature:
 
@@ -359,7 +363,8 @@ const includesStringIgnoreDiacritics = constructFilterFn({
 
 Register the variant by name in the `filterFns` registry or pass it directly to the `filterFn` column option, just like any other custom filter function.
 
-> **Note:** The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
+> [!NOTE]
+> The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
 
 ### Customize Column Filtering
 

--- a/docs/framework/ember/guide/column-ordering.md
+++ b/docs/framework/ember/guide/column-ordering.md
@@ -40,7 +40,8 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual **Column Ordering** - A manually specified column order is applied.
 3. [Grouping](./grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
-> **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
+> [!NOTE]
+> `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 
 ### Column Order State
 
@@ -63,7 +64,8 @@ const table = useTable(() => ({
 }))
 ```
 
-> **Note:** If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
+> [!NOTE]
+> If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
 
 #### Managing Column Order State
 

--- a/docs/framework/ember/guide/column-pinning.md
+++ b/docs/framework/ember/guide/column-pinning.md
@@ -131,7 +131,8 @@ const table = useTable(() => ({
 
 ### Useful Column Pinning APIs
 
-> Note: These APIs are available when using `columnPinningFeature`.
+> [!NOTE]
+> These APIs are available when using `columnPinningFeature`.
 
 There are a handful of useful Column API methods to help you implement column pinning features:
 

--- a/docs/framework/ember/guide/column-visibility.md
+++ b/docs/framework/ember/guide/column-visibility.md
@@ -94,7 +94,8 @@ table = useTable(() => ({
 
 Alternatively, if you don't need to manage the column visibility state outside of the table, you can still set the initial default column visibility state using the `initialState` option.
 
-> **Note**: If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
+> [!NOTE]
+> If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
 
 ```ts
 const features = tableFeatures({ columnVisibilityFeature })

--- a/docs/framework/ember/guide/expanding.md
+++ b/docs/framework/ember/guide/expanding.md
@@ -113,7 +113,8 @@ const table = useTable(() => ({
 }))
 ```
 
-> **Note:** You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
+> [!NOTE]
+> You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
 
 ### Custom Expanding UI
 

--- a/docs/framework/ember/guide/fuzzy-filtering.md
+++ b/docs/framework/ember/guide/fuzzy-filtering.md
@@ -45,7 +45,8 @@ table = useTable(() => ({
 }))
 ```
 
-> **Note:** The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
+> [!NOTE]
+> The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
 
 ## Fuzzy Filtering (Ember) Guide
 
@@ -55,7 +56,8 @@ You can implement client-side fuzzy filtering by defining a custom filter functi
 
 Fuzzy filtering is mostly used with global filtering, but you can also apply it to individual columns. We will discuss how to implement fuzzy filtering for both cases.
 
-> **Note:** You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
+> [!NOTE]
+> You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
 > TanStack Match Sorter Utils is a fork of [match-sorter](https://github.com/kentcdodds/match-sorter) by Kent C. Dodds. It was forked in order to work better with TanStack Table's row by row filtering approach.
 
 Using the match-sorter libraries is optional, but the TanStack Match Sorter Utils library provides a great way to both fuzzy filter and sort by the rank information it returns, so that rows can be sorted by their closest matches to the search query.

--- a/docs/framework/ember/guide/global-filtering.md
+++ b/docs/framework/ember/guide/global-filtering.md
@@ -39,7 +39,8 @@ table = useTable(() => ({
 }))
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
 
 ## Global Filtering (Ember) Guide
 
@@ -212,7 +213,8 @@ handleGlobalFilter = (event: Event) => {
 
 If you want to use a custom global filter function, you can define the function and pass it to the `globalFilterFn` option.
 
-> **Note:** It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
+> [!NOTE]
+> It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
 
 ```gts
 const customFilterFn = (row, columnId, filterValue) => {
@@ -240,7 +242,8 @@ table = useTable(() => ({
 }))
 ```
 
-> NOTE: Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
+> [!NOTE]
+> Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
 
 ### Disable Global Filtering
 

--- a/docs/framework/ember/guide/grouping.md
+++ b/docs/framework/ember/guide/grouping.md
@@ -8,7 +8,8 @@ Want to skip to the implementation? Check out these Ember examples:
 
 - [Grouping](../examples/grouping)
 
-> **Note:** `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
+> [!NOTE]
+> `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
 
 ### Grouping Setup
 
@@ -131,7 +132,8 @@ const table = useTable(() => ({
 }))
 ```
 
-> **Note:** There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
+> [!NOTE]
+> There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
 
 ### Controlled Grouping State
 

--- a/docs/framework/ember/guide/pagination.md
+++ b/docs/framework/ember/guide/pagination.md
@@ -106,7 +106,8 @@ const table = useTable(() => ({
 }))
 ```
 
-> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+> [!NOTE]
+> Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
 
 ### Pagination State
 
@@ -189,7 +190,8 @@ const table = useTable(() => ({
 }))
 ```
 
-> **Note**: Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
+> [!NOTE]
+> Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
 
 ### Pagination Options
 
@@ -236,7 +238,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
-> **Note**: These pagination APIs are available when using `rowPaginationFeature`.
+> [!NOTE]
+> These pagination APIs are available when using `rowPaginationFeature`.
 
 Because Ember templates extract method references without binding them, wire the pagination controls up through action methods and getters on your component instead of calling table methods directly in the template:
 

--- a/docs/framework/ember/guide/row-selection.md
+++ b/docs/framework/ember/guide/row-selection.md
@@ -50,7 +50,8 @@ console.log(table.getGroupedSelectedRowModel().rows) //get grouped client-side s
 
 In event handlers or other non-render code, you can also read the current snapshot with `table.atoms.rowSelection.get()`. This read does not subscribe a component to future changes, so prefer `table.store.state.rowSelection` in render positions (a getter or a template binding).
 
-> Note: If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
+> [!NOTE]
+> If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
 
 ### Manage Row Selection State
 
@@ -304,7 +305,8 @@ const columns = columnHelper.columns([
 ])
 ```
 
-> **Note:** The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
+> [!NOTE]
+> The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
 
 #### Connect Row Selection APIs to UI
 

--- a/docs/framework/ember/guide/sorting.md
+++ b/docs/framework/ember/guide/sorting.md
@@ -42,7 +42,8 @@ table = useTable(() => ({
 }))
 ```
 
-> **NOTE**: Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
+> [!NOTE]
+> Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
 
 ## Sorting (Ember) Guide
 
@@ -148,7 +149,8 @@ table = useTable(() => ({
 }))
 ```
 
-> **NOTE**: Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
+> [!NOTE]
+> Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
 
 ### Client-Side vs Server-Side Sorting
 
@@ -185,7 +187,8 @@ table = useTable(() => ({
 
 Hoisting the sorting state into your own scope (with an external atom or the `state.sorting` plus `onSortingChange` pattern) is covered in the [Controlled Sorting State](#controlled-sorting-state) section above.
 
-> **NOTE**: When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
+> [!NOTE]
+> When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
 
 ### Client-Side Sorting
 
@@ -251,7 +254,8 @@ const myCustomSortFn: SortFn<TFeatures, TData> = (
 }
 ```
 
-> Note: The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
+> [!NOTE]
+> The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
 
 Every sorting function receives 2 rows and a column ID and is expected to compare the two rows using the column ID to return `-1`, `0`, or `1` in ascending order. Here's a cheat sheet:
 
@@ -407,7 +411,8 @@ table = useTable(() => ({
 }))
 ```
 
-> **NOTE**: You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
+> [!NOTE]
+> You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
 
 #### Invert Sorting
 
@@ -435,7 +440,8 @@ If not specified, the default value for `sortUndefined` is `1`, and undefined va
 - `-1` - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
 - `1` - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
 
-> NOTE: `'first'` and `'last'` options are available in v9.
+> [!NOTE]
+> `'first'` and `'last'` options are available in v9.
 
 ```ts
 const columns = columnHelper.columns([

--- a/docs/framework/ember/guide/table-state.md
+++ b/docs/framework/ember/guide/table-state.md
@@ -124,7 +124,8 @@ export default class PersonTable extends Component {
 }
 ```
 
-> **Note:** TanStack Table v9 uses prototype-based methods that require `this` binding. Ember templates extract function references without binding them, so wrap table, column, and row method calls in small module-level helper functions (or getters) instead of calling them directly in a template. For example, `const getCanSort = (column) => column.getCanSort()`, then call `(getCanSort header.column)` from the template.
+> [!NOTE]
+> TanStack Table v9 uses prototype-based methods that require `this` binding. Ember templates extract function references without binding them, so wrap table, column, and row method calls in small module-level helper functions (or getters) instead of calling them directly in a template. For example, `const getCanSort = (column) => column.getCanSort()`, then call `(getCanSort header.column)` from the template.
 
 ### Setting Table State
 
@@ -178,7 +179,8 @@ table = useTable(() => ({
 }))
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. The precedence is `atoms[key]` > `state[key]` > internal `baseAtoms[key]`: external atoms take precedence over external `state`, and external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. The precedence is `atoms[key]` > `state[key]` > internal `baseAtoms[key]`: external atoms take precedence over external `state`, and external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/framework/lit/guide/cell-selection.md
+++ b/docs/framework/lit/guide/cell-selection.md
@@ -120,7 +120,8 @@ const table = this.tableController.table({
 })
 ```
 
-> Note: a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
+> [!NOTE]
+> a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
 
 ### Useful Row Ids
 
@@ -237,7 +238,8 @@ function getCellClassName(cell) {
 }
 ```
 
-> Tip: draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
+> [!TIP]
+> draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
 
 ### Keyboard Navigation
 

--- a/docs/framework/lit/guide/column-filtering.md
+++ b/docs/framework/lit/guide/column-filtering.md
@@ -56,7 +56,8 @@ class MyTable extends LitElement {
 }
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
 
 ## Column Filtering (Lit) Guide
 
@@ -91,7 +92,8 @@ const table = this.tableController.table({
 })
 ```
 
-> **Note:** When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
+> [!NOTE]
+> When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
 
 ### Client-Side Filtering
 
@@ -226,7 +228,8 @@ const table = this.tableController.table({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
+> [!NOTE]
+> Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
 
 ### FilterFns
 
@@ -257,7 +260,8 @@ You can also define your own custom filter functions, either inline as the `filt
 
 #### Custom Filter Functions
 
-> **Note:** These filter functions only run during client-side filtering.
+> [!NOTE]
+> These filter functions only run during client-side filtering.
 
 Whether you register a custom filter function in the `filterFns` slot on `tableFeatures` or pass it directly as a `filterFn` column option, it should have the following signature:
 
@@ -371,7 +375,8 @@ const includesStringIgnoreDiacritics = constructFilterFn({
 
 Register the variant by name in the `filterFns` registry or pass it directly to the `filterFn` column option, just like any other custom filter function.
 
-> **Note:** The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
+> [!NOTE]
+> The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
 
 ### Customize Column Filtering
 

--- a/docs/framework/lit/guide/column-ordering.md
+++ b/docs/framework/lit/guide/column-ordering.md
@@ -54,7 +54,8 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual **Column Ordering** - A manually specified column order is applied.
 3. [Grouping](./grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
-> **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
+> [!NOTE]
+> `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 
 ### Column Order State
 
@@ -77,7 +78,8 @@ const table = this.tableController.table({
 })
 ```
 
-> **Note:** If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
+> [!NOTE]
+> If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
 
 #### Managing Column Order State
 

--- a/docs/framework/lit/guide/column-pinning.md
+++ b/docs/framework/lit/guide/column-pinning.md
@@ -139,7 +139,8 @@ const table = this.tableController.table({
 
 ### Useful Column Pinning APIs
 
-> Note: These APIs are available when using `columnPinningFeature`.
+> [!NOTE]
+> These APIs are available when using `columnPinningFeature`.
 
 There are a handful of useful Column API methods to help you implement column pinning features:
 

--- a/docs/framework/lit/guide/column-visibility.md
+++ b/docs/framework/lit/guide/column-visibility.md
@@ -108,7 +108,8 @@ const table = this.tableController.table({
 
 Alternatively, if you don't need to manage the column visibility state outside of the table, you can still set the initial default column visibility state using the `initialState` option.
 
-> **Note**: If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
+> [!NOTE]
+> If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
 
 ```ts
 const features = tableFeatures({ columnVisibilityFeature })

--- a/docs/framework/lit/guide/expanding.md
+++ b/docs/framework/lit/guide/expanding.md
@@ -126,7 +126,8 @@ const table = this.tableController.table({
 })
 ```
 
-> **Note:** You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
+> [!NOTE]
+> You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
 
 ### Custom Expanding UI
 

--- a/docs/framework/lit/guide/fuzzy-filtering.md
+++ b/docs/framework/lit/guide/fuzzy-filtering.md
@@ -56,7 +56,8 @@ class MyTable extends LitElement {
 }
 ```
 
-> **Note:** The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
+> [!NOTE]
+> The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
 
 ## Fuzzy Filtering (Lit) Guide
 
@@ -66,7 +67,8 @@ You can implement client-side fuzzy filtering by defining a custom filter functi
 
 Fuzzy filtering is mostly used with global filtering, but you can also apply it to individual columns. We will discuss how to implement fuzzy filtering for both cases.
 
-> **Note:** You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
+> [!NOTE]
+> You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
 > TanStack Match Sorter Utils is a fork of [match-sorter](https://github.com/kentcdodds/match-sorter) by Kent C. Dodds. It was forked in order to work better with TanStack Table's row by row filtering approach.
 
 Using the match-sorter libraries is optional, but the TanStack Match Sorter Utils library provides a great way to both fuzzy filter and sort by the rank information it returns, so that rows can be sorted by their closest matches to the search query.
@@ -223,4 +225,5 @@ You can then pass this sorting function directly to the `sortFn` option of the c
 }
 ```
 
-> **Note:** Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would only work if you also registered the function in the `sortFns` slot on `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips registration entirely.
+> [!NOTE]
+> Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would only work if you also registered the function in the `sortFns` slot on `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips registration entirely.

--- a/docs/framework/lit/guide/global-filtering.md
+++ b/docs/framework/lit/guide/global-filtering.md
@@ -52,7 +52,8 @@ class MyTable extends LitElement {
 }
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
 
 ## Global Filtering (Lit) Guide
 
@@ -216,7 +217,8 @@ html`
 
 If you want to use a custom global filter function, you can define the function and pass it to the `globalFilterFn` option.
 
-> **Note:** It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
+> [!NOTE]
+> It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
 
 ```ts
 const customFilterFn = (row, columnId, filterValue) => {
@@ -244,7 +246,8 @@ const table = this.tableController.table({
 })
 ```
 
-> NOTE: Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
+> [!NOTE]
+> Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
 
 ### Disable Global Filtering
 

--- a/docs/framework/lit/guide/grouping.md
+++ b/docs/framework/lit/guide/grouping.md
@@ -8,7 +8,8 @@ Want to skip to the implementation? Check out these Lit examples:
 
 - [Grouping](../examples/grouping)
 
-> **Note:** `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
+> [!NOTE]
+> `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
 
 ### Grouping Setup
 
@@ -145,7 +146,8 @@ const table = this.tableController.table({
 })
 ```
 
-> **Note:** There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
+> [!NOTE]
+> There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
 
 ### Controlled Grouping State
 

--- a/docs/framework/lit/guide/pagination.md
+++ b/docs/framework/lit/guide/pagination.md
@@ -120,7 +120,8 @@ const table = this.tableController.table({
 })
 ```
 
-> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+> [!NOTE]
+> Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
 
 ### Pagination State
 
@@ -203,7 +204,8 @@ const table = this.tableController.table({
 })
 ```
 
-> **Note**: Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
+> [!NOTE]
+> Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
 
 ### Pagination Options
 
@@ -250,7 +252,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
-> **Note**: These pagination APIs are available when using `rowPaginationFeature`.
+> [!NOTE]
+> These pagination APIs are available when using `rowPaginationFeature`.
 
 ```ts
 html`

--- a/docs/framework/lit/guide/row-selection.md
+++ b/docs/framework/lit/guide/row-selection.md
@@ -64,7 +64,8 @@ console.log(table.getGroupedSelectedRowModel().rows) //get grouped client-side s
 
 In event handlers or other non-render code, you can also read the current snapshot with `table.atoms.rowSelection.get()`. In your `render` method, prefer `table.state.rowSelection` (or the `table.subscribe` directive), since the `TableController` keeps the host updated through the table store subscription.
 
-> Note: If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
+> [!NOTE]
+> If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
 
 ### Manage Row Selection State
 
@@ -261,7 +262,8 @@ html`
 `
 ```
 
-> **Note:** The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
+> [!NOTE]
+> The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
 
 #### Connect Row Selection APIs to UI
 

--- a/docs/framework/lit/guide/sorting.md
+++ b/docs/framework/lit/guide/sorting.md
@@ -56,7 +56,8 @@ class MyTable extends LitElement {
 }
 ```
 
-> **NOTE**: Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
+> [!NOTE]
+> Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
 
 ## Sorting (Lit) Guide
 
@@ -171,7 +172,8 @@ const table = this.tableController.table({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
+> [!NOTE]
+> Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
 
 ### Client-Side vs Server-Side Sorting
 
@@ -207,7 +209,8 @@ const table = this.tableController.table({
 
 Hoisting the sorting state into your own scope (with an external atom or the `state.sorting` plus `onSortingChange` pattern) is covered in the [Controlled Sorting State](#controlled-sorting-state) section above.
 
-> **NOTE**: When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
+> [!NOTE]
+> When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
 
 ### Client-Side Sorting
 
@@ -273,7 +276,8 @@ const myCustomSortFn: SortFn<TFeatures, TData> = (
 }
 ```
 
-> Note: The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
+> [!NOTE]
+> The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
 
 Every sorting function receives 2 rows and a column ID and is expected to compare the two rows using the column ID to return `-1`, `0`, or `1` in ascending order. Here's a cheat sheet:
 
@@ -431,7 +435,8 @@ const table = this.tableController.table({
 })
 ```
 
-> **NOTE**: You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
+> [!NOTE]
+> You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
 
 #### Invert Sorting
 
@@ -460,7 +465,8 @@ If not specified, the default value for `sortUndefined` is `1`, and undefined va
 - `-1` - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
 - `1` - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
 
-> NOTE: `'first'` and `'last'` options are available in v9.
+> [!NOTE]
+> `'first'` and `'last'` options are available in v9.
 
 ```ts
 const columns = [

--- a/docs/framework/lit/guide/table-state.md
+++ b/docs/framework/lit/guide/table-state.md
@@ -182,7 +182,8 @@ const table = this.tableController.table({
 })
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/framework/octane/guide/cell-selection.md
+++ b/docs/framework/octane/guide/cell-selection.md
@@ -112,7 +112,8 @@ const table = useTable({
 })
 ```
 
-> Note: a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
+> [!NOTE]
+> a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
 
 ### Useful Row Ids
 
@@ -225,7 +226,8 @@ function getCellClassName(cell) {
 }
 ```
 
-> Tip: draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
+> [!TIP]
+> draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
 
 ### Keyboard Navigation
 

--- a/docs/framework/octane/guide/column-filtering.md
+++ b/docs/framework/octane/guide/column-filtering.md
@@ -42,7 +42,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
 
 ## Column Filtering (Octane) Guide
 
@@ -77,7 +78,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
+> [!NOTE]
+> When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
 
 ### Client-Side Filtering
 
@@ -204,7 +206,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
+> [!NOTE]
+> Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
 
 ### FilterFns
 
@@ -235,7 +238,8 @@ You can also define your own custom filter functions, either inline as the `filt
 
 #### Custom Filter Functions
 
-> **Note:** These filter functions only run during client-side filtering.
+> [!NOTE]
+> These filter functions only run during client-side filtering.
 
 Whether you register a custom filter function in the `filterFns` slot on `tableFeatures` or pass it directly as a `filterFn` column option, it should have the following signature:
 
@@ -355,7 +359,8 @@ const includesStringIgnoreDiacritics = constructFilterFn({
 
 Register the variant by name in the `filterFns` registry or pass it directly to the `filterFn` column option, just like any other custom filter function.
 
-> **Note:** The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
+> [!NOTE]
+> The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
 
 ### Customize Column Filtering
 

--- a/docs/framework/octane/guide/column-ordering.md
+++ b/docs/framework/octane/guide/column-ordering.md
@@ -40,7 +40,8 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual **Column Ordering** - A manually specified column order is applied.
 3. [Grouping](./grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
-> **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
+> [!NOTE]
+> `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 
 ### Column Order State
 
@@ -63,7 +64,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
+> [!NOTE]
+> If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
 
 #### Managing Column Order State
 

--- a/docs/framework/octane/guide/column-pinning.md
+++ b/docs/framework/octane/guide/column-pinning.md
@@ -121,7 +121,8 @@ const table = useTable({
 
 ### Useful Column Pinning APIs
 
-> Note: These APIs are available when using `columnPinningFeature`.
+> [!NOTE]
+> These APIs are available when using `columnPinningFeature`.
 
 There are a handful of useful Column API methods to help you implement column pinning features:
 

--- a/docs/framework/octane/guide/column-visibility.md
+++ b/docs/framework/octane/guide/column-visibility.md
@@ -92,7 +92,8 @@ const table = useTable({
 
 Alternatively, if you don't need to manage the column visibility state outside of the table, you can still set the initial default column visibility state using the `initialState` option.
 
-> **Note**: If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
+> [!NOTE]
+> If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
 
 ```tsx
 const features = tableFeatures({ columnVisibilityFeature })

--- a/docs/framework/octane/guide/expanding.md
+++ b/docs/framework/octane/guide/expanding.md
@@ -112,7 +112,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
+> [!NOTE]
+> You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
 
 ### Custom Expanding UI
 

--- a/docs/framework/octane/guide/fuzzy-filtering.md
+++ b/docs/framework/octane/guide/fuzzy-filtering.md
@@ -49,7 +49,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
+> [!NOTE]
+> The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
 
 ## Fuzzy Filtering (Octane) Guide
 
@@ -59,7 +60,8 @@ You can implement client-side fuzzy filtering by defining a custom filter functi
 
 Fuzzy filtering is mostly used with global filtering, but you can also apply it to individual columns. We will discuss how to implement fuzzy filtering for both cases.
 
-> **Note:** You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
+> [!NOTE]
+> You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
 > TanStack Match Sorter Utils is a fork of [match-sorter](https://github.com/kentcdodds/match-sorter) by Kent C. Dodds. It was forked in order to work better with TanStack Table's row by row filtering approach.
 
 Using the match-sorter libraries is optional, but the TanStack Match Sorter Utils library provides a great way to both fuzzy filter and sort by the rank information it returns, so that rows can be sorted by their closest matches to the search query.
@@ -218,4 +220,5 @@ You can then pass this sorting function directly to the `sortFn` option of the c
 }
 ```
 
-> **Note:** Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would require you to also add it to the `sortFns` slot on `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips registration.
+> [!NOTE]
+> Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would require you to also add it to the `sortFns` slot on `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips registration.

--- a/docs/framework/octane/guide/global-filtering.md
+++ b/docs/framework/octane/guide/global-filtering.md
@@ -38,7 +38,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
 
 ## Global Filtering (Octane) Guide
 
@@ -196,13 +197,15 @@ return (
 )
 ```
 
-> **Note:** Use `onInput` for text inputs in Octane. `onChange` is the native change event and only fires on blur or Enter, not on every keystroke.
+> [!NOTE]
+> Use `onInput` for text inputs in Octane. `onChange` is the native change event and only fires on blur or Enter, not on every keystroke.
 
 ### Custom Global Filter Function
 
 If you want to use a custom global filter function, you can define the function and pass it to the `globalFilterFn` option.
 
-> **Note:** It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
+> [!NOTE]
+> It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
 
 ```tsx
 const customFilterFn = (row, columnId, filterValue) => {
@@ -230,7 +233,8 @@ const table = useTable({
 })
 ```
 
-> NOTE: Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
+> [!NOTE]
+> Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
 
 ### Disable Global Filtering
 

--- a/docs/framework/octane/guide/grouping.md
+++ b/docs/framework/octane/guide/grouping.md
@@ -8,7 +8,8 @@ Want to skip to the implementation? Check out these Octane examples:
 
 - [Grouping](../examples/grouping)
 
-> **Note:** `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
+> [!NOTE]
+> `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
 
 ### Grouping Setup
 
@@ -131,7 +132,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
+> [!NOTE]
+> There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
 
 ### Controlled Grouping State
 

--- a/docs/framework/octane/guide/pagination.md
+++ b/docs/framework/octane/guide/pagination.md
@@ -106,7 +106,8 @@ const table = useTable({
 })
 ```
 
-> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+> [!NOTE]
+> Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
 
 ### Pagination State
 
@@ -189,7 +190,8 @@ const table = useTable({
 })
 ```
 
-> **Note**: Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
+> [!NOTE]
+> Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
 
 ### Pagination Options
 
@@ -236,7 +238,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
-> **Note**: These pagination APIs are available when using `rowPaginationFeature`.
+> [!NOTE]
+> These pagination APIs are available when using `rowPaginationFeature`.
 
 ```tsx
 <Button

--- a/docs/framework/octane/guide/row-selection.md
+++ b/docs/framework/octane/guide/row-selection.md
@@ -50,7 +50,8 @@ console.log(table.getGroupedSelectedRowModel().rows) //get grouped client-side s
 
 In event handlers or other non-render code, you can also read the current snapshot with `table.atoms.rowSelection.get()`. This read does not subscribe a component to future changes, so prefer `table.state.rowSelection` (or `table.Subscribe`) in render positions.
 
-> Note: If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
+> [!NOTE]
+> If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
 
 ### Manage Row Selection State
 
@@ -249,7 +250,8 @@ const columns = [
 ]
 ```
 
-> **Note:** The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
+> [!NOTE]
+> The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
 
 #### Connect Row Selection APIs to UI
 

--- a/docs/framework/octane/guide/sorting.md
+++ b/docs/framework/octane/guide/sorting.md
@@ -41,7 +41,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
+> [!NOTE]
+> Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
 
 ## Sorting (Octane) Guide
 
@@ -140,7 +141,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
+> [!NOTE]
+> Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
 
 ### Client-Side vs Server-Side Sorting
 
@@ -177,7 +179,8 @@ const table = useTable({
 
 Hoisting the sorting state into your own scope (with an external atom or the `state.sorting` plus `onSortingChange` pattern) is covered in the [Controlled Sorting State](#controlled-sorting-state) section above.
 
-> **NOTE**: When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
+> [!NOTE]
+> When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
 
 ### Client-Side Sorting
 
@@ -243,7 +246,8 @@ const myCustomSortFn: SortFn<TFeatures, TData> = (
 }
 ```
 
-> Note: The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
+> [!NOTE]
+> The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
 
 Every sorting function receives 2 rows and a column ID and is expected to compare the two rows using the column ID to return `-1`, `0`, or `1` in ascending order. Here's a cheat sheet:
 
@@ -407,7 +411,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
+> [!NOTE]
+> You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
 
 #### Invert Sorting
 
@@ -436,7 +441,8 @@ If not specified, the default value for `sortUndefined` is `1`, and undefined va
 - `-1` - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
 - `1` - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
 
-> NOTE: `'first'` and `'last'` options are available in v9.
+> [!NOTE]
+> `'first'` and `'last'` options are available in v9.
 
 ```tsx
 const columns = [

--- a/docs/framework/octane/guide/table-state.md
+++ b/docs/framework/octane/guide/table-state.md
@@ -236,7 +236,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/framework/preact/guide/cell-selection.md
+++ b/docs/framework/preact/guide/cell-selection.md
@@ -112,7 +112,8 @@ const table = useTable({
 })
 ```
 
-> Note: a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
+> [!NOTE]
+> a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
 
 ### Useful Row Ids
 
@@ -229,7 +230,8 @@ function getCellClassName(cell) {
 }
 ```
 
-> Tip: draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
+> [!TIP]
+> draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
 
 ### Keyboard Navigation
 

--- a/docs/framework/preact/guide/column-filtering.md
+++ b/docs/framework/preact/guide/column-filtering.md
@@ -42,7 +42,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
 
 ## Column Filtering (Preact) Guide
 
@@ -77,7 +78,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
+> [!NOTE]
+> When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
 
 ### Client-Side Filtering
 
@@ -204,7 +206,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
+> [!NOTE]
+> Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
 
 ### FilterFns
 
@@ -235,7 +238,8 @@ You can also define your own custom filter functions, either inline as the `filt
 
 #### Custom Filter Functions
 
-> **Note:** These filter functions only run during client-side filtering.
+> [!NOTE]
+> These filter functions only run during client-side filtering.
 
 Whether you register a custom filter function in the `filterFns` slot on `tableFeatures` or pass it directly as a `filterFn` column option, it should have the following signature:
 
@@ -355,7 +359,8 @@ const includesStringIgnoreDiacritics = constructFilterFn({
 
 Register the variant by name in the `filterFns` registry or pass it directly to the `filterFn` column option, just like any other custom filter function.
 
-> **Note:** The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
+> [!NOTE]
+> The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
 
 ### Customize Column Filtering
 

--- a/docs/framework/preact/guide/column-ordering.md
+++ b/docs/framework/preact/guide/column-ordering.md
@@ -40,7 +40,8 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual **Column Ordering** - A manually specified column order is applied.
 3. [Grouping](./grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
-> **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
+> [!NOTE]
+> `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 
 ### Column Order State
 
@@ -63,7 +64,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
+> [!NOTE]
+> If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
 
 #### Managing Column Order State
 

--- a/docs/framework/preact/guide/column-pinning.md
+++ b/docs/framework/preact/guide/column-pinning.md
@@ -121,7 +121,8 @@ const table = useTable({
 
 ### Useful Column Pinning APIs
 
-> Note: These APIs are available when using `columnPinningFeature`.
+> [!NOTE]
+> These APIs are available when using `columnPinningFeature`.
 
 There are a handful of useful Column API methods to help you implement column pinning features:
 

--- a/docs/framework/preact/guide/column-visibility.md
+++ b/docs/framework/preact/guide/column-visibility.md
@@ -92,7 +92,8 @@ const table = useTable({
 
 Alternatively, if you don't need to manage the column visibility state outside of the table, you can still set the initial default column visibility state using the `initialState` option.
 
-> **Note**: If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
+> [!NOTE]
+> If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
 
 ```tsx
 const features = tableFeatures({ columnVisibilityFeature })

--- a/docs/framework/preact/guide/expanding.md
+++ b/docs/framework/preact/guide/expanding.md
@@ -112,7 +112,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
+> [!NOTE]
+> You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
 
 ### Custom Expanding UI
 

--- a/docs/framework/preact/guide/fuzzy-filtering.md
+++ b/docs/framework/preact/guide/fuzzy-filtering.md
@@ -49,7 +49,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
+> [!NOTE]
+> The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
 
 ## Fuzzy Filtering (Preact) Guide
 
@@ -59,7 +60,8 @@ You can implement client-side fuzzy filtering by defining a custom filter functi
 
 Fuzzy filtering is mostly used with global filtering, but you can also apply it to individual columns. We will discuss how to implement fuzzy filtering for both cases.
 
-> **Note:** You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
+> [!NOTE]
+> You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
 > TanStack Match Sorter Utils is a fork of [match-sorter](https://github.com/kentcdodds/match-sorter) by Kent C. Dodds. It was forked in order to work better with TanStack Table's row by row filtering approach.
 
 Using the match-sorter libraries is optional, but the TanStack Match Sorter Utils library provides a great way to both fuzzy filter and sort by the rank information it returns, so that rows can be sorted by their closest matches to the search query.
@@ -218,4 +220,5 @@ You can then pass this sorting function directly to the `sortFn` option of the c
 }
 ```
 
-> **Note:** Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would require you to also add it to the `sortFns` slot on `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips registration.
+> [!NOTE]
+> Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would require you to also add it to the `sortFns` slot on `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips registration.

--- a/docs/framework/preact/guide/global-filtering.md
+++ b/docs/framework/preact/guide/global-filtering.md
@@ -38,7 +38,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
 
 ## Global Filtering (Preact) Guide
 
@@ -196,13 +197,15 @@ return (
 )
 ```
 
-> **Note:** Use `onInput` for text inputs in Preact. Without `preact/compat`, `onChange` is the native change event and only fires on blur or Enter, not on every keystroke.
+> [!NOTE]
+> Use `onInput` for text inputs in Preact. Without `preact/compat`, `onChange` is the native change event and only fires on blur or Enter, not on every keystroke.
 
 ### Custom Global Filter Function
 
 If you want to use a custom global filter function, you can define the function and pass it to the `globalFilterFn` option.
 
-> **Note:** It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
+> [!NOTE]
+> It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
 
 ```tsx
 const customFilterFn = (row, columnId, filterValue) => {
@@ -230,7 +233,8 @@ const table = useTable({
 })
 ```
 
-> NOTE: Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
+> [!NOTE]
+> Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
 
 ### Disable Global Filtering
 

--- a/docs/framework/preact/guide/grouping.md
+++ b/docs/framework/preact/guide/grouping.md
@@ -8,7 +8,8 @@ Want to skip to the implementation? Check out these Preact examples:
 
 - [Grouping](../examples/grouping)
 
-> **Note:** `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
+> [!NOTE]
+> `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
 
 ### Grouping Setup
 
@@ -131,7 +132,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
+> [!NOTE]
+> There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
 
 ### Controlled Grouping State
 

--- a/docs/framework/preact/guide/pagination.md
+++ b/docs/framework/preact/guide/pagination.md
@@ -106,7 +106,8 @@ const table = useTable({
 })
 ```
 
-> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+> [!NOTE]
+> Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
 
 #### Using TanStack Query
 
@@ -275,7 +276,8 @@ const table = useTable({
 })
 ```
 
-> **Note**: Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
+> [!NOTE]
+> Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
 
 ### Pagination Options
 
@@ -322,7 +324,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
-> **Note**: These pagination APIs are available when using `rowPaginationFeature`.
+> [!NOTE]
+> These pagination APIs are available when using `rowPaginationFeature`.
 
 ```tsx
 <Button

--- a/docs/framework/preact/guide/row-selection.md
+++ b/docs/framework/preact/guide/row-selection.md
@@ -50,7 +50,8 @@ console.log(table.getGroupedSelectedRowModel().rows) //get grouped client-side s
 
 In event handlers or other non-render code, you can also read the current snapshot with `table.atoms.rowSelection.get()`. This read does not subscribe a component to future changes, so prefer `table.state.rowSelection` (or `table.Subscribe`) in render positions.
 
-> Note: If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
+> [!NOTE]
+> If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
 
 ### Manage Row Selection State
 
@@ -249,7 +250,8 @@ const columns = [
 ]
 ```
 
-> **Note:** The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
+> [!NOTE]
+> The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
 
 #### Connect Row Selection APIs to UI
 

--- a/docs/framework/preact/guide/sorting.md
+++ b/docs/framework/preact/guide/sorting.md
@@ -41,7 +41,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
+> [!NOTE]
+> Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
 
 ## Sorting (Preact) Guide
 
@@ -140,7 +141,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
+> [!NOTE]
+> Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
 
 ### Client-Side vs Server-Side Sorting
 
@@ -177,7 +179,8 @@ const table = useTable({
 
 Hoisting the sorting state into your own scope (with an external atom or the `state.sorting` plus `onSortingChange` pattern) is covered in the [Controlled Sorting State](#controlled-sorting-state) section above.
 
-> **NOTE**: When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
+> [!NOTE]
+> When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
 
 ### Client-Side Sorting
 
@@ -243,7 +246,8 @@ const myCustomSortFn: SortFn<TFeatures, TData> = (
 }
 ```
 
-> Note: The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
+> [!NOTE]
+> The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
 
 Every sorting function receives 2 rows and a column ID and is expected to compare the two rows using the column ID to return `-1`, `0`, or `1` in ascending order. Here's a cheat sheet:
 
@@ -407,7 +411,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
+> [!NOTE]
+> You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
 
 #### Invert Sorting
 
@@ -436,7 +441,8 @@ If not specified, the default value for `sortUndefined` is `1`, and undefined va
 - `-1` - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
 - `1` - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
 
-> NOTE: `'first'` and `'last'` options are available in v9.
+> [!NOTE]
+> `'first'` and `'last'` options are available in v9.
 
 ```tsx
 const columns = [

--- a/docs/framework/preact/guide/table-state.md
+++ b/docs/framework/preact/guide/table-state.md
@@ -237,7 +237,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/framework/react/guide/cell-selection.md
+++ b/docs/framework/react/guide/cell-selection.md
@@ -30,7 +30,8 @@ const table = useTable({
 
 ## Cell Selection (React) Guide
 
-> Note: When the optional [cell spanning](./cell-spanning) feature is registered, selection rectangles expand to fully enclose any merged cell they touch, so a merge is always entirely selected or entirely unselected.
+> [!NOTE]
+> When the optional [cell spanning](./cell-spanning) feature is registered, selection rectangles expand to fully enclose any merged cell they touch, so a merge is always entirely selected or entirely unselected.
 
 The cell selection feature keeps track of spreadsheet-style rectangular selections. A user can click a cell, drag across a block of cells, Shift-click to extend, and Ctrl/Cmd-drag to add or subtract a rectangle based on whether the starting cell is selected. Let's take a look at some common use cases.
 
@@ -114,7 +115,8 @@ const table = useTable({
 })
 ```
 
-> Note: a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
+> [!NOTE]
+> a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
 
 ### Useful Row Ids
 
@@ -230,7 +232,8 @@ function getCellClassName(cell) {
 }
 ```
 
-> Tip: draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
+> [!TIP]
+> draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
 
 ### Keyboard Navigation
 

--- a/docs/framework/react/guide/column-filtering.md
+++ b/docs/framework/react/guide/column-filtering.md
@@ -42,7 +42,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
 
 ## Column Filtering (React) Guide
 
@@ -77,7 +78,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
+> [!NOTE]
+> When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
 
 ### Client-Side Filtering
 
@@ -204,7 +206,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
+> [!NOTE]
+> Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
 
 ### FilterFns
 
@@ -235,7 +238,8 @@ You can also define your own custom filter functions, either inline as the `filt
 
 #### Custom Filter Functions
 
-> **Note:** These filter functions only run during client-side filtering.
+> [!NOTE]
+> These filter functions only run during client-side filtering.
 
 Whether you register a custom filter function in the `filterFns` slot on `tableFeatures` or pass it directly as a `filterFn` column option, it should have the following signature:
 
@@ -355,7 +359,8 @@ const includesStringIgnoreDiacritics = constructFilterFn({
 
 Register the variant by name in the `filterFns` registry or pass it directly to the `filterFn` column option, just like any other custom filter function.
 
-> **Note:** The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
+> [!NOTE]
+> The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
 
 ### Customize Column Filtering
 

--- a/docs/framework/react/guide/column-ordering.md
+++ b/docs/framework/react/guide/column-ordering.md
@@ -41,7 +41,8 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual **Column Ordering** - A manually specified column order is applied.
 3. [Grouping](./grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
-> **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
+> [!NOTE]
+> `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 
 ### Column Order State
 
@@ -64,7 +65,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
+> [!NOTE]
+> If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
 
 #### Managing Column Order State
 

--- a/docs/framework/react/guide/column-pinning.md
+++ b/docs/framework/react/guide/column-pinning.md
@@ -121,7 +121,8 @@ const table = useTable({
 
 ### Useful Column Pinning APIs
 
-> Note: These APIs are available when using `columnPinningFeature`.
+> [!NOTE]
+> These APIs are available when using `columnPinningFeature`.
 
 There are a handful of useful Column API methods to help you implement column pinning features:
 

--- a/docs/framework/react/guide/column-visibility.md
+++ b/docs/framework/react/guide/column-visibility.md
@@ -92,7 +92,8 @@ const table = useTable({
 
 Alternatively, if you don't need to manage the column visibility state outside of the table, you can still set the initial default column visibility state using the `initialState` option.
 
-> **Note**: If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
+> [!NOTE]
+> If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
 
 ```tsx
 const features = tableFeatures({ columnVisibilityFeature })
@@ -159,7 +160,8 @@ const columnLabels: Record<string, string> = {
 }
 ```
 
-> **Note**: `column.columnDef.header` is a header render template. It can be a
+> [!NOTE]
+> `column.columnDef.header` is a header render template. It can be a
 > string, JSX, or a function that needs a header context and should be rendered
 > with `flexRender` when you are rendering actual table headers. A column
 > visibility menu is usually rendering columns rather than header objects, and a

--- a/docs/framework/react/guide/expanding.md
+++ b/docs/framework/react/guide/expanding.md
@@ -112,7 +112,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
+> [!NOTE]
+> You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
 
 ### Custom Expanding UI
 

--- a/docs/framework/react/guide/fuzzy-filtering.md
+++ b/docs/framework/react/guide/fuzzy-filtering.md
@@ -44,7 +44,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
+> [!NOTE]
+> The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
 
 ## Fuzzy Filtering (React) Guide
 
@@ -54,7 +55,8 @@ You can implement client-side fuzzy filtering by defining a custom filter functi
 
 Fuzzy filtering is mostly used with global filtering, but you can also apply it to individual columns. We will discuss how to implement fuzzy filtering for both cases.
 
-> **Note:** You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
+> [!NOTE]
+> You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
 > TanStack Match Sorter Utils is a fork of [match-sorter](https://github.com/kentcdodds/match-sorter) by Kent C. Dodds. It was forked in order to work better with TanStack Table's row by row filtering approach.
 
 Using the match-sorter libraries is optional, but the TanStack Match Sorter Utils library provides a great way to both fuzzy filter and sort by the rank information it returns, so that rows can be sorted by their closest matches to the search query.

--- a/docs/framework/react/guide/global-filtering.md
+++ b/docs/framework/react/guide/global-filtering.md
@@ -38,7 +38,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
 
 ## Global Filtering (React) Guide
 
@@ -198,7 +199,8 @@ return (
 
 If you want to use a custom global filter function, you can define the function and pass it to the `globalFilterFn` option.
 
-> **Note:** It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
+> [!NOTE]
+> It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
 
 ```tsx
 const customFilterFn = (row, columnId, filterValue) => {
@@ -226,7 +228,8 @@ const table = useTable({
 })
 ```
 
-> NOTE: Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
+> [!NOTE]
+> Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
 
 ### Disable Global Filtering
 

--- a/docs/framework/react/guide/grouping.md
+++ b/docs/framework/react/guide/grouping.md
@@ -8,7 +8,8 @@ Want to skip to the implementation? Check out these React examples:
 
 - [Grouping](../examples/grouping)
 
-> **Note:** `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
+> [!NOTE]
+> `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
 
 ### Grouping Setup
 
@@ -131,7 +132,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
+> [!NOTE]
+> There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
 
 ### Controlled Grouping State
 

--- a/docs/framework/react/guide/pagination.md
+++ b/docs/framework/react/guide/pagination.md
@@ -106,7 +106,8 @@ const table = useTable({
 })
 ```
 
-> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+> [!NOTE]
+> Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
 
 #### Using TanStack Query
 
@@ -272,7 +273,8 @@ const table = useTable({
 })
 ```
 
-> **Note**: Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
+> [!NOTE]
+> Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
 
 ### Pagination Options
 
@@ -319,7 +321,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
-> **Note**: These pagination APIs are available when using `rowPaginationFeature`.
+> [!NOTE]
+> These pagination APIs are available when using `rowPaginationFeature`.
 
 ```tsx
 <Button

--- a/docs/framework/react/guide/row-selection.md
+++ b/docs/framework/react/guide/row-selection.md
@@ -50,7 +50,8 @@ console.log(table.getGroupedSelectedRowModel().rows) //get grouped client-side s
 
 In event handlers or other non-render code, you can also read the current snapshot with `table.atoms.rowSelection.get()`. This read does not subscribe a component to future changes, so prefer `table.state.rowSelection` (or `table.Subscribe`) in render positions.
 
-> Note: If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
+> [!NOTE]
+> If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
 
 ### Manage Row Selection State
 
@@ -250,7 +251,8 @@ const columns = [
 ]
 ```
 
-> **Note:** The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
+> [!NOTE]
+> The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
 
 #### Connect Row Selection APIs to UI
 

--- a/docs/framework/react/guide/sorting.md
+++ b/docs/framework/react/guide/sorting.md
@@ -41,7 +41,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
+> [!NOTE]
+> Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
 
 ## Sorting (React) Guide
 
@@ -140,7 +141,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
+> [!NOTE]
+> Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
 
 ### Client-Side vs Server-Side Sorting
 
@@ -177,7 +179,8 @@ const table = useTable({
 
 Hoisting the sorting state into your own scope (with an external atom or the `state.sorting` plus `onSortingChange` pattern) is covered in the [Controlled Sorting State](#controlled-sorting-state) section above.
 
-> **NOTE**: When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
+> [!NOTE]
+> When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
 
 ### Client-Side Sorting
 
@@ -243,7 +246,8 @@ const myCustomSortFn: SortFn<TFeatures, TData> = (
 }
 ```
 
-> Note: The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
+> [!NOTE]
+> The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
 
 Every sorting function receives 2 rows and a column ID and is expected to compare the two rows using the column ID to return `-1`, `0`, or `1` in ascending order. Here's a cheat sheet:
 
@@ -407,7 +411,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
+> [!NOTE]
+> You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
 
 #### Invert Sorting
 
@@ -436,7 +441,8 @@ If not specified, the default value for `sortUndefined` is `1`, and undefined va
 - `-1` - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
 - `1` - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
 
-> NOTE: `'first'` and `'last'` options are available in v9.
+> [!NOTE]
+> `'first'` and `'last'` options are available in v9.
 
 ```tsx
 const columns = [

--- a/docs/framework/react/guide/table-state.md
+++ b/docs/framework/react/guide/table-state.md
@@ -296,7 +296,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/framework/react/guide/use-legacy-table.md
+++ b/docs/framework/react/guide/use-legacy-table.md
@@ -4,7 +4,8 @@ title: Using useLegacyTable for Incremental Migration
 
 The `useLegacyTable` hook provides a compatibility layer that accepts the v8-style API while using v9 under the hood. This is useful for teams that need to migrate incrementally or have large codebases where a full migration isn't immediately practical.
 
-> **Warning:** `useLegacyTable` is **deprecated** and intended only as a temporary migration aid. It includes all features by default, resulting in a larger bundle size compared to the tree-shakeable v9 API. Plan to migrate to `useTable` for better performance and smaller bundles.
+> [!WARNING]
+> `useLegacyTable` is **deprecated** and intended only as a temporary migration aid. It includes all features by default, resulting in a larger bundle size compared to the tree-shakeable v9 API. Plan to migrate to `useTable` for better performance and smaller bundles.
 
 ## When to Use `useLegacyTable`
 

--- a/docs/framework/solid/guide/cell-selection.md
+++ b/docs/framework/solid/guide/cell-selection.md
@@ -120,7 +120,8 @@ const table = createTable({
 })
 ```
 
-> Note: a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
+> [!NOTE]
+> a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
 
 ### Useful Row Ids
 
@@ -237,7 +238,8 @@ function getCellClassName(cell) {
 }
 ```
 
-> Tip: draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
+> [!TIP]
+> draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
 
 ### Keyboard Navigation
 

--- a/docs/framework/solid/guide/column-filtering.md
+++ b/docs/framework/solid/guide/column-filtering.md
@@ -46,7 +46,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
 
 ## Column Filtering (Solid) Guide
 
@@ -81,7 +82,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
+> [!NOTE]
+> When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
 
 ### Client-Side Filtering
 
@@ -209,7 +211,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
+> [!NOTE]
+> Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
 
 ### FilterFns
 
@@ -240,7 +243,8 @@ You can also define your own custom filter functions, either inline as the `filt
 
 #### Custom Filter Functions
 
-> **Note:** These filter functions only run during client-side filtering.
+> [!NOTE]
+> These filter functions only run during client-side filtering.
 
 Whether you register a custom filter function in the `filterFns` slot on `tableFeatures` or pass it directly as a `filterFn` column option, it should have the following signature:
 
@@ -354,7 +358,8 @@ const includesStringIgnoreDiacritics = constructFilterFn({
 
 Register the variant by name in the `filterFns` registry or pass it directly to the `filterFn` column option, just like any other custom filter function.
 
-> **Note:** The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
+> [!NOTE]
+> The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
 
 ### Customize Column Filtering
 

--- a/docs/framework/solid/guide/column-ordering.md
+++ b/docs/framework/solid/guide/column-ordering.md
@@ -44,7 +44,8 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual **Column Ordering** - A manually specified column order is applied.
 3. [Grouping](./grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
-> **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
+> [!NOTE]
+> `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 
 ### Column Order State
 
@@ -67,7 +68,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
+> [!NOTE]
+> If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
 
 #### Managing Column Order State
 

--- a/docs/framework/solid/guide/column-pinning.md
+++ b/docs/framework/solid/guide/column-pinning.md
@@ -127,7 +127,8 @@ const table = createTable({
 
 ### Useful Column Pinning APIs
 
-> Note: These APIs are available when using `columnPinningFeature`.
+> [!NOTE]
+> These APIs are available when using `columnPinningFeature`.
 
 There are a handful of useful Column API methods to help you implement column pinning features:
 

--- a/docs/framework/solid/guide/column-visibility.md
+++ b/docs/framework/solid/guide/column-visibility.md
@@ -97,7 +97,8 @@ const table = createTable({
 
 Alternatively, if you don't need to manage the column visibility state outside of the table, you can still set the initial default column visibility state using the `initialState` option.
 
-> **Note**: If `columnVisibility` is provided to both `initialState` and a controlled option (`atoms` or `state`), the controlled value will take precedence and `initialState` will be ignored. Only provide `columnVisibility` in one place.
+> [!NOTE]
+> If `columnVisibility` is provided to both `initialState` and a controlled option (`atoms` or `state`), the controlled value will take precedence and `initialState` will be ignored. Only provide `columnVisibility` in one place.
 
 ```tsx
 const features = tableFeatures({ columnVisibilityFeature })

--- a/docs/framework/solid/guide/expanding.md
+++ b/docs/framework/solid/guide/expanding.md
@@ -116,7 +116,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
+> [!NOTE]
+> You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
 
 ### Custom Expanding UI
 

--- a/docs/framework/solid/guide/fuzzy-filtering.md
+++ b/docs/framework/solid/guide/fuzzy-filtering.md
@@ -46,7 +46,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
+> [!NOTE]
+> The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
 
 ## Fuzzy Filtering (Solid) Guide
 
@@ -56,7 +57,8 @@ You can implement client-side fuzzy filtering by defining a custom filter functi
 
 Fuzzy filtering is mostly used with global filtering, but you can also apply it to individual columns. We will discuss how to implement fuzzy filtering for both cases.
 
-> **Note:** You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
+> [!NOTE]
+> You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
 > TanStack Match Sorter Utils is a fork of [match-sorter](https://github.com/kentcdodds/match-sorter) by Kent C. Dodds. It was forked in order to work better with TanStack Table's row by row filtering approach.
 
 Using the match-sorter libraries is optional, but the TanStack Match Sorter Utils library provides a great way to both fuzzy filter and sort by the rank information it returns, so that rows can be sorted by their closest matches to the search query.
@@ -222,4 +224,5 @@ You can then pass this sorting function directly to the `sortFn` option of the c
 }
 ```
 
-> **Note:** Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would only work if you also registered the function in the `sortFns` slot on `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips that step.
+> [!NOTE]
+> Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would only work if you also registered the function in the `sortFns` slot on `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips that step.

--- a/docs/framework/solid/guide/global-filtering.md
+++ b/docs/framework/solid/guide/global-filtering.md
@@ -42,7 +42,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
 
 ## Global Filtering (Solid) Guide
 
@@ -204,7 +205,8 @@ return (
 
 If you want to use a custom global filter function, you can define the function and pass it to the `globalFilterFn` option.
 
-> **Note:** It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
+> [!NOTE]
+> It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
 
 ```tsx
 const customFilterFn = (row, columnId, filterValue) => {
@@ -232,7 +234,8 @@ const table = createTable({
 })
 ```
 
-> NOTE: Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
+> [!NOTE]
+> Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
 
 ### Disable Global Filtering
 

--- a/docs/framework/solid/guide/grouping.md
+++ b/docs/framework/solid/guide/grouping.md
@@ -8,7 +8,8 @@ Want to skip to the implementation? Check out these Solid examples:
 
 - [Grouping](../examples/grouping)
 
-> **Note:** `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
+> [!NOTE]
+> `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
 
 Use getters for reactive inputs such as `data` when passing Solid signals to `createTable`.
 
@@ -135,7 +136,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
+> [!NOTE]
+> There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
 
 ### Controlled Grouping State
 

--- a/docs/framework/solid/guide/pagination.md
+++ b/docs/framework/solid/guide/pagination.md
@@ -110,7 +110,8 @@ const table = createTable({
 })
 ```
 
-> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+> [!NOTE]
+> Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
 
 #### Using TanStack Query
 
@@ -292,7 +293,8 @@ const table = createTable({
 })
 ```
 
-> **Note**: Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
+> [!NOTE]
+> Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
 
 ### Pagination Options
 
@@ -339,7 +341,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
-> **Note**: These pagination APIs are available when using `rowPaginationFeature`.
+> [!NOTE]
+> These pagination APIs are available when using `rowPaginationFeature`.
 
 ```tsx
 <button

--- a/docs/framework/solid/guide/row-selection.md
+++ b/docs/framework/solid/guide/row-selection.md
@@ -54,7 +54,8 @@ console.log(table.getGroupedSelectedRowModel().rows) //get grouped client-side s
 
 In Solid, the table's state atoms are backed by Solid signals, so `table.atoms.rowSelection.get()` is a reactive read when called inside a tracked scope (JSX, `createMemo`, `createEffect`, or `table.Subscribe`). In event handlers or other untracked code, the same call simply returns the current value.
 
-> Note: If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
+> [!NOTE]
+> If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
 
 ### Manage Row Selection State
 
@@ -255,7 +256,8 @@ const columns = [
 ]
 ```
 
-> **Note:** The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
+> [!NOTE]
+> The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
 
 #### Connect Row Selection APIs to UI
 

--- a/docs/framework/solid/guide/sorting.md
+++ b/docs/framework/solid/guide/sorting.md
@@ -45,7 +45,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
+> [!NOTE]
+> Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
 
 ## Sorting (Solid) Guide
 
@@ -145,7 +146,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
+> [!NOTE]
+> Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
 
 ### Client-Side vs Server-Side Sorting
 
@@ -182,7 +184,8 @@ const table = createTable({
 
 Hoisting the sorting state into your own scope (with an external atom or the `state.sorting` plus `onSortingChange` pattern) is covered in the [Controlled Sorting State](#controlled-sorting-state) section above.
 
-> **NOTE**: When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
+> [!NOTE]
+> When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
 
 ### Client-Side Sorting
 
@@ -248,7 +251,8 @@ const myCustomSortFn: SortFn<TFeatures, TData> = (
 }
 ```
 
-> Note: The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
+> [!NOTE]
+> The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
 
 Every sorting function receives 2 rows and a column ID and is expected to compare the two rows using the column ID to return `-1`, `0`, or `1` in ascending order. Here's a cheat sheet:
 
@@ -406,7 +410,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
+> [!NOTE]
+> You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
 
 #### Invert Sorting
 
@@ -435,7 +440,8 @@ If not specified, the default value for `sortUndefined` is `1`, and undefined va
 - `-1` - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
 - `1` - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
 
-> NOTE: `'first'` and `'last'` options are available in v9.
+> [!NOTE]
+> `'first'` and `'last'` options are available in v9.
 
 ```tsx
 const columns = [

--- a/docs/framework/solid/guide/table-state.md
+++ b/docs/framework/solid/guide/table-state.md
@@ -224,7 +224,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/framework/svelte/guide/cell-selection.md
+++ b/docs/framework/svelte/guide/cell-selection.md
@@ -130,7 +130,8 @@ const table = createTable({
 })
 ```
 
-> Note: a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
+> [!NOTE]
+> a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
 
 ### Useful Row Ids
 
@@ -247,7 +248,8 @@ function getCellClassName(cell) {
 }
 ```
 
-> Tip: draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
+> [!TIP]
+> draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
 
 ### Keyboard Navigation
 

--- a/docs/framework/svelte/guide/column-filtering.md
+++ b/docs/framework/svelte/guide/column-filtering.md
@@ -46,7 +46,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
 
 ## Column Filtering (Svelte) Guide
 
@@ -81,7 +82,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
+> [!NOTE]
+> When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
 
 ### Client-Side Filtering
 
@@ -221,7 +223,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
+> [!NOTE]
+> Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
 
 ### FilterFns
 
@@ -252,7 +255,8 @@ You can also define your own custom filter functions, either inline as the `filt
 
 #### Custom Filter Functions
 
-> **Note:** These filter functions only run during client-side filtering.
+> [!NOTE]
+> These filter functions only run during client-side filtering.
 
 Whether you register a custom filter function in the `filterFns` slot on `tableFeatures` or pass it directly as a `filterFn` column option, it should have the following signature:
 
@@ -366,7 +370,8 @@ const includesStringIgnoreDiacritics = constructFilterFn({
 
 Register the variant by name in the `filterFns` registry or pass it directly to the `filterFn` column option, just like any other custom filter function.
 
-> **Note:** The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
+> [!NOTE]
+> The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
 
 ### Customize Column Filtering
 

--- a/docs/framework/svelte/guide/column-ordering.md
+++ b/docs/framework/svelte/guide/column-ordering.md
@@ -44,7 +44,8 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual **Column Ordering** - A manually specified column order is applied.
 3. [Grouping](./grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
-> **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
+> [!NOTE]
+> `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 
 ### Column Order State
 
@@ -67,7 +68,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
+> [!NOTE]
+> If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
 
 #### Managing Column Order State
 

--- a/docs/framework/svelte/guide/column-pinning.md
+++ b/docs/framework/svelte/guide/column-pinning.md
@@ -128,7 +128,8 @@ const table = createTable({
 
 ### Useful Column Pinning APIs
 
-> Note: These APIs are available when using `columnPinningFeature`.
+> [!NOTE]
+> These APIs are available when using `columnPinningFeature`.
 
 There are a handful of useful Column API methods to help you implement column pinning features:
 

--- a/docs/framework/svelte/guide/column-visibility.md
+++ b/docs/framework/svelte/guide/column-visibility.md
@@ -99,7 +99,8 @@ const table = createTable({
 
 Alternatively, if you don't need to manage the column visibility state outside of the table, you can still set the initial default column visibility state using the `initialState` option.
 
-> **Note**: If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
+> [!NOTE]
+> If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
 
 ```ts
 const features = tableFeatures({ columnVisibilityFeature })

--- a/docs/framework/svelte/guide/expanding.md
+++ b/docs/framework/svelte/guide/expanding.md
@@ -116,7 +116,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
+> [!NOTE]
+> You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
 
 ### Custom Expanding UI
 

--- a/docs/framework/svelte/guide/fuzzy-filtering.md
+++ b/docs/framework/svelte/guide/fuzzy-filtering.md
@@ -48,7 +48,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
+> [!NOTE]
+> The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
 
 ## Fuzzy Filtering (Svelte) Guide
 
@@ -58,7 +59,8 @@ You can implement client-side fuzzy filtering by defining a custom filter functi
 
 Fuzzy filtering is mostly used with global filtering, but you can also apply it to individual columns. We will discuss how to implement fuzzy filtering for both cases.
 
-> **Note:** You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
+> [!NOTE]
+> You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
 > TanStack Match Sorter Utils is a fork of [match-sorter](https://github.com/kentcdodds/match-sorter) by Kent C. Dodds. It was forked in order to work better with TanStack Table's row by row filtering approach.
 
 Using the match-sorter libraries is optional, but the TanStack Match Sorter Utils library provides a great way to both fuzzy filter and sort by the rank information it returns, so that rows can be sorted by their closest matches to the search query.
@@ -211,4 +213,5 @@ You can then pass this sorting function directly to the `sortFn` option of the c
 }
 ```
 
-> **Note:** Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would only work if you also registered the function in the `sortFns` slot of `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips registration.
+> [!NOTE]
+> Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would only work if you also registered the function in the `sortFns` slot of `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips registration.

--- a/docs/framework/svelte/guide/global-filtering.md
+++ b/docs/framework/svelte/guide/global-filtering.md
@@ -42,7 +42,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
 
 ## Global Filtering (Svelte) Guide
 
@@ -205,7 +206,8 @@ TanStack table will not add a global filter input UI to your table. You should m
 
 If you want to use a custom global filter function, you can define the function and pass it to the `globalFilterFn` option.
 
-> **Note:** It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
+> [!NOTE]
+> It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
 
 ```ts
 const customFilterFn = (row, columnId, filterValue) => {
@@ -235,7 +237,8 @@ const table = createTable({
 })
 ```
 
-> NOTE: Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
+> [!NOTE]
+> Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
 
 ### Disable Global Filtering
 

--- a/docs/framework/svelte/guide/grouping.md
+++ b/docs/framework/svelte/guide/grouping.md
@@ -8,7 +8,8 @@ Want to skip to the implementation? Check out these Svelte examples:
 
 - [Grouping](../examples/grouping)
 
-> **Note:** `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
+> [!NOTE]
+> `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
 
 Use getters for reactive inputs such as `data` when passing Svelte state to `createTable`.
 
@@ -135,7 +136,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
+> [!NOTE]
+> There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
 
 ### Controlled Grouping State
 

--- a/docs/framework/svelte/guide/pagination.md
+++ b/docs/framework/svelte/guide/pagination.md
@@ -110,7 +110,8 @@ const table = createTable({
 })
 ```
 
-> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+> [!NOTE]
+> Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
 
 #### Using TanStack Query
 
@@ -300,7 +301,8 @@ const table = createTable({
 })
 ```
 
-> **Note**: Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
+> [!NOTE]
+> Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
 
 ### Pagination Options
 
@@ -348,7 +350,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
-> **Note**: These pagination APIs are available when using `rowPaginationFeature`.
+> [!NOTE]
+> These pagination APIs are available when using `rowPaginationFeature`.
 
 ```svelte
 <button onclick={() => table.firstPage()} disabled={!table.getCanPreviousPage()}>{'<<'}</button>

--- a/docs/framework/svelte/guide/row-selection.md
+++ b/docs/framework/svelte/guide/row-selection.md
@@ -61,7 +61,8 @@ const selectedCount = $derived(Object.keys(rowSelection).length)
 
 Outside a tracked context, `table.atoms.rowSelection.get()` is simply the current snapshot.
 
-> Note: If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
+> [!NOTE]
+> If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
 
 ### Manage Row Selection State
 
@@ -270,7 +271,8 @@ The `indeterminate` checkbox property cannot be set from markup, so define a sma
 />
 ```
 
-> **Note:** The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
+> [!NOTE]
+> The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
 
 #### Connect Row Selection APIs to UI
 

--- a/docs/framework/svelte/guide/sorting.md
+++ b/docs/framework/svelte/guide/sorting.md
@@ -45,7 +45,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
+> [!NOTE]
+> Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
 
 ## Sorting (Svelte) Guide
 
@@ -155,7 +156,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
+> [!NOTE]
+> Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
 
 ### Client-Side vs Server-Side Sorting
 
@@ -194,7 +196,8 @@ const table = createTable({
 
 Hoisting the sorting state into your own scope (with an external atom or the `state.sorting` plus `onSortingChange` pattern) is covered in the [Controlled Sorting State](#controlled-sorting-state) section above.
 
-> **NOTE**: When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
+> [!NOTE]
+> When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
 
 ### Client-Side Sorting
 
@@ -260,7 +263,8 @@ const myCustomSortFn: SortFn<TFeatures, TData> = (
 }
 ```
 
-> Note: The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
+> [!NOTE]
+> The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
 
 Every sorting function receives 2 rows and a column ID and is expected to compare the two rows using the column ID to return `-1`, `0`, or `1` in ascending order. Here's a cheat sheet:
 
@@ -420,7 +424,8 @@ const table = createTable({
 })
 ```
 
-> **NOTE**: You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
+> [!NOTE]
+> You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
 
 #### Invert Sorting
 
@@ -449,7 +454,8 @@ If not specified, the default value for `sortUndefined` is `1`, and undefined va
 - `-1` - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
 - `1` - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
 
-> NOTE: `'first'` and `'last'` options are available in v9.
+> [!NOTE]
+> `'first'` and `'last'` options are available in v9.
 
 ```ts
 const columns = [

--- a/docs/framework/svelte/guide/table-state.md
+++ b/docs/framework/svelte/guide/table-state.md
@@ -192,7 +192,8 @@ const table = createTable({
 })
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/framework/svelte/quick-start.md
+++ b/docs/framework/svelte/quick-start.md
@@ -4,7 +4,7 @@ title: Quick Start
 
 TanStack Table is a headless table library. It manages your table's state and logic (sorting, filtering, pagination, selection, and more) while you keep 100% control over the markup and styles. This page gets you from install to a rendering Svelte table, then shows how to layer on your first feature.
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > This version of `@tanstack/svelte-table` only supports Svelte 5 or newer. For Svelte 3/4 support, use version 8 of `@tanstack/svelte-table`.
 
 ## Installation

--- a/docs/framework/svelte/quick-start.md
+++ b/docs/framework/svelte/quick-start.md
@@ -4,7 +4,8 @@ title: Quick Start
 
 TanStack Table is a headless table library. It manages your table's state and logic (sorting, filtering, pagination, selection, and more) while you keep 100% control over the markup and styles. This page gets you from install to a rendering Svelte table, then shows how to layer on your first feature.
 
-> **IMPORTANT:** This version of `@tanstack/svelte-table` only supports Svelte 5 or newer. For Svelte 3/4 support, use version 8 of `@tanstack/svelte-table`.
+> [!IMPORTANT] 
+> This version of `@tanstack/svelte-table` only supports Svelte 5 or newer. For Svelte 3/4 support, use version 8 of `@tanstack/svelte-table`.
 
 ## Installation
 

--- a/docs/framework/vanilla/guide/table-state.md
+++ b/docs/framework/vanilla/guide/table-state.md
@@ -167,7 +167,8 @@ const table = constructTable({
 })
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/framework/vue/guide/cell-selection.md
+++ b/docs/framework/vue/guide/cell-selection.md
@@ -119,7 +119,8 @@ const table = useTable({
 })
 ```
 
-> Note: a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
+> [!NOTE]
+> a drag emits one change per cell boundary the pointer crosses, so `onCellSelectionChange` fires repeatedly during a drag. If you are syncing selection to a server or a URL, debounce it or commit on `mouseup`.
 
 ### Useful Row Ids
 
@@ -236,7 +237,8 @@ function getCellClassName(cell) {
 }
 ```
 
-> Tip: draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
+> [!TIP]
+> draw the outline with `box-shadow: inset ...` rather than `border`. On a `border-collapse` table a thicker border widens the shared grid line, which makes rows change height as cells become selected. A box-shadow never affects layout.
 
 ### Keyboard Navigation
 

--- a/docs/framework/vue/guide/column-filtering.md
+++ b/docs/framework/vue/guide/column-filtering.md
@@ -44,7 +44,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter functions this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `filterFn` column option with no registration at all.
 
 ## Column Filtering (Vue) Guide
 
@@ -79,7 +80,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
+> [!NOTE]
+> When using manual filtering, many of the options that are discussed in the rest of this guide will have no effect. When `manualFiltering` is set to `true`, the table instance will not apply any filtering logic to the rows that are passed to it. Instead, it will assume that the rows are already filtered and will use the `data` that you pass to it as-is.
 
 ### Client-Side Filtering
 
@@ -214,7 +216,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
+> [!NOTE]
+> Do not use both `initialState.columnFilters` and `state.columnFilters` at the same time, as the controlled `state.columnFilters` value will override the `initialState.columnFilters`.
 
 ### FilterFns
 
@@ -245,7 +248,8 @@ You can also define your own custom filter functions, either inline as the `filt
 
 #### Custom Filter Functions
 
-> **Note:** These filter functions only run during client-side filtering.
+> [!NOTE]
+> These filter functions only run during client-side filtering.
 
 Whether you register a custom filter function in the `filterFns` slot on `tableFeatures` or pass it directly as a `filterFn` column option, it should have the following signature:
 
@@ -359,7 +363,8 @@ const includesStringIgnoreDiacritics = constructFilterFn({
 
 Register the variant by name in the `filterFns` registry or pass it directly to the `filterFn` column option, just like any other custom filter function.
 
-> **Note:** The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
+> [!NOTE]
+> The table applies `resolveFilterValue` once per filter before any rows are tested. If you ever call a filter function directly (outside of a table), resolve the filter value yourself: `myFilterFn(row, columnId, myFilterFn.resolveFilterValue?.(rawValue) ?? rawValue)`.
 
 ### Customize Column Filtering
 

--- a/docs/framework/vue/guide/column-ordering.md
+++ b/docs/framework/vue/guide/column-ordering.md
@@ -42,7 +42,8 @@ There are 3 table features that can reorder columns, which happen in the followi
 2. Manual **Column Ordering** - A manually specified column order is applied.
 3. [Grouping](./grouping) - If grouping is enabled, a grouping state is active, and `tableOptions.groupedColumnMode` is set to `'reorder' | 'remove'`, then the grouped columns are reordered to the start of the column flow.
 
-> **Note:** `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
+> [!NOTE]
+> `columnOrder` state will only affect unpinned columns if used in conjunction with column pinning.
 
 ### Column Order State
 
@@ -65,7 +66,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
+> [!NOTE]
+> If you are using the `state` table option to also specify the `columnOrder` state, the `initialState` will have no effect. Only specify particular states in either `initialState` or `state`, not both.
 
 #### Managing Column Order State
 

--- a/docs/framework/vue/guide/column-pinning.md
+++ b/docs/framework/vue/guide/column-pinning.md
@@ -128,7 +128,8 @@ const table = useTable({
 
 ### Useful Column Pinning APIs
 
-> Note: These APIs are available when using `columnPinningFeature`.
+> [!NOTE]
+> These APIs are available when using `columnPinningFeature`.
 
 There are a handful of useful Column API methods to help you implement column pinning features:
 

--- a/docs/framework/vue/guide/column-visibility.md
+++ b/docs/framework/vue/guide/column-visibility.md
@@ -97,7 +97,8 @@ const table = useTable({
 
 Alternatively, if you don't need to manage the column visibility state outside of the table, you can still set the initial default column visibility state using the `initialState` option.
 
-> **Note**: If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
+> [!NOTE]
+> If `columnVisibility` is provided to both `initialState` and `state`, the `state` initialization will take precedence and `initialState` will be ignored. Do not provide `columnVisibility` to both `initialState` and `state`, only one or the other.
 
 ```ts
 const features = tableFeatures({ columnVisibilityFeature })

--- a/docs/framework/vue/guide/expanding.md
+++ b/docs/framework/vue/guide/expanding.md
@@ -114,7 +114,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
+> [!NOTE]
+> You can have a complicated `getSubRows` function, but keep in mind that it will run for every row and every sub-row. This can be expensive if the function is not optimized. Async functions are not supported.
 
 ### Custom Expanding UI
 

--- a/docs/framework/vue/guide/fuzzy-filtering.md
+++ b/docs/framework/vue/guide/fuzzy-filtering.md
@@ -51,7 +51,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
+> [!NOTE]
+> The `filterFns` and `sortFns` registries above list only the custom `fuzzy` functions this guide uses. Spreading the entire built-in registries (`filterFns: { ...filterFns, fuzzy: fuzzyFilter }`) still works, but it puts every built-in function in your bundle. Register just the functions you use, or pass functions directly to the `filterFn` and `sortFn` column options with no registration.
 
 ## Fuzzy Filtering (Vue) Guide
 
@@ -61,7 +62,8 @@ You can implement client-side fuzzy filtering by defining a custom filter functi
 
 Fuzzy filtering is mostly used with global filtering, but you can also apply it to individual columns. We will discuss how to implement fuzzy filtering for both cases.
 
-> **Note:** You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
+> [!NOTE]
+> You will need to install the `@tanstack/match-sorter-utils` library to use fuzzy filtering.
 > TanStack Match Sorter Utils is a fork of [match-sorter](https://github.com/kentcdodds/match-sorter) by Kent C. Dodds. It was forked in order to work better with TanStack Table's row by row filtering approach.
 
 Using the match-sorter libraries is optional, but the TanStack Match Sorter Utils library provides a great way to both fuzzy filter and sort by the rank information it returns, so that rows can be sorted by their closest matches to the search query.
@@ -212,4 +214,5 @@ You can then pass this sorting function directly to the `sortFn` option of the c
 }
 ```
 
-> **Note:** Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would only work if you also added `fuzzySort` to the `sortFns` slot in `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips that step.
+> [!NOTE]
+> Unlike `filterFn: 'fuzzy'` above, `fuzzySort` is passed as a function rather than a string. A string reference like `sortFn: 'fuzzySort'` would only work if you also added `fuzzySort` to the `sortFns` slot in `tableFeatures` (e.g. `sortFns: { fuzzySort }`). Passing the function directly skips that step.

--- a/docs/framework/vue/guide/global-filtering.md
+++ b/docs/framework/vue/guide/global-filtering.md
@@ -40,7 +40,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
+> [!NOTE]
+> The `filterFns` registry above lists only the built-in filter function this table uses. Spreading the entire built-in `filterFns` registry (`filterFns: { ...filterFns }`) still works, but it puts every built-in filter function in your bundle. Register just the functions you use, or pass a function directly to the `globalFilterFn` option with no registration at all.
 
 ## Global Filtering (Vue) Guide
 
@@ -204,7 +205,8 @@ TanStack table will not add a global filter input UI to your table. You should m
 
 If you want to use a custom global filter function, you can define the function and pass it to the `globalFilterFn` option.
 
-> **Note:** It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
+> [!NOTE]
+> It is often a popular idea to use fuzzy filtering functions for global filtering. This is discussed in the [Fuzzy Filtering Guide](./fuzzy-filtering).
 
 ```ts
 const customFilterFn = (row, columnId, filterValue) => {
@@ -234,7 +236,8 @@ const table = useTable({
 })
 ```
 
-> NOTE: Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
+> [!NOTE]
+> Do not use both `initialState.globalFilter` and a controlled `globalFilter` (via `atoms` or `state`) at the same time, as the controlled value will override `initialState.globalFilter`.
 
 ### Disable Global Filtering
 

--- a/docs/framework/vue/guide/grouping.md
+++ b/docs/framework/vue/guide/grouping.md
@@ -8,7 +8,8 @@ Want to skip to the implementation? Check out these Vue examples:
 
 - [Grouping](../examples/grouping)
 
-> **Note:** `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
+> [!NOTE]
+> `columnGroupingFeature` and `rowAggregationFeature` are now separate features. Register either one independently, or register both when grouped rows should also calculate aggregate values. See the [Aggregation Guide](./aggregation) for aggregation setup.
 
 Vue refs can be passed directly where the adapter expects reactive table options.
 
@@ -133,7 +134,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
+> [!NOTE]
+> There are not currently many known easy ways to do server-side grouping with TanStack Table. You will need to do lots of custom cell rendering to make this work.
 
 ### Controlled Grouping State
 

--- a/docs/framework/vue/guide/pagination.md
+++ b/docs/framework/vue/guide/pagination.md
@@ -108,7 +108,8 @@ const table = useTable({
 })
 ```
 
-> **Note**: Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
+> [!NOTE]
+> Setting the `manualPagination` option to `true` will make the table instance assume that the `data` that you pass in is already paginated.
 
 #### Using TanStack Query
 
@@ -301,7 +302,8 @@ const table = useTable({
 })
 ```
 
-> **Note**: Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
+> [!NOTE]
+> Do NOT provide the `pagination` slice in more than one of the `atoms`, `state`, and `initialState` options. Controlled values (`atoms` or `state`) will overwrite `initialState`. Only use one of them.
 
 ### Pagination Options
 
@@ -349,7 +351,8 @@ There are several pagination table instance APIs that are useful for hooking up 
 - `setPagination`: Useful for setting all of the pagination state at once.
 - `resetPagination`: Useful for resetting the table state to the original pagination state.
 
-> **Note**: These pagination APIs are available when using `rowPaginationFeature`.
+> [!NOTE]
+> These pagination APIs are available when using `rowPaginationFeature`.
 
 ```vue
 <button

--- a/docs/framework/vue/guide/row-selection.md
+++ b/docs/framework/vue/guide/row-selection.md
@@ -50,7 +50,8 @@ console.log(table.getFilteredSelectedRowModel().rows) //get filtered client-side
 console.log(table.getGroupedSelectedRowModel().rows) //get grouped client-side selected rows
 ```
 
-> Note: If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
+> [!NOTE]
+> If you are using `manualPagination`, be aware that the `getSelectedRowModel` API will only return selected rows on the current page because table row models can only generate rows based on the `data` that is passed in. Row selection state, however, can contain row ids that are not present in the `data` array just fine.
 
 ### Manage Row Selection State
 
@@ -247,7 +248,8 @@ If you need more granular control over these function handlers, you can always j
 />
 ```
 
-> **Note:** The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
+> [!NOTE]
+> The `getCanSelectSubRows()` and `getIsAllSubRowsSelected()` clauses on the row checkbox only matter for tables with sub-rows. With flat data, `row.getIsSelected()` alone is enough. See the expanding example for the full pattern, including the `deselectParents` option for pruning stale parent ids when children are deselected.
 
 #### Connect Row Selection APIs to UI
 

--- a/docs/framework/vue/guide/sorting.md
+++ b/docs/framework/vue/guide/sorting.md
@@ -43,7 +43,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
+> [!NOTE]
+> Spreading the entire built-in registry (`sortFns: { ...sortFns }`) still works, but it puts every built-in sorting function in your bundle. Registering just the functions you use, or passing a function directly to the `sortFn` column option, is recommended. The default `sortFn: 'auto'` resolves to `alphanumeric`, `text`, or `datetime` from the registry based on the column's data type, so register the ones your columns rely on.
 
 ## Sorting (Vue) Guide
 
@@ -146,7 +147,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
+> [!NOTE]
+> Do not use both `initialState.sorting` and `state.sorting` at the same time, as the controlled `state.sorting` value will override the `initialState.sorting`.
 
 ### Client-Side vs Server-Side Sorting
 
@@ -183,7 +185,8 @@ const table = useTable({
 
 Hoisting the sorting state into your own scope (with an external atom or the `state.sorting` plus `onSortingChange` pattern) is covered in the [Controlled Sorting State](#controlled-sorting-state) section above.
 
-> **NOTE**: When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
+> [!NOTE]
+> When `manualSorting` is set to `true`, the table will assume that the data that you provide is already sorted, and will not apply any sorting to it.
 
 ### Client-Side Sorting
 
@@ -249,7 +252,8 @@ const myCustomSortFn: SortFn<TFeatures, TData> = (
 }
 ```
 
-> Note: The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
+> [!NOTE]
+> The comparison function does not need to take whether or not the column is in descending or ascending order into account. The row models will take care of that logic. `sortFn` functions only need to provide a consistent comparison.
 
 Every sorting function receives 2 rows and a column ID and is expected to compare the two rows using the column ID to return `-1`, `0`, or `1` in ascending order. Here's a cheat sheet:
 
@@ -409,7 +413,8 @@ const table = useTable({
 })
 ```
 
-> **NOTE**: You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
+> [!NOTE]
+> You may want to explicitly set the `sortDescFirst` column option on any columns that have nullable values. The table may not be able to properly determine if a column is a number or a string if it contains nullable values.
 
 #### Invert Sorting
 
@@ -438,7 +443,8 @@ If not specified, the default value for `sortUndefined` is `1`, and undefined va
 - `-1` - Undefined values will be sorted with higher priority (ascending) (if ascending, undefined will appear on the beginning of the list)
 - `1` - Undefined values will be sorted with lower priority (descending) (if ascending, undefined will appear on the end of the list)
 
-> NOTE: `'first'` and `'last'` options are available in v9.
+> [!NOTE]
+> `'first'` and `'last'` options are available in v9.
 
 ```ts
 const columns = [

--- a/docs/framework/vue/guide/table-state.md
+++ b/docs/framework/vue/guide/table-state.md
@@ -220,7 +220,8 @@ const table = useTable({
 })
 ```
 
-> **Note:** Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
+> [!NOTE]
+> Do not provide the same state slice in multiple ownership places unless you intentionally want one to win. For a slice like `pagination`, prefer exactly one of `initialState.pagination`, `atoms.pagination`, or `state.pagination` as the source of truth. External atoms take precedence over external `state`; external `state` syncs into the table's internal base atom.
 
 #### Resetting to Initial State
 

--- a/docs/guide/cells.md
+++ b/docs/guide/cells.md
@@ -34,7 +34,8 @@ Every cell stores a reference to its parent [row](./rows) and [column](./columns
 
 The recommended way to access data values from a cell is to use either the `cell.getValue` or `cell.renderValue` APIs. Using either of these APIs will cache the results of the accessor functions and keep rendering efficient. The only difference between the two is that `cell.renderValue` will return either the value or the `renderFallbackValue` if the value is undefined, whereas `cell.getValue` will return the value or `undefined` if the value is undefined.
 
-> Note: The `cell.getValue` and `cell.renderValue` APIs are shortcuts for the `row.getValue` and `row.renderValue` APIs, respectively.
+> [!NOTE]
+> The `cell.getValue` and `cell.renderValue` APIs are shortcuts for the `row.getValue` and `row.renderValue` APIs, respectively.
 
 ```js
 // Access the value for this cell's own column

--- a/docs/guide/client-side-vs-server-side.md
+++ b/docs/guide/client-side-vs-server-side.md
@@ -32,7 +32,8 @@ title: Client-Side vs Server-Side Guide
 
 <!-- ::end:framework -->
 
-> [!IMPORTANT] TanStack Table supports both client-side and server-side row processing!
+> [!IMPORTANT]
+> TanStack Table supports both client-side and server-side row processing!
 
 More accurately, TanStack Table lets you bring your own backend or other manual approach to processing data for features such as filtering, grouping, sorting, expanding, aggregating, faceting, and pagination.
 

--- a/docs/guide/column-defs.md
+++ b/docs/guide/column-defs.md
@@ -2,7 +2,8 @@
 title: Column Definitions Guide
 ---
 
-> Note: This guide is about setting up column definitions for your table and NOT about the actual [`column`](./columns) objects that are generated within the table instance.
+> [!NOTE]
+> This guide is about setting up column definitions for your table and NOT about the actual [`column`](./columns) objects that are generated within the table instance.
 
 Column defs are the single most important part of building a table. They are responsible for:
 
@@ -28,7 +29,8 @@ While column defs are just plain objects at the end of the day, a `createColumnH
 
 In v9, `createColumnHelper` requires two type parameters: `TFeatures` (from your `features` object) and `TData` (your row type). Use `typeof features` to get the features type.
 
-> Note: If you use the `createTableHook` factory, it returns a `createAppColumnHelper` that is already bound to your features type, so you only pass `TData`. See the [Composable Tables Guide](../framework/react/guide/composable-tables).
+> [!NOTE]
+> If you use the `createTableHook` factory, it returns a `createAppColumnHelper` that is already bound to your features type, so you only pass `TData`. See the [Composable Tables Guide](../framework/react/guide/composable-tables).
 
 Here's an example of creating and using a column helper:
 
@@ -200,7 +202,8 @@ columnHelper.accessor(row => row[1], {
 }
 ```
 
-> Note: When using `accessorKey` with array data, the key must be a string (e.g. `'1'`, not the number `1`).
+> [!NOTE]
+> When using `accessorKey` with array data, the key must be a string (e.g. `'1'`, not the number `1`).
 
 ### Accessor Functions
 

--- a/docs/guide/columns.md
+++ b/docs/guide/columns.md
@@ -2,7 +2,8 @@
 title: Columns Guide
 ---
 
-> Note: This guide is about the actual `column` objects that are generated within the table instance and NOT about setting up the [column definitions](./column-defs) for your table.
+> [!NOTE]
+> This guide is about the actual `column` objects that are generated within the table instance and NOT about setting up the [column definitions](./column-defs) for your table.
 
 This quick guide will discuss the different ways you can retrieve and interact with `column` objects in TanStack Table.
 

--- a/docs/guide/data.md
+++ b/docs/guide/data.md
@@ -133,7 +133,8 @@ const columns = [
 
 This is discussed in more detail in the [Column Def Guide](./column-defs).
 
-> NOTE: The "keys" in your JSON data can usually be anything, but any periods in an `accessorKey` will be interpreted as a deep key path. If a key in your data contains a literal period, use an `accessorFn` to read it instead.
+> [!NOTE]
+> The "keys" in your JSON data can usually be anything, but any periods in an `accessorKey` will be interpreted as a deep key path. If a key in your data contains a literal period, use an `accessorFn` to read it instead.
 
 ### Nested Sub-Row Data
 

--- a/docs/guide/headers.md
+++ b/docs/guide/headers.md
@@ -59,7 +59,8 @@ There are a few properties on `header` objects that are only useful if the heade
 - `placeholderId`: The unique identifier for the placeholder header.
 - `subHeaders`: The array of sub/child headers that belong to this header. Will be empty if the header is a leaf header.
 
-> Note: `header.index` refers to its index within the header group (row of headers), i.e. its position from left to right. It is not the same as `header.depth`, which refers to the header group "row index".
+> [!NOTE]
+> `header.index` refers to its index within the header group (row of headers), i.e. its position from left to right. It is not the same as `header.depth`, which refers to the header group "row index".
 
 ### Header Parent Objects
 
@@ -100,6 +101,7 @@ If your column tree is uneven (some leaf columns are nested deeper than others),
 }
 ```
 
-> Note: This recipe is for the `<thead>` section only. Footer groups render the header rows in reverse order, which puts a spanning placeholder below the cells it would need to cover, so keep the `header.isPlaceholder` empty-cell pattern in the `<tfoot>` section.
+> [!NOTE]
+> This recipe is for the `<thead>` section only. Footer groups render the header rows in reverse order, which puts a spanning placeholder below the cells it would need to cover, so keep the `header.isPlaceholder` empty-cell pattern in the `<tfoot>` section.
 
 The body-cell equivalent of this convention lives in the optional `cellSpanningFeature`. See the [Cell Spanning Guide](../framework/react/guide/cell-spanning).

--- a/docs/guide/helpers.md
+++ b/docs/guide/helpers.md
@@ -48,7 +48,8 @@ const features = tableFeatures({
 })
 ```
 
-> Note: the full built-in registries (`filterFns`, `sortFns`, `aggregationFns`) can still be spread into these slots, but they are deprecated because they put every built-in function in your bundle. Register only the functions you use under their conventional string keys, or pass functions directly to the `filterFn`, `sortFn`, and `aggregationFn` column options with no registration at all. String keys, including the default `'auto'`, only resolve functions that are registered.
+> [!NOTE]
+> the full built-in registries (`filterFns`, `sortFns`, `aggregationFns`) can still be spread into these slots, but they are deprecated because they put every built-in function in your bundle. Register only the functions you use under their conventional string keys, or pass functions directly to the `filterFn`, `sortFn`, and `aggregationFn` column options with no registration at all. String keys, including the default `'auto'`, only resolve functions that are registered.
 
 Keep `features` stable. In most apps, define it outside your component or in shared table setup code. Since `typeof features` is used throughout the table's types, stable features also make it easier to reuse column helpers, column definitions, and shared options.
 

--- a/docs/guide/row-models.md
+++ b/docs/guide/row-models.md
@@ -77,7 +77,8 @@ const table = useTable({
 })
 ```
 
-> Note: the full built-in registries (`filterFns`, `sortFns`, `aggregationFns`) can still be spread into these slots, but they are deprecated because they pull every built-in function into your bundle. Register only the functions you use under their conventional string keys, or pass functions directly to the `filterFn`, `sortFn`, and `aggregationFn` column options with no registration at all. String keys, including the default `'auto'`, only resolve functions that are registered.
+> [!NOTE]
+> the full built-in registries (`filterFns`, `sortFns`, `aggregationFns`) can still be spread into these slots, but they are deprecated because they pull every built-in function into your bundle. Register only the functions you use under their conventional string keys, or pass functions directly to the `filterFn`, `sortFn`, and `aggregationFn` column options with no registration at all. String keys, including the default `'auto'`, only resolve functions that are registered.
 
 ## Function Registries
 

--- a/docs/guide/rows.md
+++ b/docs/guide/rows.md
@@ -53,7 +53,8 @@ const table = useTable({
 })
 ```
 
-> Note: In some features like grouping and expanding, the `row.id` will have an additional string appended to it.
+> [!NOTE]
+> In some features like grouping and expanding, the `row.id` will have an additional string appended to it.
 
 ### Row Numbers and Display Indexes
 
@@ -84,7 +85,8 @@ const firstName = row.getValue('firstName') // read the row value from the first
 const renderedLastName = row.renderValue('lastName') // render the value from the lastName column
 ```
 
-> Note: `cell.getValue` and `cell.renderValue` are shortcuts for the `row.getValue` and `row.renderValue` APIs, respectively.
+> [!NOTE]
+> `cell.getValue` and `cell.renderValue` are shortcuts for the `row.getValue` and `row.renderValue` APIs, respectively.
 
 ### Access Original Row Data
 

--- a/docs/guide/table-and-column-meta.md
+++ b/docs/guide/table-and-column-meta.md
@@ -542,7 +542,8 @@ const features = tableFeatures({
 })
 ```
 
-> Note: the `filterFns` and `sortFns` slots above register only the functions this table uses. The full built-in registries (`filterFns`, `sortFns`, `aggregationFns` exported from the package) can still be spread into these slots, but they are deprecated because they put every built-in function in your bundle. Import individual functions such as `sortFn_alphanumeric` instead, or pass functions directly in your column definitions.
+> [!NOTE]
+> the `filterFns` and `sortFns` slots above register only the functions this table uses. The full built-in registries (`filterFns`, `sortFns`, `aggregationFns` exported from the package) can still be spread into these slots, but they are deprecated because they put every built-in function in your bundle. Import individual functions such as `sortFn_alphanumeric` instead, or pass functions directly in your column definitions.
 
 Now `columnFiltersMeta` on every row is typed as `FuzzyFilterMeta` for tables built from this `features` object. The `filterMeta` slot is, like `tableMeta` and `columnMeta`, a phantom type-only entry: `metaHelper<FuzzyFilterMeta>()` returns `{}` at runtime and is stripped from the registered features.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,8 @@
 title: Overview
 ---
 
-> NOTE: If you are upgrading from TanStack Table v8, start with the migration guide for your framework:
+> [!NOTE]
+> If you are upgrading from TanStack Table v8, start with the migration guide for your framework:
 
 <!-- ::start:framework -->
 


### PR DESCRIPTION
## 🎯 Changes

The callout at the start of https://tanstack.com/table/latest/docs/framework/svelte/quick-start currently uses a plain blockquote, which causes it to get wrapped in additional quotes.

This PR matches the markup to what is used in the [devtools docs](https://github.com/TanStack/devtools/blob/53805408af7e6010e209f21a073204411bc1267f/docs/vite-plugin.md?plain=1#L76-L77), with the assumption that it is also supported in the table docs.

_The change was made through GitHub's editor and not tested locally._

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized notes, tips, and warnings across framework and core guides with consistent Markdown callouts.
  * Improved the visibility and readability of guidance covering filtering, sorting, pagination, selection, state, columns, and other features.
  * Preserved existing instructional content, compatibility guidance, API details, and behavior notes.
  * Clarified selected setup, migration, performance, and deprecation notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->