### PR TITLE
fix(table-core): flatten grouped parent rows ahead of their sub-rows

### DIFF
--- a/.changeset/grouped-flat-rows-parent-first.md
+++ b/.changeset/grouped-flat-rows-parent-first.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Fix `getGroupedRowModel().flatRows` listing every group row after its own descendants. Group rows now come first at every depth, which aligns the flattened result with the grouped `rows` tree and with the core, paginated and sorted row models.

--- a/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
+++ b/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
@@ -107,17 +107,14 @@ function _createGroupedRowModel<
       return rows.map((row) => {
         row.depth = depth
 
-        // Every row is pushed into flatRows/rowsById exactly once, by its
-        // parent frame: rows returned here are pushed by the caller (the
-        // parent group's loop or the root loop), so only descendants below
-        // the terminal depth are pushed here.
+        // Every row is pushed into flatRows/rowsById exactly once, by its own
+        // frame and before it descends, so a parent stays ahead of its own
+        // sub-rows.
+        groupedFlatRows.push(row)
+        groupedRowsById[row.id] = row
+
         if (row.subRows.length) {
           row.subRows = groupUpRecursively(row.subRows, depth + 1, row.id)
-          for (let i = 0; i < row.subRows.length; i++) {
-            const subRow = row.subRows[i]!
-            groupedFlatRows.push(subRow)
-            groupedRowsById[subRow.id] = subRow
-          }
         }
 
         return row
@@ -134,6 +131,11 @@ function _createGroupedRowModel<
       ([groupingValue, groupedRows], index) => {
         let id = `${columnId}:${groupingValue}`
         id = parentId ? `${parentId}>${id}` : id
+
+        // Take this group's slot before descending, so it stays ahead of its
+        // own sub-rows.
+        const flatIndex = groupedFlatRows.length
+        groupedFlatRows.push(undefined as unknown as Row<TFeatures, TData>)
 
         // First, Recurse to group sub rows before aggregation
         const subRows = groupUpRecursively(groupedRows, depth + 1, id)
@@ -206,10 +208,8 @@ function _createGroupedRowModel<
           },
         })
 
-        subRows.forEach((subRow) => {
-          groupedFlatRows.push(subRow)
-          groupedRowsById[subRow.id] = subRow
-        })
+        groupedFlatRows[flatIndex] = row
+        groupedRowsById[id] = row
 
         return row
       },
@@ -219,11 +219,6 @@ function _createGroupedRowModel<
   }
 
   const groupedRows = groupUpRecursively(rowModel.rows, 0)
-
-  groupedRows.forEach((subRow) => {
-    groupedFlatRows.push(subRow)
-    groupedRowsById[subRow.id] = subRow
-  })
 
   return {
     rows: groupedRows,

--- a/packages/table-core/src/worker/rebuildRowModel.ts
+++ b/packages/table-core/src/worker/rebuildRowModel.ts
@@ -46,7 +46,9 @@ export function rebuildRowModel<
   // filtered model never touches them. Without this distinction a filtered
   // rebuild could zero depths assigned by a grouped/sorted tree rebuild.
   const resetDepths = stage !== 'filtered'
-  const flattenParentsFirst = stage === 'sorted'
+  // Only the filtered model still flattens post-order; every stage that can
+  // carry synthetic group rows lists a parent ahead of its own descendants.
+  const flattenParentsFirst = stage !== 'filtered'
 
   if (payload.kind === 'flat') {
     const { indices } = payload
@@ -84,7 +86,7 @@ export function rebuildRowModel<
         continue
       }
 
-      // Sorted flatRows preserve the recursive rows order. Reserve the
+      // These flatRows preserve the recursive rows order. Reserve the
       // synthetic parent's position before rebuilding its descendants, then
       // fill it once the row can be constructed from those descendants.
       const flatIndex = flattenParentsFirst ? flatRows.length : -1

--- a/packages/table-core/tests/implementation/features/column-grouping/createGroupedRowModel.test.ts
+++ b/packages/table-core/tests/implementation/features/column-grouping/createGroupedRowModel.test.ts
@@ -38,6 +38,22 @@ function makeTable(data: Array<TestRow>, grouping: Array<string>) {
   })
 }
 
+function flattenRows<TRow extends { subRows: Array<TRow> }>(rows: Array<TRow>) {
+  const flatRows: Array<TRow> = []
+
+  const visit = (nestedRows: Array<TRow>) => {
+    for (const row of nestedRows) {
+      flatRows.push(row)
+      if (row.subRows.length) {
+        visit(row.subRows)
+      }
+    }
+  }
+
+  visit(rows)
+  return flatRows
+}
+
 function expectUniqueFlatRowIds(rowModel: RowModel<any, any>) {
   const ids = rowModel.flatRows.map((row) => row.id)
   expect(new Set(ids).size).toBe(ids.length)
@@ -153,6 +169,72 @@ describe('createGroupedRowModel flatRows contain every row exactly once', () => 
     expect(rowModel.rows.length).toBe(3)
     expect(rowModel.flatRows.length).toBe(3)
     expectUniqueFlatRowIds(rowModel)
+  })
+})
+
+describe('createGroupedRowModel flatRows follow the grouped rows tree', () => {
+  it('lists a group ahead of its own rows over flat data', () => {
+    const data: Array<TestRow> = [
+      { status: 'a', firstName: 'one' },
+      { status: 'a', firstName: 'two' },
+      { status: 'b', firstName: 'three' },
+    ]
+    const rowModel = makeTable(data, ['status']).getGroupedRowModel()
+
+    expect(rowModel.flatRows.map((row) => row.id)).toEqual([
+      'status:a',
+      '0',
+      '1',
+      'status:b',
+      '2',
+    ])
+  })
+
+  it('lists a group ahead of its own rows at every grouping depth', () => {
+    const data: Array<TestRow> = [
+      { status: 'a', firstName: 'x' },
+      { status: 'a', firstName: 'y' },
+      { status: 'b', firstName: 'x' },
+    ]
+    const rowModel = makeTable(data, [
+      'status',
+      'firstName',
+    ]).getGroupedRowModel()
+
+    expect(rowModel.flatRows.map((row) => row.id)).toEqual([
+      'status:a',
+      'status:a>firstName:x',
+      '0',
+      'status:a>firstName:y',
+      '1',
+      'status:b',
+      'status:b>firstName:x',
+      '2',
+    ])
+  })
+
+  it('lists a parent ahead of its own sub-rows below the terminal grouping depth', () => {
+    // 2 parents, each with 2 children, each with 2 grandchildren
+    const data = generateTestData(2, 2, 2)
+    data[0]!.status = 'single'
+    data[1]!.status = 'complicated'
+
+    const table = constructTable<typeof features, Person>({
+      features,
+      renderFallbackValue: '',
+      data,
+      columns: [
+        { accessorKey: 'status', id: 'status' },
+        { accessorKey: 'firstName', id: 'firstName' },
+      ] as Array<ColumnDef<typeof features, Person, any>>,
+      getSubRows: (originalRow) => originalRow.subRows,
+      initialState: { grouping: ['status'] },
+    })
+    const rowModel = table.getGroupedRowModel()
+
+    expect(rowModel.flatRows.map((row) => row.id)).toEqual(
+      flattenRows(rowModel.rows).map((row) => row.id),
+    )
   })
 })
 

--- a/packages/table-core/tests/unit/worker/serializeRebuild.test.ts
+++ b/packages/table-core/tests/unit/worker/serializeRebuild.test.ts
@@ -234,6 +234,7 @@ describe('serializeRowModel -> rebuildRowModel round trip', () => {
     const { rebuilt } = roundTrip(workerTable, mainTable, model, 'grouped')
 
     expect(ids(rebuilt.rows)).toEqual(ids(model.rows))
+    expect(ids(rebuilt.flatRows)).toEqual(ids(model.flatRows))
     const firstGroup = rebuilt.rows[0]!
     const firstSubGroup = firstGroup.subRows[0]!
     expect(firstSubGroup.groupingColumnId).toBe('age')

--- a/perf-new.md
+++ b/perf-new.md
@@ -69,6 +69,15 @@ coverage in `tests/implementation/features/column-grouping/createGroupedRowModel
 values 8→5, nonexistent-column grouping 6→3 flatRows; all with duplicate-id checks). The
 benchmark comparison layer gained a known-delta allowlist annotating the intentional v8↔v9
 `outputFlatRows` mismatch for grouping scenarios.
+
+**2026-08-14 follow-up (#6551):** accepted delta (a) is withdrawn. Pushing each row from its
+parent's frame left every group row behind its own descendants at every depth, not just below the
+terminal depth, and #6529 removed the "the sorted model already emits postorder" justification.
+Each frame now pushes the rows it returns, and a group reserves its flat-array slot before it
+descends, so grouped `flatRows` matches the `rows` tree the way core, paginated and sorted already
+do. Worker-backed grouped tree reconstruction mirrors it. The exactly-once property and delta (b)
+are unchanged.
+
 **Location:** `packages/table-core/src/features/column-grouping/createGroupedRowModel.ts:86–87` (terminal-branch push) and `:179–182` (parent group's subRows push); v8 has the identical double-push in `table-v8/packages/table-core/src/utils/getGroupedRowModel.ts`
 **Category:** `bug`, `allocation`, `big-o`
 


### PR DESCRIPTION
## 🎯 Changes

In `_createGroupedRowModel` every frame pushes the rows its *caller* asked for, so a group row only reaches `flatRows` once the parent's loop runs, which is after that group's whole subtree is already in. The result is that every group row sits behind its own descendants, at every depth, not just below the terminal grouping depth.

With `grouping: ['a']` over three flat rows and no tree data:

```ts
table.getGroupedRowModel().rows.map((r) => r.id)
// ['a:1', 'a:2']

table.getGroupedRowModel().flatRows.map((r) => r.id)
// before: ['0', '1', '2', 'a:1', 'a:2']
// after:  ['a:1', '0', '1', 'a:2', '2']
```

That disagrees with the grouped `rows` tree, and with how `createCoreRowModel`, `createPaginatedRowModel` and (since #6529) `createSortedRowModel` flatten. Each frame now pushes the rows it returns, and a group takes its `flatRows` slot before it descends, the same reservation #6529 used for the sorted parent. The worker's grouped tree rebuild follows, so `getGroupedRowModel().flatRows` matches between the sync and worker paths. Rows are still pushed exactly once, which was the point of the N1 fix; I updated that entry in `perf-new.md` since its accepted delta (a) no longer holds.

Fixes #6551

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

Three tests added to `createGroupedRowModel.test.ts` (single-level, multi-level, and tree data below the terminal depth) and one `flatRows` assertion added to the nested-grouping worker round trip. All four fail on `main` and pass with the fix. `@tanstack/table-core` is at 63 files / 1319 tests. The affected run over 407 projects is green apart from `@tanstack/ember-table:test:lib`, which fails the same way on an untouched `main` here ("Browser failed to connect within 120s").

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected grouped row ordering so flattened results consistently list each parent group before its descendants at every nesting level.
  - Aligned worker-rebuilt row models with the same parent-first ordering across applicable processing stages.
  - Preserved consistent flattened row results for grouped, sorted, paginated, and core row models.
- **Tests**
  - Added coverage for nested grouped data and verified flattened row order during model reconstruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->