### PR TITLE
fix(table-core): guard process.env access with isDev() for non-Node environments

### DIFF
--- a/packages/table-core/src/core/columns/constructColumn.ts
+++ b/packages/table-core/src/core/columns/constructColumn.ts
@@ -1,4 +1,5 @@
 import type { Table_Internal } from '../../types/Table'
+import { isDev } from '../../utils'
 import type { CellData, RowData } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
 import type {
@@ -74,7 +75,7 @@ export function constructColumn<
         for (let i = 0; i < keys.length; i++) {
           const key = keys[i]!
           result = result?.[key]
-          if (process.env.NODE_ENV === 'development' && result === undefined) {
+          if (isDev() && result === undefined) {
             console.warn(
               `"${key}" in deeply nested key "${accessorKey}" returned undefined.`,
             )
@@ -90,7 +91,7 @@ export function constructColumn<
   }
 
   if (!id) {
-    if (process.env.NODE_ENV === 'development') {
+    if (isDev()) {
       throw new Error(
         resolvedColumnDef.accessorFn
           ? `coreColumnsFeature require an id when using an accessorFn`

--- a/packages/table-core/src/core/columns/coreColumnsFeature.utils.ts
+++ b/packages/table-core/src/core/columns/coreColumnsFeature.utils.ts
@@ -1,4 +1,5 @@
 import { callMemoOrStaticFn, makeObjectMap } from '../../utils'
+import { isDev } from '../../utils'
 import { table_getOrderColumnsFn } from '../../features/column-ordering/columnOrderingFeature.utils'
 import { constructColumn } from './constructColumn'
 import type { Table_Internal } from '../../types/Table'
@@ -280,7 +281,7 @@ export function table_getColumn<
 ): Column<TFeatures, TData, unknown> | undefined {
   const column = table.getAllFlatColumnsById()[columnId]
 
-  if (process.env.NODE_ENV === 'development' && !column) {
+  if (isDev() && !column) {
     console.warn(`[Table] Column with id '${columnId}' does not exist.`)
   }
 

--- a/packages/table-core/src/core/rows/coreRowsFeature.utils.ts
+++ b/packages/table-core/src/core/rows/coreRowsFeature.utils.ts
@@ -1,4 +1,5 @@
 import { flattenBy, hasOwn, makeObjectMap } from '../../utils'
+import { isDev } from '../../utils'
 import { constructCell } from '../cells/constructCell'
 import type { Table_Internal } from '../../types/Table'
 import type { RowData } from '../../types/type-utils'
@@ -348,7 +349,7 @@ export function table_getRow<
   if (!row) {
     row = table.getCoreRowModel().rowsById[rowId]
     if (!row) {
-      if (process.env.NODE_ENV === 'development') {
+      if (isDev()) {
         throw new Error(`getRow could not find row with ID: ${rowId}`)
       }
       throw new Error()

--- a/packages/table-core/src/core/table/constructTable.ts
+++ b/packages/table-core/src/core/table/constructTable.ts
@@ -1,4 +1,5 @@
 import { shallow } from '@tanstack/store'
+import { isDev } from '../../utils'
 import { coreFeatures } from '../coreFeatures'
 import { cloneState, hasOwn } from '../../utils'
 import { atomToStore } from '../reactivity/coreReactivityFeature.utils'
@@ -223,7 +224,7 @@ export function constructTable<
   }
 
   if (
-    process.env.NODE_ENV === 'development' &&
+    isDev() &&
     (tableOptions.debugAll || tableOptions.debugTable)
   ) {
     const features = Object.keys(table._features)

--- a/packages/table-core/src/features/column-filtering/columnFilteringFeature.utils.ts
+++ b/packages/table-core/src/features/column-filtering/columnFilteringFeature.utils.ts
@@ -1,4 +1,5 @@
 import {
+  isDev,
   cloneState,
   functionalUpdate,
   isFunction,
@@ -85,7 +86,7 @@ export function column_getAutoFilterFn<
 
   const filterFn = filterFns?.[filterFnName]
 
-  if (process.env.NODE_ENV === 'development' && !filterFn) {
+  if (isDev() && !filterFn) {
     console.warn(
       `filterFn '${filterFnName}' (auto) for column '${column.id}' is not registered`,
     )
@@ -123,7 +124,7 @@ export function column_getFilterFn<
       : filterFns?.[column.columnDef.filterFn as string]
 
   if (
-    process.env.NODE_ENV === 'development' &&
+    isDev() &&
     !filterFn &&
     column.columnDef.filterFn !== 'auto' // the auto picker warns on its own
   ) {

--- a/packages/table-core/src/features/global-filtering/globalFilteringFeature.utils.ts
+++ b/packages/table-core/src/features/global-filtering/globalFilteringFeature.utils.ts
@@ -1,4 +1,5 @@
 import { filterFn_includesString } from '../column-filtering/filterFns'
+import { isDev } from '../../utils'
 import { cloneState, isFunction } from '../../utils'
 import type { Column_Internal } from '../../types/Column'
 import type { FilterFn } from '../column-filtering/columnFilteringFeature.types'
@@ -75,7 +76,7 @@ export function table_getGlobalFilterFn<
       : filterFns?.[globalFilterFn as string]
 
   if (
-    process.env.NODE_ENV === 'development' &&
+    isDev() &&
     !filterFn &&
     globalFilterFn != null
   ) {

--- a/packages/table-core/src/features/row-aggregation/rowAggregationFeature.utils.ts
+++ b/packages/table-core/src/features/row-aggregation/rowAggregationFeature.utils.ts
@@ -1,4 +1,5 @@
 import { hasOwn, makeObjectMap } from '../../utils'
+import { isDev } from '../../utils'
 import type { Cell } from '../../types/Cell'
 import type { Column, Column_Internal } from '../../types/Column'
 import type { Row } from '../../types/Row'
@@ -48,7 +49,7 @@ function isAggregationFnDescriptor(
 }
 
 function warn(message: string) {
-  if (process.env.NODE_ENV === 'development') {
+  if (isDev()) {
     console.warn(message)
   }
 }

--- a/packages/table-core/src/features/row-sorting/rowSortingFeature.utils.ts
+++ b/packages/table-core/src/features/row-sorting/rowSortingFeature.utils.ts
@@ -1,4 +1,5 @@
 import { cloneState, isFunction, setStateSlice } from '../../utils'
+import { isDev } from '../../utils'
 import { reSplitAlphaNumeric, sortFn_basic } from './sortFns'
 import type { CellData, RowData, Updater } from '../../types/type-utils'
 import type { TableFeatures } from '../../types/TableFeatures'
@@ -146,7 +147,7 @@ export function column_getAutoSortFn<
     let sortFn = sortFns?.[sortFnName]
 
     if (!sortFn) {
-      if (process.env.NODE_ENV === 'development') {
+      if (isDev()) {
         console.warn(
           `sortFn '${sortFnName}' (auto) for column '${column.id}' is not registered`,
         )
@@ -230,7 +231,7 @@ export function column_getSortFn<
 
   const sortFn = sortFns?.[column.columnDef.sortFn as string]
 
-  if (process.env.NODE_ENV === 'development' && !sortFn) {
+  if (isDev() && !sortFn) {
     console.warn(
       `sortFn '${String(column.columnDef.sortFn)}' for column '${column.id}' is not registered`,
     )

--- a/packages/table-core/src/utils.ts
+++ b/packages/table-core/src/utils.ts
@@ -1,4 +1,5 @@
 import type { Table_Internal } from './types/Table'
+import { isDev } from './utils'
 import type { NoInfer, RowData, Updater } from './types/type-utils'
 import type { TableFeatures } from './types/TableFeatures'
 import type { TableState, TableState_All } from './types/TableState'
@@ -8,6 +9,19 @@ import type { TableState, TableState_All } from './types/TableState'
  *
  * If the updater is a function it is called with the previous value; otherwise the updater value is returned directly.
  */
+
+/**
+ * Returns true when running in development mode.
+ * Safe in environments without Node.js globals (e.g. vanilla JS via
+ * importmap) where `process` is not defined.
+ */
+export function isDev(): boolean {
+  return (
+    typeof process !== 'undefined' &&
+    process.env != null &&
+    process.env.NODE_ENV !== 'production'
+  )
+}
 export function functionalUpdate<T>(updater: Updater<T>, input: T): T {
   return typeof updater === 'function'
     ? (updater as (i: T) => T)(input)
@@ -405,7 +419,7 @@ export function tableMemo<
   let debug: boolean | undefined
   let debugCache: boolean | undefined
 
-  if (process.env.NODE_ENV === 'development') {
+  if (isDev()) {
     const { debugAll } = table.options
     const { parentName } = getFunctionNameInfo(fnName, '.')
 
@@ -467,7 +481,7 @@ export function tableMemo<
   }
 
   const debugOptions =
-    process.env.NODE_ENV === 'development'
+    isDev()
       ? {
           onBeforeCompare: () => {
             if (debugCache) {

--- a/packages/table-core/src/worker/createWorkerRowModel.ts
+++ b/packages/table-core/src/worker/createWorkerRowModel.ts
@@ -1,4 +1,5 @@
 import { tableMemo } from '../utils'
+import { isDev } from '../utils'
 import { getTableWorkerBridge, syncTableWorker } from './createTableWorker'
 import { rebuildRowModel } from './rebuildRowModel'
 import { tableWorkerPipeline } from './tableWorkerProtocol'
@@ -60,7 +61,7 @@ export function createWorkerRowModel(
     let warned = false
 
     const warnOnce = (message: string) => {
-      if (process.env.NODE_ENV === 'development' && !warned) {
+      if (isDev() && !warned) {
         warned = true
         console.warn(`[table-worker] ${message}`)
       }


### PR DESCRIPTION
Fixes #6078

Raw `process.env.NODE_ENV` references throw `process is not defined` when @tanstack/table-core is consumed in vanilla JS without a bundler (e.g. Rails importmap).

Add a safe `isDev()` utility that checks for the existence of `process` before accessing it, and replace all dev-only guards across table-core.

```ts
function isDev(): boolean {
  return typeof process !== "undefined" && process.env?.NODE_ENV !== "production"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-mode compatibility in browser and worker environments by avoiding reliance on Node.js-specific environment globals.
  * Standardized development warnings and diagnostic logging across table features, including columns, rows, filtering, sorting, and aggregation.

* **Refactor**
  * Centralized development-environment detection for more consistent debug behavior and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->