### PR TITLE
fix(table-core): invalidate value cache when accessorFn changes

### DIFF
--- a/packages/table-core/src/core/rows/constructRow.ts
+++ b/packages/table-core/src/core/rows/constructRow.ts
@@ -51,6 +51,7 @@ export const constructRow = <
   row._displayIndexCache = -1
   row._uniqueValuesCache = makeObjectMap()
   row._valuesCache = makeObjectMap()
+  row._accessorFnsCache = makeObjectMap()
   row.depth = depth
   row.id = id
   row.index = rowIndex

--- a/packages/table-core/src/core/rows/coreRowsFeature.types.ts
+++ b/packages/table-core/src/core/rows/coreRowsFeature.types.ts
@@ -25,6 +25,7 @@ export interface Row_CoreProperties<
   _displayIndexCache: number
   _uniqueValuesCache: Record<string, unknown>
   _valuesCache: Record<string, unknown>
+  _accessorFnsCache: Record<string, unknown>
   /**
    * The depth of the row (if nested or grouped) relative to the root row array.
    */

--- a/packages/table-core/src/core/rows/coreRowsFeature.utils.ts
+++ b/packages/table-core/src/core/rows/coreRowsFeature.utils.ts
@@ -79,16 +79,21 @@ export function row_getValue<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>, columnId: string) {
-  if (hasOwn(row._valuesCache, columnId)) {
+  const column = row.table.getColumn(columnId)
+
+  if (
+    hasOwn(row._valuesCache, columnId) &&
+    hasOwn(row._accessorFnsCache, columnId) &&
+    row._accessorFnsCache[columnId] === column?.accessorFn
+  ) {
     return row._valuesCache[columnId]
   }
-
-  const column = row.table.getColumn(columnId)
 
   if (!column?.accessorFn) {
     return undefined
   }
 
+  row._accessorFnsCache[columnId] = column.accessorFn
   row._valuesCache[columnId] = column.accessorFn(row.original, row.index)
 
   return row._valuesCache[columnId]
@@ -109,11 +114,15 @@ export function row_getUniqueValues<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(row: Row<TFeatures, TData>, columnId: string) {
-  if (hasOwn(row._uniqueValuesCache, columnId)) {
+  const column = row.table.getColumn(columnId)
+
+  if (
+    hasOwn(row._uniqueValuesCache, columnId) &&
+    hasOwn(row._accessorFnsCache, columnId) &&
+    row._accessorFnsCache[columnId] === column?.accessorFn
+  ) {
     return row._uniqueValuesCache[columnId]
   }
-
-  const column = row.table.getColumn(columnId)
 
   if (!column?.accessorFn) {
     return undefined
@@ -124,6 +133,7 @@ export function row_getUniqueValues<
     return row._uniqueValuesCache[columnId]
   }
 
+  row._accessorFnsCache[columnId] = column.accessorFn
   row._uniqueValuesCache[columnId] = column.columnDef.getUniqueValues(
     row.original,
     row.index,


### PR DESCRIPTION
Fixes #5363

`row_getValue` and `row_getUniqueValues` cache values per `columnId` but never verify the accessor function is still the one that produced the cached value. When a column's `accessorFn` is updated (e.g. driven by external state), stale cached values keep being returned, so the column never reflects the new value.

Track the `accessorFn` alongside each cached value and treat the cache as stale when the function reference changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated table value caching to reflect changes to column accessor functions.
  * Ensured displayed values and unique-value results are recalculated when accessor logic changes.
  * Improved cache handling for more accurate table results after column updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->