### PR TITLE
fix(table-core): preserve columnFiltersMeta in filterRowModelFromLeafs

### DIFF
--- a/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
+++ b/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
@@ -63,6 +63,7 @@ function filterRowModelFromLeafs<
       ) as Row<TFeatures, TData> &
         Partial<Row_ColumnFiltering<TFeatures, TData>>
       newRow.columnFilters = row.columnFilters
+      newRow.columnFiltersMeta = row.columnFiltersMeta
 
       if (row.subRows.length && depth < maxDepth) {
         newRow.subRows = recurseFilterRows(row.subRows, depth + 1)


### PR DESCRIPTION
Fixes #6074

When `filterFromLeafRows` is true, `filterRowModelFromLeafs` recreates each row via `constructRow` and copies `columnFilters`, but neglects to copy `columnFiltersMeta`. Users who store filter-rank metadata (e.g. for fuzzy-sort use cases) find their data wiped on every filter recalculation.

Copy `columnFiltersMeta` alongside `columnFilters` when building the filtered row model from leaf rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved column filter metadata when filtering nested or hierarchical table rows.
  * Ensured filtered rows retain the metadata needed for consistent filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->