### PR TITLE
fix(vue-table): return null for empty string renders to avoid hydration mismatch

### DIFF
--- a/packages/vue-table/src/FlexRender.ts
+++ b/packages/vue-table/src/FlexRender.ts
@@ -43,6 +43,13 @@ export function flexRender(render: any, props: any): any {
       return rendered
     }
 
+    // An empty string renders to nothing on the server but Vue still emits a
+    // text node, producing a hydration mismatch when the client renders the
+    // same empty cell. Return null so both sides agree on no output.
+    if (rendered === '') {
+      return null
+    }
+
     if (typeof rendered === 'function' || typeof rendered === 'object') {
       return h(rendered, props)
     }


### PR DESCRIPTION
Fixes #6077

`flexRender` returns `""` for columns whose cell/header renders an empty string. During SSR the server emits no text node, but Vue's hydration expects one, causing a mismatch error.

Treat the empty string like null/undefined and return null so server and client agree on no output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty table cells rendering inconsistently between server-side and client-side rendering.
  * Empty-string cell content now displays consistently as an empty cell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->