### PR TITLE
fix(table-core): count array values correctly in facetedUniqueValues

### DIFF
--- a/packages/table-core/src/features/column-faceting/createFacetedUniqueValues.ts
+++ b/packages/table-core/src/features/column-faceting/createFacetedUniqueValues.ts
@@ -82,10 +82,16 @@ function _createFacetedUniqueValues<
       if (!values) continue
 
       for (let j = 0; j < values.length; j++) {
-        const value = values[j]
-        const previousValue = facetedUniqueValues.get(value)
+        const value = values[j]!
+        // Array-valued cells (e.g. multi-select columns) are wrapped in a
+        // single-item array by getUniqueValues, so `value` is an array. Arrays
+        // compare by reference in a Map, so two equal arrays would count as
+        // distinct facets. Normalize array values to a stable string key so
+        // the facet count is correct.
+        const key = Array.isArray(value) ? JSON.stringify(value) : value
+        const previousValue = facetedUniqueValues.get(key)
         facetedUniqueValues.set(
-          value,
+          key,
           previousValue === undefined ? 1 : previousValue + 1,
         )
       }


### PR DESCRIPTION
Fixes #5405

When a cell value is an array (e.g. multi-select columns), `getUniqueValues` wraps it producing a nested array. `Map` lookup then compares arrays by reference, so equal arrays count as distinct facets and the facet list never shows the right frequency.

Normalize array values to a stable JSON string key before counting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed faceted filtering so identical array-valued entries are counted as a single unique value.
  * Preserved existing handling for scalar facet values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->