### PR TITLE
fix(table-core): keep columnFiltersMeta when filtering from leaf rows

### DIFF
--- a/.changeset/quick-dryers-attend.md
+++ b/.changeset/quick-dryers-attend.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Fix `columnFiltersMeta` being dropped from every row of the filtered row model when `filterFromLeafRows` is enabled. The leaf-up filter path rebuilds each row with `constructRow` and copied only `columnFilters` onto the copy, leaving the meta as the empty map that `constructRow` initialises. Rank metadata recorded by a filter function's `addMeta` callback — the basis for rank-aware sorting in the fuzzy filtering guide — now survives on parent rows and sub-rows alike, and each row keeps the meta produced by its own filter run.

--- a/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
+++ b/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
@@ -62,7 +62,13 @@ function filterRowModelFromLeafs<
         row.parentId,
       ) as Row<TFeatures, TData> &
         Partial<Row_ColumnFiltering<TFeatures, TData>>
+      // `constructRow` gives the copy empty filter maps, so both halves of the
+      // row's filter state have to be carried over from the source row. The
+      // meta belongs to the row that produced it: each row is tagged
+      // independently in the pre-filter pass, so it is copied across rather
+      // than inherited from a parent or aggregated from `subRows`
       newRow.columnFilters = row.columnFilters
+      newRow.columnFiltersMeta = row.columnFiltersMeta
 
       if (row.subRows.length && depth < maxDepth) {
         newRow.subRows = recurseFilterRows(row.subRows, depth + 1)

--- a/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
+++ b/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
@@ -512,6 +512,99 @@ describe('createFilteredRowModel', () => {
       expect(preRows[0]!.columnFiltersMeta.name).toEqual({ globalHit: 'keep' })
       expect(preRows[1]!.columnFiltersMeta.name).toEqual({ globalHit: 'drop' })
     })
+
+    // A rank-scoring filter in the shape used by the fuzzy filtering docs: it
+    // records a score for every row it inspects so a sortingFn can order rows
+    // by match quality afterwards.
+    const rankFilterFn: FilterFn<typeof features, any> = (
+      row,
+      columnId,
+      filterValue,
+      addMeta,
+    ) => {
+      const value = row.getValue<string>(columnId)
+      const rank = value.startsWith(filterValue as string) ? value.length : 0
+      addMeta?.({ itemRank: { rank } })
+      return rank > 0
+    }
+
+    const rankColumns: Array<ColumnDef<typeof features, NestedRow, any>> = [
+      { accessorKey: 'name', id: 'name', filterFn: rankFilterFn },
+    ]
+
+    function makeRankTable(options: {
+      data: Array<NestedRow>
+      filterFromLeafRows?: boolean
+    }) {
+      return constructTable<typeof features, NestedRow>({
+        features,
+        columns: rankColumns,
+        data: options.data,
+        getSubRows: (row) => row.subRows,
+        filterFromLeafRows: options.filterFromLeafRows,
+        initialState: {
+          columnFilters: [{ id: 'name', value: 'keep' }],
+        },
+      })
+    }
+
+    it('should keep each row its own columnFiltersMeta on sub-rows when filtering from leaf rows', () => {
+      const table = makeRankTable({
+        filterFromLeafRows: true,
+        data: [
+          { name: 'drop-parent', subRows: [{ name: 'keep-child' }] },
+          { name: 'keep-parent-long', subRows: [{ name: 'drop-child' }] },
+        ],
+      })
+
+      const rows = table.getFilteredRowModel().rows
+      expect(rowNames(rows)).toEqual(['drop-parent', 'keep-parent-long'])
+
+      // The sub-row is retained because it matched, and it carries the rank
+      // that its own filter run produced
+      const subRow = rows[0]!.subRows[0]!
+      expect(rowNames(rows[0]!.subRows)).toEqual(['keep-child'])
+      expect(subRow.columnFiltersMeta.name).toEqual({
+        itemRank: { rank: 'keep-child'.length },
+      })
+
+      // Meta belongs to the row that produced it: the retained parent keeps its
+      // own non-matching score rather than inheriting the sub-row's, and the
+      // matching parent keeps a score derived from its own value
+      expect(rows[0]!.columnFiltersMeta.name).toEqual({
+        itemRank: { rank: 0 },
+      })
+      expect(rows[1]!.columnFiltersMeta.name).toEqual({
+        itemRank: { rank: 'keep-parent-long'.length },
+      })
+    })
+
+    it('should keep columnFiltersMeta on top-level rows that have no sub-rows when filtering from leaf rows', () => {
+      const table = makeRankTable({
+        filterFromLeafRows: true,
+        data: [{ name: 'keep-a' }, { name: 'keep-bb' }, { name: 'drop-c' }],
+      })
+
+      const rows = table.getFilteredRowModel().rows
+      expect(rowNames(rows)).toEqual(['keep-a', 'keep-bb'])
+      expect(rows.map((row) => row.columnFiltersMeta.name)).toEqual([
+        { itemRank: { rank: 'keep-a'.length } },
+        { itemRank: { rank: 'keep-bb'.length } },
+      ])
+    })
+
+    it('should keep columnFiltersMeta on top-level rows when filtering from the root down', () => {
+      const table = makeRankTable({
+        data: [{ name: 'keep-a' }, { name: 'keep-bb' }, { name: 'drop-c' }],
+      })
+
+      const rows = table.getFilteredRowModel().rows
+      expect(rowNames(rows)).toEqual(['keep-a', 'keep-bb'])
+      expect(rows.map((row) => row.columnFiltersMeta.name)).toEqual([
+        { itemRank: { rank: 'keep-a'.length } },
+        { itemRank: { rank: 'keep-bb'.length } },
+      ])
+    })
   })
 
   describe('row.columnFilters flags', () => {


### PR DESCRIPTION
## 🎯 Changes

Fixes #6074

`filterRowModelFromLeafs` rebuilds every row with `constructRow` and copies `columnFilters` onto the copy but not `columnFiltersMeta`. Since `initRowInstanceData` initialises both maps as empty, the meta is not `undefined` but silently reset to `{}`, so the rank metadata a filter records through `addMeta` is wiped and the `rowA.columnFiltersMeta[columnId]` guard in the fuzzy-filtering guide's sort function skips instead of throwing. This copies the meta across alongside `columnFilters`.

**Why a per-row copy rather than inheriting or aggregating.** `_createFilteredRowModel` already tags every row of the pre-filtered model in a flat pre-pass, so meta is computed independently at every depth: the leaf-up path loses data that exists rather than data needing derivation. Inheriting the parent's meta would stamp a parent's rank onto its sub-rows and produce wrong sort order within a group instead of a visible break. Aggregating sub-row ranks into the parent would overwrite the parent's own score, which the issue author explicitly argued against, noting a `sortingFn` already has `row.subRows`.

Nothing in `table-core` reads `columnFiltersMeta`, so restoring it cannot change any filtering, faceting, or pagination result.

Left alone deliberately: `filterRowModelFromRoot` clones matching parents with `subRows` and copies neither field, so those lose both under the default option. That path has an in-core consumer (`row.columnFilters`), so aligning the two is a broader decision than this bug covers. Happy to follow up separately. `perf-todo.md` records this gap at `filterRowsUtils.ts:65` as needing "a deliberate, documented decision either way".

**Tests** in `createFilteredRowModel.test.ts`, added to the existing `columnFiltersMeta` describe block with a rank-scoring `addMeta` filter: nested rows under `filterFromLeafRows: true` (the retained non-matching parent keeps rank `0` rather than inheriting its child's, which pins per-row over inherited semantics), flat top-level rows under the same option, and flat rows on the default root-down path. The first two fail on `main`, the third passes either way.

Verified from `packages/table-core`: `npx vitest run` (63 files, 1319 passed), the changed test file (36 passed, 2 failing with the src fix stashed), `npx tsc` and the declaration-emit config, `npx eslint ./src`, and `prettier --check` on changed files, all clean. `pnpm run test:pr` is green for every lint, types, lib and build target; the only failures are the Angular example builds, which cannot run on my machine because the Angular CLI wants Node 24.15.0 and I am on 24.14.1.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved column filter metadata when filtering hierarchical data from leaf rows.
  - Ensured metadata added by filter callbacks remains available on parent rows, sub-rows, and top-level rows.
  - Improved consistency between leaf-first and root-down filtering results.

- **Tests**
  - Added coverage for metadata retention across matching and non-matching hierarchical filter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

