### PR TITLE
fix: flatRows ordering, aggregation fallback, React context types, pagination example

### DIFF
--- a/examples/react/pagination/src/main.tsx
+++ b/examples/react/pagination/src/main.tsx
@@ -86,6 +86,9 @@ function MyTable({
       features,
       columns,
       data,
+      // Stable row ids are required when `manualPagination` passes only the
+      // current page of rows (for example from a server or TanStack Query).
+      getRowId: (row) => row.id,
       // initialState: { pagination: { pageIndex: 1, pageSize: 20 } }, // set the initial page once
       // atoms: { pagination: paginationAtom }, // preferred: own pagination state with an external atom
       // state: { pagination }, // classic controlled state; pair with onPaginationChange

--- a/examples/react/pagination/src/makeData.ts
+++ b/examples/react/pagination/src/makeData.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker'
 
 export type Person = {
+  id: string
   firstName: string
   lastName: string
   age: number
@@ -18,8 +19,9 @@ const range = (len: number) => {
   return arr
 }
 
-const newPerson = (): Person => {
+const newPerson = (id: string): Person => {
   return {
+    id,
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
     age: faker.number.int(40),
@@ -36,9 +38,9 @@ const newPerson = (): Person => {
 export function makeData(...lens: Array<number>) {
   const makeDataLevel = (depth = 0): Array<Person> => {
     const len = lens[depth]
-    return range(len).map((_d): Person => {
+    return range(len).map((index): Person => {
       return {
-        ...newPerson(),
+        ...newPerson(String(index)),
         subRows: lens[depth + 1] ? makeDataLevel(depth + 1) : undefined,
       }
     })

--- a/packages/react-table/src/contextTypes.ts
+++ b/packages/react-table/src/contextTypes.ts
@@ -1,0 +1,24 @@
+import type {
+  CellContext as CoreCellContext,
+  CellData,
+  HeaderContext as CoreHeaderContext,
+  RowData,
+  TableFeatures,
+} from '@tanstack/table-core'
+import type { ReactTable } from './useTable'
+
+export type ReactCellContext<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData = CellData,
+> = Omit<CoreCellContext<TFeatures, TData, TValue>, 'table'> & {
+  table: ReactTable<TFeatures, TData>
+}
+
+export type ReactHeaderContext<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+  TValue extends CellData = CellData,
+> = Omit<CoreHeaderContext<TFeatures, TData, TValue>, 'table'> & {
+  table: ReactTable<TFeatures, TData>
+}

--- a/packages/react-table/src/index.ts
+++ b/packages/react-table/src/index.ts
@@ -1,5 +1,10 @@
 export * from '@tanstack/table-core'
 
+export type {
+  ReactCellContext as CellContext,
+  ReactHeaderContext as HeaderContext,
+} from './contextTypes'
+
 export * from './FlexRender'
 export * from './Subscribe'
 export * from './createTableHook'

--- a/packages/react-table/tests/contextTypes.test.ts
+++ b/packages/react-table/tests/contextTypes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import {
+  createColumnHelper,
+  rowPaginationFeature,
+  tableFeatures,
+  useTable,
+} from '../src'
+import type { CellContext, ReactTable } from '../src'
+
+type Person = {
+  firstName: string
+}
+
+const features = tableFeatures({
+  rowPaginationFeature,
+})
+
+describe('react context types', () => {
+  it('types cell and header contexts with ReactTable', () => {
+    const columnHelper = createColumnHelper<typeof features, Person>()
+
+    type CellTable = CellContext<
+      typeof features,
+      Person,
+      string
+    >['table']
+
+    expectTypeOf<CellTable>().toEqualTypeOf<
+      ReactTable<typeof features, Person>
+    >()
+
+    const columns = columnHelper.columns([
+      columnHelper.accessor('firstName', {
+        cell: ({ table }) => {
+          expectTypeOf(table).toEqualTypeOf<
+            ReactTable<typeof features, Person>
+          >()
+          return table.state
+        },
+      }),
+    ])
+
+    expectTypeOf(columns).toBeArray()
+    expectTypeOf(useTable).toBeFunction()
+  })
+})

--- a/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
+++ b/packages/table-core/src/features/column-filtering/filterRowsUtils.ts
@@ -27,6 +27,21 @@ export function filterRows<
   return filterRowModelFromRoot(rows, filterRowImpl, table)
 }
 
+function pushRowsParentFirst<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>(
+  rows: Array<Row<TFeatures, TData>>,
+  flatRows: Array<Row<TFeatures, TData>>,
+): void {
+  for (const row of rows) {
+    flatRows.push(row)
+    if (row.subRows.length) {
+      pushRowsParentFirst(row.subRows, flatRows)
+    }
+  }
+}
+
 function filterRowModelFromLeafs<
   TFeatures extends TableFeatures,
   TData extends RowData,
@@ -37,7 +52,6 @@ function filterRowModelFromLeafs<
   ) => Array<Row<TFeatures, TData>> | undefined,
   table: Table_Internal<TFeatures, TData>,
 ): RowModel<TFeatures, TData> {
-  const newFilteredFlatRows: Array<Row<TFeatures, TData>> = []
   const newFilteredRowsById = makeObjectMap<Row<TFeatures, TData>>()
   const maxDepth = table.options.maxLeafRowFilterDepth ?? 100
 
@@ -71,14 +85,12 @@ function filterRowModelFromLeafs<
         if (filterRow(row) && !newRow.subRows.length) {
           filteredRows.push(row)
           newFilteredRowsById[row.id] = row
-          newFilteredFlatRows.push(row)
           continue
         }
 
         if (filterRow(row) || newRow.subRows.length) {
           filteredRows.push(row)
           newFilteredRowsById[row.id] = row
-          newFilteredFlatRows.push(row)
           continue
         }
       } else {
@@ -86,7 +98,6 @@ function filterRowModelFromLeafs<
         if (filterRow(row)) {
           filteredRows.push(row)
           newFilteredRowsById[row.id] = row
-          newFilteredFlatRows.push(row)
         }
       }
     }
@@ -94,8 +105,12 @@ function filterRowModelFromLeafs<
     return filteredRows
   }
 
+  const rows = recurseFilterRows(rowsToFilter)
+  const newFilteredFlatRows: Array<Row<TFeatures, TData>> = []
+  pushRowsParentFirst(rows, newFilteredFlatRows)
+
   return {
-    rows: recurseFilterRows(rowsToFilter),
+    rows,
     flatRows: newFilteredFlatRows,
     rowsById: newFilteredRowsById,
   }
@@ -109,7 +124,6 @@ function filterRowModelFromRoot<
   filterRow: (row: Row<TFeatures, TData>) => any,
   table: Table_Internal<TFeatures, TData>,
 ): RowModel<TFeatures, TData> {
-  const newFilteredFlatRows: Array<Row<TFeatures, TData>> = []
   const newFilteredRowsById = makeObjectMap<Row<TFeatures, TData>>()
   const maxDepth = table.options.maxLeafRowFilterDepth ?? 100
 
@@ -142,20 +156,15 @@ function filterRowModelFromRoot<
         }
 
         filteredRows.push(row)
-        newFilteredFlatRows.push(row)
         newFilteredRowsById[row.id] = row
 
         // When maxLeafRowFilterDepth stops the recursion, the kept row's
         // subtree stays visible through row.subRows, so those descendants
-        // must still enter flatRows and rowsById to keep the flat
-        // representation (and anything derived from it, like facet counts)
-        // consistent with the visible tree
+        // must still enter rowsById to keep the flat representation (and
+        // anything derived from it, like facet counts) consistent with the
+        // visible tree.
         if (row.subRows.length && depth >= maxDepth) {
-          addSubRowsToFlatArrays(
-            row.subRows,
-            newFilteredFlatRows,
-            newFilteredRowsById,
-          )
+          addSubRowsToRowsById(row.subRows, newFilteredRowsById)
         }
       }
     }
@@ -163,26 +172,28 @@ function filterRowModelFromRoot<
     return filteredRows
   }
 
+  const rows = recurseFilterRows(rowsToFilter)
+  const newFilteredFlatRows: Array<Row<TFeatures, TData>> = []
+  pushRowsParentFirst(rows, newFilteredFlatRows)
+
   return {
-    rows: recurseFilterRows(rowsToFilter),
+    rows,
     flatRows: newFilteredFlatRows,
     rowsById: newFilteredRowsById,
   }
 }
 
-function addSubRowsToFlatArrays<
+function addSubRowsToRowsById<
   TFeatures extends TableFeatures,
   TData extends RowData,
 >(
   subRows: Array<Row<TFeatures, TData>>,
-  flatRows: Array<Row<TFeatures, TData>>,
   rowsById: Record<string, Row<TFeatures, TData>>,
 ): void {
   for (const subRow of subRows) {
-    flatRows.push(subRow)
     rowsById[subRow.id] = subRow
     if (subRow.subRows.length) {
-      addSubRowsToFlatArrays(subRow.subRows, flatRows, rowsById)
+      addSubRowsToRowsById(subRow.subRows, rowsById)
     }
   }
 }

--- a/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
+++ b/packages/table-core/src/features/column-grouping/createGroupedRowModel.ts
@@ -107,17 +107,8 @@ function _createGroupedRowModel<
       return rows.map((row) => {
         row.depth = depth
 
-        // Every row is pushed into flatRows/rowsById exactly once, by its
-        // parent frame: rows returned here are pushed by the caller (the
-        // parent group's loop or the root loop), so only descendants below
-        // the terminal depth are pushed here.
         if (row.subRows.length) {
           row.subRows = groupUpRecursively(row.subRows, depth + 1, row.id)
-          for (let i = 0; i < row.subRows.length; i++) {
-            const subRow = row.subRows[i]!
-            groupedFlatRows.push(subRow)
-            groupedRowsById[subRow.id] = subRow
-          }
         }
 
         return row
@@ -206,11 +197,6 @@ function _createGroupedRowModel<
           },
         })
 
-        subRows.forEach((subRow) => {
-          groupedFlatRows.push(subRow)
-          groupedRowsById[subRow.id] = subRow
-        })
-
         return row
       },
     )
@@ -220,15 +206,29 @@ function _createGroupedRowModel<
 
   const groupedRows = groupUpRecursively(rowModel.rows, 0)
 
-  groupedRows.forEach((subRow) => {
-    groupedFlatRows.push(subRow)
-    groupedRowsById[subRow.id] = subRow
-  })
+  pushGroupedRowsParentFirst(groupedRows, groupedFlatRows, groupedRowsById)
 
   return {
     rows: groupedRows,
     flatRows: groupedFlatRows,
     rowsById: groupedRowsById,
+  }
+}
+
+function pushGroupedRowsParentFirst<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>(
+  rows: Array<Row<TFeatures, TData>>,
+  flatRows: Array<Row<TFeatures, TData>>,
+  rowsById: Record<string, Row<TFeatures, TData>>,
+): void {
+  for (const row of rows) {
+    flatRows.push(row)
+    rowsById[row.id] = row
+    if (row.subRows.length) {
+      pushGroupedRowsParentFirst(row.subRows, flatRows, rowsById)
+    }
   }
 }
 

--- a/packages/table-core/src/features/row-aggregation/rowAggregationFeature.ts
+++ b/packages/table-core/src/features/row-aggregation/rowAggregationFeature.ts
@@ -4,7 +4,6 @@ import {
   column_getAggregationFns,
   column_getAggregationValue,
   column_getAutoAggregationFn,
-  formatAggregatedCellValue,
 } from './rowAggregationFeature.utils'
 import type { TableFeature } from '../../types/TableFeatures'
 
@@ -13,8 +12,6 @@ import type { TableFeature } from '../../types/TableFeatures'
  */
 export const rowAggregationFeature: TableFeature = {
   getDefaultColumnDef: () => ({
-    aggregatedCell: ({ column, getValue }: any) =>
-      formatAggregatedCellValue(getValue(), column.columnDef.aggregationFn),
     aggregationFn: 'auto',
     maxAggregationDepth: 0,
   }),

--- a/packages/table-core/src/flex-render.ts
+++ b/packages/table-core/src/flex-render.ts
@@ -2,6 +2,7 @@ import type { Cell } from './types/Cell'
 import type { Header } from './types/Header'
 import type { TableFeatures } from './types/TableFeatures'
 import type { CellData, RowData } from './types/type-utils'
+import { formatAggregatedCellValue } from './features/row-aggregation/rowAggregationFeature.utils'
 
 /**
  * Renders a static value or render function with the provided props.
@@ -70,7 +71,13 @@ export function FlexRender<
     }
     if (groupingCell.getIsAggregated?.()) {
       return flexRender(
-        groupingDef.aggregatedCell ?? def.cell,
+        groupingDef.aggregatedCell ??
+          def.cell ??
+          ((context) =>
+            formatAggregatedCellValue(
+              context.getValue(),
+              context.column.columnDef.aggregationFn,
+            )),
         cell.getContext(),
       )
     }

--- a/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
+++ b/packages/table-core/tests/implementation/features/column-filtering/createFilteredRowModel.test.ts
@@ -323,14 +323,11 @@ describe('createFilteredRowModel', () => {
       const table = makeNestedTable({ maxLeafRowFilterDepth: 1 })
       const model = table.getFilteredRowModel()
 
-      // Depth-1 children are still filtered (drop-a2 removed), while the
-      // depth-2 subtree of keep-a1 is kept as-is and joins flatRows. The
-      // pre-existing flatRows order pushes recursed children before their
-      // parent.
+      // depth-2 subtree of keep-a1 is kept as-is and joins flatRows.
       expect(rowNames(model.flatRows)).toEqual([
+        'keep-a',
         'keep-a1',
         'drop-a1a',
-        'keep-a',
         'keep-c',
         'keep-d',
       ])
@@ -714,6 +711,47 @@ describe('createFilteredRowModel', () => {
       })
 
       expect(table.getFilteredRowModel()).toBe(table.getPreFilteredRowModel())
+    })
+  })
+
+  describe('flatRows ordering', () => {
+    it('should list each parent before its own sub-rows in flatRows', () => {
+      const table = constructTable({
+        features,
+        columns: [
+          {
+            accessorKey: 'name',
+            id: 'name',
+            filterFn: () => true,
+          },
+        ],
+        data: [
+          {
+            name: 'a',
+            subRows: [{ name: 'a1' }, { name: 'a2' }],
+          },
+          {
+            name: 'b',
+            subRows: [{ name: 'b1' }],
+          },
+        ],
+        getSubRows: (row) => row.subRows,
+        initialState: {
+          columnFilters: [{ id: 'name', value: 'filtered' }],
+        },
+      })
+
+      expect(table.getCoreRowModel().flatRows.map((row) => row.id)).toEqual([
+        '0',
+        '0.0',
+        '0.1',
+        '1',
+        '1.0',
+      ])
+
+      expect(
+        table.getFilteredRowModel().flatRows.map((row) => row.id),
+      ).toEqual(['0', '0.0', '0.1', '1', '1.0'])
     })
   })
 })

--- a/packages/table-core/tests/implementation/features/column-grouping/createGroupedRowModel.test.ts
+++ b/packages/table-core/tests/implementation/features/column-grouping/createGroupedRowModel.test.ts
@@ -495,6 +495,26 @@ describe('createGroupedRowModel manualGrouping', () => {
   })
 })
 
+describe('createGroupedRowModel flatRows ordering', () => {
+  it('should list each group row before its own descendants in flatRows', () => {
+    const data: Array<TestRow> = [
+      { status: 'a', firstName: 'one' },
+      { status: 'a', firstName: 'two' },
+      { status: 'b', firstName: 'three' },
+    ]
+    const table = makeTable(data, ['status'])
+    const rowModel = table.getGroupedRowModel()
+
+    expect(rowModel.flatRows.map((row) => row.id)).toEqual([
+      'status:a',
+      '0',
+      '1',
+      'status:b',
+      '2',
+    ])
+  })
+})
+
 describe('createGroupedRowModel rowsById', () => {
   it('should contain group row ids and leaf ids exactly once', () => {
     const data: Array<TestRow> = [

--- a/packages/table-core/tests/unit/flex-render.test.ts
+++ b/packages/table-core/tests/unit/flex-render.test.ts
@@ -188,10 +188,9 @@ describe('FlexRender with the column grouping feature', () => {
     expect(FlexRender({ cell })).toBe('Region Europe')
   })
 
-  // `rowAggregationFeature` supplies a default `aggregatedCell`, so a column
-  // that declares none still renders the formatted aggregate rather than
-  // falling through to its `cell` template.
-  it('should use the feature default when a column defines no aggregatedCell', () => {
+  // `rowAggregationFeature` formats aggregated values when a column defines
+  // neither `aggregatedCell` nor `cell`.
+  it('should format aggregated values when a column defines no aggregatedCell or cell', () => {
     const table = constructTable({
       features: groupingFeatures,
       data,
@@ -201,7 +200,6 @@ describe('FlexRender with the column grouping feature', () => {
           id: 'amount',
           accessorKey: 'amount',
           aggregationFn: 'sum',
-          cell: (context) => `Amount ${String(context.getValue())}`,
         },
       ],
       initialState: { grouping: ['region'] },
@@ -211,5 +209,27 @@ describe('FlexRender with the column grouping feature', () => {
 
     expect(cell.getIsAggregated()).toBe(true)
     expect(FlexRender({ cell })).toBe('3')
+  })
+
+  it('should fall back to the cell template when aggregatedCell is not defined', () => {
+    const table = constructTable({
+      features: groupingFeatures,
+      data,
+      columns: [
+        { id: 'region', accessorKey: 'region' },
+        {
+          id: 'amount',
+          accessorKey: 'amount',
+          aggregationFn: 'mean',
+          cell: (context) => `${String(context.getValue())}%`,
+        },
+      ],
+      initialState: { grouping: ['region'] },
+    })
+    const row = table.getRowModel().rows[0]!
+    const cell = row.getAllCells().find((c) => c.column.id === 'amount')!
+
+    expect(cell.getIsAggregated()).toBe(true)
+    expect(FlexRender({ cell })).toBe('1.5%')
   })
 })


### PR DESCRIPTION
## Summary

This PR fixes five related issues in TanStack Table v9:

- **#6536** — `getFilteredRowModel().flatRows` now uses parent-before-children ordering (matching core, paginated, and sorted row models) by flattening the filtered tree after filtering completes.
- **#6551** — `getGroupedRowModel().flatRows` uses the same parent-first flatten pass instead of pushing descendants before their group rows.
- **#5778** — Removes the default `aggregatedCell` from `rowAggregationFeature.getDefaultColumnDef`. `FlexRender` now resolves aggregated cells as `aggregatedCell ?? cell ?? formatAggregatedCellValue(...)`, so a column's `cell` template applies to aggregated rows when `aggregatedCell` is omitted.
- **#6230** — `@tanstack/react-table` re-exports `CellContext` and `HeaderContext` with `table: ReactTable` so column templates can access `table.Subscribe` with correct types.
- **#4848** — React pagination example adds stable `id` fields and `getRowId`, with a comment explaining why this is required for manual/server pagination.

## Test plan

- [x] `pnpm exec vitest run tests/implementation/features/column-filtering/createFilteredRowModel.test.ts`
- [x] `pnpm exec vitest run tests/implementation/features/column-grouping/createGroupedRowModel.test.ts`
- [x] `pnpm exec vitest run tests/unit/flex-render.test.ts`
- [x] `pnpm exec vitest run tests/contextTypes.test.ts` (react-table)
- [x] `pnpm --filter @tanstack/table-core build`

Fixes #6536, #6551, #5778, #6230, #4848


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hierarchical filtering and grouped-row display so parent rows consistently appear before their descendants.
  * Fixed row identification in the pagination example for more stable table behavior.
  * Improved aggregated cell rendering when custom formatting is not provided.

* **Developer Experience**
  * Added React-specific cell and header context types to improve TypeScript support and editor guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->