### PR TITLE
feat(table-core): add mode aggregation function

### DIFF
--- a/.changeset/neat-rows-mode.md
+++ b/.changeset/neat-rows-mode.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': minor
+---
+
+Add `mode` aggregation function to `aggregationFns` to compute statistical mode with first-encountered tie breaking.

--- a/packages/table-core/src/features/row-aggregation/aggregationFns.ts
+++ b/packages/table-core/src/features/row-aggregation/aggregationFns.ts
@@ -282,6 +282,39 @@ export const aggregationFn_median = constructAggregationFn<
   },
 })
 
+/**
+ * Computes the statistical mode (most frequent value) of the row values.
+ * If multiple values have the same maximum frequency, returns the first one encountered.
+ * Returns `undefined` when no rows are present.
+ */
+export const aggregationFn_mode = constructAggregationFn<
+  any,
+  any,
+  unknown,
+  unknown
+>({
+  aggregate: (context) => {
+    const rows = context.rows
+    if (!rows.length) return undefined
+
+    let maxCount = 0
+    let modeValue: unknown = undefined
+    const counts = new Map<unknown, number>()
+
+    for (let i = 0; i < rows.length; i++) {
+      const value = context.getValue(rows[i]!)
+      const count = (counts.get(value) ?? 0) + 1
+      counts.set(value, count)
+      if (count > maxCount) {
+        maxCount = count
+        modeValue = value
+      }
+    }
+
+    return modeValue
+  },
+})
+
 /** Collects distinct row values using JavaScript `Set` semantics. */
 export const aggregationFn_unique = constructAggregationFn<
   any,
@@ -373,6 +406,7 @@ export const aggregationFns = {
   extent: aggregationFn_extent,
   mean: aggregationFn_mean,
   median: aggregationFn_median,
+  mode: aggregationFn_mode,
   unique: aggregationFn_unique,
   uniqueCount: aggregationFn_uniqueCount,
   count: aggregationFn_count,

--- a/packages/table-core/src/features/row-aggregation/aggregationFns.ts
+++ b/packages/table-core/src/features/row-aggregation/aggregationFns.ts
@@ -297,9 +297,8 @@ export const aggregationFn_mode = constructAggregationFn<
     const rows = context.rows
     if (!rows.length) return undefined
 
-    let maxCount = 0
-    let modeValue: unknown = undefined
     const counts = new Map<unknown, number>()
+    let maxCount = 0
 
     for (let i = 0; i < rows.length; i++) {
       const value = context.getValue(rows[i]!)
@@ -307,11 +306,17 @@ export const aggregationFn_mode = constructAggregationFn<
       counts.set(value, count)
       if (count > maxCount) {
         maxCount = count
-        modeValue = value
       }
     }
 
-    return modeValue
+    for (let i = 0; i < rows.length; i++) {
+      const value = context.getValue(rows[i]!)
+      if (counts.get(value) === maxCount) {
+        return value
+      }
+    }
+
+    return undefined
   },
 })
 

--- a/packages/table-core/tests/unit/fns/aggregationFns.test.ts
+++ b/packages/table-core/tests/unit/fns/aggregationFns.test.ts
@@ -121,15 +121,16 @@ describe('aggregation function definitions', () => {
   })
 
   it('calculates mode and returns first encountered value on tie', () => {
+    expect(aggregationFn_mode.aggregate(context(['a', 'b', 'b', 'a']))).toBe(
+      'a',
+    )
     expect(
       aggregationFn_mode.aggregate(context(['a', 'b', 'a', 'c', 'b', 'a'])),
     ).toBe('a')
     expect(
       aggregationFn_mode.aggregate(context(['a', 'b', 'a', 'b', 'c'])),
     ).toBe('a')
-    expect(
-      aggregationFn_mode.aggregate(context([1, 2, 2, 3, 2, 1])),
-    ).toBe(2)
+    expect(aggregationFn_mode.aggregate(context([1, 2, 2, 3, 2, 1]))).toBe(2)
     expect(
       aggregationFn_mode.aggregate(context([null, undefined, null, 'x'])),
     ).toBeNull()

--- a/packages/table-core/tests/unit/fns/aggregationFns.test.ts
+++ b/packages/table-core/tests/unit/fns/aggregationFns.test.ts
@@ -8,6 +8,7 @@ import {
   aggregationFn_mean,
   aggregationFn_median,
   aggregationFn_min,
+  aggregationFn_mode,
   aggregationFn_sum,
   aggregationFn_unique,
   aggregationFn_uniqueCount,
@@ -117,6 +118,22 @@ describe('aggregation function definitions', () => {
     expect(
       aggregationFn_last.aggregate(context(['a', 'b', undefined])),
     ).toBeUndefined()
+  })
+
+  it('calculates mode and returns first encountered value on tie', () => {
+    expect(
+      aggregationFn_mode.aggregate(context(['a', 'b', 'a', 'c', 'b', 'a'])),
+    ).toBe('a')
+    expect(
+      aggregationFn_mode.aggregate(context(['a', 'b', 'a', 'b', 'c'])),
+    ).toBe('a')
+    expect(
+      aggregationFn_mode.aggregate(context([1, 2, 2, 3, 2, 1])),
+    ).toBe(2)
+    expect(
+      aggregationFn_mode.aggregate(context([null, undefined, null, 'x'])),
+    ).toBeNull()
+    expect(aggregationFn_mode.aggregate(context([]))).toBeUndefined()
   })
 
   it('preserves custom definition result inference', () => {


### PR DESCRIPTION
## 🎯 Changes

TanStack Table provides built-in aggregation functions for `sum`, `min`, `max`, `extent`, `mean`, `median`, `unique`, `uniqueCount`, `count`, `first`, and `last`, but lacked a built-in statistical `mode` aggregation function for nominal/categorical and discrete values (Issue #5864).

This PR:
- Adds `aggregationFn_mode` to `packages/table-core/src/features/row-aggregation/aggregationFns.ts` to compute the statistical mode (most frequent value) across rows.
- Resolves frequency ties by returning the first encountered value.
- Correctly counts distinct values (including nullish/mixed types) and returns `undefined` when no rows are present.
- Registers `mode: aggregationFn_mode` in `aggregationFns` and exports `aggregationFn_mode`.
- Adds comprehensive unit tests in `packages/table-core/tests/unit/fns/aggregationFns.test.ts` for value frequency, tie resolution order, nullish handling, and empty rows.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm test` and `pnpm test:e2e`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `mode` aggregation option for tables, returning the most frequently occurring value.
  * Ties are resolved by selecting the first value encountered.
  * Empty datasets return no value, while null and undefined values are preserved.
  * The new option is available alongside the existing table aggregation functions.

* **Tests**
  * Added coverage for common values, ties, empty inputs, and null or undefined entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->