### PR TITLE
fix(table-core): clear row value caches when column defs are replaced

### DIFF
--- a/.changeset/stale-accessor-values.md
+++ b/.changeset/stale-accessor-values.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Clear row value caches when column definitions are replaced, so a column whose `accessorFn` changes no longer serves the value produced by the previous accessor.

--- a/packages/table-core/src/core/table/coreTablesFeature.utils.ts
+++ b/packages/table-core/src/core/table/coreTablesFeature.utils.ts
@@ -187,6 +187,34 @@ export function table_mergeOptions<
 }
 
 /**
+ * Clears every built row's accessor-value caches. Both are keyed by column id
+ * and rows outlive column-definition swaps, so a replaced `accessorFn` would
+ * otherwise never be read again. Emptied in place because sorted and grouped
+ * row clones share these objects by reference.
+ */
+function table_clearRowValueCaches<
+  TFeatures extends TableFeatures,
+  TData extends RowData,
+>(table: Table_Internal<TFeatures, TData>): void {
+  if (!table._rowModels.coreRowModel) {
+    return
+  }
+
+  const rows = table.getCoreRowModel().flatRows
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!
+
+    for (const key in row._valuesCache) {
+      delete row._valuesCache[key]
+    }
+    for (const key in row._uniqueValuesCache) {
+      delete row._uniqueValuesCache[key]
+    }
+  }
+}
+
+/**
  * Updates the table options object.
  *
  * The updater receives the current resolved options and the merged result is
@@ -213,6 +241,9 @@ export function table_setOptions<
     table.options as TableOptions<TFeatures, TData>,
   )
   const mergedOptions = table_mergeOptions(table, newOptions)
+  if (mergedOptions.columns !== table.options.columns) {
+    table_clearRowValueCaches(table)
+  }
 
   if (table.optionsStore) {
     table.optionsStore.set(() => mergedOptions)

--- a/packages/table-core/tests/unit/core/rows/coreRowsFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/core/rows/coreRowsFeature.utils.test.ts
@@ -96,6 +96,14 @@ function makeNestedTable(
   })
 }
 
+function makeAccessorTable(accessorFn: (person: Person) => string) {
+  return constructTable({
+    features,
+    data: generateTestData(1),
+    columns: [{ id: 'name', accessorFn }],
+  })
+}
+
 describe('row_getValue', () => {
   it('should read and cache the accessor value', () => {
     const table = makeTable(1)
@@ -112,6 +120,62 @@ describe('row_getValue', () => {
     const row = table.getRowModel().rows[0]!
 
     expect(row_getValue(row, 'not-a-column')).toBeUndefined()
+  })
+
+  it('should re-read the value when the column accessor is replaced', () => {
+    const table = makeAccessorTable((person) => `${person.firstName} last`)
+    const row = table.getCoreRowModel().rows[0]!
+    const original = row_getValue(row, 'name')
+
+    table.setOptions((old) => ({
+      ...old,
+      columns: [
+        {
+          id: 'name',
+          accessorFn: (person: Person) => `${person.firstName} replaced`,
+        },
+      ],
+    }))
+
+    expect(table.getCoreRowModel().rows[0]!).toBe(row)
+    expect(row_getValue(row, 'name')).not.toBe(original)
+    expect(row_getValue(row, 'name')).toBe(`${row.original.firstName} replaced`)
+  })
+
+  it('should not expose stale values to subscribers notified during the options update', () => {
+    const table = makeAccessorTable(() => 'original')
+    const row = table.getCoreRowModel().rows[0]!
+    row_getValue(row, 'name')
+
+    const observed: Array<unknown> = []
+    const subscription = table.optionsStore!.subscribe(() => {
+      observed.push(row_getValue(row, 'name'))
+    })
+
+    table.setOptions((old) => ({
+      ...old,
+      columns: [{ id: 'name', accessorFn: () => 'replaced' }],
+    }))
+    subscription.unsubscribe()
+
+    expect(observed).toEqual(['replaced'])
+  })
+
+  it('should call the replacement accessor exactly once per read cycle', () => {
+    const table = makeAccessorTable(() => 'original')
+    const row = table.getCoreRowModel().rows[0]!
+    row_getValue(row, 'name')
+
+    const replacement = vi.fn(() => 'replaced')
+    table.setOptions((old) => ({
+      ...old,
+      columns: [{ id: 'name', accessorFn: replacement }],
+    }))
+
+    row_getValue(row, 'name')
+    row_getValue(row, 'name')
+
+    expect(replacement).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -137,6 +201,20 @@ describe('row_getUniqueValues', () => {
     expect(row_getUniqueValues(row, 'firstName')).toEqual(['x', 'y'])
     expect(row_getUniqueValues(row, 'firstName')).toEqual(['x', 'y'])
     expect(getUniqueValues).toHaveBeenCalledTimes(1)
+  })
+
+  it('should re-read unique values when the column accessor is replaced', () => {
+    const table = makeAccessorTable(() => 'original')
+    const row = table.getCoreRowModel().rows[0]!
+
+    expect(row_getUniqueValues(row, 'name')).toEqual(['original'])
+
+    table.setOptions((old) => ({
+      ...old,
+      columns: [{ id: 'name', accessorFn: () => 'replaced' }],
+    }))
+
+    expect(row_getUniqueValues(row, 'name')).toEqual(['replaced'])
   })
 
   it('should return undefined for unknown columns', () => {


### PR DESCRIPTION
## 🎯 Changes

Fixes #5363. Supersedes #5582, whose diagnosis this builds on; @takoshi credited there.

- Clear `_valuesCache` and `_uniqueValuesCache` on every built row from `table_setOptions` when `options.columns` identity changes, so a replaced `accessorFn` is read again.
- Empty both caches in place rather than replacing them. Sorted and grouped row clones copy these objects by reference via `copyInstancePropertiesWithoutMemos`, so they are invalidated alongside their source rows.
- Guard the walk on `table._rowModels.coreRowModel` so it never forces the core row model to build.
- Add regression coverage for a replaced `accessorFn` through `row_getValue` and `row_getUniqueValues`, and for the replacement accessor running exactly once per read cycle.

Rows are only rebuilt when `options.data` identity changes (`createCoreRowModel` memo deps are `[table.options.data]`), and both caches are keyed by column id, so rows outlive a column-definition swap holding values the previous accessor produced.

Performance impact: `row_getValue` and `row_getUniqueValues` are untouched, so the per-cell read path is unchanged. Comparing accessor identity on read, as #5582 did, puts a `getColumn` dispatch on the cache-hit path; at 20k rows x 10 columns with every value warm that measured ~56ms per pass against ~6.5ms on main. Interleaved runs of this change against main show no measurable difference: 6.7 / 7.4 / 7.9ms on main, 6.0 / 6.7 / 5.8ms here. The clear is O(rows) and runs only when column definitions are replaced. `createGroupedRowModel`'s separate `_valuesCache` path needs no change; `options.columns` is already in its memo deps, so those rows are rebuilt and the stale values reaching them came from the leaf rows.

Validation:

- `pnpm --filter @tanstack/table-core test:lib` — 1333 passed, and the three new tests confirmed failing on main
- `pnpm --filter @tanstack/react-table test:lib` — 34 passed
- `pnpm --filter @tanstack/table-core test:types`
- ESLint and Prettier

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm test` and `pnpm test:e2e`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale row values after replacing column definitions or accessor logic.
  * Row values and unique values now correctly reflect updated accessors.
  * Preserved row instances while ensuring updated values are returned consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->