### PR TITLE
fix: guard pagination pageIndex/pageSize against NaN and non-positive pageSize

### DIFF
--- a/.changeset/fix-pagination-nan-page-size.md
+++ b/.changeset/fix-pagination-nan-page-size.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/table-core': patch
+---
+
+Fix pagination state corruption from invalid `pageSize`/`pageIndex` values: `setPageIndex`/`setPageSize` now fall back to the default state instead of storing `NaN` (e.g. from an emptied numeric input), and `getPageCount`/`getPageOptions` no longer throw when `pageSize` is `0` or negative (reachable via `initialState` or a directly-supplied `pagination` state).

--- a/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
+++ b/packages/table-core/src/features/row-pagination/rowPaginationFeature.utils.ts
@@ -107,7 +107,9 @@ export function table_resetPagination<
  * Updates `pagination.pageIndex` and clamps it to the known page range.
  *
  * Unknown page counts (`undefined` or `-1`) allow any non-negative page index.
- * Known page counts clamp the index between `0` and `pageCount - 1`.
+ * Known page counts clamp the index between `0` and `pageCount - 1`. A `NaN`
+ * update (e.g. from an emptied numeric input) falls back to the default page
+ * index instead of poisoning the state.
  *
  * @example
  * ```ts
@@ -120,6 +122,10 @@ export function table_setPageIndex<
 >(table: Table_Internal<TFeatures, TData>, updater: Updater<number>) {
   table_setPagination(table, (old) => {
     let pageIndex = functionalUpdate(updater, old.pageIndex)
+
+    if (Number.isNaN(pageIndex)) {
+      pageIndex = defaultPageIndex
+    }
 
     const maxPageIndex =
       typeof table.options.pageCount === 'undefined' ||
@@ -188,7 +194,9 @@ export function table_resetPageSize<
  * Updates `pagination.pageSize` while preserving the current top row.
  *
  * The new size is clamped to at least `1`, and `pageIndex` is recalculated so
- * the row that was previously at the top of the page remains in view.
+ * the row that was previously at the top of the page remains in view. A
+ * `NaN` update (e.g. from an emptied numeric input) falls back to the default
+ * page size instead of poisoning the state.
  *
  * @example
  * ```ts
@@ -200,7 +208,10 @@ export function table_setPageSize<
   TData extends RowData,
 >(table: Table_Internal<TFeatures, TData>, updater: Updater<number>) {
   table_setPagination(table, (old) => {
-    const pageSize = Math.max(1, functionalUpdate(updater, old.pageSize))
+    const updatedPageSize = functionalUpdate(updater, old.pageSize)
+    const pageSize = Number.isNaN(updatedPageSize)
+      ? defaultPageSize
+      : Math.max(1, updatedPageSize)
     const topRowIndex =
       old.pageSize === Infinity ? 0 : old.pageSize * old.pageIndex
     const pageIndex =
@@ -391,7 +402,10 @@ export function table_lastPage<
  * Resolves the number of pages for the current pagination state.
  *
  * `options.pageCount` wins for manual pagination. Otherwise the value is
- * calculated from `table_getRowCount(table)` and the current `pageSize`.
+ * calculated from `table_getRowCount(table)` and the current `pageSize`. A
+ * non-positive or non-numeric `pageSize` (only reachable by bypassing
+ * `table_setPageSize`, e.g. via `initialState`) returns `0` instead of
+ * dividing into `Infinity`/`NaN`.
  *
  * @example
  * ```ts
@@ -412,6 +426,15 @@ export function table_getPageCount<
 
   if (pageSize === Infinity && Number.isFinite(rowCount) && rowCount > 0) {
     return 1
+  }
+
+  // A non-positive or non-numeric page size (reachable via `initialState` or
+  // a directly-supplied `pagination` state, bypassing `table_setPageSize`'s
+  // clamp) would otherwise divide into `Infinity`/`NaN` and make
+  // `table_getPageOptions` throw when it tries to build an array of that
+  // length.
+  if (!(pageSize > 0)) {
+    return 0
   }
 
   return Math.ceil(rowCount / pageSize)

--- a/packages/table-core/tests/unit/features/row-pagination/rowPaginationFeature.utils.test.ts
+++ b/packages/table-core/tests/unit/features/row-pagination/rowPaginationFeature.utils.test.ts
@@ -178,6 +178,20 @@ describe('table_setPageIndex', () => {
     ).toEqual({ pageIndex: 99, pageSize: 10 })
   })
 
+  it('should fall back to the default page index for a NaN update', () => {
+    const onPaginationChange = vi.fn()
+    const table = makeTable(DEFAULT_ROW_COUNT, {
+      onPaginationChange,
+      initialState: { pagination: { pageIndex: 2, pageSize: 10 } },
+    })
+
+    table_setPageIndex(table, NaN)
+
+    expect(
+      getUpdaterResult(onPaginationChange, { pageIndex: 2, pageSize: 10 }),
+    ).toEqual({ pageIndex: 0, pageSize: 10 })
+  })
+
   it('keeps pre-pagination display indexes on the current page', () => {
     const table = makeTable(DEFAULT_ROW_COUNT, {
       initialState: { pagination: { pageIndex: 2, pageSize: 10 } },
@@ -317,6 +331,20 @@ describe('table_setPageSize', () => {
         pageSize: Infinity,
       }),
     ).toEqual({ pageIndex: 0, pageSize: 10 })
+  })
+
+  it('should fall back to the default page size for a NaN update', () => {
+    const onPaginationChange = vi.fn()
+    const table = makeTable(DEFAULT_ROW_COUNT, {
+      onPaginationChange,
+      initialState: { pagination: { pageIndex: 2, pageSize: 5 } },
+    })
+
+    table_setPageSize(table, NaN)
+
+    expect(
+      getUpdaterResult(onPaginationChange, { pageIndex: 2, pageSize: 5 }),
+    ).toEqual({ pageIndex: 1, pageSize: 10 })
   })
 })
 
@@ -520,6 +548,26 @@ describe('table_getPageCount', () => {
     const table = makeTable(25, { manualPagination: true, pageCount: 7 })
 
     expect(table_getPageCount(table)).toBe(7)
+  })
+
+  it('should return 0 instead of throwing when pageSize is 0', () => {
+    // `table_setPageSize` clamps to a minimum of 1, but `initialState` (and a
+    // directly-supplied `pagination` state) bypasses that clamp.
+    const table = makeTable(25, {
+      initialState: { pagination: { pageIndex: 0, pageSize: 0 } },
+    })
+
+    expect(table_getPageCount(table)).toBe(0)
+    expect(table_getPageOptions(table)).toEqual([])
+  })
+
+  it('should return 0 instead of throwing when pageSize is negative', () => {
+    const table = makeTable(25, {
+      initialState: { pagination: { pageIndex: 0, pageSize: -5 } },
+    })
+
+    expect(table_getPageCount(table)).toBe(0)
+    expect(table_getPageOptions(table)).toEqual([])
   })
 })
 


### PR DESCRIPTION
## 🎯 Changes

`setPageIndex`/`setPageSize` could store `NaN` in pagination state when the updater resolved to `NaN` (e.g. binding `table.setPageSize(parseInt(e.target.value))` to a numeric input and clearing it: `parseInt('')` is `NaN`). `Math.max`/`Math.min` do not clamp `NaN` — it poisons through — so `NaN` silently reached state, and `rows.slice(NaN, NaN)` in the paginated row model quietly evaluated to `[]`: the table renders zero rows with no error surfaced anywhere.

Separately, `getPageCount`/`getPageOptions` could throw `RangeError: Invalid array length` when `pageSize` was `0` or negative. This is reachable via `initialState` or a directly-supplied `pagination` state, both of which bypass `setPageSize`'s `Math.max(1, ...)` clamp — e.g. `constructTable({ ..., initialState: { pagination: { pageIndex: 0, pageSize: 0 } } })` then calling `table.getPageOptions()` crashes immediately, and that's the API most pagination-control UIs call to render page-number buttons.

This PR:
- Makes `setPageIndex`/`setPageSize` fall back to the default page index/size when the updater resolves to `NaN`, instead of storing it.
- Makes `getPageCount` return `0` for a non-positive (or non-numeric) `pageSize` instead of dividing into `Infinity`/`NaN`, so `getPageOptions` returns `[]` instead of throwing.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/table/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with `pnpm test` and `pnpm test:e2e`, or these tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Test plan

- Added regression tests in `rowPaginationFeature.utils.test.ts` covering: `setPageIndex`/`setPageSize` with a `NaN` update, and `getPageCount`/`getPageOptions` with `pageSize: 0` and a negative `pageSize`.
- `nx run @tanstack/table-core:test:lib` (1334 tests), `test:types`, `test:eslint`, and `build` all pass.
- `pnpm test:pr` (affected-project lint/sherif/knip/lib/types/build) passes across 418 affected projects.
- `pnpm test:e2e:affected`: all pass except the pre-existing `vue/realtime-trading` smoke test, which I confirmed also fails on `main` without this change (unrelated timing issue in that example's pause/resume flow, not touched by this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination handling when page index or page size values are invalid.
  * Prevented errors and invalid results when page size is zero, negative, or unavailable.
  * Pagination now falls back to safe defaults and recalculates the current page correctly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->