### PR TITLE
fix(react-table): type aggregatedCell against bound cellComponents in createAppColumnHelper

### DIFF
--- a/packages/react-table/src/createTableHook.tsx
+++ b/packages/react-table/src/createTableHook.tsx
@@ -97,9 +97,12 @@ export type AppColumnDefBase<
   THeaderComponents extends Record<string, ComponentType<any>>,
 > = Omit<
   IdentifiedColumnDef<TFeatures, TData, TValue>,
-  'cell' | 'header' | 'footer'
+  'cell' | 'aggregatedCell' | 'header' | 'footer'
 > & {
   cell?: AppColumnDefTemplate<
+    AppCellContext<TFeatures, TData, TValue, TCellComponents>
+  >
+  aggregatedCell?: AppColumnDefTemplate<
     AppCellContext<TFeatures, TData, TValue, TCellComponents>
   >
   header?: AppColumnDefTemplate<
@@ -120,9 +123,12 @@ export type AppDisplayColumnDef<
   THeaderComponents extends Record<string, ComponentType<any>>,
 > = Omit<
   DisplayColumnDef<TFeatures, TData, unknown>,
-  'cell' | 'header' | 'footer'
+  'cell' | 'aggregatedCell' | 'header' | 'footer'
 > & {
   cell?: AppColumnDefTemplate<
+    AppCellContext<TFeatures, TData, unknown, TCellComponents>
+  >
+  aggregatedCell?: AppColumnDefTemplate<
     AppCellContext<TFeatures, TData, unknown, TCellComponents>
   >
   header?: AppColumnDefTemplate<
@@ -143,9 +149,12 @@ export type AppGroupColumnDef<
   THeaderComponents extends Record<string, ComponentType<any>>,
 > = Omit<
   GroupColumnDef<TFeatures, TData, unknown>,
-  'cell' | 'header' | 'footer' | 'columns'
+  'cell' | 'aggregatedCell' | 'header' | 'footer' | 'columns'
 > & {
   cell?: AppColumnDefTemplate<
+    AppCellContext<TFeatures, TData, unknown, TCellComponents>
+  >
+  aggregatedCell?: AppColumnDefTemplate<
     AppCellContext<TFeatures, TData, unknown, TCellComponents>
   >
   header?: AppColumnDefTemplate<
@@ -173,7 +182,7 @@ export type AppColumnHelper<
 > = {
   /**
    * Creates a data column definition with an accessor key or function.
-   * The cell, header, and footer contexts include pre-bound components.
+   * The cell, aggregatedCell, header, and footer contexts include pre-bound components.
    */
   accessor: <
     TAccessor extends AccessorFn<TData> | DeepKeys<TData>,
@@ -212,7 +221,7 @@ export type AppColumnHelper<
 
   /**
    * Creates a display column definition for non-data columns.
-   * The cell, header, and footer contexts include pre-bound components.
+   * The cell, aggregatedCell, header, and footer contexts include pre-bound components.
    */
   display: (
     column: AppDisplayColumnDef<
@@ -225,7 +234,7 @@ export type AppColumnHelper<
 
   /**
    * Creates a group column definition with nested child columns.
-   * The cell, header, and footer contexts include pre-bound components.
+   * The cell, aggregatedCell, header, and footer contexts include pre-bound components.
    */
   group: (
     column: AppGroupColumnDef<
@@ -725,7 +734,7 @@ export function createTableHook<
 
   /**
    * Create a column helper pre-bound to the features and components configured in this table hook.
-   * The cell, header, and footer contexts include pre-bound components (e.g., `cell.TextCell`).
+   * The cell, aggregatedCell, header, and footer contexts include pre-bound components (e.g., `cell.TextCell`).
    * @example
    * ```tsx
    * const columnHelper = createAppColumnHelper<Person>()

--- a/packages/react-table/tests/createAppColumnHelper.test-d.tsx
+++ b/packages/react-table/tests/createAppColumnHelper.test-d.tsx
@@ -1,0 +1,60 @@
+// Type-level tests for `createAppColumnHelper`, checked by `test:types` (tsc).
+// Not executed by vitest (the `.test-d.` name is excluded from its run glob).
+
+import * as React from 'react'
+import { rowAggregationFeature, tableFeatures } from '@tanstack/table-core'
+import { test } from 'vitest'
+import { createTableHook, createTableHookContexts } from '../src'
+
+type Person = {
+  id: string
+  name: string
+}
+
+const features = tableFeatures({
+  rowAggregationFeature,
+})
+const contexts = createTableHookContexts<typeof features, Person>()
+
+function NameCell() {
+  const cell = contexts.useCellContext<string>()
+
+  return <span>{cell.getValue().toUpperCase()}</span>
+}
+
+const appTable = createTableHook({
+  features,
+  tableContext: contexts.tableContext,
+  cellContext: contexts.cellContext,
+  headerContext: contexts.headerContext,
+  cellComponents: { NameCell },
+})
+const columnHelper = appTable.createAppColumnHelper<Person>()
+
+test('aggregatedCell is bound to cellComponents like cell', () => {
+  columnHelper.accessor('name', {
+    id: 'name',
+    // The bound `cellComponents` are available on the cell context here...
+    cell: ({ cell }) => <cell.NameCell />,
+    // ...and must be equally available on the aggregatedCell context.
+    aggregatedCell: ({ cell }) => <cell.NameCell />,
+  })
+
+  columnHelper.display({
+    id: 'display',
+    cell: ({ cell }) => <cell.NameCell />,
+    aggregatedCell: ({ cell }) => <cell.NameCell />,
+  })
+
+  columnHelper.group({
+    id: 'group',
+    aggregatedCell: ({ cell }) => <cell.NameCell />,
+    columns: [],
+  })
+
+  columnHelper.accessor('name', {
+    id: 'guard',
+    // @ts-expect-error a component that was not registered is not bound
+    aggregatedCell: ({ cell }) => <cell.NotRegistered />,
+  })
+})


### PR DESCRIPTION
## Problem

`createAppColumnHelper` (from `createTableHook`) returns column-definition types whose render props are enhanced with the registered `cellComponents` / `headerComponents`, so you can write `cell: ({ cell }) => <cell.MyCell />`. This worked for `cell`, `header`, and `footer`, but **not** for `aggregatedCell`: inside it the `cell` render prop was the plain core `Cell`, with no bound components, so `({ cell }) => <cell.MyCell />` was a type error.

Fixes #6583

## Cause

`AppColumnDefBase` (and its siblings `AppDisplayColumnDef` / `AppGroupColumnDef`) `Omit` the core `cell | header | footer` keys and re-declare them against the enhanced `AppCellContext` / `AppHeaderContext`. `aggregatedCell` — contributed by `rowAggregationFeature` and typed against the cell context, exactly like `cell` — was never part of that omit-and-enhance set, so it retained its core type.

## Fix

Add `'aggregatedCell'` to the omitted keys and re-declare it mirroring `cell` (both share the cell context) in `AppColumnDefBase`, `AppDisplayColumnDef`, and `AppGroupColumnDef`. This is a **type-only, localized** change; the runtime column helper is untouched (components are still bound at render time). JSDoc that enumerates the bound contexts was updated to mention `aggregatedCell`.

## Testing

- Added `packages/react-table/tests/createAppColumnHelper.test-d.tsx`, a type-level test (checked by `tsc` via `test:types`, excluded from the vitest run by its `.test-d.` name) asserting `aggregatedCell` accepts a bound component name across `accessor` / `display` / `group`, with a `@ts-expect-error` guard that an unregistered component is still rejected. Confirmed it **fails** before the fix and **passes** after.
- `pnpm --filter @tanstack/react-table test:types` → passes.
- `pnpm --filter @tanstack/react-table test:lib` → 6 files, 34 tests passing.
- ESLint on the changed files → clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom rendering of aggregated cell values across accessor, display, and group columns.
  - Registered cell components are now available when rendering aggregated cells, with type checking to prevent unsupported components.

- **Tests**
  - Added type-level coverage validating aggregated-cell rendering and component registration across column helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->